### PR TITLE
[Feat] 이벤트 섹션 컴포넌트 추가

### DIFF
--- a/src/components/spot/EventInfoSection.tsx
+++ b/src/components/spot/EventInfoSection.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import {
+  ExternalLink,
+  SpotCategory,
+  SECTION_HEADERS,
+  CATEGORY_CONFIG,
+} from '@/types'
+import { ExternalLinkCard } from './ExternalLinkCard'
+
+/**
+ * EventInfoSection 컴포넌트 Props
+ */
+interface EventInfoSectionProps {
+  /** 스팟 ID */
+  spotId: string
+  /** 카테고리 (sports, music, game) */
+  category: 'sports' | 'music' | 'game'
+  /** 외부 링크 목록 */
+  externalLinks: ExternalLink[]
+}
+
+/**
+ * EventInfoSection 컴포넌트
+ *
+ * 스포츠/음악 카테고리용 이벤트 정보 섹션입니다.
+ * 외부 링크 카드를 그리드 레이아웃으로 표시합니다.
+ *
+ * Requirements:
+ * - 3.1: 공식 일정 페이지 외부 링크 표시
+ * - 3.2: 티켓 예매 사이트 외부 링크 표시
+ * - 5.2: 카테고리별 헤더 텍스트 (경기 일정/공연 정보)
+ * - 5.4: 빈 상태 메시지 표시
+ */
+export function EventInfoSection({
+  category,
+  externalLinks,
+}: EventInfoSectionProps) {
+  // 카테고리별 헤더 텍스트
+  const headerText = SECTION_HEADERS.events[category] || '이벤트 정보'
+  const categoryConfig = CATEGORY_CONFIG[category as SpotCategory]
+
+  // 카테고리별 빈 상태 메시지
+  const emptyMessages: Record<string, { title: string; description: string }> =
+    {
+      sports: {
+        title: '등록된 경기 정보가 없습니다',
+        description: '공식 홈페이지나 티켓 예매 링크를 추가해보세요!',
+      },
+      music: {
+        title: '등록된 공연 정보가 없습니다',
+        description: '공연장 홈페이지나 예매 링크를 추가해보세요!',
+      },
+      game: {
+        title: '등록된 e스포츠 정보가 없습니다',
+        description: '대회 일정이나 스트리밍 링크를 추가해보세요!',
+      },
+    }
+
+  const emptyMessage = emptyMessages[category] || emptyMessages.sports
+
+  return (
+    <div className="overflow-hidden rounded-lg bg-white shadow-md">
+      <div className="p-6">
+        {/* 헤더 */}
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-2xl">{categoryConfig?.icon || '📅'}</span>
+          <h2 className="text-2xl font-bold text-gray-900">{headerText}</h2>
+        </div>
+
+        {/* 설명 텍스트 */}
+        <p className="mb-4 text-sm text-gray-500">
+          {category === 'sports' &&
+            '경기 일정 확인 및 티켓 예매를 위한 링크입니다.'}
+          {category === 'music' &&
+            '공연 일정 확인 및 티켓 예매를 위한 링크입니다.'}
+          {category === 'game' && 'e스포츠 대회 일정 및 관련 정보 링크입니다.'}
+        </p>
+
+        {/* 외부 링크 그리드 또는 빈 상태 */}
+        {externalLinks.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {externalLinks.map((link) => (
+              <ExternalLinkCard key={link.id} link={link} />
+            ))}
+          </div>
+        ) : (
+          <div className="py-8 text-center">
+            <div className="mb-3 text-3xl">📅</div>
+            <p className="text-gray-600">{emptyMessage.title}</p>
+            <p className="mt-1 text-sm text-gray-500">
+              {emptyMessage.description}
+            </p>
+          </div>
+        )}
+
+        {/* 팁 메시지 */}
+        {externalLinks.length > 0 && (
+          <div className="mt-6 rounded-lg bg-navy-50 p-4">
+            <div className="flex items-start gap-2">
+              <span className="text-lg">💡</span>
+              <div>
+                <p className="text-sm font-medium text-navy-800">팁</p>
+                <p className="text-sm text-navy-600">
+                  {category === 'sports' &&
+                    '경기 당일은 혼잡할 수 있으니 미리 예매하세요!'}
+                  {category === 'music' &&
+                    '인기 공연은 빠르게 매진되니 예매 일정을 확인하세요!'}
+                  {category === 'game' &&
+                    '대회 일정에 맞춰 방문하면 특별한 경험을 할 수 있어요!'}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/spot/SpotContentSection.tsx
+++ b/src/components/spot/SpotContentSection.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { SpotCategory, CATEGORY_SECTIONS, ExternalLink } from '@/types'
+import SceneGallery from './SceneGallery'
+import { EventInfoSection } from './EventInfoSection'
+
+/**
+ * SpotContentSection 컴포넌트 Props
+ */
+interface SpotContentSectionProps {
+  /** 스팟 ID */
+  spotId: string
+  /** 스팟 카테고리 */
+  category: SpotCategory
+  /** 외부 링크 목록 (이벤트 섹션용) */
+  externalLinks?: ExternalLink[]
+}
+
+/**
+ * SpotContentSection 컨테이너 컴포넌트
+ *
+ * 카테고리에 따라 적절한 콘텐츠 섹션을 렌더링합니다.
+ * - animation, movie_drama: SceneGallery (작품 속 장면)
+ * - sports, music: EventInfoSection (이벤트 정보)
+ * - game: 둘 다 표시
+ * - other: 일반 정보 (현재는 빈 상태)
+ *
+ * Requirements:
+ * - 1.1: animation/movie_drama → 작품 속 장면 섹션
+ * - 1.2: sports/music → 이벤트 정보 섹션
+ * - 1.3: game → 둘 다 표시
+ * - 1.4: other → 일반 정보 섹션
+ */
+export function SpotContentSection({
+  spotId,
+  category,
+  externalLinks = [],
+}: SpotContentSectionProps) {
+  // 카테고리별 표시할 섹션 결정
+  const sections = CATEGORY_SECTIONS[category] || ['info']
+
+  // 이벤트 섹션을 표시할 수 있는 카테고리인지 확인
+  const isEventCategory = (
+    cat: SpotCategory
+  ): cat is 'sports' | 'music' | 'game' => {
+    return cat === 'sports' || cat === 'music' || cat === 'game'
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 작품 속 장면 섹션 (scenes) */}
+      {sections.includes('scenes') && <SceneGallery spotId={spotId} />}
+
+      {/* 이벤트 정보 섹션 (events) */}
+      {sections.includes('events') && isEventCategory(category) && (
+        <EventInfoSection
+          spotId={spotId}
+          category={category}
+          externalLinks={externalLinks}
+        />
+      )}
+
+      {/* 일반 정보 섹션 (info) - other 카테고리용 */}
+      {sections.includes('info') && (
+        <div className="overflow-hidden rounded-lg bg-white shadow-md">
+          <div className="p-6">
+            <div className="mb-4 flex items-center gap-2">
+              <span className="text-2xl">📍</span>
+              <h2 className="text-2xl font-bold text-gray-900">정보</h2>
+            </div>
+            <p className="text-sm text-gray-500">
+              이 장소에 대한 추가 정보가 곧 제공될 예정입니다.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 📋 개요
스팟 상세 페이지에서 카테고리별 콘텐츠 섹션을 표시하는 컴포넌트를 구현했습니다.

## 🎯 변경 사항

### Task 3.1 - EventInfoSection 컴포넌트
- `src/components/spot/EventInfoSection.tsx` 생성
- 외부 링크 카드 그리드 레이아웃 (2열)
- 카테고리별 헤더 텍스트 (경기 일정/공연 정보/e스포츠 경기)
- 빈 상태 메시지 및 팁 메시지 표시

### Task 3.2 - SpotContentSection 컨테이너 컴포넌트
- `src/components/spot/SpotContentSection.tsx` 생성
- 카테고리에 따라 SceneGallery 또는 EventInfoSection 렌더링
- game 카테고리는 둘 다 표시
- other 카테고리는 일반 정보 섹션 표시

## 📌 관련 Requirements
- 1.1, 1.2, 1.3, 1.4 (카테고리별 콘텐츠 섹션 분기)
- 3.1, 3.2 (이벤트 정보 섹션)
- 5.2, 5.4 (카테고리별 UI 차별화)

## ✅ 테스트
- [x] TypeScript 타입 체크 통과
- [x] ESLint/Prettier 통과

Closes #139
