### PR TITLE
[Feat] Task 7.1 - 스팟 수정 페이지 구현

### DIFF
--- a/.kiro/specs/not-a-trip-rebrand/tasks.md
+++ b/.kiro/specs/not-a-trip-rebrand/tasks.md
@@ -63,34 +63,34 @@
     - 필터 상태에 따른 스팟 표시
     - _Requirements: 2.2_
 
-- [ ] 5. 스팟 등록 페이지 구현 (회원 전용)
-  - [ ] 5.1 스팟 등록 페이지 생성
+- [-] 5. 스팟 등록 페이지 구현 (회원 전용)
+  - [x] 5.1 스팟 등록 페이지 생성
     - `src/app/spots/register/page.tsx` 생성
     - 기본 폼 레이아웃 구현
     - 비로그인 시 로그인 페이지로 리다이렉트
     - _Requirements: 4.1, 4.8_
-  - [ ] 5.2 스팟 등록 폼 구현
+  - [x] 5.2 스팟 등록 폼 구현
     - 필수 필드: 이름, 설명, 주소, 카테고리
     - 선택 필드: 사진 (최대 5장), 관련 콘텐츠
     - 로그인 사용자 정보 자동 설정 (authorId, authorName)
     - _Requirements: 4.2, 4.3_
-  - [ ] 5.3 AddressSearch 컴포넌트 구현
+  - [x] 5.3 AddressSearch 컴포넌트 구현
     - `src/components/spot/AddressSearch.tsx` 생성
     - 주소 검색/자동완성 기능
     - 선택 시 좌표 자동 설정
     - _Requirements: 4.4, 4.5_
-  - [ ] 5.4 LocationPicker 컴포넌트 구현
+  - [x] 5.4 LocationPicker 컴포넌트 구현
     - `src/components/spot/LocationPicker.tsx` 생성
     - 지도 클릭으로 위치 선택
     - 마커 드래그 기능
     - 역지오코딩 주소 제안
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
-  - [ ] 5.5 RelatedContentForm 컴포넌트 구현
+  - [x] 5.5 RelatedContentForm 컴포넌트 구현
     - `src/components/spot/RelatedContentForm.tsx` 생성
     - 관련 콘텐츠 추가/삭제 UI
     - 콘텐츠 타입 선택
     - _Requirements: 4.3_
-  - [ ] 5.6 스팟 등록 API 구현
+  - [x] 5.6 스팟 등록 API 구현
     - `POST /api/spots` 구현
     - 필수 필드 유효성 검사
     - 인증된 사용자만 등록 가능 (세션 검증)
@@ -104,25 +104,25 @@
     - **Property 7: 스팟 등록 인증 검증**
     - _For any_ 스팟 등록 요청에서, 인증되지 않은 사용자는 등록이 거부되어야 함
     - **Validates: Requirements 4.8**
-  - [ ] 5.9 useSpotRegistration 훅 구현
+  - [x] 5.9 useSpotRegistration 훅 구현
     - `src/hooks/useSpotRegistration.ts` 생성
     - 스팟 등록 mutation
     - 폼 상태 관리
     - _Requirements: 4.7_
 
-- [ ] 6. Checkpoint - 스팟 등록 기능 확인
+- [x] 6. Checkpoint - 스팟 등록 기능 확인
   - 스팟 등록 폼 동작 확인
   - 비로그인 시 리다이렉트 확인
   - 회원 등록 테스트
   - 사용자 피드백 수렴
 
-- [ ] 7. 스팟 수정/삭제 기능 구현 (회원 전용)
-  - [ ] 7.1 스팟 수정 페이지 구현
+- [-] 7. 스팟 수정/삭제 기능 구현 (회원 전용)
+  - [x] 7.1 스팟 수정 페이지 구현
     - `src/app/spots/[id]/edit/page.tsx` 생성
     - 기존 데이터 로드 및 수정 폼
     - 본인 스팟만 수정 가능
     - _Requirements: 6.1_
-  - [ ] 7.2 스팟 수정 API 구현
+  - [-] 7.2 스팟 수정 API 구현
     - `PUT /api/spots/[id]` 구현
     - 인증된 사용자만 수정 가능
     - 본인 스팟 여부 검증 (authorId === userId)

--- a/src/app/spots/[id]/edit/page.tsx
+++ b/src/app/spots/[id]/edit/page.tsx
@@ -1,0 +1,585 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { useAuth } from '@/hooks/useAuth'
+import { useSpotEdit } from '@/hooks/useSpotEdit'
+import { useSpotDetail } from '@/hooks/useSpotDetail'
+import { AddressSearch } from '@/components/spot/AddressSearch'
+import { RelatedContentForm } from '@/components/spot/RelatedContentForm'
+import { CATEGORY_CONFIG, SpotCategory } from '@/types'
+
+// LocationPicker는 Leaflet을 사용하므로 SSR 비활성화
+const LocationPicker = dynamic(
+  () =>
+    import('@/components/spot/LocationPicker').then(
+      (mod) => mod.LocationPicker
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-64 w-full animate-pulse rounded-lg bg-navy-100" />
+    ),
+  }
+)
+
+/**
+ * 스팟 수정 폼 스켈레톤
+ */
+function EditFormSkeleton() {
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      <div className="animate-pulse space-y-6">
+        <div className="h-16 w-full rounded-lg bg-gray-200"></div>
+        <div>
+          <div className="mb-2 h-4 w-20 rounded bg-gray-200"></div>
+          <div className="h-12 w-full rounded-lg bg-gray-200"></div>
+        </div>
+        <div>
+          <div className="mb-2 h-4 w-20 rounded bg-gray-200"></div>
+          <div className="h-12 w-full rounded-lg bg-gray-200"></div>
+        </div>
+        <div>
+          <div className="mb-2 h-4 w-20 rounded bg-gray-200"></div>
+          <div className="h-32 w-full rounded-lg bg-gray-200"></div>
+        </div>
+        <div className="h-64 w-full rounded-lg bg-gray-200"></div>
+        <div className="flex justify-end gap-3 pt-4">
+          <div className="h-10 w-20 rounded-lg bg-gray-200"></div>
+          <div className="h-10 w-20 rounded-lg bg-gray-200"></div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 권한 없음 컴포넌트
+ */
+function NoPermission() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow-md">
+        <div className="text-center">
+          <svg
+            className="mx-auto mb-4 h-16 w-16 text-red-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
+          </svg>
+          <h2 className="mb-2 text-xl font-bold text-gray-900">
+            수정 권한이 없습니다
+          </h2>
+          <p className="mb-4 text-gray-600">
+            본인이 등록한 스팟만 수정할 수 있습니다.
+          </p>
+          <Link
+            href="/"
+            className="inline-flex items-center rounded-md bg-navy-600 px-4 py-2 text-white transition-colors hover:bg-navy-700"
+          >
+            메인으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 스팟 수정 폼 컴포넌트
+ *
+ * Requirements:
+ * - 6.1: 기존 데이터 로드 및 수정 폼
+ * - 6.2: 본인 스팟만 수정 가능
+ */
+function SpotEditForm({ spotId }: { spotId: string }) {
+  const router = useRouter()
+  const {
+    formData,
+    setFormData,
+    errors,
+    isLoading,
+    isSubmitting,
+    isDeleting,
+    handleChange,
+    handleSubmit,
+    handleDelete,
+  } = useSpotEdit(spotId)
+
+  // 취소 핸들러
+  const handleCancel = () => {
+    if (confirm('수정 중인 내용이 있습니다. 정말 취소하시겠습니까?')) {
+      router.push(`/spots/${spotId}`)
+    }
+  }
+
+  if (isLoading) {
+    return <EditFormSkeleton />
+  }
+
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      {/* 에러 메시지 표시 */}
+      {errors.length > 0 && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4">
+          <div className="flex items-start gap-3">
+            <svg
+              className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <div>
+              <h3 className="font-medium text-red-800">
+                입력 내용을 확인해주세요
+              </h3>
+              <ul className="mt-1 list-inside list-disc text-sm text-red-700">
+                {errors.map((error, index) => (
+                  <li key={index}>{error}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 수정 폼 */}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* 기본 정보 섹션 */}
+        <div className="border-b border-navy-100 pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-navy-800">
+            기본 정보
+          </h2>
+
+          {/* 스팟 이름 */}
+          <div className="mb-4">
+            <label
+              htmlFor="name"
+              className="mb-2 block text-sm font-medium text-navy-700"
+            >
+              스팟 이름 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              id="name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              placeholder="스팟 이름을 입력하세요"
+              className="w-full rounded-lg border border-navy-200 px-4 py-3 text-navy-800 placeholder-navy-400 transition-colors focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
+              maxLength={100}
+            />
+            <p className="mt-1 text-right text-xs text-navy-400">
+              {formData.name.length}/100
+            </p>
+          </div>
+
+          {/* 카테고리 */}
+          <div className="mb-4">
+            <label
+              htmlFor="category"
+              className="mb-2 block text-sm font-medium text-navy-700"
+            >
+              카테고리 <span className="text-red-500">*</span>
+            </label>
+            <select
+              id="category"
+              name="category"
+              value={formData.category}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-navy-200 px-4 py-3 text-navy-800 transition-colors focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
+            >
+              <option value="">카테고리를 선택하세요</option>
+              {(Object.keys(CATEGORY_CONFIG) as SpotCategory[]).map((key) => (
+                <option key={key} value={key}>
+                  {CATEGORY_CONFIG[key].icon} {CATEGORY_CONFIG[key].label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 설명 */}
+          <div>
+            <label
+              htmlFor="description"
+              className="mb-2 block text-sm font-medium text-navy-700"
+            >
+              설명 <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              placeholder="스팟에 대한 설명을 입력하세요"
+              rows={4}
+              className="w-full resize-none rounded-lg border border-navy-200 px-4 py-3 text-navy-800 placeholder-navy-400 transition-colors focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
+              maxLength={2000}
+            />
+            <p className="mt-1 text-right text-xs text-navy-400">
+              {formData.description.length}/2000
+            </p>
+          </div>
+        </div>
+
+        {/* 위치 정보 섹션 */}
+        <div className="border-b border-navy-100 pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-navy-800">
+            위치 정보
+          </h2>
+
+          {/* 주소 검색 */}
+          <div className="mb-4">
+            <label className="mb-2 block text-sm font-medium text-navy-700">
+              주소 <span className="text-red-500">*</span>
+            </label>
+            <AddressSearch
+              initialValue={formData.address}
+              onSelect={(address, coordinates) => {
+                setFormData((prev) => ({
+                  ...prev,
+                  address,
+                  coordinates,
+                }))
+              }}
+            />
+          </div>
+
+          {/* 지도 위치 선택 */}
+          <LocationPicker
+            initialCoordinates={formData.coordinates || undefined}
+            onLocationChange={(coordinates) => {
+              setFormData((prev) => ({
+                ...prev,
+                coordinates,
+              }))
+            }}
+            onAddressSuggestion={(address) => {
+              if (!formData.address) {
+                setFormData((prev) => ({
+                  ...prev,
+                  address,
+                }))
+              }
+            }}
+          />
+        </div>
+
+        {/* 사진 섹션 */}
+        <div className="border-b border-navy-100 pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-navy-800">
+            사진{' '}
+            <span className="text-xs font-normal text-navy-400">
+              (선택, 최대 5장)
+            </span>
+          </h2>
+          <div className="rounded-lg border-2 border-dashed border-navy-200 bg-navy-50 p-8">
+            <div className="flex flex-col items-center justify-center text-center">
+              <svg
+                className="mb-2 h-12 w-12 text-navy-300"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <p className="text-sm text-navy-500">
+                사진 업로드 기능은 추후 구현 예정입니다
+              </p>
+              <p className="text-xs text-navy-400">JPG, PNG 형식 (최대 5MB)</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 관련 콘텐츠 섹션 */}
+        <div className="border-b border-navy-100 pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-navy-800">
+            관련 콘텐츠{' '}
+            <span className="text-xs font-normal text-navy-400">(선택)</span>
+          </h2>
+          <RelatedContentForm
+            value={formData.relatedContent}
+            onChange={(contents) => {
+              setFormData((prev) => ({
+                ...prev,
+                relatedContent: contents,
+              }))
+            }}
+          />
+        </div>
+
+        {/* 버튼 영역 */}
+        <div className="flex items-center justify-between pt-4">
+          {/* 삭제 버튼 */}
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isDeleting || isSubmitting}
+            className="rounded-lg border border-red-300 px-4 py-2.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isDeleting ? (
+              <span className="flex items-center gap-2">
+                <svg
+                  className="h-4 w-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                삭제 중...
+              </span>
+            ) : (
+              '스팟 삭제'
+            )}
+          </button>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="rounded-lg border border-navy-300 px-6 py-2.5 text-sm font-medium text-navy-600 transition-colors hover:bg-navy-50"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || isDeleting}
+              className="rounded-lg bg-navy-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? (
+                <span className="flex items-center gap-2">
+                  <svg
+                    className="h-4 w-4 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  수정 중...
+                </span>
+              ) : (
+                '수정하기'
+              )}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+/**
+ * 로그인 필요 모달 컴포넌트
+ */
+function LoginRequiredModal({
+  isOpen,
+  onConfirm,
+}: {
+  isOpen: boolean
+  onConfirm: () => void
+}) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+        <div className="mb-4 flex justify-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
+            <svg
+              className="h-6 w-6 text-amber-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+              />
+            </svg>
+          </div>
+        </div>
+        <h3 className="mb-2 text-center text-lg font-semibold text-navy-800">
+          로그인이 필요한 서비스입니다
+        </h3>
+        <p className="mb-6 text-center text-sm text-navy-500">
+          스팟을 수정하려면 로그인이 필요합니다.
+          <br />
+          로그인 페이지로 이동합니다.
+        </p>
+        <button
+          onClick={onConfirm}
+          className="w-full rounded-lg bg-navy-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+        >
+          로그인하러 가기
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 스팟 수정 페이지
+ *
+ * Requirements:
+ * - 6.1: 스팟 수정 페이지에서 기존 데이터 로드 및 수정
+ * - 6.2: 인증된 사용자만 본인 스팟 수정 가능
+ */
+export default function SpotEditPage() {
+  const params = useParams()
+  const router = useRouter()
+  const spotId = params.id as string
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth()
+  const { data: spot, isLoading: spotLoading } = useSpotDetail(spotId)
+  const [showLoginModal, setShowLoginModal] = useState(false)
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      setShowLoginModal(true)
+    }
+  }, [isAuthenticated, authLoading])
+
+  const handleLoginConfirm = () => {
+    router.push(`/auth/signin?callbackUrl=/spots/${spotId}/edit`)
+  }
+
+  // 로딩 중
+  if (authLoading || spotLoading) {
+    return (
+      <main className="min-h-screen bg-navy-50">
+        <div className="border-b border-navy-200 bg-white px-4 py-4">
+          <div className="mx-auto max-w-4xl">
+            <Link
+              href={`/spots/${spotId}`}
+              className="flex items-center gap-2 text-navy-500 hover:text-navy-700"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10 19l-7-7m0 0l7-7m-7 7h18"
+                />
+              </svg>
+              <span>스팟으로 돌아가기</span>
+            </Link>
+            <h1 className="mt-2 text-xl font-bold text-navy-800">스팟 수정</h1>
+          </div>
+        </div>
+        <div className="mx-auto max-w-4xl px-4 py-6">
+          <EditFormSkeleton />
+        </div>
+        <LoginRequiredModal
+          isOpen={showLoginModal}
+          onConfirm={handleLoginConfirm}
+        />
+      </main>
+    )
+  }
+
+  // 비로그인 상태
+  if (!isAuthenticated) {
+    return (
+      <main className="min-h-screen bg-navy-50">
+        <div className="border-b border-navy-200 bg-white px-4 py-4">
+          <div className="mx-auto max-w-4xl">
+            <h1 className="text-xl font-bold text-navy-800">스팟 수정</h1>
+          </div>
+        </div>
+        <div className="mx-auto max-w-4xl px-4 py-6">
+          <EditFormSkeleton />
+        </div>
+        <LoginRequiredModal isOpen={true} onConfirm={handleLoginConfirm} />
+      </main>
+    )
+  }
+
+  // 권한 확인: 본인 스팟만 수정 가능 (Requirements 6.2)
+  if (spot && spot.authorId && spot.authorId !== user?.id) {
+    return <NoPermission />
+  }
+
+  return (
+    <main className="min-h-screen bg-navy-50">
+      <div className="border-b border-navy-200 bg-white px-4 py-4">
+        <div className="mx-auto max-w-4xl">
+          <Link
+            href={`/spots/${spotId}`}
+            className="flex items-center gap-2 text-navy-500 hover:text-navy-700"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            <span>스팟으로 돌아가기</span>
+          </Link>
+          <h1 className="mt-2 text-xl font-bold text-navy-800">스팟 수정</h1>
+          <p className="text-sm text-navy-500">스팟 정보를 수정하세요</p>
+        </div>
+      </div>
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        <SpotEditForm spotId={spotId} />
+      </div>
+    </main>
+  )
+}

--- a/src/hooks/useSpotEdit.ts
+++ b/src/hooks/useSpotEdit.ts
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState, useCallback, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { SpotCategory, RelatedContent, UpdateSpotInput } from '@/types'
+import { SpotFormData } from './useSpotRegistration'
+import { spotKeys } from './useSpots'
+
+// 스팟 상세 데이터 인터페이스 (수정용)
+interface SpotEditData {
+  id: string
+  name: string
+  description: string
+  photos: string[]
+  address: string
+  coordinates: [number, number]
+  category?: SpotCategory
+  relatedContent?: RelatedContent[]
+  authorId?: string
+  authorName?: string
+}
+
+interface UseSpotEditReturn {
+  formData: SpotFormData
+  setFormData: React.Dispatch<React.SetStateAction<SpotFormData>>
+  errors: string[]
+  isLoading: boolean
+  isSubmitting: boolean
+  isDeleting: boolean
+  handleChange: (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => void
+  handleSubmit: (e: React.FormEvent) => Promise<void>
+  handleDelete: () => Promise<void>
+  validateForm: () => string[]
+}
+
+/**
+ * 스팟 수정 훅
+ *
+ * Requirements:
+ * - 6.1: 스팟 수정 페이지에서 기존 데이터 로드 및 수정
+ * - 6.2: 인증된 사용자만 본인 스팟 수정 가능
+ */
+export function useSpotEdit(spotId: string): UseSpotEditReturn {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const [formData, setFormData] = useState<SpotFormData>({
+    name: '',
+    description: '',
+    address: '',
+    coordinates: null,
+    category: '',
+    photos: [],
+    relatedContent: [],
+  })
+  const [errors, setErrors] = useState<string[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  // 스팟 데이터 조회
+  const { data: spot, isLoading } = useQuery({
+    queryKey: spotKeys.detail(spotId),
+    queryFn: async (): Promise<SpotEditData> => {
+      const response = await fetch(`/api/spots/${spotId}`)
+      if (!response.ok) {
+        throw new Error('스팟을 불러올 수 없습니다')
+      }
+      return response.json()
+    },
+    enabled: !!spotId,
+  })
+
+  // 스팟 데이터가 로드되면 폼에 설정
+  useEffect(() => {
+    if (spot) {
+      setFormData({
+        name: spot.name,
+        description: spot.description,
+        address: spot.address,
+        coordinates: spot.coordinates
+          ? { lat: spot.coordinates[0], lng: spot.coordinates[1] }
+          : null,
+        category: spot.category || '',
+        photos: spot.photos || [],
+        relatedContent: spot.relatedContent || [],
+      })
+    }
+  }, [spot])
+
+  // 필드 변경 핸들러
+  const handleChange = useCallback(
+    (
+      e: React.ChangeEvent<
+        HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+      >
+    ) => {
+      const { name, value } = e.target
+      setFormData((prev) => ({ ...prev, [name]: value }))
+    },
+    []
+  )
+
+  // 유효성 검사
+  const validateForm = useCallback((): string[] => {
+    const validationErrors: string[] = []
+
+    if (!formData.name.trim()) {
+      validationErrors.push('스팟 이름은 필수입니다')
+    } else if (formData.name.trim().length < 2) {
+      validationErrors.push('스팟 이름은 2자 이상이어야 합니다')
+    }
+
+    if (!formData.category) {
+      validationErrors.push('카테고리를 선택해주세요')
+    }
+
+    if (!formData.description.trim()) {
+      validationErrors.push('설명은 필수입니다')
+    } else if (formData.description.trim().length < 10) {
+      validationErrors.push('설명은 10자 이상이어야 합니다')
+    }
+
+    if (!formData.address.trim()) {
+      validationErrors.push('주소는 필수입니다')
+    }
+
+    if (!formData.coordinates) {
+      validationErrors.push('지도에서 위치를 선택해주세요')
+    }
+
+    return validationErrors
+  }, [formData])
+
+  // 스팟 수정 제출 핸들러
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+
+      const validationErrors = validateForm()
+      if (validationErrors.length > 0) {
+        setErrors(validationErrors)
+        return
+      }
+
+      setErrors([])
+      setIsSubmitting(true)
+
+      try {
+        const requestBody: UpdateSpotInput = {
+          name: formData.name.trim(),
+          description: formData.description.trim(),
+          address: formData.address.trim(),
+          coordinates: formData.coordinates!,
+          category: formData.category as SpotCategory,
+          photos: formData.photos,
+          relatedContent: formData.relatedContent,
+        }
+
+        const response = await fetch(`/api/spots/${spotId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        })
+
+        const data = await response.json()
+
+        if (!response.ok) {
+          if (data.details) {
+            setErrors(data.details)
+          } else {
+            setErrors([data.error || '스팟 수정에 실패했습니다'])
+          }
+          return
+        }
+
+        // 캐시 무효화
+        queryClient.invalidateQueries({ queryKey: spotKeys.detail(spotId) })
+        queryClient.invalidateQueries({ queryKey: spotKeys.all })
+
+        // 성공 시 스팟 상세 페이지로 이동
+        router.push(`/spots/${spotId}`)
+      } catch {
+        setErrors(['스팟 수정에 실패했습니다. 다시 시도해주세요.'])
+      } finally {
+        setIsSubmitting(false)
+      }
+    },
+    [formData, validateForm, spotId, router, queryClient]
+  )
+
+  // 스팟 삭제 핸들러
+  const handleDelete = useCallback(async () => {
+    if (
+      !confirm(
+        '정말로 이 스팟을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'
+      )
+    ) {
+      return
+    }
+
+    setIsDeleting(true)
+
+    try {
+      const response = await fetch(`/api/spots/${spotId}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        setErrors([data.error || '스팟 삭제에 실패했습니다'])
+        return
+      }
+
+      // 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: spotKeys.all })
+
+      // 성공 시 메인 페이지로 이동 (Requirements 6.5)
+      router.push('/')
+    } catch {
+      setErrors(['스팟 삭제에 실패했습니다. 다시 시도해주세요.'])
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [spotId, router, queryClient])
+
+  return {
+    formData,
+    setFormData,
+    errors,
+    isLoading,
+    isSubmitting,
+    isDeleting,
+    handleChange,
+    handleSubmit,
+    handleDelete,
+    validateForm,
+  }
+}

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -32,6 +32,10 @@ export interface SpotDetailData {
   address: string
   coordinates: [number, number]
   relatedMedia: MediaInfo[]
+  // 작성자 정보 (마이그레이션 전 optional)
+  authorId?: string
+  authorName?: string
+  isGuestSpot?: boolean
 }
 
 // API response types


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #115

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 스팟 수정 페이지 및 수정용 훅 구현 (Task 7.1)

---

## 📋 변경 사항

- [x] `src/app/spots/[id]/edit/page.tsx` 스팟 수정 페이지 생성
- [x] `src/hooks/useSpotEdit.ts` 스팟 수정 훅 구현
- [x] `src/hooks/useSpots.ts` SpotDetailData 타입에 authorId 필드 추가
- [x] 기존 데이터 로드 및 수정 폼 구현
- [x] 본인 스팟만 수정 가능하도록 권한 검증

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- **Requirements**: 6.1
- Task 7.2, 7.3, 7.6은 별도 브랜치에서 진행 예정 (500줄 이하 원칙)
