### PR TITLE
Feat/141  spot detail content section  add

### DIFF
--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -13,7 +13,7 @@ import Link from 'next/link'
 import dynamic from 'next/dynamic'
 import NearbyFacilities from '@/components/spot/NearbyFacilities'
 import SpotCommunitySection from '@/components/spot/SpotCommunitySection'
-import SceneGallery from '@/components/spot/SceneGallery'
+import { SpotContentSection } from '@/components/spot/SpotContentSection'
 
 // 지도 컴포넌트를 동적으로 로드 (SSR 방지)
 const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
@@ -231,8 +231,12 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
         </div>
       )}
 
-      {/* Scene Gallery - 전체 너비로 더 큰 이미지 표시 */}
-      <SceneGallery spotId={spot.id} />
+      {/* Category-specific Content Section - 카테고리별 콘텐츠 (Requirements 1.1, 1.2) */}
+      <SpotContentSection
+        spotId={spot.id}
+        category={(spot.category as SpotCategory) || 'other'}
+        externalLinks={spot.externalLinks}
+      />
 
       {/* Location Map */}
       <div className="overflow-hidden rounded-lg bg-white shadow-md">

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -8,7 +8,7 @@ import {
   useToggleLike,
   useCreateScene,
 } from '@/hooks/useScenes'
-import { Scene } from '@/types'
+import { Scene, SpotCategory, SECTION_HEADERS, SECTION_ICONS } from '@/types'
 import SceneImageModal from './SceneImageModal'
 
 interface SceneCardProps {
@@ -532,9 +532,14 @@ function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
 
 interface SceneGalleryProps {
   spotId: string
+  /** 스팟 카테고리 (아이콘/헤더 텍스트 결정용) */
+  category?: SpotCategory
 }
 
-export default function SceneGallery({ spotId }: SceneGalleryProps) {
+export default function SceneGallery({
+  spotId,
+  category = 'animation',
+}: SceneGalleryProps) {
   useSession() // 세션 상태 유지 (향후 확장용)
   const { data: scenes, isLoading, error } = useScenesBySpot(spotId)
   const toggleLike = useToggleLike()
@@ -615,13 +620,28 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
     setImageModalIndex(null)
   }
 
+  // 카테고리별 헤더 텍스트와 아이콘 (Requirements 5.3)
+  const headerText = SECTION_HEADERS.scenes[category] || '작품 속 장면'
+  const headerIcon =
+    category === 'game'
+      ? '🎮'
+      : category === 'movie_drama'
+        ? '🎥'
+        : SECTION_ICONS.scenes
+
+  // 카테고리별 설명 텍스트
+  const descriptionText =
+    category === 'game'
+      ? '이 장소가 등장한 게임 장면들입니다. 마음에 드는 장면에 좋아요를 눌러주세요!'
+      : '이 장소가 등장한 작품 속 장면들입니다. 마음에 드는 장면에 좋아요를 눌러주세요!'
+
   return (
     <div className="overflow-hidden rounded-lg bg-white shadow-md">
       <div className="p-6">
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-2xl">🎬</span>
-            <h2 className="text-2xl font-bold text-gray-900">작품 속 장면</h2>
+            <span className="text-2xl">{headerIcon}</span>
+            <h2 className="text-2xl font-bold text-gray-900">{headerText}</h2>
           </div>
           <button
             onClick={() => setShowAddModal(true)}
@@ -645,8 +665,7 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
         </div>
 
         <p className="mb-4 text-sm text-gray-500">
-          이 장소가 등장한 애니메이션 장면들입니다. 마음에 드는 장면에 좋아요를
-          눌러주세요! (다시 클릭하면 취소됩니다)
+          {descriptionText} (다시 클릭하면 취소됩니다)
         </p>
 
         {isLoading || isLoadingLikes ? (
@@ -657,7 +676,7 @@ export default function SceneGallery({ spotId }: SceneGalleryProps) {
           </div>
         ) : !scenes || scenes.length === 0 ? (
           <div className="py-8 text-center">
-            <div className="mb-3 text-3xl">🎬</div>
+            <div className="mb-3 text-3xl">{headerIcon}</div>
             <p className="text-gray-600">아직 등록된 장면이 없습니다</p>
             <p className="mt-1 text-sm text-gray-500">
               첫 번째 장면을 추가해보세요!

--- a/src/components/spot/SpotContentSection.tsx
+++ b/src/components/spot/SpotContentSection.tsx
@@ -49,7 +49,9 @@ export function SpotContentSection({
   return (
     <div className="space-y-6">
       {/* 작품 속 장면 섹션 (scenes) */}
-      {sections.includes('scenes') && <SceneGallery spotId={spotId} />}
+      {sections.includes('scenes') && (
+        <SceneGallery spotId={spotId} category={category} />
+      )}
 
       {/* 이벤트 정보 섹션 (events) */}
       {sections.includes('events') && isEventCategory(category) && (

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { SpotCategory, RelatedContent } from '@/types'
+import { SpotCategory, RelatedContent, ExternalLink } from '@/types'
 
 // Types for spot data
 export interface SpotPin {
@@ -34,6 +34,7 @@ export interface SpotDetailData {
   category?: SpotCategory // 스팟 카테고리 (마이그레이션 전 optional)
   relatedMedia?: MediaInfo[] // 기존 호환성 유지 (deprecated)
   relatedContent?: RelatedContent[] // 새로운 관련 콘텐츠 (Requirements 3.3)
+  externalLinks?: ExternalLink[] // 외부 링크 (스포츠/음악 카테고리용)
   // 작성자 정보 (마이그레이션 전 optional)
   authorId?: string
   authorName?: string


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #141

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 스팟 상세 페이지에서 카테고리에 따라 적합한 콘텐츠 섹션(SpotContentSection)을 표시하도록 변경

---

## 📋 변경 사항

- [x] 스팟 상세 페이지에서 기존 SceneGallery를 SpotContentSection으로 교체
- [x] SpotDetailData 타입에 externalLinks 필드 추가
- [x] SceneGallery 컴포넌트에 category prop 추가하여 카테고리별 아이콘/헤더 표시
- [x] SpotContentSection에서 SceneGallery에 category 전달

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

**Requirements 대응:**
- 1.1: animation/movie_drama → 작품 속 장면 섹션
- 1.2: sports/music → 이벤트 정보 섹션
- 5.3: 섹션 아이콘이 카테고리와 일치

**카테고리별 아이콘:**
- animation: 🎬 (작품 속 장면)
- movie_drama: 🎥 (작품 속 장면)
- game: 🎮 (게임 속 장면)
- sports: ⚽ (경기 일정)
- music: 🎵 (공연 정보)


## 📸 스크린샷 (선택)

<img width="1571" height="1001" alt="image" src="https://github.com/user-attachments/assets/caac215d-c3e7-4048-98da-e6fb22be876a" />
<img width="1314" height="908" alt="image" src="https://github.com/user-attachments/assets/60816c92-e4a1-49e8-9b27-3b8eb4ab048e" />
<img width="1259" height="887" alt="image" src="https://github.com/user-attachments/assets/3466b6f1-dda5-4e05-a361-c4b7425b4f4d" />

---

