### PR TITLE
[Feat] 근처 편의시설 기능 구현 및 지도 마커 표시

### DIFF
--- a/scripts/seed-facilities.ts
+++ b/scripts/seed-facilities.ts
@@ -1,0 +1,144 @@
+/**
+ * MongoDB 편의시설 시드 데이터 스크립트
+ * 테스트용 편의시설 데이터를 MongoDB에 추가합니다.
+ *
+ * 실행 방법:
+ * npx tsx scripts/seed-facilities.ts
+ */
+
+import { MongoClient } from 'mongodb'
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017'
+const MONGODB_DB = process.env.MONGODB_DB || 'anime-pilgrimage-map'
+
+// 시드 데이터 - 스가 신사 (SPOT-001) 근처 편의시설
+const SEED_FACILITIES = [
+  // 스가 신사 근처 편의시설들
+  {
+    name: '세븐일레븐 요츠야점',
+    type: 'convenience_store',
+    address: '도쿄도 신주쿠구 요츠야 1-2-3',
+    coordinates: { lat: 35.6772, lng: 139.6513 },
+  },
+  {
+    name: '스타벅스 요츠야점',
+    type: 'cafe',
+    address: '도쿄도 신주쿠구 요츠야 1-3-4',
+    coordinates: { lat: 35.6752, lng: 139.6493 },
+  },
+  {
+    name: '요츠야 라멘',
+    type: 'restaurant',
+    address: '도쿄도 신주쿠구 요츠야 1-4-5',
+    coordinates: { lat: 35.6782, lng: 139.6523 },
+  },
+  {
+    name: 'JR 요츠야역',
+    type: 'station',
+    address: '도쿄도 신주쿠구 요츠야 1-1-1',
+    coordinates: { lat: 35.6742, lng: 139.6483 },
+  },
+  {
+    name: '패밀리마트 스가초점',
+    type: 'convenience_store',
+    address: '도쿄도 신주쿠구 스가초 5-1',
+    coordinates: { lat: 35.6792, lng: 139.6533 },
+  },
+  {
+    name: '도토루 커피 요츠야점',
+    type: 'cafe',
+    address: '도쿄도 신주쿠구 요츠야 1-5-6',
+    coordinates: { lat: 35.6732, lng: 139.6473 },
+  },
+  {
+    name: '요츠야 스시',
+    type: 'restaurant',
+    address: '도쿄도 신주쿠구 요츠야 1-6-7',
+    coordinates: { lat: 35.6802, lng: 139.6543 },
+  },
+  {
+    name: '요츠야 약국',
+    type: 'other',
+    address: '도쿄도 신주쿠구 요츠야 1-7-8',
+    coordinates: { lat: 35.6722, lng: 139.6463 },
+  },
+
+  // 가마쿠라 건널목 (SPOT-002) 근처 편의시설들
+  {
+    name: '로손 가마쿠라점',
+    type: 'convenience_store',
+    address: '가나가와현 가마쿠라시 고시고에 1-2-1',
+    coordinates: { lat: 35.3094, lng: 139.5513 },
+  },
+  {
+    name: '가마쿠라 해변 카페',
+    type: 'cafe',
+    address: '가나가와현 가마쿠라시 고시고에 1-3-2',
+    coordinates: { lat: 35.3074, lng: 139.5493 },
+  },
+  {
+    name: '에노덴 가마쿠라코코마에역',
+    type: 'station',
+    address: '가나가와현 가마쿠라시 고시고에 1-1-32',
+    coordinates: { lat: 35.3084, lng: 139.5503 },
+  },
+  {
+    name: '가마쿠라 해산물 레스토랑',
+    type: 'restaurant',
+    address: '가나가와현 가마쿠라시 고시고에 1-4-3',
+    coordinates: { lat: 35.3104, lng: 139.5523 },
+  },
+
+  // 지우펀 (SPOT-003) 근처 편의시설들
+  {
+    name: '지우펀 찻집',
+    type: 'cafe',
+    address: '대만 신베이시 루이팡구 지우펀 기산가 142호',
+    coordinates: { lat: 25.1099, lng: 121.8453 },
+  },
+  {
+    name: '지우펀 전통 레스토랑',
+    type: 'restaurant',
+    address: '대만 신베이시 루이팡구 지우펀 기산가 156호',
+    coordinates: { lat: 25.1079, lng: 121.8433 },
+  },
+  {
+    name: '지우펀 편의점',
+    type: 'convenience_store',
+    address: '대만 신베이시 루이팡구 지우펀 기산가 120호',
+    coordinates: { lat: 25.1109, lng: 121.8463 },
+  },
+]
+
+async function seedFacilities() {
+  const client = new MongoClient(MONGODB_URI)
+
+  try {
+    console.log('MongoDB에 연결 중...')
+    await client.connect()
+    console.log('MongoDB 연결 성공!')
+
+    const db = client.db(MONGODB_DB)
+    const collection = db.collection('facilities')
+
+    // 기존 데이터 삭제
+    console.log('기존 편의시설 데이터 삭제 중...')
+    await collection.deleteMany({})
+
+    // 시드 데이터 삽입
+    console.log('편의시설 시드 데이터 삽입 중...')
+    const result = await collection.insertMany(SEED_FACILITIES)
+
+    console.log(
+      `✅ ${result.insertedCount}개의 편의시설 데이터가 추가되었습니다!`
+    )
+  } catch (error) {
+    console.error('❌ 편의시설 시드 데이터 삽입 실패:', error)
+    process.exit(1)
+  } finally {
+    await client.close()
+    console.log('MongoDB 연결 종료')
+  }
+}
+
+seedFacilities()

--- a/src/app/api/spots/[id]/facilities/route.ts
+++ b/src/app/api/spots/[id]/facilities/route.ts
@@ -5,7 +5,7 @@ import { NearbyFacility, FacilityType } from '@/types'
 
 // MongoDB document interfaces
 interface SpotDocument {
-  _id: ObjectId
+  id: string // 커스텀 ID 사용
   coordinates: {
     lat: number
     lng: number
@@ -62,18 +62,10 @@ export async function GET(
     const radiusKm = parseFloat(searchParams.get('radius') || '2') // Default 2km radius
     const maxResults = parseInt(searchParams.get('limit') || '50') // Default 50 results
 
-    // Validate ObjectId format
-    if (!ObjectId.isValid(id)) {
-      return NextResponse.json(
-        { error: 'Invalid spot ID format' },
-        { status: 400 }
-      )
-    }
-
-    // Get spot coordinates
+    // Get spot coordinates using custom id field
     const spotsCollection = await getCollection<SpotDocument>('spots')
     const spot = await spotsCollection.findOne(
-      { _id: new ObjectId(id) },
+      { id }, // 커스텀 ID로 검색
       { projection: { coordinates: 1 } }
     )
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,17 +6,17 @@
   --background: #ffffff;
   --foreground: #171717;
 
-  /* Navy theme colors */
-  --navy-50: #f8fafc;
-  --navy-100: #f1f5f9;
-  --navy-200: #e2e8f0;
-  --navy-300: #cbd5e1;
-  --navy-400: #94a3b8;
-  --navy-500: #64748b;
-  --navy-600: #475569;
-  --navy-700: #334155;
-  --navy-800: #1e293b;
-  --navy-900: #0f172a;
+  /* Navy theme colors - Tailwind와 일치 */
+  --navy-50: #f0f3f9;
+  --navy-100: #d9e0ed;
+  --navy-200: #b3c1db;
+  --navy-300: #8da2c9;
+  --navy-400: #6783b7;
+  --navy-500: #4164a5;
+  --navy-600: #345084;
+  --navy-700: #273c63;
+  --navy-800: #1a2842;
+  --navy-900: #0d1421;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
-import 'leaflet/dist/leaflet.css'
 import { Providers } from '@/lib/providers'
 
 const geistSans = Geist({
@@ -26,6 +25,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossOrigin=""
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
+import 'leaflet/dist/leaflet.css'
 import { Providers } from '@/lib/providers'
 
 const geistSans = Geist({

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -9,9 +9,6 @@ import Link from 'next/link'
 import dynamic from 'next/dynamic'
 import NearbyFacilities from '@/components/spot/NearbyFacilities'
 
-// Leaflet CSS를 전역으로 로드
-import 'leaflet/dist/leaflet.css'
-
 // 지도 컴포넌트를 동적으로 로드 (SSR 방지)
 const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
   ssr: false,

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -6,7 +6,6 @@ import { Map as LeafletMap } from 'leaflet'
 import { useMapStore } from '@/stores/mapStore'
 import { SpotPin as SpotPinType } from '@/types'
 import SpotPin from './SpotPin'
-import 'leaflet/dist/leaflet.css'
 import './map.css'
 
 interface PilgrimageMapProps {
@@ -34,6 +33,11 @@ export default function PilgrimageMap({
   useEffect(() => {
     const map = mapRef.current
     if (!map) return
+
+    // 지도 크기 재계산 (중요!)
+    setTimeout(() => {
+      map.invalidateSize()
+    }, 100)
 
     // Update store when map view changes
     const handleMoveEnd = () => {
@@ -68,11 +72,20 @@ export default function PilgrimageMap({
         touchZoom={true}
         boxZoom={true}
         keyboard={true}
+        whenReady={() => {
+          // 지도가 준비되면 크기 재계산
+          setTimeout(() => {
+            mapRef.current?.invalidateSize()
+          }, 100)
+        }}
       >
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
           className="map-tiles"
+          maxZoom={19}
+          tileSize={256}
+          zoomOffset={0}
         />
 
         {/* 스팟 핀 렌더링 */}

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -118,6 +118,7 @@ export default function SpotDetailMap({
         const allPoints = [[lat, lng], ...facilities.map((f) => f.coordinates)]
 
         // Leaflet의 LatLngBounds 사용
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const L = (window as any).L
         if (L) {
           const bounds = allPoints.reduce((bounds, point) => {
@@ -181,30 +182,39 @@ export default function SpotDetailMap({
         </Marker>
 
         {/* 편의시설 마커들 */}
-        {facilities.map((facility) => (
-          <Marker
-            key={facility.id}
-            position={facility.coordinates}
-            icon={facilityIcons[facility.type]}
-          >
-            <Popup>
-              <div className="p-2">
-                <div className="mb-1 flex items-center justify-between">
-                  <h4 className="font-semibold text-gray-900">
-                    {facility.name}
-                  </h4>
-                  <span className="rounded bg-navy-100 px-2 py-1 text-xs text-navy-800">
-                    {facilityTypeLabels[facility.type]}
-                  </span>
+        {facilities.map((facility) => {
+          // 좌표 유효성 검사
+          const coords = facility.coordinates
+          if (!coords || !Array.isArray(coords) || coords.length !== 2) {
+            return null
+          }
+          return (
+            <Marker
+              key={facility.id}
+              position={[coords[0], coords[1]]}
+              icon={facilityIcons[facility.type]}
+            >
+              <Popup>
+                <div className="p-2">
+                  <div className="mb-1 flex items-center justify-between">
+                    <h4 className="font-semibold text-gray-900">
+                      {facility.name}
+                    </h4>
+                    <span className="rounded bg-navy-100 px-2 py-1 text-xs text-navy-800">
+                      {facilityTypeLabels[facility.type]}
+                    </span>
+                  </div>
+                  <p className="mb-1 text-sm text-gray-600">
+                    {facility.address}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    스팟에서 약 {Math.round(facility.distance)}m
+                  </p>
                 </div>
-                <p className="mb-1 text-sm text-gray-600">{facility.address}</p>
-                <p className="text-xs text-gray-500">
-                  스팟에서 약 {Math.round(facility.distance)}m
-                </p>
-              </div>
-            </Popup>
-          </Marker>
-        ))}
+              </Popup>
+            </Marker>
+          )
+        })}
       </MapContainer>
 
       {/* 범례 */}

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -159,6 +159,9 @@ export default function SpotDetailMap({
           attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
           url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
           className="map-tiles"
+          maxZoom={19}
+          tileSize={256}
+          zoomOffset={0}
           crossOrigin=""
         />
 

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -117,22 +117,21 @@ export default function SpotDetailMap({
       if (hasValidCoordinates && facilities.length > 0) {
         const allPoints = [[lat, lng], ...facilities.map((f) => f.coordinates)]
 
-        const bounds = allPoints.reduce(
-          (bounds: any, point) => {
+        // Leaflet의 LatLngBounds 사용
+        const L = (window as any).L
+        if (L) {
+          const bounds = allPoints.reduce((bounds, point) => {
             return bounds.extend(point)
-          },
-          new (window as any).L.LatLngBounds()
-        )
+          }, new L.LatLngBounds())
 
-        // 적절한 패딩을 추가하여 지도 영역 조정
-        map.fitBounds(bounds, { padding: [20, 20] })
+          // 적절한 패딩을 추가하여 지도 영역 조정
+          map.fitBounds(bounds, { padding: [20, 20] })
+        }
       }
     }, 300)
 
     return () => clearTimeout(timer)
   }, [lat, lng, facilities, hasValidCoordinates])
-
-  console.log('SpotDetailMap - Rendering map component')
 
   return (
     <div className={`relative w-full ${className}`} style={{ height: '384px' }}>

--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -1,97 +1,43 @@
 /* Leaflet map styling with navy theme */
+/* 주의: Leaflet 기본 CSS가 CDN에서 로드된 후 적용됨 */
 
-/* 중요: Leaflet 기본 스타일 강제 적용 */
+/* 지도 컨테이너 기본 스타일 */
 .leaflet-container {
-  height: 100% !important;
-  width: 100% !important;
-  position: relative !important;
-  outline: 0 !important;
-  background: #d9e0ed !important; /* navy-100 */
-  overflow: hidden !important;
-  border-radius: 0.5rem;
-  font-family: inherit !important;
-  z-index: 0 !important;
+  background: #d9e0ed; /* navy-100 */
+  font-family: inherit;
 }
 
-/* 타일 컨테이너 크기 강제 설정 */
-.leaflet-tile-container {
-  overflow: hidden !important;
-  width: 256px !important;
-  height: 256px !important;
+/* 타일 스타일 */
+.map-tiles {
+  filter: brightness(0.97) contrast(1.02);
 }
 
-.leaflet-tile {
-  filter: inherit;
-  visibility: inherit !important;
-  opacity: 1 !important;
-  image-rendering: optimizeQuality;
-  width: 256px !important;
-  height: 256px !important;
-}
-
-.leaflet-tile-pane {
-  position: absolute !important;
-  left: 0 !important;
-  top: 0 !important;
-  z-index: 200 !important;
-}
-
-.leaflet-map-pane {
-  position: absolute !important;
-  left: 0 !important;
-  top: 0 !important;
-}
-
-.leaflet-layer {
-  position: relative !important;
-}
-
-.leaflet-control-container {
-  pointer-events: none;
-}
-
-.leaflet-control {
-  pointer-events: auto;
-}
-
-/* Override default Leaflet control styles with navy theme */
+/* 줌 컨트롤 스타일 - navy 테마 */
 .leaflet-control-zoom a {
   background-color: #345084 !important; /* navy-600 */
   border-color: #4164a5 !important; /* navy-500 */
   color: white !important;
-  text-decoration: none !important;
 }
 
 .leaflet-control-zoom a:hover {
   background-color: #273c63 !important; /* navy-700 */
 }
 
-/* Style the map tiles */
-.map-tiles {
-  filter: brightness(0.95) contrast(1.05);
-}
-
-/* Custom popup styling */
+/* 팝업 스타일 */
 .leaflet-popup-content-wrapper {
-  background: white !important;
-  border: 1px solid #b3c1db !important; /* navy-200 */
-  border-radius: 0.5rem !important;
+  background: white;
+  border: 1px solid #b3c1db; /* navy-200 */
+  border-radius: 0.5rem;
   box-shadow:
     0 10px 15px -3px rgba(0, 0, 0, 0.1),
-    0 4px 6px -2px rgba(0, 0, 0, 0.05) !important;
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
 .leaflet-popup-tip {
-  background: white !important;
-  border-color: #b3c1db !important; /* navy-200 */
+  background: white;
 }
 
-/* Ensure map container has proper styling */
-.leaflet-container {
-  background: #d9e0ed !important; /* navy-100 */
-}
-
-/* Attribution styling */
+/* Attribution 스타일 */
 .leaflet-control-attribution {
   background: rgba(26, 40, 66, 0.8) !important; /* navy-800/80 */
   color: white !important;
@@ -102,30 +48,7 @@
   color: #b3c1db !important; /* navy-200 */
 }
 
-/* Zoom control positioning */
-.leaflet-top.leaflet-right {
-  top: 60px;
-  right: 16px;
-}
-
-/* Loading spinner for map */
-.leaflet-container.leaflet-loading {
-  background: #d9e0ed !important; /* navy-100 */
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-  .leaflet-control-zoom {
-    transform: scale(0.9);
-  }
-
-  .leaflet-top.leaflet-right {
-    top: 50px;
-    right: 12px;
-  }
-}
-
-/* SpotPin custom marker styles */
+/* SpotPin 커스텀 마커 스타일 */
 .custom-spot-pin {
   background: transparent !important;
   border: none !important;
@@ -135,13 +58,12 @@
   z-index: 1000 !important;
 }
 
-/* Spot popup styling */
+/* 스팟 팝업 스타일 */
 .spot-popup .leaflet-popup-content-wrapper {
   background: white !important;
   border: 2px solid #8da2c9 !important; /* navy-300 */
   border-radius: 0.75rem !important;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
-  backdrop-filter: blur(10px);
   max-width: 350px !important;
   min-width: 320px !important;
   padding: 0 !important;
@@ -154,22 +76,9 @@
 
 .spot-popup .leaflet-popup-tip {
   background: white !important;
-  border-color: #8da2c9 !important; /* navy-300 */
 }
 
-.spot-popup-content {
-  padding: 1rem;
-}
-
-.spot-popup-content h3 {
-  color: #1a2842 !important; /* navy-800 */
-}
-
-.spot-popup-content button:hover {
-  color: #1a2842 !important; /* navy-800 */
-}
-
-/* Enhanced marker animations */
+/* 마커 애니메이션 */
 @keyframes spot-pin-pulse {
   0%,
   100% {
@@ -182,19 +91,7 @@
   }
 }
 
-@keyframes spot-pin-ring-pulse {
-  0%,
-  100% {
-    opacity: 0.6;
-    transform: rotate(-45deg) scale(1);
-  }
-  50% {
-    opacity: 0.3;
-    transform: rotate(-45deg) scale(1.1);
-  }
-}
-
-/* Hover effects for spot pins */
+/* 호버 효과 */
 .spot-pin-container:hover .spot-pin-marker {
   transform: rotate(-45deg) scale(1.1) !important;
   box-shadow:
@@ -202,7 +99,7 @@
     0 3px 6px rgba(0, 0, 0, 0.15) !important;
 }
 
-/* Selected marker animation */
+/* 선택된 마커 애니메이션 */
 @keyframes pulse-marker {
   0% {
     box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.7);
@@ -217,4 +114,11 @@
 
 .custom-spot-pin.selected > div {
   animation: pulse-marker 2s infinite;
+}
+
+/* 반응형 조정 */
+@media (max-width: 768px) {
+  .leaflet-control-zoom {
+    transform: scale(0.9);
+  }
 }

--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -4,40 +4,46 @@
 .leaflet-container {
   height: 100% !important;
   width: 100% !important;
-  position: relative;
-  outline: 0;
-  background: #ddd;
-  overflow: hidden;
+  position: relative !important;
+  outline: 0 !important;
+  background: #d9e0ed !important; /* navy-100 */
+  overflow: hidden !important;
   border-radius: 0.5rem;
+  font-family: inherit !important;
+  z-index: 0 !important;
+}
+
+/* 타일 컨테이너 크기 강제 설정 */
+.leaflet-tile-container {
+  overflow: hidden !important;
+  width: 256px !important;
+  height: 256px !important;
 }
 
 .leaflet-tile {
   filter: inherit;
-  visibility: inherit;
-  opacity: 1;
+  visibility: inherit !important;
+  opacity: 1 !important;
   image-rendering: optimizeQuality;
-}
-
-.leaflet-tile-container {
-  overflow: hidden;
-  width: 256px;
-  height: 256px;
+  width: 256px !important;
+  height: 256px !important;
 }
 
 .leaflet-tile-pane {
-  position: absolute;
-  left: 0;
-  top: 0;
+  position: absolute !important;
+  left: 0 !important;
+  top: 0 !important;
+  z-index: 200 !important;
 }
 
 .leaflet-map-pane {
-  position: absolute;
-  left: 0;
-  top: 0;
+  position: absolute !important;
+  left: 0 !important;
+  top: 0 !important;
 }
 
 .leaflet-layer {
-  position: relative;
+  position: relative !important;
 }
 
 .leaflet-control-container {
@@ -48,13 +54,16 @@
   pointer-events: auto;
 }
 
-/* Override default Leaflet control styles */
+/* Override default Leaflet control styles with navy theme */
 .leaflet-control-zoom a {
-  @apply border-navy-500 bg-navy-600 text-white;
+  background-color: #345084 !important; /* navy-600 */
+  border-color: #4164a5 !important; /* navy-500 */
+  color: white !important;
+  text-decoration: none !important;
 }
 
 .leaflet-control-zoom a:hover {
-  @apply bg-navy-700;
+  background-color: #273c63 !important; /* navy-700 */
 }
 
 /* Style the map tiles */
@@ -62,27 +71,35 @@
   filter: brightness(0.95) contrast(1.05);
 }
 
-/* Custom popup styling (for future use) */
+/* Custom popup styling */
 .leaflet-popup-content-wrapper {
-  @apply rounded-lg border border-navy-200 bg-white shadow-lg;
+  background: white !important;
+  border: 1px solid #b3c1db !important; /* navy-200 */
+  border-radius: 0.5rem !important;
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05) !important;
 }
 
 .leaflet-popup-tip {
-  @apply border-navy-200 bg-white;
+  background: white !important;
+  border-color: #b3c1db !important; /* navy-200 */
 }
 
 /* Ensure map container has proper styling */
 .leaflet-container {
-  @apply bg-navy-50;
+  background: #d9e0ed !important; /* navy-100 */
 }
 
 /* Attribution styling */
 .leaflet-control-attribution {
-  @apply bg-navy-800/80 text-xs text-white;
+  background: rgba(26, 40, 66, 0.8) !important; /* navy-800/80 */
+  color: white !important;
+  font-size: 0.75rem !important;
 }
 
 .leaflet-control-attribution a {
-  @apply text-navy-200;
+  color: #b3c1db !important; /* navy-200 */
 }
 
 /* Zoom control positioning */
@@ -93,13 +110,13 @@
 
 /* Loading spinner for map */
 .leaflet-container.leaflet-loading {
-  @apply bg-navy-100;
+  background: #d9e0ed !important; /* navy-100 */
 }
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .leaflet-control-zoom {
-    @apply scale-90;
+    transform: scale(0.9);
   }
 
   .leaflet-top.leaflet-right {
@@ -110,8 +127,8 @@
 
 /* SpotPin custom marker styles */
 .custom-spot-pin {
-  background: transparent;
-  border: none;
+  background: transparent !important;
+  border: none !important;
 }
 
 .custom-spot-pin:hover {
@@ -120,31 +137,36 @@
 
 /* Spot popup styling */
 .spot-popup .leaflet-popup-content-wrapper {
-  @apply rounded-xl border-2 border-navy-300 bg-white p-0 shadow-2xl;
+  background: white !important;
+  border: 2px solid #8da2c9 !important; /* navy-300 */
+  border-radius: 0.75rem !important;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
   backdrop-filter: blur(10px);
   max-width: 350px !important;
   min-width: 320px !important;
+  padding: 0 !important;
 }
 
 .spot-popup .leaflet-popup-content {
-  @apply m-0;
+  margin: 0 !important;
   width: 100% !important;
 }
 
 .spot-popup .leaflet-popup-tip {
-  @apply border-navy-300 bg-white;
+  background: white !important;
+  border-color: #8da2c9 !important; /* navy-300 */
 }
 
 .spot-popup-content {
-  @apply p-4;
+  padding: 1rem;
 }
 
 .spot-popup-content h3 {
-  @apply text-navy-800;
+  color: #1a2842 !important; /* navy-800 */
 }
 
 .spot-popup-content button:hover {
-  @apply text-navy-800;
+  color: #1a2842 !important; /* navy-800 */
 }
 
 /* Enhanced marker animations */

--- a/src/hooks/useSpotDetail.ts
+++ b/src/hooks/useSpotDetail.ts
@@ -50,11 +50,6 @@ export type FacilityType =
   | 'station'
   | 'other'
 
-interface NearbyFacilitiesResponse {
-  facilities: NearbyFacility[]
-  total: number
-}
-
 export function useNearbyFacilities(spotId: string | null) {
   return useQuery({
     queryKey: [...spotKeys.detail(spotId || ''), 'facilities'],
@@ -71,8 +66,9 @@ export function useNearbyFacilities(spotId: string | null) {
         )
       }
 
-      const data: NearbyFacilitiesResponse = await response.json()
-      return data.facilities
+      // API returns array directly (not wrapped in { facilities: ... })
+      const data: NearbyFacility[] = await response.json()
+      return data
     },
     enabled: !!spotId,
     staleTime: 15 * 60 * 1000, // 15 minutes for facility data (changes less frequently)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,8 @@ const config: Config = {
           800: '#1a2842',
           900: '#0d1421',
         },
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
       },
     },
   },


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #26

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 스팟 상세 페이지에서 근처 편의시설(음식점, 편의점, 카페, 역 등)을 지도에 마커로 표시하고 목록으로 보여주는 기능 구현

---

## 📋 변경 사항

- [x] 편의시설 시드 데이터 스크립트 추가 (`scripts/seed-facilities.ts`)
- [x] 편의시설 API 커스텀 ID 지원으로 수정 (`src/app/api/spots/[id]/facilities/route.ts`)
- [x] SpotDetailMap 편의시설 마커 표시 기능 구현
- [x] 편의시설 마커 좌표 유효성 검사 추가
- [x] 지도 타일 로딩 문제 해결 (CARTO 타일 서버 사용)
- [x] 편의시설 API 응답 형식 수정 (배열 직접 반환)
- [x] 타입 경고 및 불필요한 console.log 제거

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- 스팟 상세 페이지에서 편의시설 마커가 표시되는 스크린샷 첨부 권장 -->

---

## 📝 추가 정보 (선택)

### 편의시설 마커 색상
- 🔴 빨간색: 성지순례 스팟
- 🟠 주황색: 음식점
- 🔵 파란색: 편의점
- 🟢 초록색: 카페
- 🟣 보라색: 역/정류장
- ⚪ 회색: 기타

### 시드 데이터 실행 방법
```bash
npx tsx scripts/seed-facilities.ts
