### PR TITLE
[Feat] Task 5.3~5.4 - AddressSearch, LocationPicker 컴포넌트 구현

### DIFF
--- a/src/app/spots/register/page.tsx
+++ b/src/app/spots/register/page.tsx
@@ -2,15 +2,29 @@
 
 import { useEffect, useState, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import { useAuth } from '@/hooks/useAuth'
 import { AddressSearch } from '@/components/spot/AddressSearch'
-import { LocationPicker } from '@/components/spot/LocationPicker'
 import {
   CATEGORY_CONFIG,
   SpotCategory,
   Coordinates,
   RelatedContent,
 } from '@/types'
+
+// LocationPicker는 Leaflet을 사용하므로 SSR 비활성화
+const LocationPicker = dynamic(
+  () =>
+    import('@/components/spot/LocationPicker').then(
+      (mod) => mod.LocationPicker
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-64 w-full animate-pulse rounded-lg bg-navy-100" />
+    ),
+  }
+)
 
 // 폼 상태 인터페이스
 interface SpotFormData {

--- a/src/app/spots/register/page.tsx
+++ b/src/app/spots/register/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { AddressSearch } from '@/components/spot/AddressSearch'
+import { LocationPicker } from '@/components/spot/LocationPicker'
 import {
   CATEGORY_CONFIG,
   SpotCategory,
@@ -341,58 +342,25 @@ function SpotRegisterForm() {
             />
           </div>
 
-          {/* 좌표 표시 */}
-          {formData.coordinates && (
-            <div className="mb-4 rounded-lg border border-navy-200 bg-navy-50 p-3">
-              <p className="text-sm text-navy-600">
-                📍 선택된 좌표: {formData.coordinates.lat.toFixed(6)},{' '}
-                {formData.coordinates.lng.toFixed(6)}
-              </p>
-            </div>
-          )}
-
-          {/* 지도 위치 선택 (플레이스홀더 - Task 5.4에서 LocationPicker로 교체) */}
-          <div
-            className="cursor-pointer rounded-lg border-2 border-dashed border-navy-200 bg-navy-50 p-8 transition-colors hover:border-navy-300 hover:bg-navy-100"
-            onClick={() => {
-              // 임시: 테스트용 좌표 설정 (LocationPicker 구현 전까지)
-              if (!formData.coordinates) {
+          {/* 지도 위치 선택 */}
+          <LocationPicker
+            initialCoordinates={formData.coordinates || undefined}
+            onLocationChange={(coordinates) => {
+              setFormData((prev) => ({
+                ...prev,
+                coordinates,
+              }))
+            }}
+            onAddressSuggestion={(address) => {
+              // 주소가 비어있을 때만 자동 설정
+              if (!formData.address) {
                 setFormData((prev) => ({
                   ...prev,
-                  coordinates: { lat: 35.6762, lng: 139.6503 },
-                  address: prev.address || '도쿄, 일본',
+                  address,
                 }))
               }
             }}
-          >
-            <div className="flex flex-col items-center justify-center text-center">
-              <svg
-                className="mb-2 h-12 w-12 text-navy-300"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
-              <p className="text-sm text-navy-500">
-                클릭하여 테스트 좌표 설정 (LocationPicker는 Task 5.4에서 구현)
-              </p>
-              <p className="text-xs text-navy-400">
-                실제 지도 컴포넌트가 여기에 표시됩니다
-              </p>
-            </div>
-          </div>
+          />
         </div>
 
         {/* 사진 섹션 */}

--- a/src/app/spots/register/page.tsx
+++ b/src/app/spots/register/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
+import { AddressSearch } from '@/components/spot/AddressSearch'
 import {
   CATEGORY_CONFIG,
   SpotCategory,
@@ -325,35 +326,19 @@ function SpotRegisterForm() {
 
           {/* 주소 검색 */}
           <div className="mb-4">
-            <label
-              htmlFor="address"
-              className="mb-2 block text-sm font-medium text-navy-700"
-            >
+            <label className="mb-2 block text-sm font-medium text-navy-700">
               주소 <span className="text-red-500">*</span>
             </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                id="address"
-                name="address"
-                value={formData.address}
-                onChange={handleChange}
-                placeholder="주소를 입력하세요 (검색 기능은 Task 5.3에서 구현)"
-                className="flex-1 rounded-lg border border-navy-200 px-4 py-3 text-navy-800 placeholder-navy-400 transition-colors focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
-              />
-              <button
-                type="button"
-                className="rounded-lg bg-navy-600 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-navy-700"
-                onClick={() =>
-                  alert('주소 검색 기능은 Task 5.3에서 구현됩니다.')
-                }
-              >
-                검색
-              </button>
-            </div>
-            <p className="mt-1 text-xs text-navy-400">
-              주소 검색 또는 지도에서 직접 위치를 선택하세요
-            </p>
+            <AddressSearch
+              initialValue={formData.address}
+              onSelect={(address, coordinates) => {
+                setFormData((prev) => ({
+                  ...prev,
+                  address,
+                  coordinates,
+                }))
+              }}
+            />
           </div>
 
           {/* 좌표 표시 */}
@@ -366,16 +351,18 @@ function SpotRegisterForm() {
             </div>
           )}
 
-          {/* 지도 위치 선택 (플레이스홀더) */}
+          {/* 지도 위치 선택 (플레이스홀더 - Task 5.4에서 LocationPicker로 교체) */}
           <div
             className="cursor-pointer rounded-lg border-2 border-dashed border-navy-200 bg-navy-50 p-8 transition-colors hover:border-navy-300 hover:bg-navy-100"
             onClick={() => {
-              // 임시: 테스트용 좌표 설정
-              setFormData((prev) => ({
-                ...prev,
-                coordinates: { lat: 35.6762, lng: 139.6503 },
-                address: prev.address || '도쿄, 일본',
-              }))
+              // 임시: 테스트용 좌표 설정 (LocationPicker 구현 전까지)
+              if (!formData.coordinates) {
+                setFormData((prev) => ({
+                  ...prev,
+                  coordinates: { lat: 35.6762, lng: 139.6503 },
+                  address: prev.address || '도쿄, 일본',
+                }))
+              }
             }}
           >
             <div className="flex flex-col items-center justify-center text-center">

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -10,8 +10,16 @@ interface AddressSearchProps {
 
 interface AddressResult {
   address: string
-  roadAddress?: string
+  placeType?: string
   coordinates: Coordinates
+}
+
+interface NominatimResult {
+  lat: string
+  lon: string
+  display_name: string
+  type: string
+  class: string
 }
 
 /**
@@ -21,7 +29,7 @@ interface AddressResult {
  * - 4.4: 주소 검색/자동완성 기능
  * - 4.5: 선택 시 좌표 자동 설정
  *
- * Kakao 주소 검색 API 사용
+ * Nominatim (OpenStreetMap) API 사용 - 전세계 주소 검색 지원
  */
 export function AddressSearch({
   onSelect,
@@ -50,7 +58,7 @@ export function AddressSearch({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  // Kakao 주소 검색 API 호출
+  // Nominatim 주소 검색 API 호출
   const searchAddress = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim() || searchQuery.length < 2) {
       setResults([])
@@ -62,12 +70,12 @@ export function AddressSearch({
     setError(null)
 
     try {
-      // Kakao Local API 사용 (REST API)
+      // Nominatim API 사용 (OpenStreetMap)
       const response = await fetch(
-        `https://dapi.kakao.com/v2/local/search/address.json?query=${encodeURIComponent(searchQuery)}`,
+        `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(searchQuery)}&limit=5&addressdetails=1`,
         {
           headers: {
-            Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+            'Accept-Language': 'ko,en',
           },
         }
       )
@@ -76,49 +84,18 @@ export function AddressSearch({
         throw new Error('주소 검색에 실패했습니다')
       }
 
-      const data = await response.json()
+      const data: NominatimResult[] = await response.json()
 
-      const addressResults: AddressResult[] = data.documents.map(
-        (doc: any) => ({
-          address: doc.address_name || doc.address?.address_name,
-          roadAddress: doc.road_address?.address_name,
-          coordinates: {
-            lat: parseFloat(doc.y),
-            lng: parseFloat(doc.x),
-          },
-        })
-      )
+      const addressResults: AddressResult[] = data.map((item) => ({
+        address: item.display_name,
+        placeType: item.type,
+        coordinates: {
+          lat: parseFloat(item.lat),
+          lng: parseFloat(item.lon),
+        },
+      }))
 
-      // 주소 검색 결과가 없으면 키워드 검색 시도
-      if (addressResults.length === 0) {
-        const keywordResponse = await fetch(
-          `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(searchQuery)}`,
-          {
-            headers: {
-              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
-            },
-          }
-        )
-
-        if (keywordResponse.ok) {
-          const keywordData = await keywordResponse.json()
-
-          const keywordResults: AddressResult[] = keywordData.documents.map(
-            (doc: any) => ({
-              address: doc.address_name,
-              roadAddress: doc.road_address_name,
-              coordinates: {
-                lat: parseFloat(doc.y),
-                lng: parseFloat(doc.x),
-              },
-            })
-          )
-          setResults(keywordResults.slice(0, 5))
-        }
-      } else {
-        setResults(addressResults.slice(0, 5))
-      }
-
+      setResults(addressResults)
       setIsOpen(true)
     } catch (err) {
       setError(
@@ -148,10 +125,9 @@ export function AddressSearch({
 
   // 결과 선택
   const handleSelect = (result: AddressResult) => {
-    const displayAddress = result.roadAddress || result.address
-    setQuery(displayAddress)
+    setQuery(result.address)
     setIsOpen(false)
-    onSelect(displayAddress, result.coordinates)
+    onSelect(result.address, result.coordinates)
   }
 
   // 검색 버튼 클릭
@@ -180,7 +156,7 @@ export function AddressSearch({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onFocus={() => results.length > 0 && setIsOpen(true)}
-            placeholder="주소를 검색하세요 (예: 서울시 강남구)"
+            placeholder="주소 또는 장소명 검색 (예: Tokyo Dome, 서울역)"
             className="w-full rounded-lg border border-navy-200 px-4 py-3 pr-10 text-navy-800 placeholder-navy-400 transition-colors focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
           />
           {isLoading && (
@@ -252,12 +228,11 @@ export function AddressSearch({
                 </svg>
                 <div>
                   <p className="text-sm font-medium text-navy-800">
-                    {result.roadAddress || result.address}
+                    {result.address}
                   </p>
-                  {result.roadAddress &&
-                    result.address !== result.roadAddress && (
-                      <p className="text-xs text-navy-400">{result.address}</p>
-                    )}
+                  {result.placeType && (
+                    <p className="text-xs text-navy-400">{result.placeType}</p>
+                  )}
                 </div>
               </div>
             </button>
@@ -273,7 +248,7 @@ export function AddressSearch({
       )}
 
       <p className="mt-1 text-xs text-navy-400">
-        주소 또는 장소명을 입력하세요
+        전세계 주소 및 장소명 검색 가능 (Powered by OpenStreetMap)
       </p>
     </div>
   )

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { Coordinates } from '@/types'
+
+interface AddressSearchProps {
+  onSelect: (address: string, coordinates: Coordinates) => void
+  initialValue?: string
+}
+
+interface AddressResult {
+  address: string
+  roadAddress?: string
+  coordinates: Coordinates
+}
+
+/**
+ * 주소 검색 컴포넌트
+ *
+ * Requirements:
+ * - 4.4: 주소 검색/자동완성 기능
+ * - 4.5: 선택 시 좌표 자동 설정
+ *
+ * Kakao 주소 검색 API 사용
+ */
+export function AddressSearch({
+  onSelect,
+  initialValue = '',
+}: AddressSearchProps) {
+  const [query, setQuery] = useState(initialValue)
+  const [results, setResults] = useState<AddressResult[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<NodeJS.Timeout | null>(null)
+
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  // Kakao 주소 검색 API 호출
+  const searchAddress = useCallback(async (searchQuery: string) => {
+    if (!searchQuery.trim() || searchQuery.length < 2) {
+      setResults([])
+      setIsOpen(false)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      // Kakao Local API 사용 (REST API)
+      const response = await fetch(
+        `https://dapi.kakao.com/v2/local/search/address.json?query=${encodeURIComponent(searchQuery)}`,
+        {
+          headers: {
+            Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+          },
+        }
+      )
+
+      if (!response.ok) {
+        throw new Error('주소 검색에 실패했습니다')
+      }
+
+      const data = await response.json()
+
+      const addressResults: AddressResult[] = data.documents.map(
+        (doc: any) => ({
+          address: doc.address_name || doc.address?.address_name,
+          roadAddress: doc.road_address?.address_name,
+          coordinates: {
+            lat: parseFloat(doc.y),
+            lng: parseFloat(doc.x),
+          },
+        })
+      )
+
+      // 주소 검색 결과가 없으면 키워드 검색 시도
+      if (addressResults.length === 0) {
+        const keywordResponse = await fetch(
+          `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(searchQuery)}`,
+          {
+            headers: {
+              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+            },
+          }
+        )
+
+        if (keywordResponse.ok) {
+          const keywordData = await keywordResponse.json()
+
+          const keywordResults: AddressResult[] = keywordData.documents.map(
+            (doc: any) => ({
+              address: doc.address_name,
+              roadAddress: doc.road_address_name,
+              coordinates: {
+                lat: parseFloat(doc.y),
+                lng: parseFloat(doc.x),
+              },
+            })
+          )
+          setResults(keywordResults.slice(0, 5))
+        }
+      } else {
+        setResults(addressResults.slice(0, 5))
+      }
+
+      setIsOpen(true)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '주소 검색 중 오류가 발생했습니다'
+      )
+      setResults([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // 디바운스된 검색
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setQuery(value)
+
+    // 기존 타이머 취소
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+    }
+
+    // 300ms 후 검색 실행
+    debounceRef.current = setTimeout(() => {
+      searchAddress(value)
+    }, 300)
+  }
+
+  // 결과 선택
+  const handleSelect = (result: AddressResult) => {
+    const displayAddress = result.roadAddress || result.address
+    setQuery(displayAddress)
+    setIsOpen(false)
+    onSelect(displayAddress, result.coordinates)
+  }
+
+  // 검색 버튼 클릭
+  const handleSearchClick = () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+    }
+    searchAddress(query)
+  }
+
+  // Enter 키 처리
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSearchClick()
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            value={query}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            onFocus={() => results.length > 0 && setIsOpen(true)}
+            placeholder="주소를 검색하세요 (예: 서울시 강남구)"
+            className="w-full rounded-lg border border-navy-200 px-4 py-3 pr-10 text-navy-800 placeholder-navy-400 transition-colors focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
+          />
+          {isLoading && (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              <svg
+                className="h-5 w-5 animate-spin text-navy-400"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleSearchClick}
+          disabled={isLoading}
+          className="rounded-lg bg-navy-600 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-navy-700 disabled:opacity-50"
+        >
+          검색
+        </button>
+      </div>
+
+      {/* 에러 메시지 */}
+      {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+
+      {/* 검색 결과 드롭다운 */}
+      {isOpen && results.length > 0 && (
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-navy-200 bg-white shadow-lg">
+          {results.map((result, index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={() => handleSelect(result)}
+              className="w-full px-4 py-3 text-left transition-colors hover:bg-navy-50"
+            >
+              <div className="flex items-start gap-2">
+                <svg
+                  className="mt-0.5 h-4 w-4 flex-shrink-0 text-navy-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+                <div>
+                  <p className="text-sm font-medium text-navy-800">
+                    {result.roadAddress || result.address}
+                  </p>
+                  {result.roadAddress &&
+                    result.address !== result.roadAddress && (
+                      <p className="text-xs text-navy-400">{result.address}</p>
+                    )}
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* 검색 결과 없음 */}
+      {isOpen && results.length === 0 && !isLoading && query.length >= 2 && (
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-navy-200 bg-white p-4 text-center shadow-lg">
+          <p className="text-sm text-navy-500">검색 결과가 없습니다</p>
+        </div>
+      )}
+
+      <p className="mt-1 text-xs text-navy-400">
+        주소 또는 장소명을 입력하세요
+      </p>
+    </div>
+  )
+}

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -72,7 +72,7 @@ export function LocationPicker({
     }
   }, [initialCoordinates])
 
-  // 역지오코딩 (좌표 → 주소)
+  // 역지오코딩 (좌표 → 주소) - Nominatim API 사용
   const reverseGeocode = useCallback(
     async (coordinates: Coordinates) => {
       if (!onAddressSuggestion) return
@@ -80,23 +80,18 @@ export function LocationPicker({
       setIsLoading(true)
       try {
         const response = await fetch(
-          `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${coordinates.lng}&y=${coordinates.lat}`,
+          `https://nominatim.openstreetmap.org/reverse?format=json&lat=${coordinates.lat}&lon=${coordinates.lng}&addressdetails=1`,
           {
             headers: {
-              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+              'Accept-Language': 'ko,en',
             },
           }
         )
 
         if (response.ok) {
           const data = await response.json()
-          if (data.documents && data.documents.length > 0) {
-            const doc = data.documents[0]
-            const address =
-              doc.road_address?.address_name || doc.address?.address_name
-            if (address) {
-              onAddressSuggestion(address)
-            }
+          if (data.display_name) {
+            onAddressSuggestion(data.display_name)
           }
         }
       } catch {

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet'
+import { Map as LeafletMap, Icon, LatLng } from 'leaflet'
+import { Coordinates } from '@/types'
+
+// 커스텀 마커 아이콘
+const customIcon = new Icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  iconRetinaUrl:
+    'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
+interface LocationPickerProps {
+  initialCoordinates?: Coordinates
+  onLocationChange: (coordinates: Coordinates) => void
+  onAddressSuggestion?: (address: string) => void
+}
+
+// 지도 클릭 이벤트 핸들러 컴포넌트
+function MapClickHandler({
+  onLocationSelect,
+}: {
+  onLocationSelect: (latlng: LatLng) => void
+}) {
+  useMapEvents({
+    click: (e) => {
+      onLocationSelect(e.latlng)
+    },
+  })
+  return null
+}
+
+/**
+ * 위치 선택 컴포넌트
+ *
+ * Requirements:
+ * - 5.1: 지도 기반 위치 선택
+ * - 5.2: 지도 클릭으로 마커 배치
+ * - 5.3: 좌표 자동 업데이트
+ * - 5.4: 마커 드래그 기능
+ * - 5.5: 역지오코딩 주소 제안
+ */
+export function LocationPicker({
+  initialCoordinates,
+  onLocationChange,
+  onAddressSuggestion,
+}: LocationPickerProps) {
+  const mapRef = useRef<LeafletMap | null>(null)
+  const [markerPosition, setMarkerPosition] = useState<Coordinates | null>(
+    initialCoordinates || null
+  )
+  const [isLoading, setIsLoading] = useState(false)
+
+  // 초기 좌표가 변경되면 마커 위치 업데이트
+  useEffect(() => {
+    if (initialCoordinates) {
+      setMarkerPosition(initialCoordinates)
+      // 지도 중심도 이동
+      if (mapRef.current) {
+        mapRef.current.setView(
+          [initialCoordinates.lat, initialCoordinates.lng],
+          15
+        )
+      }
+    }
+  }, [initialCoordinates])
+
+  // 역지오코딩 (좌표 → 주소)
+  const reverseGeocode = useCallback(
+    async (coordinates: Coordinates) => {
+      if (!onAddressSuggestion) return
+
+      setIsLoading(true)
+      try {
+        const response = await fetch(
+          `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${coordinates.lng}&y=${coordinates.lat}`,
+          {
+            headers: {
+              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+            },
+          }
+        )
+
+        if (response.ok) {
+          const data = await response.json()
+          if (data.documents && data.documents.length > 0) {
+            const doc = data.documents[0]
+            const address =
+              doc.road_address?.address_name || doc.address?.address_name
+            if (address) {
+              onAddressSuggestion(address)
+            }
+          }
+        }
+      } catch {
+        // 역지오코딩 실패 시 무시
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [onAddressSuggestion]
+  )
+
+  // 위치 선택 핸들러
+  const handleLocationSelect = useCallback(
+    (latlng: LatLng) => {
+      const coordinates: Coordinates = {
+        lat: latlng.lat,
+        lng: latlng.lng,
+      }
+      setMarkerPosition(coordinates)
+      onLocationChange(coordinates)
+      reverseGeocode(coordinates)
+    },
+    [onLocationChange, reverseGeocode]
+  )
+
+  // 마커 드래그 종료 핸들러
+  const handleMarkerDragEnd = useCallback(
+    (e: L.DragEndEvent) => {
+      const marker = e.target
+      const position = marker.getLatLng()
+      const coordinates: Coordinates = {
+        lat: position.lat,
+        lng: position.lng,
+      }
+      setMarkerPosition(coordinates)
+      onLocationChange(coordinates)
+      reverseGeocode(coordinates)
+    },
+    [onLocationChange, reverseGeocode]
+  )
+
+  // 기본 중심 좌표 (서울)
+  const defaultCenter: [number, number] = [37.5665, 126.978]
+  const center: [number, number] = markerPosition
+    ? [markerPosition.lat, markerPosition.lng]
+    : defaultCenter
+
+  return (
+    <div className="relative">
+      {/* 안내 메시지 */}
+      <div className="mb-2 flex items-center gap-2 text-sm text-navy-500">
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <span>지도를 클릭하거나 마커를 드래그하여 위치를 선택하세요</span>
+        {isLoading && (
+          <svg
+            className="h-4 w-4 animate-spin text-navy-400"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+        )}
+      </div>
+
+      {/* 지도 컨테이너 */}
+      <div className="h-64 w-full overflow-hidden rounded-lg border-2 border-navy-200">
+        <MapContainer
+          center={center}
+          zoom={markerPosition ? 15 : 6}
+          className="h-full w-full"
+          ref={mapRef}
+          zoomControl={false}
+          scrollWheelZoom={true}
+          doubleClickZoom={false}
+          dragging={true}
+          touchZoom={true}
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
+            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+            maxZoom={19}
+          />
+
+          {/* 클릭 이벤트 핸들러 */}
+          <MapClickHandler onLocationSelect={handleLocationSelect} />
+
+          {/* 마커 */}
+          {markerPosition && (
+            <Marker
+              position={[markerPosition.lat, markerPosition.lng]}
+              icon={customIcon}
+              draggable={true}
+              eventHandlers={{
+                dragend: handleMarkerDragEnd,
+              }}
+            />
+          )}
+        </MapContainer>
+      </div>
+
+      {/* 줌 컨트롤 */}
+      <div className="absolute right-2 top-10 z-[1000] flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={() => mapRef.current?.zoomIn()}
+          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-gray-100"
+          aria-label="확대"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 6v12m6-6H6"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onClick={() => mapRef.current?.zoomOut()}
+          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-gray-100"
+          aria-label="축소"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M18 12H6"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* 선택된 좌표 표시 */}
+      {markerPosition && (
+        <div className="mt-2 rounded-lg border border-navy-200 bg-navy-50 p-2">
+          <p className="text-xs text-navy-600">
+            📍 {markerPosition.lat.toFixed(6)}, {markerPosition.lng.toFixed(6)}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #111

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 스팟 등록 페이지에 주소 검색 및 지도 위치 선택 기능 구현

---

## 📋 변경 사항

- [x] AddressSearch 컴포넌트 구현 (Nominatim API 사용)
- [x] LocationPicker 컴포넌트 구현 (Leaflet 기반)
- [x] 스팟 등록 페이지에 두 컴포넌트 통합
- [x] 전세계 주소 검색 지원 (Kakao → Nominatim 변경)
- [x] 역지오코딩 기능 구현 (지도 클릭 시 주소 자동 제안)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Nominatim (OpenStreetMap) API 사용으로 해외 주소 검색 지원 (예: Tokyo Dome, 秋葉原)
- IP 기반 rate limiting (1 req/sec per user)으로 동시 사용자 처리 가능
- Requirements: 4.4, 4.5, 5.1, 5.2, 5.3, 5.4, 5.5


## 📸 스크린샷 (선택)

<img width="1474" height="1007" alt="image" src="https://github.com/user-attachments/assets/7bb46fd3-5ac6-4b32-a73e-75eb4bc9446a" />
