### PR TITLE
[Feat] Task 12.7 - 작품별 커뮤니티 페이지 구현

### DIFF
--- a/src/app/community/media/[title]/page.tsx
+++ b/src/app/community/media/[title]/page.tsx
@@ -1,0 +1,321 @@
+'use client'
+
+import { use } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { usePostsByMedia, Post } from '@/hooks/usePosts'
+
+/**
+ * 날짜를 한국어 형식으로 포맷팅
+ */
+function formatDate(date: Date): string {
+  const now = new Date()
+  const diff = now.getTime() - date.getTime()
+  const diffDays = Math.floor(diff / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) {
+    const diffHours = Math.floor(diff / (1000 * 60 * 60))
+    if (diffHours === 0) {
+      const diffMinutes = Math.floor(diff / (1000 * 60))
+      return diffMinutes <= 0 ? '방금 전' : `${diffMinutes}분 전`
+    }
+    return `${diffHours}시간 전`
+  }
+
+  if (diffDays === 1) return '어제'
+  if (diffDays < 7) return `${diffDays}일 전`
+
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+/**
+ * 조회수를 포맷팅 (1000 이상일 경우 K 단위로 표시)
+ */
+function formatViewCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`
+  }
+  return count.toString()
+}
+
+interface PostItemProps {
+  post: Post
+  onClick: () => void
+}
+
+/**
+ * 개별 게시글 아이템 컴포넌트
+ */
+function PostItem({ post, onClick }: PostItemProps) {
+  return (
+    <article
+      onClick={onClick}
+      className="cursor-pointer border-b border-navy-100 p-4 transition-colors hover:bg-navy-50"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <h3 className="mb-2 truncate text-base font-semibold text-navy-800 hover:text-navy-600">
+            {post.title}
+          </h3>
+          <div className="flex items-center gap-3 text-sm text-navy-500">
+            <span className="flex items-center gap-1">
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                />
+              </svg>
+              <span>{post.author}</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <span>{formatDate(post.createdAt)}</span>
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-4 text-sm text-navy-400">
+          <span className="flex items-center gap-1" title="조회수">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              />
+            </svg>
+            <span>{formatViewCount(post.viewCount)}</span>
+          </span>
+          <span className="flex items-center gap-1" title="댓글수">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+              />
+            </svg>
+            <span>{post.commentCount}</span>
+          </span>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function PostListSkeleton() {
+  return (
+    <div className="divide-y divide-navy-100">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <div key={i} className="animate-pulse p-4">
+          <div className="mb-2 h-5 w-3/4 rounded bg-navy-200"></div>
+          <div className="flex gap-4">
+            <div className="h-4 w-20 rounded bg-navy-100"></div>
+            <div className="h-4 w-24 rounded bg-navy-100"></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PostListError({
+  error,
+  onRetry,
+}: {
+  error: Error
+  onRetry: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <div className="mb-4 text-4xl">😢</div>
+      <p className="mb-2 text-navy-700">게시글을 불러오는데 실패했습니다</p>
+      <p className="mb-4 text-sm text-navy-500">{error.message}</p>
+      <button
+        onClick={onRetry}
+        className="rounded-lg bg-navy-600 px-4 py-2 text-sm text-white transition-colors hover:bg-navy-700"
+      >
+        다시 시도
+      </button>
+    </div>
+  )
+}
+
+function PostListEmpty({ mediaTitle }: { mediaTitle: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <div className="mb-4 text-4xl">📝</div>
+      <p className="mb-2 text-navy-700">
+        &apos;{mediaTitle}&apos; 관련 게시글이 없습니다
+      </p>
+      <p className="text-sm text-navy-500">첫 번째 게시글을 작성해보세요!</p>
+    </div>
+  )
+}
+
+interface PageProps {
+  params: Promise<{ title: string }>
+}
+
+/**
+ * 작품별 커뮤니티 페이지
+ * Requirements 5.1: 특정 작품 관련 게시글 목록 표시
+ */
+export default function MediaCommunityPage({ params }: PageProps) {
+  const { title } = use(params)
+  const mediaTitle = decodeURIComponent(title)
+  const router = useRouter()
+  const { data: posts, isLoading, error, refetch } = usePostsByMedia(mediaTitle)
+
+  const handlePostClick = (postId: string) => {
+    router.push(`/community/${postId}`)
+  }
+
+  return (
+    <main className="min-h-screen bg-navy-50">
+      {/* 헤더 */}
+      <header className="border-b border-navy-700 bg-gradient-to-r from-navy-800 via-navy-700 to-navy-800 px-4 py-4 shadow-lg">
+        <div className="mx-auto max-w-4xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Link
+                href="/community"
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-navy-600 text-xl transition-colors hover:bg-navy-500"
+              >
+                ←
+              </Link>
+              <div>
+                <h1 className="text-xl font-bold text-white">{mediaTitle}</h1>
+                <p className="text-xs text-navy-300">작품 관련 게시글</p>
+              </div>
+            </div>
+            <nav className="flex space-x-4">
+              <Link href="/" className="text-sm text-navy-300 hover:text-white">
+                지도
+              </Link>
+              <Link
+                href="/community"
+                className="text-sm text-navy-300 hover:text-white"
+              >
+                커뮤니티
+              </Link>
+            </nav>
+          </div>
+        </div>
+      </header>
+
+      {/* 메인 콘텐츠 */}
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        {/* 작품 정보 배너 */}
+        <div className="mb-6 rounded-lg bg-gradient-to-r from-navy-700 to-navy-600 p-4 text-white shadow-md">
+          <div className="flex items-center gap-3">
+            <span className="text-3xl">🎬</span>
+            <div>
+              <h2 className="text-lg font-bold">{mediaTitle}</h2>
+              <p className="text-sm text-navy-200">
+                이 작품에 대한 이야기를 나눠보세요
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* 글쓰기 버튼 */}
+        <div className="mb-4 flex justify-end">
+          <Link
+            href={`/community/write?mediaTitle=${encodeURIComponent(mediaTitle)}`}
+            className="flex items-center gap-2 rounded-lg bg-navy-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            글쓰기
+          </Link>
+        </div>
+
+        {/* 게시글 목록 */}
+        <div className="overflow-hidden rounded-lg bg-white shadow-sm">
+          {isLoading ? (
+            <PostListSkeleton />
+          ) : error ? (
+            <PostListError error={error} onRetry={() => refetch()} />
+          ) : !posts || posts.length === 0 ? (
+            <PostListEmpty mediaTitle={mediaTitle} />
+          ) : (
+            <>
+              <div className="divide-y divide-navy-100">
+                {posts.map((post) => (
+                  <PostItem
+                    key={post.id}
+                    post={post}
+                    onClick={() => handlePostClick(post.id)}
+                  />
+                ))}
+              </div>
+              <div className="border-t border-navy-100 bg-navy-50 px-4 py-3">
+                <p className="text-center text-sm text-navy-500">
+                  총 {posts.length}개의 게시글
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -14,9 +14,10 @@ function WriteForm() {
   const searchParams = useSearchParams()
   const createPost = useCreatePost()
 
-  // URL 파라미터에서 스팟 정보 가져오기
+  // URL 파라미터에서 스팟/작품 정보 가져오기
   const spotIdParam = searchParams.get('spotId')
   const spotNameParam = searchParams.get('spotName')
+  const mediaTitleParam = searchParams.get('mediaTitle')
 
   // 폼 상태
   const [title, setTitle] = useState('')
@@ -24,11 +25,12 @@ function WriteForm() {
   const [author, setAuthor] = useState('')
   const [spotId, setSpotId] = useState<string | null>(null)
   const [spotName, setSpotName] = useState<string | null>(null)
+  const [mediaTitle, setMediaTitle] = useState<string | null>(null)
 
   // 에러 상태
   const [errors, setErrors] = useState<string[]>([])
 
-  // URL 파라미터로 스팟 정보 설정
+  // URL 파라미터로 스팟/작품 정보 설정
   useEffect(() => {
     if (spotIdParam) {
       setSpotId(spotIdParam)
@@ -36,7 +38,10 @@ function WriteForm() {
     if (spotNameParam) {
       setSpotName(decodeURIComponent(spotNameParam))
     }
-  }, [spotIdParam, spotNameParam])
+    if (mediaTitleParam) {
+      setMediaTitle(decodeURIComponent(mediaTitleParam))
+    }
+  }, [spotIdParam, spotNameParam, mediaTitleParam])
 
   // 폼 제출 핸들러
   const handleSubmit = async (e: FormEvent) => {
@@ -70,12 +75,17 @@ function WriteForm() {
         content: content.trim(),
         author: author.trim(),
         ...(spotId && { spotId }),
+        ...(mediaTitle && { mediaTitle }),
       })
 
       // 작성 완료 후 이동
-      // 스팟에서 작성한 경우 스팟 상세 페이지로, 아니면 커뮤니티 목록으로
+      // 스팟에서 작성한 경우 스팟 상세 페이지로
+      // 작품에서 작성한 경우 작품 커뮤니티 페이지로
+      // 그 외에는 커뮤니티 목록으로
       if (spotId) {
         router.push(`/spots/${spotId}`)
+      } else if (mediaTitle) {
+        router.push(`/community/media/${encodeURIComponent(mediaTitle)}`)
       } else {
         router.push('/community')
       }
@@ -88,6 +98,11 @@ function WriteForm() {
   const handleRemoveSpot = () => {
     setSpotId(null)
     setSpotName(null)
+  }
+
+  // 작품 연결 해제 핸들러
+  const handleRemoveMedia = () => {
+    setMediaTitle(null)
   }
 
   return (
@@ -159,6 +174,41 @@ function WriteForm() {
                 onClick={handleRemoveSpot}
                 className="rounded p-1 text-navy-400 transition-colors hover:bg-navy-100 hover:text-navy-600"
                 title="스팟 연결 해제"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 연결된 작품 정보 표시 */}
+        {mediaTitle && (
+          <div className="rounded-lg border border-purple-200 bg-purple-50 p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-xl">🎬</span>
+                <div>
+                  <p className="text-xs text-purple-500">연결된 작품</p>
+                  <p className="font-medium text-purple-800">{mediaTitle}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={handleRemoveMedia}
+                className="rounded p-1 text-purple-400 transition-colors hover:bg-purple-100 hover:text-purple-600"
+                title="작품 연결 해제"
               >
                 <svg
                   className="h-5 w-5"

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -165,6 +165,25 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
                   {media.year && (
                     <p className="mt-1 text-sm text-gray-600">{media.year}년</p>
                   )}
+                  <Link
+                    href={`/community/media/${encodeURIComponent(media.title)}`}
+                    className="mt-3 inline-flex items-center gap-1 text-sm text-navy-600 transition-colors hover:text-navy-800"
+                  >
+                    <span>커뮤니티 보기</span>
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </Link>
                 </div>
               ))}
             </div>

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -57,6 +57,8 @@ export const postKeys = {
   list: (filters: Record<string, unknown>) =>
     [...postKeys.lists(), { filters }] as const,
   bySpot: (spotId: string) => [...postKeys.lists(), 'spot', spotId] as const,
+  byMedia: (mediaTitle: string) =>
+    [...postKeys.lists(), 'media', mediaTitle] as const,
   details: () => [...postKeys.all, 'detail'] as const,
   detail: (id: string) => [...postKeys.details(), id] as const,
   comments: (postId: string) =>
@@ -120,6 +122,42 @@ export function usePostsBySpot(spotId: string | null) {
       }))
     },
     enabled: !!spotId,
+    staleTime: 2 * 60 * 1000, // 2 minutes for posts
+    gcTime: 5 * 60 * 1000, // 5 minutes cache time
+  })
+}
+
+/**
+ * Hook to fetch posts for a specific media title
+ * Requirements: 5.1
+ */
+export function usePostsByMedia(mediaTitle: string | null) {
+  return useQuery({
+    queryKey: postKeys.byMedia(mediaTitle || ''),
+    queryFn: async (): Promise<Post[]> => {
+      if (!mediaTitle) {
+        throw new Error('Media title is required')
+      }
+
+      const response = await fetch(
+        `/api/posts?mediaTitle=${encodeURIComponent(mediaTitle)}`
+      )
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch posts: ${response.status} ${response.statusText}`
+        )
+      }
+
+      const data: PostsResponse = await response.json()
+
+      // Convert date strings to Date objects
+      return data.posts.map((post) => ({
+        ...post,
+        createdAt: new Date(post.createdAt),
+      }))
+    },
+    enabled: !!mediaTitle,
     staleTime: 2 * 60 * 1000, // 2 minutes for posts
     gcTime: 5 * 60 * 1000, // 5 minutes cache time
   })


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #60

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 작품(애니메이션/드라마/영화)별로 관련 게시글을 모아볼 수 있는 커뮤니티 페이지 구현

---

## 📋 변경 사항

- [x] `src/app/community/media/[title]/page.tsx` - 작품별 커뮤니티 페이지 생성
- [x] `src/hooks/usePosts.ts` - `usePostsByMedia` 훅 추가 (작품별 게시글 조회)
- [x] `src/app/community/write/page.tsx` - 작품 연결 기능 추가 (mediaTitle 쿼리 파라미터 지원)
- [x] `src/app/spots/[id]/page.tsx` - 관련 작품에서 작품별 커뮤니티로 이동하는 링크 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

- 작품별 커뮤니티 접근 경로:
  - 스팟 상세 페이지 → 관련 작품 → "커뮤니티 보기" 클릭
  - 직접 URL 접근: `/community/media/{작품명}`
- 작품별 커뮤니티에서 글쓰기 시 해당 작품이 자동으로 연결됨
- Requirements 5.1 대응
