### PR TITLE
[Feat] Task 13.5 - 공통 커뮤니티 (자유게시판) 구현

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -52,12 +52,14 @@ function documentToPost(doc: PostDocument & { _id: ObjectId }): Post {
  * Query Parameters:
  * - spotId: 특정 스팟 관련 게시글만 조회
  * - mediaTitle: 특정 작품 관련 게시글만 조회 (해당 작품과 연결된 스팟의 게시글도 포함)
+ * - type: 게시글 타입 필터 ('general' - 스팟/작품과 연결되지 않은 일반 게시글)
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(request.url)
     const spotId = searchParams.get('spotId')
     const mediaTitle = searchParams.get('mediaTitle')
+    const type = searchParams.get('type')
 
     const postsCollection = await getCollection<
       PostDocument & { _id: ObjectId }
@@ -66,7 +68,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let filter: any = {}
 
-    if (spotId) {
+    if (type === 'general') {
+      // 자유게시판: 스팟/작품과 연결되지 않은 게시글만 조회
+      filter = {
+        $and: [
+          { $or: [{ spotId: { $exists: false } }, { spotId: null }] },
+          { $or: [{ mediaTitle: { $exists: false } }, { mediaTitle: null }] },
+        ],
+      }
+    } else if (spotId) {
       // 특정 스팟의 게시글만 조회
       filter.spotId = spotId
     } else if (mediaTitle) {

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -18,6 +18,10 @@ function WriteForm() {
   const spotIdParam = searchParams.get('spotId')
   const spotNameParam = searchParams.get('spotName')
   const mediaTitleParam = searchParams.get('mediaTitle')
+  const typeParam = searchParams.get('type') // 'general' for 자유게시판
+
+  // 자유게시판 모드 여부
+  const isGeneralMode = typeParam === 'general'
 
   // 폼 상태
   const [title, setTitle] = useState('')
@@ -30,18 +34,20 @@ function WriteForm() {
   // 에러 상태
   const [errors, setErrors] = useState<string[]>([])
 
-  // URL 파라미터로 스팟/작품 정보 설정
+  // URL 파라미터로 스팟/작품 정보 설정 (자유게시판 모드가 아닐 때만)
   useEffect(() => {
-    if (spotIdParam) {
-      setSpotId(spotIdParam)
+    if (!isGeneralMode) {
+      if (spotIdParam) {
+        setSpotId(spotIdParam)
+      }
+      if (spotNameParam) {
+        setSpotName(decodeURIComponent(spotNameParam))
+      }
+      if (mediaTitleParam) {
+        setMediaTitle(decodeURIComponent(mediaTitleParam))
+      }
     }
-    if (spotNameParam) {
-      setSpotName(decodeURIComponent(spotNameParam))
-    }
-    if (mediaTitleParam) {
-      setMediaTitle(decodeURIComponent(mediaTitleParam))
-    }
-  }, [spotIdParam, spotNameParam, mediaTitleParam])
+  }, [spotIdParam, spotNameParam, mediaTitleParam, isGeneralMode])
 
   // 폼 제출 핸들러
   const handleSubmit = async (e: FormEvent) => {
@@ -81,11 +87,14 @@ function WriteForm() {
       // 작성 완료 후 이동
       // 스팟에서 작성한 경우 스팟 상세 페이지로
       // 작품에서 작성한 경우 작품 커뮤니티 페이지로
+      // 자유게시판에서 작성한 경우 자유게시판 탭으로
       // 그 외에는 커뮤니티 목록으로
       if (spotId) {
         router.push(`/spots/${spotId}`)
       } else if (mediaTitle) {
         router.push(`/community/media/${encodeURIComponent(mediaTitle)}`)
+      } else if (isGeneralMode) {
+        router.push('/community?tab=general')
       } else {
         router.push('/community')
       }
@@ -140,8 +149,35 @@ function WriteForm() {
 
       {/* 작성 폼 */}
       <form onSubmit={handleSubmit} className="space-y-6">
-        {/* 연결된 스팟 정보 표시 */}
-        {spotId && spotName && (
+        {/* 자유게시판 모드 안내 */}
+        {isGeneralMode && (
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+            <div className="flex items-center gap-2">
+              <svg
+                className="h-5 w-5 text-blue-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                />
+              </svg>
+              <div>
+                <p className="font-medium text-blue-800">자유게시판</p>
+                <p className="text-sm text-blue-600">
+                  스팟이나 작품과 관계없이 자유롭게 이야기를 나눠보세요.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 연결된 스팟 정보 표시 (자유게시판 모드가 아닐 때만) */}
+        {!isGeneralMode && spotId && spotName && (
           <div className="rounded-lg border border-navy-200 bg-navy-50 p-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -193,8 +229,8 @@ function WriteForm() {
           </div>
         )}
 
-        {/* 연결된 작품 정보 표시 */}
-        {mediaTitle && (
+        {/* 연결된 작품 정보 표시 (자유게시판 모드가 아닐 때만) */}
+        {!isGeneralMode && mediaTitle && (
           <div className="rounded-lg border border-purple-200 bg-purple-50 p-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -239,20 +239,31 @@ export default function PostList({
   mediaTitle,
 }: PostListProps) {
   const router = useRouter()
+
+  // API 레벨에서 필터링 (type=general인 경우 API에서 처리)
+  const apiFilters: { spotId?: string; mediaTitle?: string; type?: 'general' } =
+    {}
+  if (spotId) {
+    apiFilters.spotId = spotId
+  } else if (mediaTitle) {
+    apiFilters.mediaTitle = mediaTitle
+  } else if (filterType === 'general') {
+    apiFilters.type = 'general'
+  }
+
   const {
     data: allPosts,
     isLoading,
     error,
     refetch,
-  } = usePosts({ spotId, mediaTitle })
+  } = usePosts(Object.keys(apiFilters).length > 0 ? apiFilters : undefined)
 
-  // 필터 타입에 따라 게시글 필터링 (spotId/mediaTitle이 없을 때만 적용)
+  // 클라이언트 사이드 필터링 (API에서 처리하지 않는 경우에만)
   const posts = allPosts?.filter((post) => {
-    // spotId나 mediaTitle이 지정된 경우 필터링 없이 모두 표시
-    if (spotId || mediaTitle) return true
+    // spotId, mediaTitle, 또는 type=general이 지정된 경우 API에서 이미 필터링됨
+    if (spotId || mediaTitle || filterType === 'general') return true
 
     if (filterType === 'all') return true
-    if (filterType === 'general') return !post.spotId && !post.mediaTitle
     if (filterType === 'spot') return !!post.spotId
     if (filterType === 'media') return !!post.mediaTitle
     return true

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -61,6 +61,7 @@ export const postKeys = {
   bySpot: (spotId: string) => [...postKeys.lists(), 'spot', spotId] as const,
   byMedia: (mediaTitle: string) =>
     [...postKeys.lists(), 'media', mediaTitle] as const,
+  byType: (type: string) => [...postKeys.lists(), 'type', type] as const,
   details: () => [...postKeys.all, 'detail'] as const,
   detail: (id: string) => [...postKeys.details(), id] as const,
   comments: (postId: string) =>
@@ -69,21 +70,28 @@ export const postKeys = {
 
 /**
  * Hook to fetch all posts for community board
- * Supports optional filtering by spotId or mediaTitle
+ * Supports optional filtering by spotId, mediaTitle, or type
  */
-export function usePosts(filters?: { spotId?: string; mediaTitle?: string }) {
-  const { spotId, mediaTitle } = filters || {}
+export function usePosts(filters?: {
+  spotId?: string
+  mediaTitle?: string
+  type?: 'general'
+}) {
+  const { spotId, mediaTitle, type } = filters || {}
 
   return useQuery({
     queryKey: spotId
       ? postKeys.bySpot(spotId)
       : mediaTitle
         ? postKeys.byMedia(mediaTitle)
-        : postKeys.lists(),
+        : type
+          ? postKeys.byType(type)
+          : postKeys.lists(),
     queryFn: async (): Promise<Post[]> => {
       const params = new URLSearchParams()
       if (spotId) params.set('spotId', spotId)
       if (mediaTitle) params.set('mediaTitle', mediaTitle)
+      if (type) params.set('type', type)
 
       const url = `/api/posts${params.toString() ? `?${params.toString()}` : ''}`
       const response = await fetch(url)


### PR DESCRIPTION
## 📋 관련 이슈
Closes #70

## 📝 변경 사항
- `GET /api/posts?type=general` API 필터링 추가
- usePosts 훅에 type 필터 옵션 추가
- PostList 컴포넌트 API 레벨 필터링 적용
- 자유게시판 글쓰기 모드 지원 (안내 UI, 스팟/작품 연결 숨김)

## ✅ 테스트
- [x] TypeScript 타입 체크 통과
- [x] Next.js 빌드 성공
- [x] 기존 테스트 모두 통과 (9 suites, 40 tests)

## 📸 스크린샷
(자유게시판 탭 및 글쓰기 화면 스크린샷 첨부)

## 🔗 Requirements
- 5.1: 게시글 목록 표시
- 5.2: 게시글 작성 시 제목과 내용 필수
