### PR TITLE
[Feat] Task 7 - API에 externalLinks 처리 추가

### DIFF
--- a/src/app/api/spots/[id]/route.ts
+++ b/src/app/api/spots/[id]/route.ts
@@ -8,7 +8,9 @@ import {
   SpotCategory,
   RelatedContent,
   UpdateSpotInput,
+  ExternalLink,
 } from '@/types'
+import { validateExternalLinks } from '@/lib/external-link-validation'
 
 // MongoDB document interface
 interface SpotDocument {
@@ -28,6 +30,7 @@ interface SpotDocument {
     year?: number
   }[]
   relatedContent?: RelatedContent[]
+  externalLinks?: ExternalLink[]
   authorId?: string
   authorName?: string
   isGuestSpot?: boolean
@@ -66,6 +69,7 @@ export async function GET(
         year: media.year,
       })),
       relatedContent: spot.relatedContent,
+      externalLinks: spot.externalLinks,
       authorId: spot.authorId,
       authorName: spot.authorName,
       isGuestSpot: spot.isGuestSpot,
@@ -139,6 +143,14 @@ export async function PUT(
       errors.push('위치 좌표는 필수입니다')
     }
 
+    // 외부 링크 유효성 검사 (Requirements 3.3, 3.4)
+    if (body.externalLinks && body.externalLinks.length > 0) {
+      const linkValidation = validateExternalLinks(body.externalLinks)
+      if (!linkValidation.isValid) {
+        errors.push(...linkValidation.errors)
+      }
+    }
+
     if (errors.length > 0) {
       return NextResponse.json(
         { error: '유효성 검사 실패', details: errors },
@@ -163,6 +175,8 @@ export async function PUT(
     if (body.category) updateFields.category = body.category
     if (body.photos) updateFields.photos = body.photos
     if (body.relatedContent) updateFields.relatedContent = body.relatedContent
+    if (body.externalLinks !== undefined)
+      updateFields.externalLinks = body.externalLinks
 
     await collection.updateOne({ id }, { $set: updateFields })
 

--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCollection } from '@/lib/db'
 import { auth } from '@/lib/auth'
-import { SpotPin, SpotCategory, CreateSpotInput, RelatedContent } from '@/types'
+import {
+  SpotPin,
+  SpotCategory,
+  CreateSpotInput,
+  RelatedContent,
+  ExternalLink,
+} from '@/types'
+import { validateExternalLinks } from '@/lib/external-link-validation'
 
 /**
  * 다음 스팟 ID 생성 (SPOT-{숫자} 형식)
@@ -53,6 +60,7 @@ interface SpotDocument {
     year?: number
   }[]
   relatedContent?: RelatedContent[]
+  externalLinks?: ExternalLink[]
   authorId?: string
   authorName?: string
   isGuestSpot?: boolean
@@ -155,6 +163,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       errors.push('위치 좌표는 필수입니다')
     }
 
+    // 외부 링크 유효성 검사 (Requirements 3.3, 3.4)
+    if (body.externalLinks && body.externalLinks.length > 0) {
+      const linkValidation = validateExternalLinks(body.externalLinks)
+      if (!linkValidation.isValid) {
+        errors.push(...linkValidation.errors)
+      }
+    }
+
     if (errors.length > 0) {
       return NextResponse.json(
         { error: '유효성 검사 실패', details: errors },
@@ -180,6 +196,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       category: body.category,
       relatedMedia: [], // 기존 호환성 유지
       relatedContent: body.relatedContent || [],
+      externalLinks: body.externalLinks || [],
       authorId: session.user.id,
       authorName:
         session.user.name || session.user.email?.split('@')[0] || '익명',


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #149

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 스팟 등록/수정 API에 외부 링크(externalLinks) 필드 저장 및 유효성 검사 기능을 추가합니다.

---

## 📋 변경 사항

- [x] POST /api/spots에 externalLinks 필드 저장 추가
- [x] PUT /api/spots/[id]에 externalLinks 필드 저장 추가
- [x] GET /api/spots/[id] 응답에 externalLinks 포함
- [x] 외부 링크 유효성 검사 적용 (URL 형식, 최대 10개, 중복 방지)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

### 커밋 내역
- `feat: 스팟 등록 api에 externallinks 처리 추가`
- `feat: 스팟 수정 api에 externallinks 처리 추가`

### Task 번호
- Task 7.1, 7.2

### Requirements
- 3.3: 외부 링크 저장
- 3.4: URL 형식 검증, 최대 10개 제한, 중복 방지
