### PR TITLE
[Feat] Task 16.8.5, 16.8.6, 16.8.8 - 댓글 비회원 비밀번호 처리 및 삭제 권한 검증

### DIFF
--- a/src/app/api/posts/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/posts/[id]/comments/[commentId]/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { ObjectId } from 'mongodb'
+import { auth } from '@/lib/auth'
+import bcrypt from 'bcryptjs'
+
+// MongoDB document interface
+interface CommentDocument {
+  _id: ObjectId
+  postId: ObjectId
+  content: string
+  author: string
+  createdAt: Date
+  password?: string
+  userId?: string
+  isGuest: boolean
+}
+
+interface PostDocument {
+  _id: ObjectId
+  commentCount: number
+}
+
+/**
+ * DELETE /api/posts/[id]/comments/[commentId] - 댓글 삭제
+ * Requirements: 5.4, 16.8.8
+ *
+ * 회원: 본인 userId 일치 시 삭제 가능
+ * 비회원: 비밀번호 해시 비교 후 삭제
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id, commentId } = await params
+
+    // ObjectId 유효성 검사
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json(
+        { error: 'Invalid post ID format' },
+        { status: 400 }
+      )
+    }
+
+    if (!ObjectId.isValid(commentId)) {
+      return NextResponse.json(
+        { error: 'Invalid comment ID format' },
+        { status: 400 }
+      )
+    }
+
+    // 댓글 조회
+    const commentsCollection = await getCollection<CommentDocument>(
+      COLLECTIONS.COMMENTS
+    )
+    const comment = await commentsCollection.findOne({
+      _id: new ObjectId(commentId),
+      postId: new ObjectId(id),
+    })
+
+    if (!comment) {
+      return NextResponse.json({ error: 'Comment not found' }, { status: 404 })
+    }
+
+    // 세션 확인
+    const session = await auth()
+    const isAuthenticated = !!session?.user
+
+    // 권한 검증
+    if (comment.isGuest) {
+      // 비회원 댓글: 비밀번호 검증 필요
+      const body = await request.json().catch(() => ({}))
+
+      if (!body.password) {
+        return NextResponse.json(
+          {
+            error: '비회원 댓글 삭제는 비밀번호가 필요합니다',
+            requirePassword: true,
+          },
+          { status: 401 }
+        )
+      }
+
+      // 비밀번호 해시 비교
+      const isPasswordValid = await bcrypt.compare(
+        body.password,
+        comment.password || ''
+      )
+
+      if (!isPasswordValid) {
+        return NextResponse.json(
+          { error: '비밀번호가 일치하지 않습니다' },
+          { status: 403 }
+        )
+      }
+    } else {
+      // 회원 댓글: userId 일치 확인
+      if (!isAuthenticated) {
+        return NextResponse.json(
+          { error: '로그인이 필요합니다' },
+          { status: 401 }
+        )
+      }
+
+      const currentUserId = session.user?.id || session.user?.email
+      if (comment.userId !== currentUserId) {
+        return NextResponse.json(
+          { error: '본인의 댓글만 삭제할 수 있습니다' },
+          { status: 403 }
+        )
+      }
+    }
+
+    // 댓글 삭제
+    await commentsCollection.deleteOne({ _id: new ObjectId(commentId) })
+
+    // 게시글의 commentCount 감소
+    const postsCollection = await getCollection<PostDocument>(COLLECTIONS.POSTS)
+    await postsCollection.updateOne(
+      { _id: new ObjectId(id) },
+      { $inc: { commentCount: -1 } }
+    )
+
+    return NextResponse.json({
+      success: true,
+      message: '댓글이 삭제되었습니다',
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error deleting comment:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete comment' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/posts/[id]/comments/route.ts
+++ b/src/app/api/posts/[id]/comments/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getCollection, COLLECTIONS } from '@/lib/db'
 import { Comment, CreateCommentInput } from '@/types'
 import { ObjectId } from 'mongodb'
+import { auth } from '@/lib/auth'
+import bcrypt from 'bcryptjs'
 
 // MongoDB document interface
 interface CommentDocument {
@@ -115,7 +117,10 @@ export async function GET(
 
 /**
  * POST /api/posts/[id]/comments - 댓글 작성
- * Requirements: 5.3, 5.4
+ * Requirements: 5.3, 5.4, 16.8.6
+ *
+ * 회원: 세션에서 userId 자동 추출, 비밀번호 불필요
+ * 비회원: 닉네임 + 비밀번호 필수, 비밀번호 해시 저장
  */
 export async function POST(
   request: NextRequest,
@@ -154,17 +159,64 @@ export async function POST(
       )
     }
 
+    // 세션 확인 (회원/비회원 구분)
+    const session = await auth()
+    const isAuthenticated = !!session?.user
+
+    // 비회원인 경우 비밀번호 필수 검증
+    if (!isAuthenticated) {
+      if (!body.password || body.password.trim().length === 0) {
+        return NextResponse.json(
+          {
+            error: 'Validation failed',
+            details: ['비회원은 비밀번호가 필수입니다'],
+          },
+          { status: 400 }
+        )
+      }
+      if (body.password.length < 4) {
+        return NextResponse.json(
+          {
+            error: 'Validation failed',
+            details: ['비밀번호는 4자 이상이어야 합니다'],
+          },
+          { status: 400 }
+        )
+      }
+    }
+
     const commentsCollection = await getCollection<
       CommentDocument & { _id: ObjectId }
     >(COLLECTIONS.COMMENTS)
 
     const now = new Date()
-    const newComment: CommentDocument = {
-      postId: new ObjectId(id),
-      content: input.content!.trim(),
-      author: body.author || '익명',
-      createdAt: now,
-      isGuest: true, // 기본값: 비회원 (추후 인증 로직에서 변경)
+
+    // 회원/비회원에 따른 댓글 데이터 구성
+    let newComment: CommentDocument
+
+    if (isAuthenticated && session.user) {
+      // 회원 댓글
+      newComment = {
+        postId: new ObjectId(id),
+        content: input.content!.trim(),
+        author:
+          session.user.name || session.user.email?.split('@')[0] || '회원',
+        createdAt: now,
+        isGuest: false,
+        userId: session.user.id || session.user.email || undefined,
+      }
+    } else {
+      // 비회원 댓글 - 비밀번호 해시 저장
+      const hashedPassword = await bcrypt.hash(body.password, 10)
+
+      newComment = {
+        postId: new ObjectId(id),
+        content: input.content!.trim(),
+        author: body.author || '익명',
+        createdAt: now,
+        isGuest: true,
+        password: hashedPassword,
+      }
     }
 
     const result = await commentsCollection.insertOne(
@@ -177,12 +229,14 @@ export async function POST(
       { $inc: { commentCount: 1 } }
     )
 
+    // 응답에서 password 제외
     const createdComment: Comment = {
       id: result.insertedId.toHexString(),
       postId: id,
       content: newComment.content,
       author: newComment.author,
       createdAt: newComment.createdAt,
+      userId: newComment.userId,
       isGuest: newComment.isGuest,
     }
 

--- a/src/components/community/CommentSection.tsx
+++ b/src/components/community/CommentSection.tsx
@@ -211,45 +211,27 @@ function CommentForm({ postId, onSuccess }: CommentFormProps) {
           <span className="text-xs text-navy-400">(으)로 작성</span>
         </div>
       ) : (
-        <>
-          {/* 비회원: 닉네임 입력 */}
-          <div>
-            <label
-              htmlFor="comment-author"
-              className="mb-1 block text-sm font-medium text-navy-700"
-            >
-              닉네임
-            </label>
-            <input
-              id="comment-author"
-              type="text"
-              value={author}
-              onChange={(e) => setAuthor(e.target.value)}
-              placeholder="익명"
-              className="w-full rounded-lg border border-navy-200 px-4 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
-              maxLength={20}
-            />
-          </div>
-
-          {/* 비회원: 비밀번호 입력 */}
-          <div>
-            <label
-              htmlFor="comment-password"
-              className="mb-1 block text-sm font-medium text-navy-700"
-            >
-              비밀번호 <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="comment-password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="댓글 삭제 시 필요합니다 (4자 이상)"
-              className="w-full rounded-lg border border-navy-200 px-4 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
-              maxLength={20}
-            />
-          </div>
-        </>
+        /* 비회원: 닉네임 + 비밀번호 한 줄 입력 */
+        <div className="flex gap-2">
+          <input
+            id="comment-author"
+            type="text"
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            placeholder="닉네임"
+            className="w-1/3 rounded-lg border border-navy-200 px-3 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
+            maxLength={20}
+          />
+          <input
+            id="comment-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호 (4자 이상) *"
+            className="w-2/3 rounded-lg border border-navy-200 px-3 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
+            maxLength={20}
+          />
+        </div>
       )}
 
       {/* 댓글 내용 입력 */}

--- a/src/components/community/CommentSection.tsx
+++ b/src/components/community/CommentSection.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { useState, FormEvent } from 'react'
-import { useComments, useCreateComment, Comment } from '@/hooks/usePosts'
+import {
+  useComments,
+  useCreateComment,
+  useDeleteComment,
+  Comment,
+} from '@/hooks/usePosts'
+import { useAuth } from '@/hooks/useAuth'
+import PasswordModal from './PasswordModal'
 
 /**
  * 날짜를 한국어 형식으로 포맷팅
@@ -32,29 +39,59 @@ function formatDate(date: Date): string {
 
 interface CommentItemProps {
   comment: Comment
+  postId: string
+  currentUserId?: string
+  onDeleteClick: (comment: Comment) => void
 }
 
 /**
  * 개별 댓글 아이템 컴포넌트
  * Requirements 5.4: 댓글 시간순 표시
  */
-function CommentItem({ comment }: CommentItemProps) {
+function CommentItem({
+  comment,
+  currentUserId,
+  onDeleteClick,
+}: CommentItemProps) {
+  // 삭제 권한 확인: 회원은 본인 댓글만, 비회원은 비밀번호로 삭제
+  const canDelete =
+    comment.isGuest || (currentUserId && comment.userId === currentUserId)
+
   return (
     <div className="border-b border-navy-100 py-4 last:border-b-0">
-      <div className="mb-2 flex items-center gap-3">
-        {/* 작성자 아바타 */}
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-navy-200 text-sm font-medium text-navy-600">
-          {comment.author.charAt(0).toUpperCase()}
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {/* 작성자 아바타 */}
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-navy-200 text-sm font-medium text-navy-600">
+            {comment.author.charAt(0).toUpperCase()}
+          </div>
+          {/* 작성자 정보 */}
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-navy-700">
+                {comment.author}
+              </span>
+              {comment.isGuest && (
+                <span className="rounded bg-navy-100 px-1.5 py-0.5 text-xs text-navy-500">
+                  비회원
+                </span>
+              )}
+            </div>
+            <span className="text-xs text-navy-400">
+              {formatDate(comment.createdAt)}
+            </span>
+          </div>
         </div>
-        {/* 작성자 정보 */}
-        <div className="flex flex-col">
-          <span className="text-sm font-medium text-navy-700">
-            {comment.author}
-          </span>
-          <span className="text-xs text-navy-400">
-            {formatDate(comment.createdAt)}
-          </span>
-        </div>
+        {/* 삭제 버튼 */}
+        {canDelete && (
+          <button
+            onClick={() => onDeleteClick(comment)}
+            className="text-xs text-navy-400 transition-colors hover:text-red-500"
+            title="댓글 삭제"
+          >
+            삭제
+          </button>
+        )}
       </div>
       {/* 댓글 내용 */}
       <p className="ml-11 whitespace-pre-wrap text-sm text-navy-600">
@@ -106,11 +143,13 @@ interface CommentFormProps {
 
 /**
  * 댓글 작성 폼 컴포넌트
- * Requirements 5.3, 5.4: 댓글 작성 기능
+ * Requirements 5.3, 5.4, 16.8.5: 댓글 작성 기능 (회원/비회원 구분)
  */
 function CommentForm({ postId, onSuccess }: CommentFormProps) {
+  const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth()
   const [content, setContent] = useState('')
   const [author, setAuthor] = useState('')
+  const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
 
   const createComment = useCreateComment()
@@ -125,16 +164,31 @@ function CommentForm({ postId, onSuccess }: CommentFormProps) {
       return
     }
 
+    // 비회원인 경우 비밀번호 필수
+    if (!isAuthenticated && !password.trim()) {
+      setError('비회원은 비밀번호가 필수입니다')
+      return
+    }
+
+    if (!isAuthenticated && password.length < 4) {
+      setError('비밀번호는 4자 이상이어야 합니다')
+      return
+    }
+
     try {
       await createComment.mutateAsync({
         postId,
         content: content.trim(),
-        author: author.trim() || '익명',
+        author: isAuthenticated
+          ? user?.name || user?.email?.split('@')[0] || '회원'
+          : author.trim() || '익명',
+        password: isAuthenticated ? undefined : password,
       })
 
       // 성공 시 폼 초기화
       setContent('')
       setAuthor('')
+      setPassword('')
       onSuccess?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : '댓글 작성에 실패했습니다')
@@ -143,24 +197,60 @@ function CommentForm({ postId, onSuccess }: CommentFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      {/* 작성자 입력 */}
-      <div>
-        <label
-          htmlFor="comment-author"
-          className="mb-1 block text-sm font-medium text-navy-700"
-        >
-          닉네임 (선택)
-        </label>
-        <input
-          id="comment-author"
-          type="text"
-          value={author}
-          onChange={(e) => setAuthor(e.target.value)}
-          placeholder="익명"
-          className="w-full rounded-lg border border-navy-200 px-4 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
-          maxLength={20}
-        />
-      </div>
+      {/* 로그인 상태 표시 */}
+      {isAuthLoading ? (
+        <div className="h-10 animate-pulse rounded-lg bg-navy-100"></div>
+      ) : isAuthenticated ? (
+        <div className="flex items-center gap-2 rounded-lg bg-navy-50 px-4 py-2">
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-navy-200 text-xs font-medium text-navy-600">
+            {(user?.name || user?.email || '회')[0].toUpperCase()}
+          </div>
+          <span className="text-sm text-navy-700">
+            {user?.name || user?.email?.split('@')[0] || '회원'}
+          </span>
+          <span className="text-xs text-navy-400">(으)로 작성</span>
+        </div>
+      ) : (
+        <>
+          {/* 비회원: 닉네임 입력 */}
+          <div>
+            <label
+              htmlFor="comment-author"
+              className="mb-1 block text-sm font-medium text-navy-700"
+            >
+              닉네임
+            </label>
+            <input
+              id="comment-author"
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="익명"
+              className="w-full rounded-lg border border-navy-200 px-4 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
+              maxLength={20}
+            />
+          </div>
+
+          {/* 비회원: 비밀번호 입력 */}
+          <div>
+            <label
+              htmlFor="comment-password"
+              className="mb-1 block text-sm font-medium text-navy-700"
+            >
+              비밀번호 <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="comment-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="댓글 삭제 시 필요합니다 (4자 이상)"
+              className="w-full rounded-lg border border-navy-200 px-4 py-2 text-sm text-navy-700 placeholder-navy-400 focus:border-navy-500 focus:outline-none focus:ring-1 focus:ring-navy-500"
+              maxLength={20}
+            />
+          </div>
+        </>
+      )}
 
       {/* 댓글 내용 입력 */}
       <div>
@@ -211,12 +301,60 @@ interface CommentSectionProps {
  * Requirements:
  * - 5.3: 게시글에 댓글 허용
  * - 5.4: 댓글 시간순 정렬 표시
+ * - 16.8.5: 비회원 비밀번호 입력 필드
+ * - 16.8.8: 댓글 삭제 권한 검증
  */
 export default function CommentSection({
   postId,
   className = '',
 }: CommentSectionProps) {
+  const { user, isAuthenticated } = useAuth()
   const { data: comments, isLoading, error, refetch } = useComments(postId)
+  const deleteComment = useDeleteComment()
+
+  // 삭제 모달 상태
+  const [deleteTarget, setDeleteTarget] = useState<Comment | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const currentUserId = isAuthenticated
+    ? user?.id || user?.email || undefined
+    : undefined
+
+  // 댓글 삭제 클릭 핸들러
+  const handleDeleteClick = (comment: Comment) => {
+    setDeleteTarget(comment)
+    setDeleteError(null)
+  }
+
+  // 댓글 삭제 확인 핸들러
+  const handleDeleteConfirm = async (password?: string) => {
+    if (!deleteTarget) return
+
+    try {
+      await deleteComment.mutateAsync({
+        postId,
+        commentId: deleteTarget.id,
+        password: deleteTarget.isGuest ? password : undefined,
+      })
+      setDeleteTarget(null)
+      setDeleteError(null)
+    } catch (err) {
+      const error = err as Error & { requirePassword?: boolean }
+      if (error.requirePassword) {
+        // 비밀번호 필요 - 모달 유지
+        setDeleteError('비밀번호를 입력해주세요')
+      } else {
+        setDeleteError(error.message || '댓글 삭제에 실패했습니다')
+      }
+    }
+  }
+
+  // 회원 댓글 삭제 (비밀번호 불필요)
+  const handleMemberDelete = () => {
+    if (deleteTarget && !deleteTarget.isGuest) {
+      handleDeleteConfirm()
+    }
+  }
 
   return (
     <div className={`rounded-lg bg-white p-6 shadow-sm ${className}`}>
@@ -264,11 +402,70 @@ export default function CommentSection({
         ) : (
           <div>
             {comments.map((comment) => (
-              <CommentItem key={comment.id} comment={comment} />
+              <CommentItem
+                key={comment.id}
+                comment={comment}
+                postId={postId}
+                currentUserId={currentUserId}
+                onDeleteClick={handleDeleteClick}
+              />
             ))}
           </div>
         )}
       </div>
+
+      {/* 비회원 댓글 삭제 비밀번호 모달 */}
+      {deleteTarget?.isGuest && (
+        <PasswordModal
+          isOpen={!!deleteTarget}
+          title="댓글 삭제"
+          description="댓글 작성 시 입력한 비밀번호를 입력해주세요."
+          isLoading={deleteComment.isPending}
+          error={deleteError}
+          onConfirm={handleDeleteConfirm}
+          onCancel={() => {
+            setDeleteTarget(null)
+            setDeleteError(null)
+          }}
+        />
+      )}
+
+      {/* 회원 댓글 삭제 확인 모달 */}
+      {deleteTarget && !deleteTarget.isGuest && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setDeleteTarget(null)}
+          />
+          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+            <h3 className="mb-2 text-lg font-semibold text-navy-800">
+              댓글 삭제
+            </h3>
+            <p className="mb-4 text-sm text-navy-600">
+              이 댓글을 삭제하시겠습니까?
+            </p>
+            {deleteError && (
+              <p className="mb-4 text-sm text-red-500">{deleteError}</p>
+            )}
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteComment.isPending}
+                className="rounded-lg border border-navy-300 px-4 py-2 text-sm font-medium text-navy-600 transition-colors hover:bg-navy-50 disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleMemberDelete}
+                disabled={deleteComment.isPending}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteComment.isPending ? '삭제 중...' : '삭제'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -21,6 +21,8 @@ export interface Comment {
   content: string
   author: string
   createdAt: Date
+  userId?: string
+  isGuest?: boolean
 }
 
 export interface CreatePostInput {
@@ -35,6 +37,7 @@ export interface CreateCommentInput {
   postId: string
   content: string
   author: string
+  password?: string
 }
 
 export interface UpdatePostInput {
@@ -304,6 +307,9 @@ export function useCreatePost() {
 
 /**
  * Hook to create a new comment
+ * Requirements: 5.4, 16.8.6
+ *
+ * 비회원 댓글 작성 시 password 필드 필요
  */
 export function useCreateComment() {
   const queryClient = useQueryClient()
@@ -318,12 +324,16 @@ export function useCreateComment() {
         body: JSON.stringify({
           content: data.content,
           author: data.author,
+          password: data.password,
         }),
       })
 
       if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
         throw new Error(
-          `Failed to create comment: ${response.status} ${response.statusText}`
+          errorData.details?.[0] ||
+            errorData.error ||
+            `Failed to create comment: ${response.status} ${response.statusText}`
         )
       }
 
@@ -332,6 +342,55 @@ export function useCreateComment() {
       return {
         ...result,
         createdAt: new Date(result.createdAt),
+      }
+    },
+    onSuccess: (_, variables) => {
+      // Invalidate comments for this post
+      queryClient.invalidateQueries({
+        queryKey: postKeys.comments(variables.postId),
+      })
+      // Also invalidate post detail to update comment count
+      queryClient.invalidateQueries({
+        queryKey: postKeys.detail(variables.postId),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to delete a comment
+ * Requirements: 5.4, 16.8.8
+ *
+ * 비회원 댓글 삭제 시 password 필드 필요
+ */
+export function useDeleteComment() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: {
+      postId: string
+      commentId: string
+      password?: string
+    }): Promise<void> => {
+      const response = await fetch(
+        `/api/posts/${data.postId}/comments/${data.commentId}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ password: data.password }),
+        }
+      )
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        const error = new Error(
+          errorData.error ||
+            `Failed to delete comment: ${response.status} ${response.statusText}`
+        ) as Error & { requirePassword?: boolean }
+        error.requirePassword = errorData.requirePassword
+        throw error
       }
     },
     onSuccess: (_, variables) => {


### PR DESCRIPTION
## 📋 작업 내용

### Task 16.8.5: 댓글 작성 폼 수정
- 로그인 사용자: 작성자 필드 자동 설정 (닉네임 표시)
- 비회원: 닉네임 + 비밀번호 입력 필드 표시
- 비회원 비밀번호 4자 이상 필수 검증

### Task 16.8.6: 댓글 API 수정
- 로그인 사용자: 세션에서 userId 자동 추출
- 비회원: 닉네임 + 비밀번호 필수, bcrypt로 비밀번호 해시 저장
- `POST /api/posts/[id]/comments` 수정

### Task 16.8.8: 댓글 삭제 권한 검증
- 회원: 본인 userId 일치 시 삭제 가능
- 비회원: 비밀번호 입력 모달 → 해시 비교 후 삭제
- `DELETE /api/posts/[id]/comments/[commentId]` 신규 구현

## 📌 관련 Requirements
- Requirements 5.4: 댓글 작성 및 시간순 정렬

## ✅ 변경 파일
- `src/app/api/posts/[id]/comments/route.ts` - 댓글 작성 API 수정
- `src/app/api/posts/[id]/comments/[commentId]/route.ts` - 댓글 삭제 API 신규
- `src/hooks/usePosts.ts` - useDeleteComment 훅 추가
- `src/components/community/CommentSection.tsx` - UI 수정

Closes #101


<img width="920" height="511" alt="image" src="https://github.com/user-attachments/assets/7f22a81e-2d60-4835-8480-864b22df0d53" />