### PR TITLE
Feat 커뮤니티 게시판을 위한 Posts API 라우트 구현

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { Post } from '@/types'
+import { ObjectId } from 'mongodb'
+
+// MongoDB document interface
+interface PostDocument {
+  _id?: ObjectId
+  title: string
+  content: string
+  author: string
+  viewCount: number
+  commentCount: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * MongoDB 문서를 Post 타입으로 변환
+ */
+function documentToPost(doc: PostDocument & { _id: ObjectId }): Post {
+  return {
+    id: doc._id.toHexString(),
+    title: doc.title,
+    content: doc.content,
+    author: doc.author,
+    viewCount: doc.viewCount,
+    commentCount: doc.commentCount,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  }
+}
+
+/**
+ * GET /api/posts/[id] - 게시글 상세 조회
+ * Requirements: 5.3
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id } = await params
+
+    // ObjectId 유효성 검사
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json(
+        { error: 'Invalid post ID format' },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<PostDocument & { _id: ObjectId }>(
+      COLLECTIONS.POSTS
+    )
+
+    // 게시글 조회
+    const post = await collection.findOne({ _id: new ObjectId(id) })
+
+    if (!post) {
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 })
+    }
+
+    // 조회수 증가
+    await collection.updateOne(
+      { _id: new ObjectId(id) },
+      { $inc: { viewCount: 1 } }
+    )
+
+    // 증가된 조회수 반영
+    const postWithIncrementedView: Post = {
+      ...documentToPost(post),
+      viewCount: post.viewCount + 1,
+    }
+
+    return NextResponse.json(postWithIncrementedView)
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching post:', error)
+    return NextResponse.json({ error: 'Failed to fetch post' }, { status: 500 })
+  }
+}

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { Post, CreatePostInput } from '@/types'
+import { ObjectId } from 'mongodb'
+
+// MongoDB document interface
+interface PostDocument {
+  _id?: ObjectId
+  title: string
+  content: string
+  author: string
+  viewCount: number
+  commentCount: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * 게시글 유효성 검사
+ * Requirements: 5.2
+ */
+function validatePostInput(
+  input: CreatePostInput
+): { valid: true } | { valid: false; errors: string[] } {
+  const errors: string[] = []
+
+  // 제목 검사: 비어있거나 공백만 있는 경우 거부
+  if (!input.title || input.title.trim().length === 0) {
+    errors.push('제목은 필수입니다')
+  }
+
+  // 내용 검사: 비어있거나 공백만 있는 경우 거부
+  if (!input.content || input.content.trim().length === 0) {
+    errors.push('내용은 필수입니다')
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors }
+  }
+
+  return { valid: true }
+}
+
+/**
+ * MongoDB 문서를 Post 타입으로 변환
+ */
+function documentToPost(doc: PostDocument & { _id: ObjectId }): Post {
+  return {
+    id: doc._id.toHexString(),
+    title: doc.title,
+    content: doc.content,
+    author: doc.author,
+    viewCount: doc.viewCount,
+    commentCount: doc.commentCount,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  }
+}
+
+/**
+ * GET /api/posts - 게시글 목록 조회
+ * Requirements: 5.1
+ */
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  try {
+    const collection = await getCollection<PostDocument & { _id: ObjectId }>(
+      COLLECTIONS.POSTS
+    )
+
+    // 최신순으로 정렬하여 조회
+    const posts = await collection.find({}).sort({ createdAt: -1 }).toArray()
+
+    // Post 타입으로 변환
+    const postList: Post[] = posts.map(documentToPost)
+
+    return NextResponse.json({ posts: postList, total: postList.length })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching posts:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch posts' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/posts - 게시글 작성
+ * Requirements: 5.2
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json()
+    const input: CreatePostInput = {
+      title: body.title,
+      content: body.content,
+    }
+
+    // 유효성 검사
+    const validation = validatePostInput(input)
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.errors },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<PostDocument & { _id: ObjectId }>(
+      COLLECTIONS.POSTS
+    )
+
+    const now = new Date()
+    const newPost: PostDocument = {
+      title: input.title.trim(),
+      content: input.content.trim(),
+      author: body.author || '익명', // 기본값: 익명
+      viewCount: 0,
+      commentCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const result = await collection.insertOne(
+      newPost as PostDocument & { _id: ObjectId }
+    )
+
+    const createdPost: Post = {
+      id: result.insertedId.toHexString(),
+      ...newPost,
+    }
+
+    return NextResponse.json(createdPost, { status: 201 })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error creating post:', error)
+    return NextResponse.json(
+      { error: 'Failed to create post' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
**## 📋 PR 정보
- **관련 Issue**: Closes #31
- **Task 번호**: 10.1
- **Requirements**: 5.1, 5.2, 5.3

## 📝 변경 내용
커뮤니티 게시판을 위한 Posts API 라우트 구현

### 구현된 API 엔드포인트
- `GET /api/posts` - 게시글 목록 조회 (최신순 정렬)
- `POST /api/posts` - 게시글 작성 (유효성 검사 포함)
- `GET /api/posts/[id]` - 게시글 상세 조회 (조회수 자동 증가)

### 주요 기능
- 제목/내용 필수 유효성 검사 (빈 값, 공백만 있는 경우 거부)
- MongoDB ObjectId 형식 검증
- 조회수 자동 증가 기능

## ✅ 체크리스트
- [x] TypeScript 타입 체크 통과
- [x] 빌드 성공
- [x] ESLint 경고 해결

## 🔗 관련 Requirements
- **5.1**: 게시글 목록 표시 (제목, 작성자, 날짜, 조회수)
- **5.2**: 게시글 작성 시 제목과 내용 필수
- **5.3**: 게시글 상세 표시 및 댓글 허용
**
