### PR TITLE
fix: api 응답 형식 불일치 수정

### DIFF
--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -37,10 +37,6 @@ interface PostsResponse {
   total: number
 }
 
-interface PostResponse {
-  post: Post
-}
-
 interface CommentsResponse {
   comments: Comment[]
   total: number
@@ -105,12 +101,12 @@ export function usePostDetail(postId: string | null) {
         )
       }
 
-      const data: PostResponse = await response.json()
+      const data = await response.json()
 
-      // Convert date string to Date object
+      // API returns Post object directly (not wrapped in { post: ... })
       return {
-        ...data.post,
-        createdAt: new Date(data.post.createdAt),
+        ...data,
+        createdAt: new Date(data.createdAt),
       }
     },
     enabled: !!postId,
@@ -175,10 +171,11 @@ export function useCreatePost() {
         )
       }
 
-      const result: PostResponse = await response.json()
+      // API returns Post object directly (not wrapped in { post: ... })
+      const result = await response.json()
       return {
-        ...result.post,
-        createdAt: new Date(result.post.createdAt),
+        ...result,
+        createdAt: new Date(result.createdAt),
       }
     },
     onSuccess: () => {
@@ -213,10 +210,11 @@ export function useCreateComment() {
         )
       }
 
+      // API returns Comment object directly (not wrapped in { comment: ... })
       const result = await response.json()
       return {
-        ...result.comment,
-        createdAt: new Date(result.comment.createdAt),
+        ...result,
+        createdAt: new Date(result.createdAt),
       }
     },
     onSuccess: (_, variables) => {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #46

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> API 응답 형식과 Hook의 기대 형식 불일치로 인한 게시글 조회 및 댓글 작성 에러 수정

---

## 📋 변경 사항

- [x] `usePostDetail` hook에서 API 응답 형식 수정 (`data.post` → `data`)
- [x] `useCreatePost` hook에서 API 응답 형식 수정 (`result.post` → `result`)
- [x] `useCreateComment` hook에서 API 응답 형식 수정 (`result.comment` → `result`)
- [x] 사용하지 않는 `PostResponse` 타입 제거

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

**버그 원인**: API는 Post/Comment 객체를 직접 반환하지만, Hook은 `{ post: Post }` / `{ comment: Comment }` 래퍼 형식을 기대하여 데이터 접근 실패

**수정 내용**: Hook에서 API 응답을 직접 사용하도록 수정
