### PR TITLE
[Feat] SpotForm에 외부 링크 섹션 추가

### DIFF
--- a/.kiro/specs/category-specific-content/tasks.md
+++ b/.kiro/specs/category-specific-content/tasks.md
@@ -62,12 +62,12 @@
     - 섹션 헤더에 카테고리 아이콘 표시
     - _Requirements: 5.3_
 
-- [ ] 5. 스팟 등록/수정 폼 업데이트
-  - [ ] 5.1 SpotForm에 외부 링크 섹션 추가
+- [x] 5. 스팟 등록/수정 폼 업데이트
+  - [x] 5.1 SpotForm에 외부 링크 섹션 추가
     - `src/components/spot/SpotForm.tsx` 수정
     - sports/music 카테고리 선택 시 외부 링크 폼 표시
     - _Requirements: 4.1_
-  - [ ] 5.2 외부 링크 유효성 검사 추가
+  - [x] 5.2 외부 링크 유효성 검사 추가
     - URL 형식 검증 (https:// 필수)
     - 최대 10개 링크 제한
     - 중복 URL 방지

--- a/src/components/spot/SpotForm.tsx
+++ b/src/components/spot/SpotForm.tsx
@@ -10,7 +10,9 @@ import {
   SpotCategory,
   Coordinates,
   RelatedContent,
+  ExternalLink,
 } from '@/types'
+import { ExternalLinkForm } from '@/components/spot/ExternalLinkForm'
 
 // LocationPicker는 Leaflet을 사용하므로 SSR 비활성화
 const LocationPicker = dynamic(
@@ -37,6 +39,7 @@ export interface SpotFormData {
   category: SpotCategory | ''
   photos: string[]
   relatedContent: RelatedContent[]
+  externalLinks: ExternalLink[]
 }
 
 /**
@@ -399,6 +402,24 @@ export function SpotForm({
             }}
           />
         </div>
+
+        {/* 외부 링크 섹션 (스포츠/음악/게임 카테고리에서만 표시) */}
+        {formData.category &&
+          ['sports', 'music', 'game'].includes(formData.category) && (
+            <div className="border-b border-navy-100 pb-6">
+              <ExternalLinkForm
+                links={formData.externalLinks}
+                onChange={(links) => {
+                  setFormData((prev) => ({
+                    ...prev,
+                    externalLinks: links,
+                  }))
+                }}
+                category={formData.category as SpotCategory}
+                disabled={isSubmitting || isDeleting}
+              />
+            </div>
+          )}
 
         {/* 버튼 영역 */}
         <div

--- a/src/hooks/useSpotEdit.ts
+++ b/src/hooks/useSpotEdit.ts
@@ -3,9 +3,15 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { SpotCategory, RelatedContent, UpdateSpotInput } from '@/types'
+import {
+  SpotCategory,
+  RelatedContent,
+  ExternalLink,
+  UpdateSpotInput,
+} from '@/types'
 import { SpotFormData } from './useSpotRegistration'
 import { spotKeys } from './useSpots'
+import { validateExternalLinks } from '@/lib/external-link-validation'
 
 // 스팟 상세 데이터 인터페이스 (수정용)
 interface SpotEditData {
@@ -17,6 +23,7 @@ interface SpotEditData {
   coordinates: [number, number]
   category?: SpotCategory
   relatedContent?: RelatedContent[]
+  externalLinks?: ExternalLink[]
   authorId?: string
   authorName?: string
 }
@@ -56,6 +63,7 @@ export function useSpotEdit(spotId: string): UseSpotEditReturn {
     category: '',
     photos: [],
     relatedContent: [],
+    externalLinks: [],
   })
   const [errors, setErrors] = useState<string[]>([])
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -87,6 +95,7 @@ export function useSpotEdit(spotId: string): UseSpotEditReturn {
         category: spot.category || '',
         photos: spot.photos || [],
         relatedContent: spot.relatedContent || [],
+        externalLinks: spot.externalLinks || [],
       })
     }
   }, [spot])
@@ -132,6 +141,18 @@ export function useSpotEdit(spotId: string): UseSpotEditReturn {
       validationErrors.push('지도에서 위치를 선택해주세요')
     }
 
+    // 외부 링크 유효성 검사 (스포츠/음악/게임 카테고리에서만)
+    if (
+      formData.category &&
+      ['sports', 'music', 'game'].includes(formData.category) &&
+      formData.externalLinks.length > 0
+    ) {
+      const linkValidation = validateExternalLinks(formData.externalLinks)
+      if (!linkValidation.isValid) {
+        validationErrors.push(...linkValidation.errors)
+      }
+    }
+
     return validationErrors
   }, [formData])
 
@@ -158,6 +179,7 @@ export function useSpotEdit(spotId: string): UseSpotEditReturn {
           category: formData.category as SpotCategory,
           photos: formData.photos,
           relatedContent: formData.relatedContent,
+          externalLinks: formData.externalLinks,
         }
 
         const response = await fetch(`/api/spots/${spotId}`, {

--- a/src/hooks/useSpotRegistration.ts
+++ b/src/hooks/useSpotRegistration.ts
@@ -6,8 +6,10 @@ import {
   SpotCategory,
   Coordinates,
   RelatedContent,
+  ExternalLink,
   CreateSpotInput,
 } from '@/types'
+import { validateExternalLinks } from '@/lib/external-link-validation'
 
 // 폼 상태 인터페이스
 export interface SpotFormData {
@@ -18,6 +20,7 @@ export interface SpotFormData {
   category: SpotCategory | ''
   photos: string[]
   relatedContent: RelatedContent[]
+  externalLinks: ExternalLink[]
 }
 
 // 초기 폼 상태
@@ -29,6 +32,7 @@ export const initialFormData: SpotFormData = {
   category: '',
   photos: [],
   relatedContent: [],
+  externalLinks: [],
 }
 
 interface UseSpotRegistrationReturn {
@@ -99,6 +103,18 @@ export function useSpotRegistration(): UseSpotRegistrationReturn {
       validationErrors.push('지도에서 위치를 선택해주세요')
     }
 
+    // 외부 링크 유효성 검사 (스포츠/음악/게임 카테고리에서만)
+    if (
+      formData.category &&
+      ['sports', 'music', 'game'].includes(formData.category) &&
+      formData.externalLinks.length > 0
+    ) {
+      const linkValidation = validateExternalLinks(formData.externalLinks)
+      if (!linkValidation.isValid) {
+        validationErrors.push(...linkValidation.errors)
+      }
+    }
+
     return validationErrors
   }, [formData])
 
@@ -126,6 +142,7 @@ export function useSpotRegistration(): UseSpotRegistrationReturn {
           category: formData.category as SpotCategory,
           photos: formData.photos,
           relatedContent: formData.relatedContent,
+          externalLinks: formData.externalLinks,
         }
 
         const response = await fetch('/api/spots', {

--- a/src/lib/external-link-validation.ts
+++ b/src/lib/external-link-validation.ts
@@ -1,0 +1,85 @@
+import { ExternalLink } from '@/types'
+
+/**
+ * 외부 링크 유효성 검사 상수
+ */
+export const EXTERNAL_LINK_LIMITS = {
+  MAX_LINKS: 10,
+  MAX_LABEL_LENGTH: 100,
+} as const
+
+/**
+ * URL이 유효한 https:// URL인지 검사
+ */
+export function isValidHttpsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 외부 링크 배열의 유효성 검사 결과
+ */
+export interface ExternalLinkValidationResult {
+  isValid: boolean
+  errors: string[]
+}
+
+/**
+ * 외부 링크 배열 유효성 검사
+ *
+ * Requirements:
+ * - 3.4: URL 형식 검증 (https:// 필수)
+ * - 3.4: 최대 10개 링크 제한
+ * - 3.4: 중복 URL 방지
+ */
+export function validateExternalLinks(
+  links: ExternalLink[]
+): ExternalLinkValidationResult {
+  const errors: string[] = []
+
+  // 최대 개수 검사
+  if (links.length > EXTERNAL_LINK_LIMITS.MAX_LINKS) {
+    errors.push(
+      `외부 링크는 최대 ${EXTERNAL_LINK_LIMITS.MAX_LINKS}개까지 등록할 수 있습니다`
+    )
+  }
+
+  // 각 링크 검사
+  const urls = new Set<string>()
+  links.forEach((link, index) => {
+    // 라벨 검사
+    if (!link.label || !link.label.trim()) {
+      errors.push(`외부 링크 ${index + 1}: 링크 이름이 필요합니다`)
+    } else if (link.label.length > EXTERNAL_LINK_LIMITS.MAX_LABEL_LENGTH) {
+      errors.push(
+        `외부 링크 ${index + 1}: 링크 이름은 ${EXTERNAL_LINK_LIMITS.MAX_LABEL_LENGTH}자 이내여야 합니다`
+      )
+    }
+
+    // URL 검사
+    if (!link.url || !link.url.trim()) {
+      errors.push(`외부 링크 ${index + 1}: URL이 필요합니다`)
+    } else if (!isValidHttpsUrl(link.url)) {
+      errors.push(
+        `외부 링크 ${index + 1}: 올바른 URL 형식이 아닙니다 (https:// 필수)`
+      )
+    }
+
+    // 중복 URL 검사
+    if (link.url && urls.has(link.url)) {
+      errors.push(`외부 링크 ${index + 1}: 중복된 URL입니다`)
+    }
+    if (link.url) {
+      urls.add(link.url)
+    }
+  })
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #145

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 스포츠/음악/게임 카테고리 스팟 등록/수정 시 외부 링크(공식 홈페이지, 티켓 예매 등)를 추가할 수 있도록 SpotForm을 확장합니다.

---

## 📋 변경 사항

- [x] SpotFormData에 externalLinks 필드 추가
- [x] SpotForm에 ExternalLinkForm 컴포넌트 통합 (sports/music/game 카테고리에서만 표시)
- [x] useSpotRegistration에 externalLinks 처리 및 유효성 검사 추가
- [x] useSpotEdit에 externalLinks 처리 및 유효성 검사 추가
- [x] 외부 링크 유효성 검사 유틸리티 함수 추가 (src/lib/external-link-validation.ts)
  - URL 형식 검증 (https:// 필수)
  - 최대 10개 링크 제한
  - 중복 URL 방지

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📌 관련 정보

- **Task 번호**: Task 5 (5.1, 5.2)
- **Requirements**: 3.4, 4.1, 4.2, 4.3, 4.4


## 📸 스크린샷 (선택)

<img width="856" height="495" alt="image" src="https://github.com/user-attachments/assets/8621d7eb-ab33-4208-9e8d-b32378de752b" />

<img width="995" height="519" alt="image" src="https://github.com/user-attachments/assets/08389bac-9a8d-4169-9045-29f6214d5427" />

---

## 📝 추가 정보 (선택)

<!-- 리뷰어가 알아야 할 특별한 사항 -->
