### PR TITLE
Feat 작품별 커뮤니티 개요 섹션 구현 및 커뮤니티 페이지 개선 (Task 13.4)

### DIFF
--- a/src/app/api/media/community-summary/route.ts
+++ b/src/app/api/media/community-summary/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { MediaCommunitySummary } from '@/types'
+
+interface SpotDocument {
+  id: string
+  relatedMedia: {
+    title: string
+    type: 'anime' | 'drama' | 'movie' | 'other'
+    year?: number
+  }[]
+}
+
+interface PostDocument {
+  mediaTitle?: string
+}
+
+/**
+ * GET /api/media/community-summary - 작품별 게시글 수 조회
+ * Requirements: 5.1
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    const spotsCollection = await getCollection<SpotDocument>(COLLECTIONS.SPOTS)
+    const postsCollection = await getCollection<PostDocument>(COLLECTIONS.POSTS)
+
+    // 모든 스팟에서 작품 정보 수집
+    const spots = await spotsCollection.find({}).toArray()
+
+    // 작품별로 중복 제거하여 수집 (title을 키로 사용)
+    const mediaMap = new Map<
+      string,
+      { title: string; type: 'anime' | 'drama' | 'movie' | 'other' }
+    >()
+
+    spots.forEach((spot) => {
+      if (spot.relatedMedia && Array.isArray(spot.relatedMedia)) {
+        spot.relatedMedia.forEach((media) => {
+          if (media.title && !mediaMap.has(media.title)) {
+            mediaMap.set(media.title, {
+              title: media.title,
+              type: media.type || 'other',
+            })
+          }
+        })
+      }
+    })
+
+    // 각 작품별 게시글 수 집계
+    const summaries: MediaCommunitySummary[] = await Promise.all(
+      Array.from(mediaMap.values()).map(async (media) => {
+        const postCount = await postsCollection.countDocuments({
+          mediaTitle: media.title,
+        })
+
+        return {
+          title: media.title,
+          type: media.type,
+          postCount,
+        }
+      })
+    )
+
+    // 게시글 수 기준 내림차순 정렬
+    summaries.sort((a, b) => b.postCount - a.postCount)
+
+    return NextResponse.json({ summaries, total: summaries.length })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching media community summary:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch media community summary' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/media/community-summary/route.ts
+++ b/src/app/api/media/community-summary/route.ts
@@ -12,11 +12,13 @@ interface SpotDocument {
 }
 
 interface PostDocument {
+  spotId?: string
   mediaTitle?: string
 }
 
 /**
  * GET /api/media/community-summary - 작품별 게시글 수 조회
+ * 작품에 연결된 모든 스팟의 게시글 수를 합산하여 반환
  * Requirements: 5.1
  */
 export async function GET(): Promise<NextResponse> {
@@ -24,39 +26,56 @@ export async function GET(): Promise<NextResponse> {
     const spotsCollection = await getCollection<SpotDocument>(COLLECTIONS.SPOTS)
     const postsCollection = await getCollection<PostDocument>(COLLECTIONS.POSTS)
 
-    // 모든 스팟에서 작품 정보 수집
+    // 모든 스팟 조회
     const spots = await spotsCollection.find({}).toArray()
 
-    // 작품별로 중복 제거하여 수집 (title을 키로 사용)
-    const mediaMap = new Map<
+    // 작품별로 연결된 스팟 ID 목록 수집
+    const mediaToSpots = new Map<
       string,
-      { title: string; type: 'anime' | 'drama' | 'movie' | 'other' }
+      {
+        title: string
+        type: 'anime' | 'drama' | 'movie' | 'other'
+        spotIds: string[]
+      }
     >()
 
     spots.forEach((spot) => {
       if (spot.relatedMedia && Array.isArray(spot.relatedMedia)) {
         spot.relatedMedia.forEach((media) => {
-          if (media.title && !mediaMap.has(media.title)) {
-            mediaMap.set(media.title, {
-              title: media.title,
-              type: media.type || 'other',
-            })
+          if (media.title) {
+            const existing = mediaToSpots.get(media.title)
+            if (existing) {
+              existing.spotIds.push(spot.id)
+            } else {
+              mediaToSpots.set(media.title, {
+                title: media.title,
+                type: media.type || 'other',
+                spotIds: [spot.id],
+              })
+            }
           }
         })
       }
     })
 
-    // 각 작품별 게시글 수 집계
+    // 각 작품별 게시글 수 집계 (연결된 스팟의 게시글 + 직접 연결된 게시글)
     const summaries: MediaCommunitySummary[] = await Promise.all(
-      Array.from(mediaMap.values()).map(async (media) => {
-        const postCount = await postsCollection.countDocuments({
+      Array.from(mediaToSpots.values()).map(async (media) => {
+        // 해당 작품과 연결된 스팟들의 게시글 수
+        const spotPostCount = await postsCollection.countDocuments({
+          spotId: { $in: media.spotIds },
+        })
+
+        // 직접 mediaTitle로 연결된 게시글 수 (스팟 없이 작품만 연결된 경우)
+        const directPostCount = await postsCollection.countDocuments({
           mediaTitle: media.title,
+          spotId: { $exists: false },
         })
 
         return {
           title: media.title,
           type: media.type,
-          postCount,
+          postCount: spotPostCount + directPostCount,
         }
       })
     )

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -18,6 +18,15 @@ interface PostDocument {
   mediaTitle?: string
 }
 
+interface SpotDocument {
+  id: string
+  relatedMedia: {
+    title: string
+    type: string
+    year?: number
+  }[]
+}
+
 /**
  * MongoDB 문서를 Post 타입으로 변환
  */
@@ -42,7 +51,7 @@ function documentToPost(doc: PostDocument & { _id: ObjectId }): Post {
  *
  * Query Parameters:
  * - spotId: 특정 스팟 관련 게시글만 조회
- * - mediaTitle: 특정 작품 관련 게시글만 조회
+ * - mediaTitle: 특정 작품 관련 게시글만 조회 (해당 작품과 연결된 스팟의 게시글도 포함)
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
@@ -50,21 +59,39 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const spotId = searchParams.get('spotId')
     const mediaTitle = searchParams.get('mediaTitle')
 
-    const collection = await getCollection<PostDocument & { _id: ObjectId }>(
-      COLLECTIONS.POSTS
-    )
+    const postsCollection = await getCollection<
+      PostDocument & { _id: ObjectId }
+    >(COLLECTIONS.POSTS)
 
-    // 필터 조건 구성
-    const filter: Record<string, string> = {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let filter: any = {}
+
     if (spotId) {
+      // 특정 스팟의 게시글만 조회
       filter.spotId = spotId
-    }
-    if (mediaTitle) {
-      filter.mediaTitle = mediaTitle
+    } else if (mediaTitle) {
+      // 작품별 조회: 해당 작품과 연결된 스팟들의 게시글도 포함
+      const spotsCollection = await getCollection<SpotDocument>(
+        COLLECTIONS.SPOTS
+      )
+
+      // 해당 작품과 연결된 스팟 ID 목록 조회
+      const spots = await spotsCollection
+        .find({ 'relatedMedia.title': mediaTitle })
+        .toArray()
+      const spotIds = spots.map((spot) => spot.id)
+
+      // 작품과 직접 연결된 게시글 OR 해당 작품의 스팟과 연결된 게시글
+      filter = {
+        $or: [
+          { mediaTitle: mediaTitle },
+          ...(spotIds.length > 0 ? [{ spotId: { $in: spotIds } }] : []),
+        ],
+      }
     }
 
     // 최신순으로 정렬하여 조회
-    const posts = await collection
+    const posts = await postsCollection
       .find(filter)
       .sort({ createdAt: -1 })
       .toArray()

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -11,9 +11,9 @@ import {
 } from '@/hooks/useSpots'
 
 /**
- * 커뮤니티 카테고리 타입
+ * 커뮤니티 카테고리 타입 (전체 카테고리 제거)
  */
-type CommunityCategory = 'all' | 'spot' | 'media' | 'general'
+type CommunityCategory = 'media' | 'spot' | 'general'
 
 interface CategoryTab {
   id: CommunityCategory
@@ -23,12 +23,12 @@ interface CategoryTab {
 }
 
 /**
- * 카테고리 탭 정의
+ * 카테고리 탭 정의 (작품별을 첫 번째로)
  */
 const categoryTabs: CategoryTab[] = [
   {
-    id: 'all',
-    label: '전체',
+    id: 'media',
+    label: '작품별',
     icon: (
       <svg
         className="h-4 w-4"
@@ -40,11 +40,11 @@ const categoryTabs: CategoryTab[] = [
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth={2}
-          d="M4 6h16M4 10h16M4 14h16M4 18h16"
+          d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
         />
       </svg>
     ),
-    description: '모든 게시글',
+    description: '애니메이션/드라마별 게시글',
   },
   {
     id: 'spot',
@@ -71,26 +71,6 @@ const categoryTabs: CategoryTab[] = [
       </svg>
     ),
     description: '성지순례 스팟별 게시글',
-  },
-  {
-    id: 'media',
-    label: '작품별',
-    icon: (
-      <svg
-        className="h-4 w-4"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
-        />
-      </svg>
-    ),
-    description: '애니메이션/드라마별 게시글',
   },
   {
     id: 'general',
@@ -149,7 +129,9 @@ function CategoryTabButton({
  * Requirements 5.6: 글쓰기 버튼 클릭 시 작성 페이지로 이동
  */
 export default function CommunityPage() {
-  const [activeCategory, setActiveCategory] = useState<CommunityCategory>('all')
+  // 초기 탭을 작품별(media)로 설정
+  const [activeCategory, setActiveCategory] =
+    useState<CommunityCategory>('media')
 
   // 현재 카테고리에 맞는 글쓰기 링크 생성
   const getWriteLink = () => {
@@ -248,9 +230,8 @@ export default function CommunityPage() {
           role="tabpanel"
           aria-label={`${categoryTabs.find((tab) => tab.id === activeCategory)?.label} 게시글`}
         >
-          {activeCategory === 'all' && <PostList />}
-          {activeCategory === 'spot' && <SpotCategorySection />}
           {activeCategory === 'media' && <MediaCategorySection />}
+          {activeCategory === 'spot' && <SpotCategorySection />}
           {activeCategory === 'general' && <PostList filterType="general" />}
         </div>
       </div>
@@ -406,6 +387,7 @@ function SpotCategorySection() {
 /**
  * 스팟 카드 컴포넌트
  * 스팟 이미지, 이름, 게시글 수를 표시
+ * 클릭 시 스팟 커뮤니티 페이지로 이동 (디테일 페이지가 아님)
  */
 function SpotCard({
   spot,
@@ -416,7 +398,7 @@ function SpotCard({
 
   return (
     <Link
-      href={`/spots/${spot.id}#community`}
+      href={`/community/spot/${spot.id}`}
       className="group block overflow-hidden rounded-lg border border-navy-100 bg-white transition-all hover:border-navy-300 hover:shadow-md"
     >
       {/* 스팟 이미지 */}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import PostList from '@/components/community/PostList'
-import { useSpotCommunitySummary } from '@/hooks/useSpots'
+import {
+  useSpotCommunitySummary,
+  useMediaCommunitySummary,
+  MediaCommunitySummary,
+} from '@/hooks/useSpots'
 
 /**
  * 커뮤니티 카테고리 타입
@@ -480,8 +484,98 @@ function SpotCard({
 /**
  * 작품별 카테고리 섹션
  * 작품 목록을 카드 형태로 표시하고 각 작품의 커뮤니티로 이동 가능
+ * Requirements: 5.1
  */
 function MediaCategorySection() {
+  const { data: mediaList, isLoading, error } = useMediaCommunitySummary()
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-2">
+          <svg
+            className="h-5 w-5 text-navy-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+            />
+          </svg>
+          <h2 className="text-lg font-semibold text-navy-800">
+            작품별 커뮤니티
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="animate-pulse rounded-lg border border-navy-100 bg-navy-50 p-4"
+            >
+              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-navy-200" />
+              <div className="mb-2 h-4 w-3/4 rounded bg-navy-200" />
+              <div className="h-3 w-1/2 rounded bg-navy-200" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <div className="mb-4 text-4xl">⚠️</div>
+          <p className="mb-2 text-navy-700">작품 정보를 불러오지 못했습니다</p>
+          <p className="text-sm text-navy-500">잠시 후 다시 시도해주세요.</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!mediaList || mediaList.length === 0) {
+    return (
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-2">
+          <svg
+            className="h-5 w-5 text-navy-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+            />
+          </svg>
+          <h2 className="text-lg font-semibold text-navy-800">
+            작품별 커뮤니티
+          </h2>
+        </div>
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <div className="mb-4 text-4xl">🎬</div>
+          <p className="mb-2 text-navy-700">등록된 작품이 없습니다</p>
+          <p className="text-sm text-navy-500">
+            스팟에 연결된 작품 정보가 표시됩니다.
+          </p>
+          <Link
+            href="/"
+            className="mt-4 rounded-lg bg-navy-100 px-4 py-2 text-sm text-navy-600 transition-colors hover:bg-navy-200"
+          >
+            지도에서 스팟 둘러보기
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="rounded-lg bg-white p-6 shadow-sm">
       <div className="mb-4 flex items-center gap-2">
@@ -504,20 +598,89 @@ function MediaCategorySection() {
         애니메이션, 드라마, 영화 등 작품을 선택하여 관련 게시글을 확인하세요.
       </p>
 
-      {/* 작품 목록 - Task 13.3에서 구현 예정 */}
-      <div className="flex flex-col items-center justify-center py-8 text-center">
-        <div className="mb-4 text-4xl">🎬</div>
-        <p className="mb-2 text-navy-700">작품별 커뮤니티 준비 중</p>
-        <p className="text-sm text-navy-500">
-          곧 작품별로 게시글을 모아볼 수 있습니다.
-        </p>
-        <Link
-          href="/"
-          className="mt-4 rounded-lg bg-navy-100 px-4 py-2 text-sm text-navy-600 transition-colors hover:bg-navy-200"
-        >
-          지도에서 작품 둘러보기
-        </Link>
+      {/* 작품 카드 그리드 */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {mediaList.map((media) => (
+          <MediaCard key={media.title} media={media} />
+        ))}
       </div>
     </div>
+  )
+}
+
+/**
+ * 작품 타입에 따른 아이콘 반환
+ */
+function getMediaTypeIcon(type: MediaCommunitySummary['type']) {
+  switch (type) {
+    case 'anime':
+      return '🎌'
+    case 'drama':
+      return '📺'
+    case 'movie':
+      return '🎬'
+    default:
+      return '🎭'
+  }
+}
+
+/**
+ * 작품 타입에 따른 라벨 반환
+ */
+function getMediaTypeLabel(type: MediaCommunitySummary['type']) {
+  switch (type) {
+    case 'anime':
+      return '애니메이션'
+    case 'drama':
+      return '드라마'
+    case 'movie':
+      return '영화'
+    default:
+      return '기타'
+  }
+}
+
+/**
+ * 작품 카드 컴포넌트
+ * 작품명, 타입, 게시글 수를 표시
+ * Requirements: 5.1
+ */
+function MediaCard({ media }: { media: MediaCommunitySummary }) {
+  return (
+    <Link
+      href={`/community/media/${encodeURIComponent(media.title)}`}
+      className="group block overflow-hidden rounded-lg border border-navy-100 bg-white p-4 transition-all hover:border-navy-300 hover:shadow-md"
+    >
+      {/* 작품 아이콘 및 타입 */}
+      <div className="mb-3 flex items-center gap-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-navy-100 text-2xl transition-colors group-hover:bg-navy-200">
+          {getMediaTypeIcon(media.type)}
+        </div>
+        <span className="rounded-full bg-navy-50 px-2 py-0.5 text-xs text-navy-600">
+          {getMediaTypeLabel(media.type)}
+        </span>
+      </div>
+
+      {/* 작품 정보 */}
+      <h3 className="mb-2 truncate font-medium text-navy-800 group-hover:text-navy-600">
+        {media.title}
+      </h3>
+      <div className="flex items-center gap-1 text-sm text-navy-500">
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+          />
+        </svg>
+        <span>게시글 {media.postCount}개</span>
+      </div>
+    </Link>
   )
 }

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import PostList from '@/components/community/PostList'
@@ -129,9 +130,73 @@ function CategoryTabButton({
  * Requirements 5.6: 글쓰기 버튼 클릭 시 작성 페이지로 이동
  */
 export default function CommunityPage() {
-  // 초기 탭을 작품별(media)로 설정
+  return (
+    <Suspense fallback={<CommunityPageSkeleton />}>
+      <CommunityPageContent />
+    </Suspense>
+  )
+}
+
+/**
+ * 로딩 스켈레톤
+ */
+function CommunityPageSkeleton() {
+  return (
+    <main className="min-h-screen bg-navy-50">
+      <header className="border-b border-navy-700 bg-gradient-to-r from-navy-800 via-navy-700 to-navy-800 px-4 py-4 shadow-lg">
+        <div className="mx-auto max-w-4xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-navy-600 text-xl">
+                🗾
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-white">커뮤니티</h1>
+                <p className="text-xs text-navy-300">
+                  성지순례 경험을 공유하세요
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        <div className="animate-pulse">
+          <div className="mb-6 flex gap-2">
+            <div className="h-10 w-24 rounded-lg bg-navy-200" />
+            <div className="h-10 w-24 rounded-lg bg-navy-200" />
+            <div className="h-10 w-24 rounded-lg bg-navy-200" />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+/**
+ * 커뮤니티 페이지 실제 콘텐츠
+ */
+function CommunityPageContent() {
+  const searchParams = useSearchParams()
+  const tabParam = searchParams.get('tab')
+
+  // URL 쿼리 파라미터로 초기 탭 설정 (삭제 후 돌아올 때 사용)
+  const getInitialTab = (): CommunityCategory => {
+    if (tabParam === 'general' || tabParam === 'spot' || tabParam === 'media') {
+      return tabParam
+    }
+    return 'media' // 기본값
+  }
+
   const [activeCategory, setActiveCategory] =
-    useState<CommunityCategory>('media')
+    useState<CommunityCategory>(getInitialTab)
+
+  // URL 파라미터 변경 시 탭 업데이트
+  useEffect(() => {
+    const newTab = getInitialTab()
+    setActiveCategory(newTab)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabParam])
 
   // 현재 카테고리에 맞는 글쓰기 링크 생성
   const getWriteLink = () => {

--- a/src/app/community/spot/[id]/page.tsx
+++ b/src/app/community/spot/[id]/page.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { use } from 'react'
+import Link from 'next/link'
+import PostList from '@/components/community/PostList'
+import { useSpotDetail } from '@/hooks/useSpotDetail'
+
+interface SpotCommunityPageProps {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * 스팟별 커뮤니티 페이지
+ * 특정 스팟에 대한 게시글 목록을 표시
+ * Requirements: 5.1, 3.1
+ */
+export default function SpotCommunityPage({ params }: SpotCommunityPageProps) {
+  const { id } = use(params)
+  const { data: spot, isLoading, error } = useSpotDetail(id)
+
+  return (
+    <main className="min-h-screen bg-navy-50">
+      {/* 헤더 */}
+      <header className="border-b border-navy-700 bg-gradient-to-r from-navy-800 via-navy-700 to-navy-800 px-4 py-4 shadow-lg">
+        <div className="mx-auto max-w-4xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Link
+                href="/community"
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-navy-600 text-xl hover:bg-navy-500"
+              >
+                ←
+              </Link>
+              <div>
+                <h1 className="text-xl font-bold text-white">
+                  {isLoading ? '로딩 중...' : spot?.name || '스팟 커뮤니티'}
+                </h1>
+                <p className="text-xs text-navy-300">스팟 관련 게시글</p>
+              </div>
+            </div>
+            <nav className="flex space-x-4">
+              <Link href="/" className="text-sm text-navy-300 hover:text-white">
+                지도
+              </Link>
+              <Link
+                href="/community"
+                className="text-sm text-navy-300 hover:text-white"
+              >
+                커뮤니티
+              </Link>
+            </nav>
+          </div>
+        </div>
+      </header>
+
+      {/* 메인 콘텐츠 */}
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        {/* 스팟 정보 카드 */}
+        {!isLoading && !error && spot && (
+          <div className="mb-6 rounded-lg bg-white p-4 shadow-sm">
+            <div className="flex items-start gap-4">
+              <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-navy-100">
+                <svg
+                  className="h-8 w-8 text-navy-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <h2 className="mb-1 text-lg font-semibold text-navy-800">
+                  {spot.name}
+                </h2>
+                <p className="mb-2 text-sm text-navy-500">{spot.address}</p>
+                {spot.relatedMedia && spot.relatedMedia.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {spot.relatedMedia.map((media, index) => (
+                      <span
+                        key={index}
+                        className="rounded-full bg-navy-100 px-2 py-0.5 text-xs text-navy-600"
+                      >
+                        {media.title}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <Link
+                href={`/spots/${id}`}
+                className="rounded-lg bg-navy-100 px-3 py-1.5 text-sm text-navy-600 transition-colors hover:bg-navy-200"
+              >
+                상세보기
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {/* 에러 상태 */}
+        {error && (
+          <div className="mb-6 rounded-lg bg-red-50 p-4 text-center">
+            <p className="text-red-600">스팟 정보를 불러오지 못했습니다.</p>
+          </div>
+        )}
+
+        {/* 글쓰기 버튼 */}
+        <div className="mb-4 flex justify-end">
+          <Link
+            href={`/community/write?spotId=${id}`}
+            className="flex items-center gap-2 rounded-lg bg-navy-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            글쓰기
+          </Link>
+        </div>
+
+        {/* 게시글 목록 */}
+        <div className="rounded-lg bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center gap-2">
+            <svg
+              className="h-5 w-5 text-navy-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+              />
+            </svg>
+            <h2 className="text-lg font-semibold text-navy-800">게시글</h2>
+          </div>
+          <PostList spotId={id} />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/components/community/PostDetail.tsx
+++ b/src/components/community/PostDetail.tsx
@@ -162,11 +162,28 @@ function PostContent({ post }: PostContentProps) {
     setIsDeleteModalOpen(true)
   }
 
+  /**
+   * 게시글 삭제 후 원래 게시판으로 리다이렉트
+   * - spotId가 있으면 스팟 커뮤니티로
+   * - mediaTitle이 있으면 작품 커뮤니티로
+   * - 둘 다 없으면 자유게시판(general 탭)으로
+   */
+  const getRedirectUrl = () => {
+    if (post.spotId) {
+      return `/community/spot/${post.spotId}`
+    }
+    if (post.mediaTitle) {
+      return `/community/media/${encodeURIComponent(post.mediaTitle)}`
+    }
+    // 자유게시판 게시글인 경우 general 탭으로 이동
+    return '/community?tab=general'
+  }
+
   const handleDeleteConfirm = () => {
     deletePost.mutate(post.id, {
       onSuccess: () => {
-        // Requirements 5.9: 삭제 후 목록 페이지로 리다이렉트
-        router.push('/community')
+        // Requirements 5.9: 삭제 후 원래 게시판으로 리다이렉트
+        router.push(getRedirectUrl())
       },
       onError: (error) => {
         alert(`삭제 실패: ${error.message}`)

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -220,6 +220,8 @@ function PostListEmpty() {
 interface PostListProps {
   className?: string
   filterType?: 'all' | 'general' | 'spot' | 'media'
+  spotId?: string
+  mediaTitle?: string
 }
 
 /**
@@ -233,12 +235,22 @@ interface PostListProps {
 export default function PostList({
   className = '',
   filterType = 'all',
+  spotId,
+  mediaTitle,
 }: PostListProps) {
   const router = useRouter()
-  const { data: allPosts, isLoading, error, refetch } = usePosts()
+  const {
+    data: allPosts,
+    isLoading,
+    error,
+    refetch,
+  } = usePosts({ spotId, mediaTitle })
 
-  // 필터 타입에 따라 게시글 필터링
+  // 필터 타입에 따라 게시글 필터링 (spotId/mediaTitle이 없을 때만 적용)
   const posts = allPosts?.filter((post) => {
+    // spotId나 mediaTitle이 지정된 경우 필터링 없이 모두 표시
+    if (spotId || mediaTitle) return true
+
     if (filterType === 'all') return true
     if (filterType === 'general') return !post.spotId && !post.mediaTitle
     if (filterType === 'spot') return !!post.spotId

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -69,12 +69,24 @@ export const postKeys = {
 
 /**
  * Hook to fetch all posts for community board
+ * Supports optional filtering by spotId or mediaTitle
  */
-export function usePosts() {
+export function usePosts(filters?: { spotId?: string; mediaTitle?: string }) {
+  const { spotId, mediaTitle } = filters || {}
+
   return useQuery({
-    queryKey: postKeys.lists(),
+    queryKey: spotId
+      ? postKeys.bySpot(spotId)
+      : mediaTitle
+        ? postKeys.byMedia(mediaTitle)
+        : postKeys.lists(),
     queryFn: async (): Promise<Post[]> => {
-      const response = await fetch('/api/posts')
+      const params = new URLSearchParams()
+      if (spotId) params.set('spotId', spotId)
+      if (mediaTitle) params.set('mediaTitle', mediaTitle)
+
+      const url = `/api/posts${params.toString() ? `?${params.toString()}` : ''}`
+      const response = await fetch(url)
 
       if (!response.ok) {
         throw new Error(

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -46,9 +46,21 @@ export interface SpotCommunitySummary {
   postCount: number
 }
 
+// Media community summary type
+export interface MediaCommunitySummary {
+  title: string
+  type: 'anime' | 'drama' | 'movie' | 'other'
+  postCount: number
+}
+
 // API response types
 interface SpotCommunitySummaryResponse {
   summaries: SpotCommunitySummary[]
+  total: number
+}
+
+interface MediaCommunitySummaryResponse {
+  summaries: MediaCommunitySummary[]
   total: number
 }
 
@@ -63,6 +75,11 @@ export const spotKeys = {
   details: () => [...spotKeys.all, 'detail'] as const,
   detail: (id: string) => [...spotKeys.details(), id] as const,
   communitySummary: () => [...spotKeys.all, 'community-summary'] as const,
+}
+
+export const mediaKeys = {
+  all: ['media'] as const,
+  communitySummary: () => [...mediaKeys.all, 'community-summary'] as const,
 }
 
 /**
@@ -143,6 +160,31 @@ export function useSpotCommunitySummary() {
       }
 
       const data: SpotCommunitySummaryResponse = await response.json()
+      return data.summaries
+    },
+    staleTime: 2 * 60 * 1000, // 2 minutes (게시글 수는 자주 변경될 수 있음)
+    gcTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+/**
+ * Hook to fetch media community summary
+ * Returns media titles with their post counts for community overview
+ * Requirements: 5.1
+ */
+export function useMediaCommunitySummary() {
+  return useQuery({
+    queryKey: mediaKeys.communitySummary(),
+    queryFn: async (): Promise<MediaCommunitySummary[]> => {
+      const response = await fetch('/api/media/community-summary')
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch media community summary: ${response.status} ${response.statusText}`
+        )
+      }
+
+      const data: MediaCommunitySummaryResponse = await response.json()
       return data.summaries
     },
     staleTime: 2 * 60 * 1000, // 2 minutes (게시글 수는 자주 변경될 수 있음)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,6 +157,12 @@ export interface SpotCommunitySummary {
   postCount: number
 }
 
+export interface MediaCommunitySummary {
+  title: string
+  type: 'anime' | 'drama' | 'movie' | 'other'
+  postCount: number
+}
+
 // ============================================
 // API Response Types
 // ============================================


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #68

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 작품별 커뮤니티 개요 섹션 구현 및 커뮤니티 페이지 개선 (Task 13.4)

---

## 📋 변경 사항

- [x] `MediaCommunitySummary` 타입 정의 추가
- [x] `GET /api/media/community-summary` API 구현 (작품별 게시글 수 조회)
- [x] `useMediaCommunitySummary` 훅 추가
- [x] 작품별 커뮤니티 개요 섹션 UI 구현 (작품명, 타입, 게시글 수)
- [x] 커뮤니티 페이지 카테고리 탭 개선 (전체 탭 제거, 초기 탭을 작품별로 변경)
- [x] 스팟별 커뮤니티 페이지 추가 (`/community/spot/[id]`)
- [x] PostList 컴포넌트에 `spotId`/`mediaTitle` 필터 지원 추가
- [x] 게시글 삭제 후 원래 게시판으로 리다이렉트 기능 구현
- [x] 작품별 게시글 조회 시 연결된 스팟의 게시글도 포함하도록 수정

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

**데이터 관계 구조:**
- 스팟(Spot) → `relatedMedia` 배열 → 작품(Media) 타이틀
- 게시글(Post)은 `spotId` 또는 `mediaTitle`을 가질 수 있음
- 작품별 커뮤니티에서는 해당 작품과 연결된 모든 스팟의 게시글도 함께 표시

**Requirements: 5.1**
