### PR TITLE
[Fix] 장면 좋아요 버그 수정 (토글, 동기화, 비회원 지원)

### DIFF
--- a/src/app/api/scenes/[id]/like/route.ts
+++ b/src/app/api/scenes/[id]/like/route.ts
@@ -4,10 +4,37 @@ import { ObjectId } from 'mongodb'
 import { auth } from '@/lib/auth'
 
 /**
+ * 클라이언트 IP 추출
+ */
+function getClientIP(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for')
+  const realIP = request.headers.get('x-real-ip')
+
+  if (forwarded) {
+    return forwarded.split(',')[0].trim()
+  }
+
+  if (realIP) {
+    return realIP
+  }
+
+  return 'unknown'
+}
+
+/**
+ * 비회원 식별자 생성 (IP + deviceId 조합)
+ */
+function getGuestIdentifier(request: NextRequest): string {
+  const ip = getClientIP(request)
+  const deviceId = request.headers.get('x-device-id') || 'no-device-id'
+  return `guest:${ip}:${deviceId}`
+}
+
+/**
  * GET /api/scenes/[id]/like - 사용자의 좋아요 상태 조회
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
   try {
@@ -29,12 +56,21 @@ export async function GET(
       return NextResponse.json({ error: 'Scene not found' }, { status: 404 })
     }
 
-    // 로그인한 사용자의 좋아요 상태 확인
+    const userLikesCollection = await getCollection(COLLECTIONS.USER_LIKES)
     let liked = false
+
     if (userId) {
-      const userLikesCollection = await getCollection(COLLECTIONS.USER_LIKES)
+      // 로그인 사용자: userId로 조회
       const existingLike = await userLikesCollection.findOne({
-        userId,
+        visitorId: userId,
+        sceneId,
+      })
+      liked = !!existingLike
+    } else {
+      // 비회원: IP + deviceId 조합으로 조회
+      const guestId = getGuestIdentifier(request)
+      const existingLike = await userLikesCollection.findOne({
+        visitorId: guestId,
         sceneId,
       })
       liked = !!existingLike
@@ -54,12 +90,13 @@ export async function GET(
 }
 
 /**
- * POST /api/scenes/[id]/like - 좋아요 토글 (로그인 사용자)
- * 로그인 사용자: 좋아요 상태 토글 (추가/취소)
- * 비로그인 사용자: 단순 좋아요 추가 (취소 불가)
+ * POST /api/scenes/[id]/like - 좋아요 토글
+ * 로그인 사용자: userId로 식별
+ * 비회원: IP + deviceId 조합으로 식별
+ * 모두 토글 방식으로 동작
  */
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
   try {
@@ -76,54 +113,44 @@ export async function POST(
     const session = await auth()
     const userId = session?.user?.id
 
+    // 방문자 식별자 결정
+    const visitorId = userId || getGuestIdentifier(request)
+    const isGuest = !userId
+
     // 장면 존재 확인
     const scene = await scenesCollection.findOne({ _id: new ObjectId(sceneId) })
     if (!scene) {
       return NextResponse.json({ error: 'Scene not found' }, { status: 404 })
     }
 
-    if (userId) {
-      // 로그인 사용자: 토글 방식
-      const existingLike = await userLikesCollection.findOne({
-        userId,
-        sceneId,
+    // 기존 좋아요 확인
+    const existingLike = await userLikesCollection.findOne({
+      visitorId,
+      sceneId,
+    })
+
+    if (existingLike) {
+      // 이미 좋아요한 경우 -> 좋아요 취소
+      await userLikesCollection.deleteOne({ visitorId, sceneId })
+      const result = await scenesCollection.findOneAndUpdate(
+        { _id: new ObjectId(sceneId), likeCount: { $gt: 0 } },
+        { $inc: { likeCount: -1 } },
+        { returnDocument: 'after' }
+      )
+
+      return NextResponse.json({
+        success: true,
+        liked: false,
+        likeCount: result?.likeCount || 0,
       })
-
-      if (existingLike) {
-        // 이미 좋아요한 경우 -> 좋아요 취소
-        await userLikesCollection.deleteOne({ userId, sceneId })
-        const result = await scenesCollection.findOneAndUpdate(
-          { _id: new ObjectId(sceneId), likeCount: { $gt: 0 } },
-          { $inc: { likeCount: -1 } },
-          { returnDocument: 'after' }
-        )
-
-        return NextResponse.json({
-          success: true,
-          liked: false,
-          likeCount: result?.likeCount || 0,
-        })
-      } else {
-        // 좋아요하지 않은 경우 -> 좋아요 추가
-        await userLikesCollection.insertOne({
-          userId,
-          sceneId,
-          createdAt: new Date(),
-        })
-        const result = await scenesCollection.findOneAndUpdate(
-          { _id: new ObjectId(sceneId) },
-          { $inc: { likeCount: 1 } },
-          { returnDocument: 'after' }
-        )
-
-        return NextResponse.json({
-          success: true,
-          liked: true,
-          likeCount: result?.likeCount || 0,
-        })
-      }
     } else {
-      // 비로그인 사용자: 단순 좋아요 추가 (취소 불가)
+      // 좋아요하지 않은 경우 -> 좋아요 추가
+      await userLikesCollection.insertOne({
+        visitorId,
+        sceneId,
+        isGuest,
+        createdAt: new Date(),
+      })
       const result = await scenesCollection.findOneAndUpdate(
         { _id: new ObjectId(sceneId) },
         { $inc: { likeCount: 1 } },
@@ -132,7 +159,7 @@ export async function POST(
 
       return NextResponse.json({
         success: true,
-        liked: false, // 비로그인은 상태 추적 불가
+        liked: true,
         likeCount: result?.likeCount || 0,
       })
     }
@@ -146,10 +173,12 @@ export async function POST(
 }
 
 /**
- * DELETE /api/scenes/[id]/like - 좋아요 취소 (로그인 사용자 전용)
+ * DELETE /api/scenes/[id]/like - 좋아요 취소
+ * 로그인 사용자: userId로 식별
+ * 비회원: IP + deviceId 조합으로 식별
  */
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
   try {
@@ -163,19 +192,15 @@ export async function DELETE(
     const session = await auth()
     const userId = session?.user?.id
 
-    if (!userId) {
-      return NextResponse.json(
-        { error: 'Login required to unlike' },
-        { status: 401 }
-      )
-    }
+    // 방문자 식별자 결정
+    const visitorId = userId || getGuestIdentifier(request)
 
     const scenesCollection = await getCollection(COLLECTIONS.SCENES)
     const userLikesCollection = await getCollection(COLLECTIONS.USER_LIKES)
 
     // 좋아요 기록 확인
     const existingLike = await userLikesCollection.findOne({
-      userId,
+      visitorId,
       sceneId,
     })
 
@@ -184,7 +209,7 @@ export async function DELETE(
     }
 
     // 좋아요 기록 삭제
-    await userLikesCollection.deleteOne({ userId, sceneId })
+    await userLikesCollection.deleteOne({ visitorId, sceneId })
 
     // 장면의 좋아요 수 감소
     const result = await scenesCollection.findOneAndUpdate(

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -16,7 +16,6 @@ interface SceneCardProps {
   onLike: (sceneId: string) => void
   isLiking: boolean
   onClick: () => void
-  isLoggedIn: boolean
   initialLiked?: boolean
 }
 
@@ -30,7 +29,6 @@ function SceneCard({
   onLike,
   isLiking,
   onClick,
-  isLoggedIn,
   initialLiked = false,
 }: SceneCardProps) {
   const [liked, setLiked] = useState(initialLiked)
@@ -45,23 +43,15 @@ function SceneCard({
     e.stopPropagation()
     if (isLiking) return
 
-    if (isLoggedIn) {
-      // 로그인 사용자: 토글 방식
-      if (liked) {
-        setLiked(false)
-        setLocalLikeCount((prev) => Math.max(0, prev - 1))
-      } else {
-        setLiked(true)
-        setLocalLikeCount((prev) => prev + 1)
-      }
-      onLike(scene.id)
+    // 로그인/비로그인 모두 토글 방식으로 동작
+    if (liked) {
+      setLiked(false)
+      setLocalLikeCount((prev) => Math.max(0, prev - 1))
     } else {
-      // 비로그인 사용자: 한 번만 좋아요 가능 (세션 내)
-      if (liked) return
       setLiked(true)
       setLocalLikeCount((prev) => prev + 1)
-      onLike(scene.id)
     }
+    onLike(scene.id)
   }
 
   return (
@@ -107,22 +97,14 @@ function SceneCard({
       {/* 좋아요 버튼 - 항상 표시 */}
       <button
         onClick={handleLike}
-        disabled={isLiking || (!isLoggedIn && liked)}
+        disabled={isLiking}
         className={`absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium shadow-md transition-all ${
           liked
             ? 'bg-red-500 text-white'
             : 'bg-white/90 text-gray-700 hover:bg-red-500 hover:text-white'
-        } ${!isLoggedIn && liked ? 'cursor-not-allowed opacity-70' : ''}`}
+        }`}
         aria-label={liked ? '좋아요 취소' : '좋아요'}
-        title={
-          isLoggedIn
-            ? liked
-              ? '좋아요 취소'
-              : '좋아요'
-            : liked
-              ? '로그인하면 좋아요를 취소할 수 있습니다'
-              : '좋아요'
-        }
+        title={liked ? '좋아요 취소' : '좋아요'}
       >
         <svg
           className="h-5 w-5"
@@ -166,7 +148,6 @@ interface CarouselProps {
   onLike: (sceneId: string) => void
   isLiking: boolean
   onSceneClick: (index: number) => void
-  isLoggedIn: boolean
   likedSceneIds: Set<string>
 }
 
@@ -178,7 +159,6 @@ function SceneCarousel({
   onLike,
   isLiking,
   onSceneClick,
-  isLoggedIn,
   likedSceneIds,
 }: CarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
@@ -239,7 +219,6 @@ function SceneCarousel({
               onLike={onLike}
               isLiking={isLiking}
               onClick={() => onSceneClick(startIdx + idx)}
-              isLoggedIn={isLoggedIn}
               initialLiked={likedSceneIds.has(scene.id)}
             />
           ))}
@@ -556,8 +535,7 @@ interface SceneGalleryProps {
 }
 
 export default function SceneGallery({ spotId }: SceneGalleryProps) {
-  const { data: session } = useSession()
-  const isLoggedIn = !!session?.user
+  useSession() // 세션 상태 유지 (향후 확장용)
   const { data: scenes, isLoading, error } = useScenesBySpot(spotId)
   const toggleLike = useToggleLike()
   const [showAddModal, setShowAddModal] = useState(false)
@@ -565,18 +543,28 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
   const [likedSceneIds, setLikedSceneIds] = useState<Set<string>>(new Set())
   const [isLoadingLikes, setIsLoadingLikes] = useState(false)
 
-  // 로그인 사용자의 좋아요 상태 일괄 조회
+  // 모든 사용자의 좋아요 상태 일괄 조회 (로그인/비로그인 모두)
   useEffect(() => {
     const fetchLikeStatuses = async () => {
-      if (!isLoggedIn || !scenes || scenes.length === 0) {
+      if (!scenes || scenes.length === 0) {
         setLikedSceneIds(new Set())
         return
       }
 
       setIsLoadingLikes(true)
       try {
+        // deviceId 헤더 포함하여 요청
+        const { getDeviceId } = await import('@/lib/device-id')
+        const deviceId = getDeviceId()
+        const headers: HeadersInit = {}
+        if (deviceId) {
+          headers['X-Device-Id'] = deviceId
+        }
+
         const likePromises = scenes.map(async (scene) => {
-          const response = await fetch(`/api/scenes/${scene.id}/like`)
+          const response = await fetch(`/api/scenes/${scene.id}/like`, {
+            headers,
+          })
           if (response.ok) {
             const data = await response.json()
             return { sceneId: scene.id, liked: data.liked }
@@ -589,32 +577,35 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
           results.filter((r) => r.liked).map((r) => r.sceneId)
         )
         setLikedSceneIds(likedIds)
-      } catch (err) {
-        console.error('Failed to fetch like statuses:', err)
+      } catch {
+        // 에러 시 빈 상태 유지
       } finally {
         setIsLoadingLikes(false)
       }
     }
 
     fetchLikeStatuses()
-  }, [isLoggedIn, scenes])
+  }, [scenes])
 
-  const handleLike = (sceneId: string) => {
-    toggleLike.mutate(sceneId, {
-      onSuccess: (data) => {
-        // 좋아요 상태 업데이트
-        setLikedSceneIds((prev) => {
-          const newSet = new Set(prev)
-          if (data.liked) {
-            newSet.add(sceneId)
-          } else {
-            newSet.delete(sceneId)
-          }
-          return newSet
-        })
-      },
-    })
-  }
+  const handleLike = useCallback(
+    (sceneId: string) => {
+      toggleLike.mutate(sceneId, {
+        onSuccess: (data) => {
+          // 좋아요 상태 업데이트
+          setLikedSceneIds((prev) => {
+            const newSet = new Set(prev)
+            if (data.liked) {
+              newSet.add(sceneId)
+            } else {
+              newSet.delete(sceneId)
+            }
+            return newSet
+          })
+        },
+      })
+    },
+    [toggleLike]
+  )
 
   const handleSceneClick = (index: number) => {
     setImageModalIndex(index)
@@ -654,10 +645,8 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
         </div>
 
         <p className="mb-4 text-sm text-gray-500">
-          이 장소가 등장한 애니메이션 장면들입니다.{' '}
-          {isLoggedIn
-            ? '마음에 드는 장면에 좋아요를 눌러주세요! (다시 클릭하면 취소됩니다)'
-            : '로그인하면 좋아요를 취소할 수 있습니다.'}
+          이 장소가 등장한 애니메이션 장면들입니다. 마음에 드는 장면에 좋아요를
+          눌러주세요! (다시 클릭하면 취소됩니다)
         </p>
 
         {isLoading || isLoadingLikes ? (
@@ -680,7 +669,6 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
             onLike={handleLike}
             isLiking={toggleLike.isPending}
             onSceneClick={handleSceneClick}
-            isLoggedIn={isLoggedIn}
             likedSceneIds={likedSceneIds}
           />
         )}
@@ -697,6 +685,7 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
           initialIndex={imageModalIndex}
           onClose={closeImageModal}
           onLike={handleLike}
+          likedSceneIds={likedSceneIds}
         />
       )}
     </div>

--- a/src/components/spot/SceneImageModal.tsx
+++ b/src/components/spot/SceneImageModal.tsx
@@ -48,12 +48,13 @@ export default function SceneImageModal({
 
   // 좋아요 처리 (토글 방식)
   const handleLike = useCallback(() => {
-    setShowLikeAnimation(true)
+    // 좋아요 추가 시에만 애니메이션 표시 (취소 시에는 표시 안 함)
+    if (!isLiked) {
+      setShowLikeAnimation(true)
+      setTimeout(() => setShowLikeAnimation(false), 1000)
+    }
     onLike(currentScene.id)
-
-    // 애니메이션 후 숨기기
-    setTimeout(() => setShowLikeAnimation(false), 1000)
-  }, [currentScene.id, onLike])
+  }, [currentScene.id, isLiked, onLike])
 
   // 더블클릭으로 좋아요
   const handleDoubleClick = useCallback(() => {
@@ -140,13 +141,12 @@ export default function SceneImageModal({
       {/* 좋아요 버튼 */}
       <button
         onClick={handleLike}
-        disabled={isLiked}
         className={`absolute right-4 top-16 z-10 flex h-10 w-10 items-center justify-center rounded-full transition-colors ${
           isLiked
             ? 'bg-red-500 text-white'
             : 'bg-white/10 text-white hover:bg-white/20'
         }`}
-        aria-label={isLiked ? '좋아요 완료' : '좋아요'}
+        aria-label={isLiked ? '좋아요 취소' : '좋아요'}
       >
         <svg
           className="h-5 w-5"

--- a/src/components/spot/SceneImageModal.tsx
+++ b/src/components/spot/SceneImageModal.tsx
@@ -9,6 +9,7 @@ interface SceneImageModalProps {
   initialIndex: number
   onClose: () => void
   onLike: (sceneId: string) => void
+  likedSceneIds: Set<string>
 }
 
 /**
@@ -23,15 +24,15 @@ export default function SceneImageModal({
   initialIndex,
   onClose,
   onLike,
+  likedSceneIds,
 }: SceneImageModalProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [scale, setScale] = useState(1)
-  const [likedScenes, setLikedScenes] = useState<Set<string>>(new Set())
   const [showLikeAnimation, setShowLikeAnimation] = useState(false)
   const imageContainerRef = useRef<HTMLDivElement>(null)
 
   const currentScene = scenes[currentIndex]
-  const isLiked = likedScenes.has(currentScene.id)
+  const isLiked = likedSceneIds.has(currentScene.id)
 
   // 이전 장면으로 이동
   const goToPrev = useCallback(() => {
@@ -45,17 +46,14 @@ export default function SceneImageModal({
     setCurrentIndex((prev) => (prev < scenes.length - 1 ? prev + 1 : 0))
   }, [scenes.length])
 
-  // 좋아요 처리
+  // 좋아요 처리 (토글 방식)
   const handleLike = useCallback(() => {
-    if (isLiked) return
-
-    setLikedScenes((prev) => new Set(prev).add(currentScene.id))
     setShowLikeAnimation(true)
     onLike(currentScene.id)
 
     // 애니메이션 후 숨기기
     setTimeout(() => setShowLikeAnimation(false), 1000)
-  }, [currentScene.id, isLiked, onLike])
+  }, [currentScene.id, onLike])
 
   // 더블클릭으로 좋아요
   const handleDoubleClick = useCallback(() => {

--- a/src/hooks/useScenes.ts
+++ b/src/hooks/useScenes.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Scene, CreateSceneInput, UserLikeStatus } from '@/types'
+import { getDeviceId } from '@/lib/device-id'
 
 // API response type
 interface ScenesResponse {
@@ -19,6 +20,22 @@ export const sceneKeys = {
   all: ['scenes'] as const,
   bySpot: (spotId: string) => [...sceneKeys.all, 'spot', spotId] as const,
   likeStatus: (sceneId: string) => [...sceneKeys.all, 'like', sceneId] as const,
+}
+
+/**
+ * deviceId 헤더를 포함한 fetch 옵션 생성
+ */
+function getHeadersWithDeviceId(): HeadersInit {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  }
+
+  const deviceId = getDeviceId()
+  if (deviceId) {
+    headers['X-Device-Id'] = deviceId
+  }
+
+  return headers
 }
 
 /**
@@ -64,7 +81,13 @@ export function useLikeStatus(sceneId: string | null) {
         throw new Error('Scene ID is required')
       }
 
-      const response = await fetch(`/api/scenes/${sceneId}/like`)
+      const deviceId = getDeviceId()
+      const headers: HeadersInit = {}
+      if (deviceId) {
+        headers['X-Device-Id'] = deviceId
+      }
+
+      const response = await fetch(`/api/scenes/${sceneId}/like`, { headers })
 
       if (!response.ok) {
         throw new Error('Failed to fetch like status')
@@ -88,9 +111,7 @@ export function useCreateScene() {
     mutationFn: async (input: CreateSceneInput): Promise<Scene> => {
       const response = await fetch(`/api/spots/${input.spotId}/scenes`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: getHeadersWithDeviceId(),
         body: JSON.stringify(input),
       })
 
@@ -111,16 +132,23 @@ export function useCreateScene() {
 }
 
 /**
- * Hook to toggle like on a scene (for logged-in users)
- * 좋아요 토글 후 캐시 무효화하지 않음 - 순서 변동 방지
+ * Hook to toggle like on a scene
+ * 로그인/비로그인 모두 토글 방식으로 동작
  */
 export function useToggleLike() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (sceneId: string): Promise<LikeToggleResponse> => {
+      const deviceId = getDeviceId()
+      const headers: HeadersInit = {}
+      if (deviceId) {
+        headers['X-Device-Id'] = deviceId
+      }
+
       const response = await fetch(`/api/scenes/${sceneId}/like`, {
         method: 'POST',
+        headers,
       })
 
       if (!response.ok) {
@@ -140,37 +168,29 @@ export function useToggleLike() {
 }
 
 /**
- * Hook to like a scene (legacy - for non-logged-in users)
- * 좋아요 후 캐시 무효화하지 않음 - 순서 변동 방지
+ * Hook to like a scene (legacy - for compatibility)
  */
 export function useLikeScene() {
-  return useMutation({
-    mutationFn: async (sceneId: string): Promise<LikeToggleResponse> => {
-      const response = await fetch(`/api/scenes/${sceneId}/like`, {
-        method: 'POST',
-      })
-
-      if (!response.ok) {
-        throw new Error('Failed to like scene')
-      }
-
-      return response.json()
-    },
-    // onSuccess에서 캐시 무효화 제거 - 로컬 상태로만 좋아요 수 업데이트
-  })
+  return useToggleLike()
 }
 
 /**
- * Hook to unlike a scene (for logged-in users)
- * 좋아요 취소 후 캐시 무효화하지 않음 - 순서 변동 방지
+ * Hook to unlike a scene
  */
 export function useUnlikeScene() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (sceneId: string): Promise<LikeToggleResponse> => {
+      const deviceId = getDeviceId()
+      const headers: HeadersInit = {}
+      if (deviceId) {
+        headers['X-Device-Id'] = deviceId
+      }
+
       const response = await fetch(`/api/scenes/${sceneId}/like`, {
         method: 'DELETE',
+        headers,
       })
 
       if (!response.ok) {
@@ -187,4 +207,37 @@ export function useUnlikeScene() {
       })
     },
   })
+}
+
+/**
+ * 여러 장면의 좋아요 상태를 일괄 조회하는 함수
+ */
+export async function fetchLikeStatuses(
+  sceneIds: string[]
+): Promise<Map<string, boolean>> {
+  const deviceId = getDeviceId()
+  const headers: HeadersInit = {}
+  if (deviceId) {
+    headers['X-Device-Id'] = deviceId
+  }
+
+  const results = new Map<string, boolean>()
+
+  await Promise.all(
+    sceneIds.map(async (sceneId) => {
+      try {
+        const response = await fetch(`/api/scenes/${sceneId}/like`, { headers })
+        if (response.ok) {
+          const data = await response.json()
+          results.set(sceneId, data.liked)
+        } else {
+          results.set(sceneId, false)
+        }
+      } catch {
+        results.set(sceneId, false)
+      }
+    })
+  )
+
+  return results
 }

--- a/src/lib/device-id.ts
+++ b/src/lib/device-id.ts
@@ -1,0 +1,56 @@
+/**
+ * Device ID 유틸리티
+ * 비회원 사용자 식별을 위한 UUID 생성 및 관리
+ */
+
+const DEVICE_ID_KEY = 'anime-pilgrim-device-id'
+
+/**
+ * UUID v4 생성 함수
+ */
+function generateUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+/**
+ * Device ID 가져오기 (없으면 생성)
+ * 클라이언트 사이드에서만 동작
+ */
+export function getDeviceId(): string | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    let deviceId = localStorage.getItem(DEVICE_ID_KEY)
+
+    if (!deviceId) {
+      deviceId = generateUUID()
+      localStorage.setItem(DEVICE_ID_KEY, deviceId)
+    }
+
+    return deviceId
+  } catch {
+    // localStorage 접근 불가 시 (시크릿 모드 등)
+    return null
+  }
+}
+
+/**
+ * Device ID 초기화 (테스트용)
+ */
+export function resetDeviceId(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    localStorage.removeItem(DEVICE_ID_KEY)
+  } catch {
+    // 무시
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #92

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 장면 좋아요 기능의 3가지 버그 수정 (카드 토글, 모달 동기화, 비회원 좋아요)

---

## 📋 변경 사항

- [x] IP + localStorage UUID 조합으로 비회원 식별 구현
- [x] 좋아요 API에 visitorId 기반 토글 로직 추가
- [x] SceneGallery에서 모든 사용자(로그인/비로그인) 좋아요 상태 조회
- [x] SceneImageModal이 부모 컴포넌트의 좋아요 상태와 동기화
- [x] 카드와 모달의 좋아요 버튼이 동일한 상태 공유

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

**수정된 버그:**
1. 카드 좋아요 버튼 재클릭 시 취소되지 않던 문제 → 토글 방식으로 수정
2. 모달 좋아요가 카드와 별개로 동작하던 문제 → 부모 상태 공유로 동기화
3. 비회원 좋아요 취소 불가 문제 → IP+deviceId 조합으로 비회원 식별 및 토글 지원

**Requirements 3.1 대응**
