### PR TITLE
[Feat] Task 16.7 - 장면 좋아요 취소 기능 구현

### DIFF
--- a/src/app/api/scenes/[id]/like/route.ts
+++ b/src/app/api/scenes/[id]/like/route.ts
@@ -1,9 +1,62 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCollection, COLLECTIONS } from '@/lib/db'
 import { ObjectId } from 'mongodb'
+import { auth } from '@/lib/auth'
 
 /**
- * POST /api/scenes/[id]/like - 장면에 좋아요 추가
+ * GET /api/scenes/[id]/like - 사용자의 좋아요 상태 조회
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: sceneId } = await params
+
+    if (!ObjectId.isValid(sceneId)) {
+      return NextResponse.json({ error: 'Invalid scene ID' }, { status: 400 })
+    }
+
+    // 세션에서 사용자 정보 가져오기
+    const session = await auth()
+    const userId = session?.user?.id
+
+    // 장면 정보 조회
+    const scenesCollection = await getCollection(COLLECTIONS.SCENES)
+    const scene = await scenesCollection.findOne({ _id: new ObjectId(sceneId) })
+
+    if (!scene) {
+      return NextResponse.json({ error: 'Scene not found' }, { status: 404 })
+    }
+
+    // 로그인한 사용자의 좋아요 상태 확인
+    let liked = false
+    if (userId) {
+      const userLikesCollection = await getCollection(COLLECTIONS.USER_LIKES)
+      const existingLike = await userLikesCollection.findOne({
+        userId,
+        sceneId,
+      })
+      liked = !!existingLike
+    }
+
+    return NextResponse.json({
+      liked,
+      likeCount: scene.likeCount || 0,
+    })
+  } catch (error) {
+    console.error('Error getting like status:', error)
+    return NextResponse.json(
+      { error: 'Failed to get like status' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/scenes/[id]/like - 좋아요 토글 (로그인 사용자)
+ * 로그인 사용자: 좋아요 상태 토글 (추가/취소)
+ * 비로그인 사용자: 단순 좋아요 추가 (취소 불가)
  */
 export async function POST(
   _request: NextRequest,
@@ -16,30 +69,84 @@ export async function POST(
       return NextResponse.json({ error: 'Invalid scene ID' }, { status: 400 })
     }
 
-    const collection = await getCollection(COLLECTIONS.SCENES)
+    const scenesCollection = await getCollection(COLLECTIONS.SCENES)
+    const userLikesCollection = await getCollection(COLLECTIONS.USER_LIKES)
 
-    const result = await collection.findOneAndUpdate(
-      { _id: new ObjectId(sceneId) },
-      { $inc: { likeCount: 1 } },
-      { returnDocument: 'after' }
-    )
+    // 세션에서 사용자 정보 가져오기
+    const session = await auth()
+    const userId = session?.user?.id
 
-    if (!result) {
+    // 장면 존재 확인
+    const scene = await scenesCollection.findOne({ _id: new ObjectId(sceneId) })
+    if (!scene) {
       return NextResponse.json({ error: 'Scene not found' }, { status: 404 })
     }
 
-    return NextResponse.json({
-      success: true,
-      likeCount: result.likeCount,
-    })
+    if (userId) {
+      // 로그인 사용자: 토글 방식
+      const existingLike = await userLikesCollection.findOne({
+        userId,
+        sceneId,
+      })
+
+      if (existingLike) {
+        // 이미 좋아요한 경우 -> 좋아요 취소
+        await userLikesCollection.deleteOne({ userId, sceneId })
+        const result = await scenesCollection.findOneAndUpdate(
+          { _id: new ObjectId(sceneId), likeCount: { $gt: 0 } },
+          { $inc: { likeCount: -1 } },
+          { returnDocument: 'after' }
+        )
+
+        return NextResponse.json({
+          success: true,
+          liked: false,
+          likeCount: result?.likeCount || 0,
+        })
+      } else {
+        // 좋아요하지 않은 경우 -> 좋아요 추가
+        await userLikesCollection.insertOne({
+          userId,
+          sceneId,
+          createdAt: new Date(),
+        })
+        const result = await scenesCollection.findOneAndUpdate(
+          { _id: new ObjectId(sceneId) },
+          { $inc: { likeCount: 1 } },
+          { returnDocument: 'after' }
+        )
+
+        return NextResponse.json({
+          success: true,
+          liked: true,
+          likeCount: result?.likeCount || 0,
+        })
+      }
+    } else {
+      // 비로그인 사용자: 단순 좋아요 추가 (취소 불가)
+      const result = await scenesCollection.findOneAndUpdate(
+        { _id: new ObjectId(sceneId) },
+        { $inc: { likeCount: 1 } },
+        { returnDocument: 'after' }
+      )
+
+      return NextResponse.json({
+        success: true,
+        liked: false, // 비로그인은 상태 추적 불가
+        likeCount: result?.likeCount || 0,
+      })
+    }
   } catch (error) {
-    console.error('Error liking scene:', error)
-    return NextResponse.json({ error: 'Failed to like scene' }, { status: 500 })
+    console.error('Error toggling like:', error)
+    return NextResponse.json(
+      { error: 'Failed to toggle like' },
+      { status: 500 }
+    )
   }
 }
 
 /**
- * DELETE /api/scenes/[id]/like - 장면 좋아요 취소
+ * DELETE /api/scenes/[id]/like - 좋아요 취소 (로그인 사용자 전용)
  */
 export async function DELETE(
   _request: NextRequest,
@@ -52,9 +159,35 @@ export async function DELETE(
       return NextResponse.json({ error: 'Invalid scene ID' }, { status: 400 })
     }
 
-    const collection = await getCollection(COLLECTIONS.SCENES)
+    // 세션에서 사용자 정보 가져오기
+    const session = await auth()
+    const userId = session?.user?.id
 
-    const result = await collection.findOneAndUpdate(
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Login required to unlike' },
+        { status: 401 }
+      )
+    }
+
+    const scenesCollection = await getCollection(COLLECTIONS.SCENES)
+    const userLikesCollection = await getCollection(COLLECTIONS.USER_LIKES)
+
+    // 좋아요 기록 확인
+    const existingLike = await userLikesCollection.findOne({
+      userId,
+      sceneId,
+    })
+
+    if (!existingLike) {
+      return NextResponse.json({ error: 'Like not found' }, { status: 404 })
+    }
+
+    // 좋아요 기록 삭제
+    await userLikesCollection.deleteOne({ userId, sceneId })
+
+    // 장면의 좋아요 수 감소
+    const result = await scenesCollection.findOneAndUpdate(
       { _id: new ObjectId(sceneId), likeCount: { $gt: 0 } },
       { $inc: { likeCount: -1 } },
       { returnDocument: 'after' }
@@ -69,6 +202,7 @@ export async function DELETE(
 
     return NextResponse.json({
       success: true,
+      liked: false,
       likeCount: result.likeCount,
     })
   } catch (error) {

--- a/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
+++ b/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
@@ -124,15 +124,32 @@ jest.mock('@/hooks/useSpotDetail', () => ({
 
 /**
  * Mock Next.js Image component
+ * Filter out Next.js specific props that are not valid HTML attributes
  */
 jest.mock('next/image', () => {
   return function MockImage({
     src,
     alt,
+    priority,
+    fill,
+    sizes,
+    quality,
+    placeholder,
+    blurDataURL,
+    loader,
+    onLoadingComplete,
     ...props
   }: {
     src: string
     alt: string
+    priority?: boolean
+    fill?: boolean
+    sizes?: string
+    quality?: number
+    placeholder?: string
+    blurDataURL?: string
+    loader?: unknown
+    onLoadingComplete?: unknown
     [key: string]: unknown
   }) {
     // eslint-disable-next-line @next/next/no-img-element
@@ -167,6 +184,35 @@ jest.mock('next/link', () => {
 jest.mock('@/components/map/SpotDetailMap', () => {
   return function MockSpotDetailMap() {
     return <div data-testid="spot-detail-map">지도 컴포넌트</div>
+  }
+})
+
+/**
+ * Mock next-auth/react for useSession
+ */
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: null,
+    status: 'unauthenticated',
+  }),
+  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+/**
+ * Mock SceneGallery component to avoid next-auth dependency issues
+ */
+jest.mock('@/components/spot/SceneGallery', () => {
+  return function MockSceneGallery() {
+    return <div data-testid="scene-gallery">장면 갤러리</div>
+  }
+})
+
+/**
+ * Mock SpotCommunitySection component
+ */
+jest.mock('@/components/spot/SpotCommunitySection', () => {
+  return function MockSpotCommunitySection() {
+    return <div data-testid="spot-community-section">커뮤니티 섹션</div>
   }
 })
 

--- a/src/components/map/__tests__/spot-preview-required-info.test.tsx
+++ b/src/components/map/__tests__/spot-preview-required-info.test.tsx
@@ -105,17 +105,35 @@ jest.mock('next/navigation', () => ({
 
 /**
  * Mock Next.js Image component
+ * Filter out Next.js specific props that are not valid HTML attributes
  */
 jest.mock('next/image', () => {
   return function MockImage({
     src,
     alt,
+    priority,
+    fill,
+    sizes,
+    quality,
+    placeholder,
+    blurDataURL,
+    loader,
+    onLoadingComplete,
     ...props
   }: {
     src: string
     alt: string
-    [key: string]: any
+    priority?: boolean
+    fill?: boolean
+    sizes?: string
+    quality?: number
+    placeholder?: string
+    blurDataURL?: string
+    loader?: unknown
+    onLoadingComplete?: unknown
+    [key: string]: unknown
   }) {
+    // eslint-disable-next-line @next/next/no-img-element
     return <img src={src} alt={alt} {...props} />
   }
 })

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -2,9 +2,10 @@
 
 import { useState, FormEvent, useCallback, useEffect } from 'react'
 import Image from 'next/image'
+import { useSession } from 'next-auth/react'
 import {
   useScenesBySpot,
-  useLikeScene,
+  useToggleLike,
   useCreateScene,
 } from '@/hooks/useScenes'
 import { Scene } from '@/types'
@@ -15,6 +16,8 @@ interface SceneCardProps {
   onLike: (sceneId: string) => void
   isLiking: boolean
   onClick: () => void
+  isLoggedIn: boolean
+  initialLiked?: boolean
 }
 
 /**
@@ -22,16 +25,43 @@ interface SceneCardProps {
  * 호버 시 중앙에 에피소드 정보 + 설명 표시
  * 클릭 시 전체보기 모달 열기
  */
-function SceneCard({ scene, onLike, isLiking, onClick }: SceneCardProps) {
-  const [liked, setLiked] = useState(false)
+function SceneCard({
+  scene,
+  onLike,
+  isLiking,
+  onClick,
+  isLoggedIn,
+  initialLiked = false,
+}: SceneCardProps) {
+  const [liked, setLiked] = useState(initialLiked)
   const [localLikeCount, setLocalLikeCount] = useState(scene.likeCount)
+
+  // initialLiked가 변경되면 상태 업데이트
+  useEffect(() => {
+    setLiked(initialLiked)
+  }, [initialLiked])
 
   const handleLike = (e: React.MouseEvent) => {
     e.stopPropagation()
-    if (liked || isLiking) return
-    setLiked(true)
-    setLocalLikeCount((prev) => prev + 1)
-    onLike(scene.id)
+    if (isLiking) return
+
+    if (isLoggedIn) {
+      // 로그인 사용자: 토글 방식
+      if (liked) {
+        setLiked(false)
+        setLocalLikeCount((prev) => Math.max(0, prev - 1))
+      } else {
+        setLiked(true)
+        setLocalLikeCount((prev) => prev + 1)
+      }
+      onLike(scene.id)
+    } else {
+      // 비로그인 사용자: 한 번만 좋아요 가능 (세션 내)
+      if (liked) return
+      setLiked(true)
+      setLocalLikeCount((prev) => prev + 1)
+      onLike(scene.id)
+    }
   }
 
   return (
@@ -77,13 +107,22 @@ function SceneCard({ scene, onLike, isLiking, onClick }: SceneCardProps) {
       {/* 좋아요 버튼 - 항상 표시 */}
       <button
         onClick={handleLike}
-        disabled={liked || isLiking}
+        disabled={isLiking || (!isLoggedIn && liked)}
         className={`absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium shadow-md transition-all ${
           liked
             ? 'bg-red-500 text-white'
             : 'bg-white/90 text-gray-700 hover:bg-red-500 hover:text-white'
-        }`}
-        aria-label={liked ? '좋아요 완료' : '좋아요'}
+        } ${!isLoggedIn && liked ? 'cursor-not-allowed opacity-70' : ''}`}
+        aria-label={liked ? '좋아요 취소' : '좋아요'}
+        title={
+          isLoggedIn
+            ? liked
+              ? '좋아요 취소'
+              : '좋아요'
+            : liked
+              ? '로그인하면 좋아요를 취소할 수 있습니다'
+              : '좋아요'
+        }
       >
         <svg
           className="h-5 w-5"
@@ -127,6 +166,8 @@ interface CarouselProps {
   onLike: (sceneId: string) => void
   isLiking: boolean
   onSceneClick: (index: number) => void
+  isLoggedIn: boolean
+  likedSceneIds: Set<string>
 }
 
 /**
@@ -137,6 +178,8 @@ function SceneCarousel({
   onLike,
   isLiking,
   onSceneClick,
+  isLoggedIn,
+  likedSceneIds,
 }: CarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [itemsPerView, setItemsPerView] = useState(1)
@@ -196,6 +239,8 @@ function SceneCarousel({
               onLike={onLike}
               isLiking={isLiking}
               onClick={() => onSceneClick(startIdx + idx)}
+              isLoggedIn={isLoggedIn}
+              initialLiked={likedSceneIds.has(scene.id)}
             />
           ))}
         </div>
@@ -511,13 +556,64 @@ interface SceneGalleryProps {
 }
 
 export default function SceneGallery({ spotId }: SceneGalleryProps) {
+  const { data: session } = useSession()
+  const isLoggedIn = !!session?.user
   const { data: scenes, isLoading, error } = useScenesBySpot(spotId)
-  const likeScene = useLikeScene()
+  const toggleLike = useToggleLike()
   const [showAddModal, setShowAddModal] = useState(false)
   const [imageModalIndex, setImageModalIndex] = useState<number | null>(null)
+  const [likedSceneIds, setLikedSceneIds] = useState<Set<string>>(new Set())
+  const [isLoadingLikes, setIsLoadingLikes] = useState(false)
+
+  // 로그인 사용자의 좋아요 상태 일괄 조회
+  useEffect(() => {
+    const fetchLikeStatuses = async () => {
+      if (!isLoggedIn || !scenes || scenes.length === 0) {
+        setLikedSceneIds(new Set())
+        return
+      }
+
+      setIsLoadingLikes(true)
+      try {
+        const likePromises = scenes.map(async (scene) => {
+          const response = await fetch(`/api/scenes/${scene.id}/like`)
+          if (response.ok) {
+            const data = await response.json()
+            return { sceneId: scene.id, liked: data.liked }
+          }
+          return { sceneId: scene.id, liked: false }
+        })
+
+        const results = await Promise.all(likePromises)
+        const likedIds = new Set(
+          results.filter((r) => r.liked).map((r) => r.sceneId)
+        )
+        setLikedSceneIds(likedIds)
+      } catch (err) {
+        console.error('Failed to fetch like statuses:', err)
+      } finally {
+        setIsLoadingLikes(false)
+      }
+    }
+
+    fetchLikeStatuses()
+  }, [isLoggedIn, scenes])
 
   const handleLike = (sceneId: string) => {
-    likeScene.mutate(sceneId)
+    toggleLike.mutate(sceneId, {
+      onSuccess: (data) => {
+        // 좋아요 상태 업데이트
+        setLikedSceneIds((prev) => {
+          const newSet = new Set(prev)
+          if (data.liked) {
+            newSet.add(sceneId)
+          } else {
+            newSet.delete(sceneId)
+          }
+          return newSet
+        })
+      },
+    })
   }
 
   const handleSceneClick = (index: number) => {
@@ -558,11 +654,13 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
         </div>
 
         <p className="mb-4 text-sm text-gray-500">
-          이 장소가 등장한 애니메이션 장면들입니다. 마음에 드는 장면에 좋아요를
-          눌러주세요!
+          이 장소가 등장한 애니메이션 장면들입니다.{' '}
+          {isLoggedIn
+            ? '마음에 드는 장면에 좋아요를 눌러주세요! (다시 클릭하면 취소됩니다)'
+            : '로그인하면 좋아요를 취소할 수 있습니다.'}
         </p>
 
-        {isLoading ? (
+        {isLoading || isLoadingLikes ? (
           <SceneGallerySkeleton />
         ) : error ? (
           <div className="py-8 text-center text-gray-500">
@@ -580,8 +678,10 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
           <SceneCarousel
             scenes={scenes}
             onLike={handleLike}
-            isLiking={likeScene.isPending}
+            isLiking={toggleLike.isPending}
             onSceneClick={handleSceneClick}
+            isLoggedIn={isLoggedIn}
+            likedSceneIds={likedSceneIds}
           />
         )}
       </div>

--- a/src/hooks/useScenes.ts
+++ b/src/hooks/useScenes.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Scene, CreateSceneInput } from '@/types'
+import { Scene, CreateSceneInput, UserLikeStatus } from '@/types'
 
 // API response type
 interface ScenesResponse {
@@ -7,10 +7,18 @@ interface ScenesResponse {
   total: number
 }
 
+// Like toggle response type
+interface LikeToggleResponse {
+  success: boolean
+  liked: boolean
+  likeCount: number
+}
+
 // Query keys
 export const sceneKeys = {
   all: ['scenes'] as const,
   bySpot: (spotId: string) => [...sceneKeys.all, 'spot', spotId] as const,
+  likeStatus: (sceneId: string) => [...sceneKeys.all, 'like', sceneId] as const,
 }
 
 /**
@@ -42,6 +50,31 @@ export function useScenesBySpot(spotId: string | null) {
     enabled: !!spotId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
+  })
+}
+
+/**
+ * Hook to get like status for a specific scene
+ */
+export function useLikeStatus(sceneId: string | null) {
+  return useQuery({
+    queryKey: sceneKeys.likeStatus(sceneId || ''),
+    queryFn: async (): Promise<UserLikeStatus> => {
+      if (!sceneId) {
+        throw new Error('Scene ID is required')
+      }
+
+      const response = await fetch(`/api/scenes/${sceneId}/like`)
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch like status')
+      }
+
+      return response.json()
+    },
+    enabled: !!sceneId,
+    staleTime: 30 * 1000, // 30 seconds
+    gcTime: 5 * 60 * 1000, // 5 minutes
   })
 }
 
@@ -78,12 +111,41 @@ export function useCreateScene() {
 }
 
 /**
- * Hook to like a scene
+ * Hook to toggle like on a scene (for logged-in users)
+ * 좋아요 토글 후 캐시 무효화하지 않음 - 순서 변동 방지
+ */
+export function useToggleLike() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (sceneId: string): Promise<LikeToggleResponse> => {
+      const response = await fetch(`/api/scenes/${sceneId}/like`, {
+        method: 'POST',
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to toggle like')
+      }
+
+      return response.json()
+    },
+    onSuccess: (data, sceneId) => {
+      // 좋아요 상태 캐시 업데이트
+      queryClient.setQueryData(sceneKeys.likeStatus(sceneId), {
+        liked: data.liked,
+        likeCount: data.likeCount,
+      })
+    },
+  })
+}
+
+/**
+ * Hook to like a scene (legacy - for non-logged-in users)
  * 좋아요 후 캐시 무효화하지 않음 - 순서 변동 방지
  */
 export function useLikeScene() {
   return useMutation({
-    mutationFn: async (sceneId: string): Promise<{ likeCount: number }> => {
+    mutationFn: async (sceneId: string): Promise<LikeToggleResponse> => {
       const response = await fetch(`/api/scenes/${sceneId}/like`, {
         method: 'POST',
       })
@@ -99,12 +161,14 @@ export function useLikeScene() {
 }
 
 /**
- * Hook to unlike a scene
+ * Hook to unlike a scene (for logged-in users)
  * 좋아요 취소 후 캐시 무효화하지 않음 - 순서 변동 방지
  */
 export function useUnlikeScene() {
+  const queryClient = useQueryClient()
+
   return useMutation({
-    mutationFn: async (sceneId: string): Promise<{ likeCount: number }> => {
+    mutationFn: async (sceneId: string): Promise<LikeToggleResponse> => {
       const response = await fetch(`/api/scenes/${sceneId}/like`, {
         method: 'DELETE',
       })
@@ -115,6 +179,12 @@ export function useUnlikeScene() {
 
       return response.json()
     },
-    // onSuccess에서 캐시 무효화 제거 - 로컬 상태로만 좋아요 수 업데이트
+    onSuccess: (data, sceneId) => {
+      // 좋아요 상태 캐시 업데이트
+      queryClient.setQueryData(sceneKeys.likeStatus(sceneId), {
+        liked: data.liked,
+        likeCount: data.likeCount,
+      })
+    },
   })
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -78,6 +78,7 @@ export const COLLECTIONS = {
   COMMENTS: 'comments',
   SCENES: 'scenes',
   USERS: 'users',
+  USER_LIKES: 'user_likes',
 } as const
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,6 +147,22 @@ export interface CreateSceneInput {
 }
 
 // ============================================
+// User Like Types (사용자 좋아요)
+// ============================================
+
+export interface UserLike {
+  id: string
+  userId: string
+  sceneId: string
+  createdAt: Date
+}
+
+export interface UserLikeStatus {
+  liked: boolean
+  likeCount: number
+}
+
+// ============================================
 // Community Summary Types
 // ============================================
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #91

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 로그인 사용자의 장면 좋아요 상태 저장 및 토글 기능 구현

---

## 📋 변경 사항

- [x] UserLike 타입 정의 추가 (`src/types/index.ts`)
- [x] USER_LIKES 컬렉션 상수 추가 (`src/lib/db.ts`)
- [x] 좋아요 토글 API 구현 (`src/app/api/scenes/[id]/like/route.ts`)
  - GET: 사용자별 좋아요 상태 조회
  - POST: 좋아요 토글 (로그인 사용자) / 단순 추가 (비로그인)
  - DELETE: 좋아요 취소 (로그인 사용자 전용)
- [x] useScenes 훅에 좋아요 토글 기능 추가 (`src/hooks/useScenes.ts`)
- [x] SceneGallery 컴포넌트 좋아요 토글 UI 구현 (`src/components/spot/SceneGallery.tsx`)
- [x] 테스트 파일 next/image 및 next-auth mock 수정

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] `npm test` 통과 (9 suites, 40 tests)

---

## 📝 추가 정보 (선택)

- Requirements: 3.1
- 로그인 사용자는 좋아요 버튼 클릭 시 토글 방식으로 동작
- 비회원 좋아요 기능은 #92에서 IP+deviceId 방식으로 개선 예정
