### PR TITLE
[Fix] 장면 등록 시 작품명 필수값 검사 제거

### DIFF
--- a/src/app/api/spots/[id]/scenes/route.ts
+++ b/src/app/api/spots/[id]/scenes/route.ts
@@ -82,17 +82,10 @@ export async function POST(
       description: body.description,
     }
 
-    // 유효성 검사
+    // 유효성 검사 - 이미지 URL만 필수 (작품명은 스팟에서 자동 관리)
     if (!input.imageUrl || input.imageUrl.trim().length === 0) {
       return NextResponse.json(
         { error: '이미지 URL은 필수입니다' },
-        { status: 400 }
-      )
-    }
-
-    if (!input.animeTitle || input.animeTitle.trim().length === 0) {
-      return NextResponse.json(
-        { error: '작품명은 필수입니다' },
         { status: 400 }
       )
     }
@@ -105,7 +98,7 @@ export async function POST(
     const newScene: SceneDocument = {
       spotId: input.spotId,
       imageUrl: input.imageUrl.trim(),
-      animeTitle: input.animeTitle.trim(),
+      animeTitle: input.animeTitle?.trim() || '',
       episodeInfo: input.episodeInfo?.trim(),
       description: input.description?.trim(),
       likeCount: 0,


### PR DESCRIPTION
## 📋 변경 사항
- 장면 등록 API에서 `animeTitle` 필수값 검사 제거
- 스팟별로 작품이 이미 연결되어 있으므로 장면 등록 시 작품명 불필요

## 🔧 수정 파일
- `src/app/api/spots/[id]/scenes/route.ts`

## ✅ 테스트
- [x] TypeScript 타입 체크 통과
- [x] Next.js 빌드 성공

## 🔗 관련 이슈
Closes #81
