### PR TITLE
[Feat] Not a Trip 리브랜딩을 위한 데이터 모델 및 타입 확장

### DIFF
--- a/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
+++ b/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
@@ -83,6 +83,7 @@ function containsRequiredInfo(
 
   // Check if related media information is present
   const hasRelatedMedia =
+    !spotData.relatedMedia ||
     spotData.relatedMedia.length === 0 ||
     spotData.relatedMedia.some((media) => content.includes(media.title)) ||
     content.includes('관련 작품')
@@ -302,9 +303,9 @@ describe('SpotDetail Required Information Property Tests', () => {
           const hasName = content.includes(spotData.name)
           const hasAddress = content.includes(spotData.address)
           const hasDescription = content.includes(spotData.description)
-          const hasRelatedMedia = spotData.relatedMedia.some((media) =>
-            content.includes(media.title)
-          )
+          const hasRelatedMedia =
+            !spotData.relatedMedia ||
+            spotData.relatedMedia.some((media) => content.includes(media.title))
 
           // Photos section should not be rendered when photos array is empty
           const photosSection = container.querySelector('h2')

--- a/src/lib/__tests__/spot-serialization.test.ts
+++ b/src/lib/__tests__/spot-serialization.test.ts
@@ -57,6 +57,9 @@ const spotArbitrary = fc.record({
  * Handles JSON serialization edge cases properly
  */
 function spotsAreEquivalent(spot1: Spot, spot2: Spot): boolean {
+  const relatedMedia1 = spot1.relatedMedia || []
+  const relatedMedia2 = spot2.relatedMedia || []
+
   return (
     spot1.id === spot2.id &&
     spot1.name === spot2.name &&
@@ -66,9 +69,9 @@ function spotsAreEquivalent(spot1: Spot, spot2: Spot): boolean {
     spot1.address === spot2.address &&
     spot1.coordinates.lat === spot2.coordinates.lat &&
     spot1.coordinates.lng === spot2.coordinates.lng &&
-    spot1.relatedMedia.length === spot2.relatedMedia.length &&
-    spot1.relatedMedia.every((media1, index) => {
-      const media2 = spot2.relatedMedia[index]
+    relatedMedia1.length === relatedMedia2.length &&
+    relatedMedia1.every((media1, index) => {
+      const media2 = relatedMedia2[index]
       return (
         media1.title === media2.title &&
         media1.type === media2.type &&

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,40 @@
 // ============================================
+// Spot Category & Content Types
+// ============================================
+
+export type SpotCategory =
+  | 'animation' // 애니메이션/만화
+  | 'sports' // 스포츠 (축구, 야구 등)
+  | 'movie_drama' // 영화/드라마
+  | 'music' // 음악/콘서트
+  | 'game' // 게임/e스포츠
+  | 'other' // 기타
+
+export type ContentType =
+  | 'anime' // 애니메이션
+  | 'movie' // 영화
+  | 'drama' // 드라마
+  | 'sports_team' // 스포츠 팀
+  | 'artist' // 아티스트/가수
+  | 'game' // 게임
+  | 'other' // 기타
+
+export interface CategoryConfig {
+  icon: string
+  color: string
+  label: string
+}
+
+export const CATEGORY_CONFIG: Record<SpotCategory, CategoryConfig> = {
+  animation: { icon: '🎬', color: '#FF6B6B', label: '애니메이션' },
+  sports: { icon: '⚽', color: '#4ECDC4', label: '스포츠' },
+  movie_drama: { icon: '🎥', color: '#45B7D1', label: '영화/드라마' },
+  music: { icon: '🎵', color: '#96CEB4', label: '음악/콘서트' },
+  game: { icon: '🎮', color: '#DDA0DD', label: '게임' },
+  other: { icon: '📍', color: '#95A5A6', label: '기타' },
+}
+
+// ============================================
 // Spot Types
 // ============================================
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,14 @@ export interface MediaInfo {
   year?: number
 }
 
+// 확장된 관련 콘텐츠 인터페이스 (다양한 콘텐츠 타입 지원)
+export interface RelatedContent {
+  name: string // 콘텐츠 이름 (작품명, 팀명, 아티스트명 등)
+  type: ContentType // 콘텐츠 타입
+  year?: number // 연도 (선택)
+  additionalInfo?: string // 추가 정보 (에피소드, 시즌 등)
+}
+
 export interface Spot {
   id: string
   name: string
@@ -56,9 +64,16 @@ export interface Spot {
   photos: string[]
   address: string
   coordinates: Coordinates
-  relatedMedia: MediaInfo[]
+  category?: SpotCategory // 스팟 카테고리 (마이그레이션 전 optional)
+  relatedMedia?: MediaInfo[] // 기존 호환성 유지 (deprecated)
+  relatedContent?: RelatedContent[] // 새로운 관련 콘텐츠 (마이그레이션 후 사용)
   createdAt: Date
   updatedAt: Date
+  // 작성자 정보 (마이그레이션 전 optional)
+  authorId?: string // 회원 작성자 ID
+  authorName?: string // 작성자 이름
+  isGuestSpot?: boolean // 비회원 등록 여부
+  password?: string // 비회원 수정/삭제용 (해시)
 }
 
 export interface SpotPin {
@@ -66,6 +81,7 @@ export interface SpotPin {
   name: string
   coordinates: [number, number]
   thumbnailUrl: string
+  category?: SpotCategory // 마이그레이션 전 optional
 }
 
 export interface SpotPreviewData {
@@ -83,8 +99,14 @@ export interface SpotDetailData {
   photos: string[]
   address: string
   coordinates: [number, number]
-  relatedMedia: MediaInfo[]
+  category?: SpotCategory // 마이그레이션 전 optional
+  relatedMedia?: MediaInfo[] // 기존 호환성 유지 (deprecated)
+  relatedContent?: RelatedContent[] // 새로운 관련 콘텐츠
   nearbyFacilities: NearbyFacility[]
+  // 작성자 정보 (마이그레이션 전 optional)
+  authorId?: string
+  authorName?: string
+  isGuestSpot?: boolean
 }
 
 // ============================================
@@ -244,7 +266,38 @@ export interface SpotResponse {
   photos: string[]
   address: string
   coordinates: [number, number]
-  relatedMedia: MediaInfo[]
+  category?: SpotCategory // 마이그레이션 전 optional
+  relatedMedia?: MediaInfo[] // 기존 호환성 유지 (deprecated)
+  relatedContent?: RelatedContent[] // 새로운 관련 콘텐츠
+  authorId?: string
+  authorName?: string
+  isGuestSpot?: boolean
+}
+
+// 스팟 등록 Input
+export interface CreateSpotInput {
+  name: string
+  description: string
+  address: string
+  coordinates: Coordinates
+  category: SpotCategory
+  photos?: string[]
+  relatedContent?: RelatedContent[]
+  // 작성자 정보
+  authorName?: string // 비회원용 닉네임
+  password?: string // 비회원용 비밀번호
+}
+
+// 스팟 수정 Input
+export interface UpdateSpotInput {
+  name?: string
+  description?: string
+  address?: string
+  coordinates?: Coordinates
+  category?: SpotCategory
+  photos?: string[]
+  relatedContent?: RelatedContent[]
+  password?: string // 비회원 수정 시 비밀번호 확인용
 }
 
 // ============================================


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #103

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> Not a Trip 리브랜딩을 위한 데이터 모델 및 타입 확장

---

## 📋 변경 사항

- [x] SpotCategory 타입 정의 (animation, sports, movie_drama, music, game, other)
- [x] ContentType 타입 정의 (anime, movie, drama, sports_team, artist, game, other)
- [x] CATEGORY_CONFIG 상수 정의 (아이콘, 색상, 라벨)
- [x] RelatedContent 인터페이스 정의 (name, type, year, additionalInfo)
- [x] Spot 모델 확장 (category, relatedContent, authorId, authorName, isGuestSpot, password)
- [x] SpotPin, SpotDetailData, SpotResponse 타입 업데이트
- [x] CreateSpotInput, UpdateSpotInput 타입 추가
- [x] 기존 테스트 파일 호환성 수정

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] `npm run type-check` 통과

---

## 📝 추가 정보 (선택)

- 기존 코드와의 호환성을 위해 새 필드들은 optional로 설정
- 마이그레이션 Task (Task 9)에서 기존 데이터 변환 예정
- Requirements: 2.1, 3.1, 3.2, 3.3, 4.8
