### PR TITLE
[Feat] 커뮤니티 메인 페이지 레이아웃 리디자인

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,7 +1,141 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
 import PostList from '@/components/community/PostList'
+
+/**
+ * 커뮤니티 카테고리 타입
+ */
+type CommunityCategory = 'all' | 'spot' | 'media' | 'general'
+
+interface CategoryTab {
+  id: CommunityCategory
+  label: string
+  icon: React.ReactNode
+  description: string
+}
+
+/**
+ * 카테고리 탭 정의
+ */
+const categoryTabs: CategoryTab[] = [
+  {
+    id: 'all',
+    label: '전체',
+    icon: (
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M4 6h16M4 10h16M4 14h16M4 18h16"
+        />
+      </svg>
+    ),
+    description: '모든 게시글',
+  },
+  {
+    id: 'spot',
+    label: '스팟별',
+    icon: (
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+        />
+      </svg>
+    ),
+    description: '성지순례 스팟별 게시글',
+  },
+  {
+    id: 'media',
+    label: '작품별',
+    icon: (
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+        />
+      </svg>
+    ),
+    description: '애니메이션/드라마별 게시글',
+  },
+  {
+    id: 'general',
+    label: '자유게시판',
+    icon: (
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+        />
+      </svg>
+    ),
+    description: '자유로운 이야기',
+  },
+]
+
+/**
+ * 카테고리 탭 컴포넌트
+ */
+function CategoryTabButton({
+  tab,
+  isActive,
+  onClick,
+}: {
+  tab: CategoryTab
+  isActive: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all ${
+        isActive
+          ? 'bg-navy-600 text-white shadow-md'
+          : 'bg-white text-navy-600 hover:bg-navy-50'
+      }`}
+      aria-selected={isActive}
+      role="tab"
+    >
+      {tab.icon}
+      <span>{tab.label}</span>
+    </button>
+  )
+}
 
 /**
  * 커뮤니티 게시판 페이지
@@ -9,6 +143,18 @@ import PostList from '@/components/community/PostList'
  * Requirements 5.6: 글쓰기 버튼 클릭 시 작성 페이지로 이동
  */
 export default function CommunityPage() {
+  const [activeCategory, setActiveCategory] = useState<CommunityCategory>('all')
+
+  // 현재 카테고리에 맞는 글쓰기 링크 생성
+  const getWriteLink = () => {
+    const params = new URLSearchParams()
+    if (activeCategory === 'general') {
+      params.set('type', 'general')
+    }
+    const queryString = params.toString()
+    return `/community/write${queryString ? `?${queryString}` : ''}`
+  }
+
   return (
     <main className="min-h-screen bg-navy-50">
       {/* 헤더 */}
@@ -46,10 +192,32 @@ export default function CommunityPage() {
 
       {/* 메인 콘텐츠 */}
       <div className="mx-auto max-w-4xl px-4 py-6">
+        {/* 카테고리 탭 네비게이션 */}
+        <div className="mb-6">
+          <div
+            className="flex flex-wrap gap-2"
+            role="tablist"
+            aria-label="커뮤니티 카테고리"
+          >
+            {categoryTabs.map((tab) => (
+              <CategoryTabButton
+                key={tab.id}
+                tab={tab}
+                isActive={activeCategory === tab.id}
+                onClick={() => setActiveCategory(tab.id)}
+              />
+            ))}
+          </div>
+          {/* 현재 카테고리 설명 */}
+          <p className="mt-3 text-sm text-navy-500">
+            {categoryTabs.find((tab) => tab.id === activeCategory)?.description}
+          </p>
+        </div>
+
         {/* 글쓰기 버튼 */}
         <div className="mb-4 flex justify-end">
           <Link
-            href="/community/write"
+            href={getWriteLink()}
             className="flex items-center gap-2 rounded-lg bg-navy-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
           >
             <svg
@@ -69,8 +237,113 @@ export default function CommunityPage() {
           </Link>
         </div>
 
-        <PostList />
+        {/* 카테고리별 콘텐츠 */}
+        <div
+          role="tabpanel"
+          aria-label={`${categoryTabs.find((tab) => tab.id === activeCategory)?.label} 게시글`}
+        >
+          {activeCategory === 'all' && <PostList />}
+          {activeCategory === 'spot' && <SpotCategorySection />}
+          {activeCategory === 'media' && <MediaCategorySection />}
+          {activeCategory === 'general' && <PostList filterType="general" />}
+        </div>
       </div>
     </main>
+  )
+}
+
+/**
+ * 스팟별 카테고리 섹션
+ * 스팟 목록을 카드 형태로 표시하고 각 스팟의 커뮤니티로 이동 가능
+ */
+function SpotCategorySection() {
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-center gap-2">
+        <svg
+          className="h-5 w-5 text-navy-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+        <h2 className="text-lg font-semibold text-navy-800">스팟별 커뮤니티</h2>
+      </div>
+      <p className="mb-6 text-sm text-navy-500">
+        성지순례 스팟을 선택하여 해당 장소에 대한 게시글을 확인하세요.
+      </p>
+
+      {/* 스팟 목록 - Task 13.2에서 구현 예정 */}
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <div className="mb-4 text-4xl">🗺️</div>
+        <p className="mb-2 text-navy-700">스팟별 커뮤니티 준비 중</p>
+        <p className="text-sm text-navy-500">
+          곧 스팟별로 게시글을 모아볼 수 있습니다.
+        </p>
+        <Link
+          href="/"
+          className="mt-4 rounded-lg bg-navy-100 px-4 py-2 text-sm text-navy-600 transition-colors hover:bg-navy-200"
+        >
+          지도에서 스팟 둘러보기
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 작품별 카테고리 섹션
+ * 작품 목록을 카드 형태로 표시하고 각 작품의 커뮤니티로 이동 가능
+ */
+function MediaCategorySection() {
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-center gap-2">
+        <svg
+          className="h-5 w-5 text-navy-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+          />
+        </svg>
+        <h2 className="text-lg font-semibold text-navy-800">작품별 커뮤니티</h2>
+      </div>
+      <p className="mb-6 text-sm text-navy-500">
+        애니메이션, 드라마, 영화 등 작품을 선택하여 관련 게시글을 확인하세요.
+      </p>
+
+      {/* 작품 목록 - Task 13.3에서 구현 예정 */}
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <div className="mb-4 text-4xl">🎬</div>
+        <p className="mb-2 text-navy-700">작품별 커뮤니티 준비 중</p>
+        <p className="text-sm text-navy-500">
+          곧 작품별로 게시글을 모아볼 수 있습니다.
+        </p>
+        <Link
+          href="/"
+          className="mt-4 rounded-lg bg-navy-100 px-4 py-2 text-sm text-navy-600 transition-colors hover:bg-navy-200"
+        >
+          지도에서 작품 둘러보기
+        </Link>
+      </div>
+    </div>
   )
 }

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -219,6 +219,7 @@ function PostListEmpty() {
 
 interface PostListProps {
   className?: string
+  filterType?: 'all' | 'general' | 'spot' | 'media'
 }
 
 /**
@@ -229,9 +230,21 @@ interface PostListProps {
  * Requirements:
  * - 5.1: 게시글 목록에 제목, 작성자, 날짜, 조회수 표시
  */
-export default function PostList({ className = '' }: PostListProps) {
+export default function PostList({
+  className = '',
+  filterType = 'all',
+}: PostListProps) {
   const router = useRouter()
-  const { data: posts, isLoading, error, refetch } = usePosts()
+  const { data: allPosts, isLoading, error, refetch } = usePosts()
+
+  // 필터 타입에 따라 게시글 필터링
+  const posts = allPosts?.filter((post) => {
+    if (filterType === 'all') return true
+    if (filterType === 'general') return !post.spotId && !post.mediaTitle
+    if (filterType === 'spot') return !!post.spotId
+    if (filterType === 'media') return !!post.mediaTitle
+    return true
+  })
 
   // 게시글 클릭 핸들러
   const handlePostClick = (postId: string) => {

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -9,6 +9,8 @@ export interface Post {
   createdAt: Date
   viewCount: number
   commentCount: number
+  spotId?: string
+  mediaTitle?: string
 }
 
 export interface Comment {


### PR DESCRIPTION
## 📋 변경 사항
커뮤니티 메인 페이지를 탭 기반 UI로 리디자인하여 카테고리별 네비게이션을 구현했습니다.

## 🎯 관련 Issue
Closes #62

## ✅ 구현 내용
- 탭 기반 카테고리 네비게이션 구현 (전체/스팟별/작품별/자유게시판)
- CategoryTabButton 컴포넌트 구현
- PostList 컴포넌트에 filterType prop 추가
- Post 타입에 spotId, mediaTitle 필드 추가
- 스팟별/작품별 섹션 플레이스홀더 UI 구현

## 📌 Requirements
- Requirements 5.1: 커뮤니티 게시판 목록 표시

## 🔗 관련 Task
- Task 13.1: 커뮤니티 메인 페이지 레이아웃 리디자인

## 📝 테스트
- [x] TypeScript 타입 체크 통과
- [x] Next.js 빌드 성공

## 📸 스크린샷
(필요시 추가)
<img width="1788" height="941" alt="image" src="https://github.com/user-attachments/assets/35b69bcb-b5a7-425f-b629-6f785af910a4" />
