### PR TITLE
feat: post 모델에 spotId, mediaTitle 필드 추가

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,8 @@ export interface Post {
   updatedAt: Date
   viewCount: number
   commentCount: number
+  spotId?: string // 연결된 스팟 ID (optional)
+  mediaTitle?: string // 연결된 작품 제목 (optional)
 }
 
 export interface Comment {
@@ -105,11 +107,15 @@ export interface Comment {
 export interface CreatePostInput {
   title: string
   content: string
+  spotId?: string // 연결된 스팟 ID (optional)
+  mediaTitle?: string // 연결된 작품 제목 (optional)
 }
 
 export interface UpdatePostInput {
   title?: string
   content?: string
+  spotId?: string | null // null로 연결 해제 가능
+  mediaTitle?: string | null // null로 연결 해제 가능
 }
 
 export interface CreateCommentInput {


### PR DESCRIPTION
## 📋 PR 개요
Post 모델에 `spotId`, `mediaTitle` 필드를 추가하여 게시글이 특정 스팟 또는 작품과 연결될 수 있도록 스키마를 수정했습니다.

## 🔗 관련 Issue
Closes #54

## ✅ 변경 사항
- `Post` 타입에 `spotId?: string` 필드 추가
- `Post` 타입에 `mediaTitle?: string` 필드 추가
- `CreatePostInput` 타입에 `spotId`, `mediaTitle` 필드 추가
- `UpdatePostInput` 타입에 `spotId`, `mediaTitle` 필드 추가 (null로 연결 해제 가능)

## 🎯 관련 Requirements
- Requirements 5.1: 커뮤니티 게시판 목록 표시
- Requirements 3.1: 스팟 상세 정보 표시

## 🧪 테스트
- [x] TypeScript 타입 체크 통과
- [x] Next.js 빌드 성공
