### PR TITLE
test: SpotPin 컴포넌트의 좌표 일치 속성 테스트(Property-Based Test) 구현

### DIFF
--- a/src/components/map/__tests__/spot-pin-coordinates.test.tsx
+++ b/src/components/map/__tests__/spot-pin-coordinates.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import fc from 'fast-check'
+import { render, cleanup } from '@testing-library/react'
+import { SpotPin as SpotPinType } from '@/types'
+import SpotPin from '../SpotPin'
+import { MapContainer } from 'react-leaflet'
+
+// Cleanup after each test to prevent DOM element accumulation
+afterEach(() => {
+  cleanup()
+})
+
+// Feature: anime-pilgrimage-map, Property 1: 스팟 핀 좌표 일치
+// Validates: Requirements 1.2
+
+/**
+ * Generators for property-based testing
+ */
+
+// Generate valid coordinates (latitude: -90 to 90, longitude: -180 to 180)
+const coordinatesArbitrary = fc.tuple(
+  fc.double({ min: -90, max: 90, noNaN: true }),
+  fc.double({ min: -180, max: 180, noNaN: true })
+) as fc.Arbitrary<[number, number]>
+
+// Generate valid SpotPin objects
+const spotPinArbitrary = fc.record({
+  id: fc
+    .string({ minLength: 1, maxLength: 50 })
+    .filter((s) => s.trim().length > 0),
+  name: fc
+    .string({ minLength: 1, maxLength: 200 })
+    .filter((s) => s.trim().length > 0),
+  coordinates: coordinatesArbitrary,
+  thumbnailUrl: fc.webUrl(),
+})
+
+/**
+ * Helper function to extract coordinates from rendered SpotPin component
+ * This function simulates how the Leaflet Marker component receives coordinates
+ */
+function extractCoordinatesFromSpotPin(spotPin: SpotPinType): [number, number] {
+  // In the actual SpotPin component, coordinates are passed directly to the Marker
+  // The Marker component uses the position prop which should match spot.coordinates
+  return spotPin.coordinates
+}
+
+/**
+ * Helper function to check if two coordinate pairs are equivalent
+ * Handles floating point precision issues
+ */
+function coordinatesAreEquivalent(
+  coords1: [number, number],
+  coords2: [number, number],
+  tolerance: number = 1e-10
+): boolean {
+  const [lat1, lng1] = coords1
+  const [lat2, lng2] = coords2
+
+  return Math.abs(lat1 - lat2) < tolerance && Math.abs(lng1 - lng2) < tolerance
+}
+
+/**
+ * Mock Zustand stores for testing
+ */
+jest.mock('@/stores/mapStore', () => ({
+  useMapStore: () => ({
+    selectedSpotId: null,
+    setSelectedSpot: jest.fn(),
+  }),
+}))
+
+jest.mock('@/stores/uiStore', () => ({
+  useUIStore: () => ({
+    openPreview: jest.fn(),
+  }),
+}))
+
+/**
+ * Mock Leaflet and react-leaflet components for testing
+ */
+jest.mock('react-leaflet', () => ({
+  Marker: ({
+    position,
+    children,
+  }: {
+    position: [number, number]
+    children: React.ReactNode
+  }) => (
+    <div data-testid="marker" data-position={JSON.stringify(position)}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popup">{children}</div>
+  ),
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+}))
+
+jest.mock('leaflet', () => ({
+  divIcon: jest.fn(() => ({ iconSize: [32, 32] })),
+}))
+
+describe('SpotPin Coordinates Property Tests', () => {
+  test('Property 1: 스팟 핀 좌표 일치', () => {
+    fc.assert(
+      fc.property(spotPinArbitrary, (spotData: SpotPinType) => {
+        // Cleanup before each iteration to prevent DOM element accumulation
+        cleanup()
+
+        // Render the SpotPin component within a MapContainer
+        const { getByTestId } = render(
+          <MapContainer center={[0, 0]} zoom={10}>
+            <SpotPin spot={spotData} />
+          </MapContainer>
+        )
+
+        // Extract the coordinates from the rendered Marker component
+        const markerElement = getByTestId('marker')
+        const renderedPosition = JSON.parse(
+          markerElement.getAttribute('data-position') || '[]'
+        ) as [number, number]
+
+        // Extract coordinates using our helper function
+        const expectedCoordinates = extractCoordinatesFromSpotPin(spotData)
+
+        // Verify that the rendered coordinates match the original spot coordinates
+        return coordinatesAreEquivalent(renderedPosition, expectedCoordinates)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  test('Property 1 Edge Case: Extreme coordinate values', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          id: fc.string({ minLength: 1 }).filter((s) => s.trim().length > 0),
+          name: fc.string({ minLength: 1 }).filter((s) => s.trim().length > 0),
+          coordinates: fc.constantFrom(
+            [-90, -180] as [number, number], // South-West extreme
+            [90, 180] as [number, number], // North-East extreme
+            [0, 0] as [number, number], // Equator/Prime Meridian
+            [-90, 180] as [number, number], // South-East extreme
+            [90, -180] as [number, number] // North-West extreme
+          ),
+          thumbnailUrl: fc.webUrl(),
+        }),
+        (spotData: SpotPinType) => {
+          // Cleanup before each iteration to prevent DOM element accumulation
+          cleanup()
+
+          const { getByTestId } = render(
+            <MapContainer center={[0, 0]} zoom={10}>
+              <SpotPin spot={spotData} />
+            </MapContainer>
+          )
+
+          const markerElement = getByTestId('marker')
+          const renderedPosition = JSON.parse(
+            markerElement.getAttribute('data-position') || '[]'
+          ) as [number, number]
+
+          const expectedCoordinates = extractCoordinatesFromSpotPin(spotData)
+
+          return coordinatesAreEquivalent(renderedPosition, expectedCoordinates)
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  test('Property 1 Edge Case: Precision boundary values', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          id: fc.string({ minLength: 1 }).filter((s) => s.trim().length > 0),
+          name: fc.string({ minLength: 1 }).filter((s) => s.trim().length > 0),
+          coordinates: fc.tuple(
+            // Generate coordinates with high precision
+            fc.double({ min: -90, max: 90, noNaN: true }).map(
+              (n) => Math.round(n * 1000000) / 1000000 // 6 decimal places precision
+            ),
+            fc.double({ min: -180, max: 180, noNaN: true }).map(
+              (n) => Math.round(n * 1000000) / 1000000 // 6 decimal places precision
+            )
+          ) as fc.Arbitrary<[number, number]>,
+          thumbnailUrl: fc.webUrl(),
+        }),
+        (spotData: SpotPinType) => {
+          // Cleanup before each iteration to prevent DOM element accumulation
+          cleanup()
+
+          const { getByTestId } = render(
+            <MapContainer center={[0, 0]} zoom={10}>
+              <SpotPin spot={spotData} />
+            </MapContainer>
+          )
+
+          const markerElement = getByTestId('marker')
+          const renderedPosition = JSON.parse(
+            markerElement.getAttribute('data-position') || '[]'
+          ) as [number, number]
+
+          const expectedCoordinates = extractCoordinatesFromSpotPin(spotData)
+
+          // Use a slightly more lenient tolerance for high-precision coordinates
+          return coordinatesAreEquivalent(
+            renderedPosition,
+            expectedCoordinates,
+            1e-6
+          )
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #12

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정
- [x] 🧪 **test**: 테스트 추가/수정

---

## ✨ 작업 개요

> Task 5.3 - SpotPin 컴포넌트의 좌표 일치 속성 테스트(Property-Based Test) 구현

---

## 📋 변경 사항

- [x] SpotPin 좌표 일치 속성 테스트 파일 생성 (`spot-pin-coordinates.test.tsx`)
- [x] fast-check 기반 Property-Based Testing 구현
- [x] 3개 테스트 케이스 작성:
  - Property 1: 스팟 핀 좌표 일치 (100회 반복)
  - Edge Case: 극단적 좌표값 테스트 (-90/-180 ~ 90/180)
  - Edge Case: 고정밀도 좌표값 테스트 (소수점 6자리)
- [x] PBT iteration 간 DOM cleanup 버그 수정
  - `fc.property` 콜백 시작 시 `cleanup()` 호출 추가
  - 여러 iteration에서 DOM 요소 누적 방지

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] `npm test` 통과 (6/6 테스트 통과)

---

## 📝 추가 정보

### 해결한 문제
Property-Based Testing에서 `fc.assert`가 단일 테스트 내에서 여러 iteration을 실행할 때, DOM 요소가 정리되지 않아 "Found multiple elements by: [data-testid="marker"]" 에러가 발생했습니다.

### 해결 방법
각 `fc.property` 콜백 함수 시작 부분에 `cleanup()` 호출을 추가하여 매 iteration마다 DOM을 정리하도록 수정했습니다.

### 검증된 속성 (Property)
- **Property 1: 스팟 핀 좌표 일치** - *For any* SpotPin 데이터에 대해, 렌더링된 마커의 좌표가 원본 스팟 좌표와 일치해야 함
- **Validates: Requirements 1.2**
