### PR TITLE
feat: page에 spotpin 추가 및 더미데이터 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,94 @@
-export default function Home() {
+'use client'
+
+import dynamic from 'next/dynamic'
+import { SpotPin as SpotPinType } from '@/types'
+
+// Leaflet은 SSR을 지원하지 않으므로 dynamic import 사용
+const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
+  ssr: false,
+  loading: () => <MapLoadingSkeleton />,
+})
+
+function MapLoadingSkeleton() {
   return (
-    <main className="min-h-screen bg-navy-900 text-white">
-      <div className="container mx-auto px-4 py-8">
-        <h1 className="text-center text-3xl font-bold">Anime Pilgrimage Map</h1>
-        <p className="mt-4 text-center text-navy-200">
+    <div className="flex h-full w-full items-center justify-center bg-navy-800">
+      <div className="text-center">
+        <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-navy-400 border-t-white"></div>
+        <p className="mt-4 text-navy-200">지도 로딩 중...</p>
+      </div>
+    </div>
+  )
+}
+
+// 테스트용 더미 스팟 데이터 (서울 주변)
+const DUMMY_SPOTS: SpotPinType[] = [
+  {
+    id: '1',
+    name: '너의 이름은 - 스가 신사',
+    coordinates: [35.6762, 139.6503], // 도쿄
+    thumbnailUrl: 'https://picsum.photos/seed/spot1/400/300',
+  },
+  {
+    id: '2',
+    name: '슬램덩크 - 가마쿠라 건널목',
+    coordinates: [35.3084, 139.5503], // 가마쿠라
+    thumbnailUrl: 'https://picsum.photos/seed/spot2/400/300',
+  },
+  {
+    id: '3',
+    name: '센과 치히로 - 지우펀',
+    coordinates: [25.1089, 121.8443], // 대만 지우펀
+    thumbnailUrl: 'https://picsum.photos/seed/spot3/400/300',
+  },
+  {
+    id: '4',
+    name: '스즈메의 문단속 - 미야자키',
+    coordinates: [31.9077, 131.4202], // 미야자키
+    thumbnailUrl: 'https://picsum.photos/seed/spot4/400/300',
+  },
+  {
+    id: '5',
+    name: '귀멸의 칼날 - 운젠 지옥',
+    coordinates: [32.7503, 130.2667], // 운젠
+    thumbnailUrl: 'https://picsum.photos/seed/spot5/400/300',
+  },
+]
+
+export default function Home() {
+  const handleSpotSelect = (spotId: string) => {
+    // eslint-disable-next-line no-console
+    console.log('Selected spot:', spotId)
+  }
+
+  return (
+    <main className="flex h-screen flex-col bg-navy-900">
+      {/* 헤더 */}
+      <header className="border-b border-navy-700 bg-navy-800 px-4 py-3">
+        <h1 className="text-center text-xl font-bold text-white">
+          🗾 Anime Pilgrimage Map
+        </h1>
+        <p className="mt-1 text-center text-sm text-navy-300">
           애니메이션 성지순례 스팟 공유 플랫폼
         </p>
+      </header>
+
+      {/* 지도 영역 */}
+      <div className="relative flex-1">
+        <PilgrimageMap
+          initialCenter={[35.6762, 139.6503]} // 도쿄 중심
+          initialZoom={6}
+          className="h-full w-full"
+          spots={DUMMY_SPOTS}
+          onSpotSelect={handleSpotSelect}
+        />
       </div>
+
+      {/* 하단 정보 */}
+      <footer className="border-t border-navy-700 bg-navy-800 px-4 py-2">
+        <p className="text-center text-xs text-navy-400">
+          📍 {DUMMY_SPOTS.length}개의 성지순례 스팟이 등록되어 있습니다
+        </p>
+      </footer>
     </main>
   )
 }

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef } from 'react'
 import { MapContainer, TileLayer } from 'react-leaflet'
 import { Map as LeafletMap } from 'leaflet'
 import { useMapStore } from '@/stores/mapStore'
+import { SpotPin as SpotPinType } from '@/types'
+import SpotPin from './SpotPin'
 import 'leaflet/dist/leaflet.css'
 import './map.css'
 
@@ -11,12 +13,16 @@ interface PilgrimageMapProps {
   initialCenter?: [number, number]
   initialZoom?: number
   className?: string
+  spots?: SpotPinType[]
+  onSpotSelect?: (spotId: string) => void
 }
 
 export default function PilgrimageMap({
   initialCenter,
   initialZoom,
   className = '',
+  spots = [],
+  onSpotSelect,
 }: PilgrimageMapProps) {
   const mapRef = useRef<LeafletMap | null>(null)
   const { center, zoom, setCenter, setZoom } = useMapStore()
@@ -68,6 +74,11 @@ export default function PilgrimageMap({
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           className="map-tiles"
         />
+
+        {/* 스팟 핀 렌더링 */}
+        {spots.map((spot) => (
+          <SpotPin key={spot.id} spot={spot} onSelect={onSpotSelect} />
+        ))}
       </MapContainer>
 
       {/* Custom map controls with navy theme */}

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { Marker, Popup } from 'react-leaflet'
+import L from 'leaflet'
+import Image from 'next/image'
+import { SpotPin as SpotPinType } from '@/types'
+import { useMapStore } from '@/stores/mapStore'
+import { useUIStore } from '@/stores/uiStore'
+
+interface SpotPinProps {
+  spot: SpotPinType
+  onSelect?: (spotId: string) => void
+}
+
+// 네이비 테마 커스텀 마커 아이콘 생성
+const createNavyIcon = (isSelected: boolean = false) => {
+  const size = isSelected ? 40 : 32
+  const color = isSelected ? '#1e3a5f' : '#2d4a6f'
+  const borderColor = isSelected ? '#fbbf24' : '#ffffff'
+
+  return L.divIcon({
+    className: 'custom-spot-pin',
+    html: `
+      <div style="
+        width: ${size}px;
+        height: ${size}px;
+        background-color: ${color};
+        border: 3px solid ${borderColor};
+        border-radius: 50% 50% 50% 0;
+        transform: rotate(-45deg);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+        transition: all 0.2s ease;
+      ">
+        <svg 
+          style="transform: rotate(45deg); width: ${size * 0.5}px; height: ${size * 0.5}px;"
+          viewBox="0 0 24 24" 
+          fill="white"
+        >
+          <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+        </svg>
+      </div>
+    `,
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size],
+    popupAnchor: [0, -size],
+  })
+}
+
+export default function SpotPin({ spot, onSelect }: SpotPinProps) {
+  const { selectedSpotId, setSelectedSpot } = useMapStore()
+  const { openPreview } = useUIStore()
+
+  const isSelected = selectedSpotId === spot.id
+
+  const handleClick = () => {
+    // 스팟 선택 상태 업데이트
+    setSelectedSpot(spot.id)
+
+    // 미리보기 팝업 열기
+    openPreview(spot.id)
+
+    // 외부 콜백 호출
+    onSelect?.(spot.id)
+  }
+
+  return (
+    <Marker
+      position={spot.coordinates}
+      icon={createNavyIcon(isSelected)}
+      eventHandlers={{
+        click: handleClick,
+      }}
+    >
+      <Popup className="spot-popup">
+        <div className="min-w-[200px] p-2">
+          {spot.thumbnailUrl && (
+            <div className="relative mb-2 h-24 w-full overflow-hidden rounded">
+              <Image
+                src={spot.thumbnailUrl}
+                alt={spot.name}
+                fill
+                className="object-cover"
+                sizes="200px"
+              />
+            </div>
+          )}
+          <h3 className="text-sm font-semibold text-navy-800">{spot.name}</h3>
+        </div>
+      </Popup>
+    </Marker>
+  )
+}

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -1,1 +1,2 @@
 export { default as PilgrimageMap } from './PilgrimageMap'
+export { default as SpotPin } from './SpotPin'

--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -59,3 +59,43 @@
     right: 12px;
   }
 }
+
+/* SpotPin custom marker styles */
+.custom-spot-pin {
+  background: transparent;
+  border: none;
+}
+
+.custom-spot-pin:hover {
+  z-index: 1000 !important;
+}
+
+/* Spot popup styling */
+.spot-popup .leaflet-popup-content-wrapper {
+  @apply rounded-lg border-2 border-navy-300 bg-white p-0 shadow-xl;
+}
+
+.spot-popup .leaflet-popup-content {
+  @apply m-0;
+}
+
+.spot-popup .leaflet-popup-tip {
+  @apply border-navy-300 bg-white;
+}
+
+/* Selected marker animation */
+@keyframes pulse-marker {
+  0% {
+    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(251, 191, 36, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0);
+  }
+}
+
+.custom-spot-pin.selected > div {
+  animation: pulse-marker 2s infinite;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #8 

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

지도에 성지순례 스팟을 마커로 표시하는 SpotPin 컴포넌트 구현

---

## 📋 변경 사항

- [x] `src/components/map/SpotPin.tsx` - SpotPin 컴포넌트 생성
- [x] `src/components/map/index.ts` - SpotPin export 추가
- [x] `src/components/map/map.css` - SpotPin 관련 스타일 추가
- [x] `src/components/map/PilgrimageMap.tsx` - spots props 및 SpotPin 렌더링 추가
- [x] `src/app/page.tsx` - 테스트용 더미 데이터로 지도 통합

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- 지도에 마커가 표시되는 스크린샷 첨부 -->

---

## 📝 추가 정보 (선택)

- **알려진 이슈**: `next/image`에서 외부 이미지 도메인(picsum.photos) 미설정으로 팝업 이미지 에러 발생 → Task 5.2.1에서 별도 처리 예정
- **Task 번호**: Task 5.2
- **Requirements**: 1.2, 2.1
