### PR TITLE
Fix/133  spotpin hover flicker  fix

### DIFF
--- a/.kiro/specs/not-a-trip-rebrand/tasks.md
+++ b/.kiro/specs/not-a-trip-rebrand/tasks.md
@@ -223,16 +223,16 @@
     - 콘텐츠 타입별 아이콘
     - _Requirements: 3.3_
 
-- [ ] 13. SpotPin 호버 깜빡임 버그 수정
-  - [ ] 13.1 호버 상태 Debounce 적용
+- [x] 13. SpotPin 호버 깜빡임 버그 수정
+  - [x] 13.1 호버 상태 Debounce 적용
     - `src/components/map/SpotPin.tsx` 수정
     - `handleMouseOver`, `handleMouseOut`에 debounce 적용 (50ms)
     - lodash debounce 또는 커스텀 훅 사용
-  - [ ] 13.2 호버 시 Z-Index 최상위 설정
+  - [x] 13.2 호버 시 Z-Index 최상위 설정
     - 호버된 핀의 zIndexOffset을 1000으로 설정
     - 선택된 핀은 500, 기본 핀은 0
     - `<Marker zIndexOffset={...} />` 적용
-  - [ ] 13.3 호버 효과 테스트
+  - [x] 13.3 호버 효과 테스트
     - 겹친 핀에서 호버 시 깜빡임 없는지 확인
     - 호버된 핀이 최상위에 표시되는지 확인
 

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { Marker } from 'react-leaflet'
 import L from 'leaflet'
 import { SpotPin as SpotPinType, CATEGORY_CONFIG, SpotCategory } from '@/types'
@@ -10,6 +10,13 @@ import { useUIStore } from '@/stores/uiStore'
 interface SpotPinProps {
   spot: SpotPinType
   onSelect?: (spotId: string) => void
+}
+
+// Z-Index 상수
+const Z_INDEX = {
+  base: 0,
+  selected: 500,
+  hovered: 1000,
 }
 
 // 핀 크기 상수
@@ -209,7 +216,26 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   const { openPreview } = useUIStore()
   const [isHovered, setIsHovered] = useState(false)
 
+  // Debounce를 위한 타이머 ref
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const isSelected = selectedSpotId === spot.id
+
+  // Z-Index 계산: 호버 > 선택 > 기본
+  const zIndexOffset = isHovered
+    ? Z_INDEX.hovered
+    : isSelected
+      ? Z_INDEX.selected
+      : Z_INDEX.base
 
   // 아이콘을 메모이제이션하여 불필요한 재생성 방지 (카테고리 색상/아이콘 적용)
   const icon = useMemo(
@@ -234,18 +260,35 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
     onSelect?.(spot.id)
   }, [spot.id, setSelectedSpot, openPreview, onSelect])
 
+  // Debounced 호버 핸들러 (50ms)
   const handleMouseOver = useCallback(() => {
-    setIsHovered(true)
+    // 기존 타이머 취소
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current)
+    }
+    // 50ms 후 호버 상태 설정
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(true)
+    }, 50)
   }, [])
 
+  // Debounced 호버 아웃 핸들러 (50ms)
   const handleMouseOut = useCallback(() => {
-    setIsHovered(false)
+    // 기존 타이머 취소
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current)
+    }
+    // 50ms 후 호버 상태 해제
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(false)
+    }, 50)
   }, [])
 
   return (
     <Marker
       position={spot.coordinates}
       icon={icon}
+      zIndexOffset={zIndexOffset}
       eventHandlers={{
         click: handleClick,
         mouseover: handleMouseOver,


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #133

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> SpotPin 컴포넌트에서 겹친 핀들 위에 마우스를 올릴 때 발생하는 깜빡임 현상 수정

---

## 📋 변경 사항

- [x] 호버 상태에 50ms debounce 적용 (handleMouseOver, handleMouseOut)
- [x] Z-Index 우선순위 설정 (호버: 1000, 선택: 500, 기본: 0)
- [x] 컴포넌트 언마운트 시 타이머 정리 로직 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---
## 📸 스크린샷 (선택)

<img width="397" height="286" alt="image" src="https://github.com/user-attachments/assets/4e4bdc57-6712-4783-ba61-ba598d6f212c" />

---
## 📝 추가 정보 (선택)

**구현 상세:**
- `useRef`를 사용하여 debounce 타이머 관리
- `useEffect` cleanup으로 메모리 누수 방지
- `zIndexOffset` prop을 Marker에 적용하여 호버된 핀이 항상 최상위에 표시되도록 함

