### PR TITLE
[Feat] 좋아요 스토어 추가 및 적용

### DIFF
--- a/.kiro/specs/zustand-global-state/tasks.md
+++ b/.kiro/specs/zustand-global-state/tasks.md
@@ -12,20 +12,20 @@
 
 ## Tasks
 
-- [ ] 1. 좋아요 상태 전역 관리
-  - [ ] 1.1 likeStore 생성
+- [x] 1. 좋아요 상태 전역 관리
+  - [x] 1.1 likeStore 생성
     - `src/stores/likeStore.ts` 생성
     - likedSceneIds, isLoadingLikes 상태 정의
     - setLikedSceneIds, addLikedScene, removeLikedScene, toggleLikedScene 액션 구현
     - selector 함수 제공 (useLikedSceneIds, useIsLoadingLikes)
     - _Requirements: 1.1_
-  - [ ] 1.2 SceneGallery에 likeStore 적용
+  - [x] 1.2 SceneGallery에 likeStore 적용
     - `src/components/spot/SceneGallery.tsx` 수정
     - 로컬 상태 likedSceneIds, isLoadingLikes를 likeStore로 교체
     - useEffect에서 likeStore.setLikedSceneIds 호출
     - handleLike에서 likeStore.toggleLikedScene 호출
     - _Requirements: 1.2, 1.3_
-  - [ ] 1.3 SceneImageModal에 likeStore 적용
+  - [x] 1.3 SceneImageModal에 likeStore 적용
     - `src/components/spot/SceneImageModal.tsx` 수정
     - props로 받던 likedSceneIds를 likeStore에서 직접 참조
     - _Requirements: 1.2_

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -7,6 +7,11 @@ import { SpotCategory, SECTION_HEADERS, SECTION_ICONS } from '@/types'
 import SceneImageModal from './SceneImageModal'
 import { API_ROUTES } from '@/lib/api-routes'
 import { SceneCarousel, AddSceneModal, SceneGallerySkeleton } from './scene'
+import {
+  useLikeStore,
+  useLikedSceneIds,
+  useIsLoadingLikes,
+} from '@/stores/likeStore'
 
 interface SceneGalleryProps {
   spotId: string
@@ -22,8 +27,11 @@ export default function SceneGallery({
   const toggleLike = useToggleLike()
   const [showAddModal, setShowAddModal] = useState(false)
   const [imageModalIndex, setImageModalIndex] = useState<number | null>(null)
-  const [likedSceneIds, setLikedSceneIds] = useState<Set<string>>(new Set())
-  const [isLoadingLikes, setIsLoadingLikes] = useState(false)
+
+  // likeStore 전역 상태 사용
+  const likedSceneIds = useLikedSceneIds()
+  const isLoadingLikes = useIsLoadingLikes()
+  const { setLikedSceneIds, toggleLikedScene, setLoadingLikes } = useLikeStore()
 
   useEffect(() => {
     const fetchLikeStatuses = async () => {
@@ -32,7 +40,7 @@ export default function SceneGallery({
         return
       }
 
-      setIsLoadingLikes(true)
+      setLoadingLikes(true)
       try {
         const { getDeviceId } = await import('@/lib/device-id')
         const deviceId = getDeviceId()
@@ -60,30 +68,22 @@ export default function SceneGallery({
       } catch {
         // 에러 시 빈 상태 유지
       } finally {
-        setIsLoadingLikes(false)
+        setLoadingLikes(false)
       }
     }
 
     fetchLikeStatuses()
-  }, [scenes])
+  }, [scenes, setLikedSceneIds, setLoadingLikes])
 
   const handleLike = useCallback(
     (sceneId: string) => {
       toggleLike.mutate(sceneId, {
-        onSuccess: (data) => {
-          setLikedSceneIds((prev) => {
-            const newSet = new Set(prev)
-            if (data.liked) {
-              newSet.add(sceneId)
-            } else {
-              newSet.delete(sceneId)
-            }
-            return newSet
-          })
+        onSuccess: () => {
+          toggleLikedScene(sceneId)
         },
       })
     },
-    [toggleLike]
+    [toggleLike, toggleLikedScene]
   )
 
   const handleSceneClick = (index: number) => {

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -7,11 +7,7 @@ import { SpotCategory, SECTION_HEADERS, SECTION_ICONS } from '@/types'
 import SceneImageModal from './SceneImageModal'
 import { API_ROUTES } from '@/lib/api-routes'
 import { SceneCarousel, AddSceneModal, SceneGallerySkeleton } from './scene'
-import {
-  useLikeStore,
-  useLikedSceneIds,
-  useIsLoadingLikes,
-} from '@/stores/likeStore'
+import { useLikeStore, useIsLoadingLikes } from '@/stores/likeStore'
 
 interface SceneGalleryProps {
   spotId: string
@@ -29,7 +25,6 @@ export default function SceneGallery({
   const [imageModalIndex, setImageModalIndex] = useState<number | null>(null)
 
   // likeStore 전역 상태 사용
-  const likedSceneIds = useLikedSceneIds()
   const isLoadingLikes = useIsLoadingLikes()
   const { setLikedSceneIds, toggleLikedScene, setLoadingLikes } = useLikeStore()
 
@@ -160,7 +155,6 @@ export default function SceneGallery({
             onLike={handleLike}
             isLiking={toggleLike.isPending}
             onSceneClick={handleSceneClick}
-            likedSceneIds={likedSceneIds}
           />
         )}
       </div>

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -175,7 +175,6 @@ export default function SceneGallery({
           initialIndex={imageModalIndex}
           onClose={closeImageModal}
           onLike={handleLike}
-          likedSceneIds={likedSceneIds}
         />
       )}
     </div>

--- a/src/components/spot/SceneImageModal.tsx
+++ b/src/components/spot/SceneImageModal.tsx
@@ -3,13 +3,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import Image from 'next/image'
 import { Scene } from '@/types'
+import { useLikedSceneIds } from '@/stores/likeStore'
 
 interface SceneImageModalProps {
   scenes: Scene[]
   initialIndex: number
   onClose: () => void
   onLike: (sceneId: string) => void
-  likedSceneIds: Set<string>
 }
 
 /**
@@ -24,8 +24,9 @@ export default function SceneImageModal({
   initialIndex,
   onClose,
   onLike,
-  likedSceneIds,
 }: SceneImageModalProps) {
+  // likeStore에서 직접 참조
+  const likedSceneIds = useLikedSceneIds()
   const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [scale, setScale] = useState(1)
   const [showLikeAnimation, setShowLikeAnimation] = useState(false)

--- a/src/components/spot/scene/SceneCard.tsx
+++ b/src/components/spot/scene/SceneCard.tsx
@@ -3,13 +3,13 @@
 import { useState, useEffect } from 'react'
 import Image from 'next/image'
 import { Scene } from '@/types'
+import { useLikedSceneIds } from '@/stores/likeStore'
 
 interface SceneCardProps {
   scene: Scene
   onLike: (sceneId: string) => void
   isLiking: boolean
   onClick: () => void
-  initialLiked?: boolean
 }
 
 /**
@@ -22,26 +22,30 @@ export function SceneCard({
   onLike,
   isLiking,
   onClick,
-  initialLiked = false,
 }: SceneCardProps) {
-  const [liked, setLiked] = useState(initialLiked)
-  const [localLikeCount, setLocalLikeCount] = useState(scene.likeCount)
+  // likeStore에서 직접 참조
+  const likedSceneIds = useLikedSceneIds()
+  const liked = likedSceneIds.has(scene.id)
 
+  // 낙관적 업데이트를 위한 로컬 좋아요 수 관리
+  const [localLikeCount, setLocalLikeCount] = useState(scene.likeCount)
+  const [prevLiked, setPrevLiked] = useState(liked)
+
+  // liked 상태가 변경되면 localLikeCount 업데이트 (낙관적 업데이트)
   useEffect(() => {
-    setLiked(initialLiked)
-  }, [initialLiked])
+    if (liked !== prevLiked) {
+      if (liked) {
+        setLocalLikeCount((prev) => prev + 1)
+      } else {
+        setLocalLikeCount((prev) => Math.max(0, prev - 1))
+      }
+      setPrevLiked(liked)
+    }
+  }, [liked, prevLiked])
 
   const handleLike = (e: React.MouseEvent) => {
     e.stopPropagation()
     if (isLiking) return
-
-    if (liked) {
-      setLiked(false)
-      setLocalLikeCount((prev) => Math.max(0, prev - 1))
-    } else {
-      setLiked(true)
-      setLocalLikeCount((prev) => prev + 1)
-    }
     onLike(scene.id)
   }
 

--- a/src/components/spot/scene/SceneCarousel.tsx
+++ b/src/components/spot/scene/SceneCarousel.tsx
@@ -9,7 +9,6 @@ interface SceneCarouselProps {
   onLike: (sceneId: string) => void
   isLiking: boolean
   onSceneClick: (index: number) => void
-  likedSceneIds: Set<string>
 }
 
 /**
@@ -20,7 +19,6 @@ export function SceneCarousel({
   onLike,
   isLiking,
   onSceneClick,
-  likedSceneIds,
 }: SceneCarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [itemsPerView, setItemsPerView] = useState(1)
@@ -72,7 +70,6 @@ export function SceneCarousel({
               onLike={onLike}
               isLiking={isLiking}
               onClick={() => onSceneClick(startIdx + idx)}
-              initialLiked={likedSceneIds.has(scene.id)}
             />
           ))}
         </div>

--- a/src/stores/likeStore.ts
+++ b/src/stores/likeStore.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+interface LikeStore {
+  likedSceneIds: Set<string>
+  isLoadingLikes: boolean
+
+  setLikedSceneIds: (ids: Set<string>) => void
+  addLikedScene: (sceneId: string) => void
+  removeLikedScene: (sceneId: string) => void
+  toggleLikedScene: (sceneId: string) => void
+  setLoadingLikes: (loading: boolean) => void
+  resetLikeState: () => void
+}
+
+export const useLikeStore = create<LikeStore>()(
+  devtools(
+    (set) => ({
+      likedSceneIds: new Set<string>(),
+      isLoadingLikes: false,
+
+      setLikedSceneIds: (ids) =>
+        set({ likedSceneIds: ids }, false, 'likeStore/setLikedSceneIds'),
+
+      addLikedScene: (sceneId) =>
+        set(
+          (state) => ({
+            likedSceneIds: new Set([...state.likedSceneIds, sceneId]),
+          }),
+          false,
+          'likeStore/addLikedScene'
+        ),
+
+      removeLikedScene: (sceneId) =>
+        set(
+          (state) => {
+            const newSet = new Set(state.likedSceneIds)
+            newSet.delete(sceneId)
+            return { likedSceneIds: newSet }
+          },
+          false,
+          'likeStore/removeLikedScene'
+        ),
+
+      toggleLikedScene: (sceneId) =>
+        set(
+          (state) => {
+            const newSet = new Set(state.likedSceneIds)
+            if (newSet.has(sceneId)) {
+              newSet.delete(sceneId)
+            } else {
+              newSet.add(sceneId)
+            }
+            return { likedSceneIds: newSet }
+          },
+          false,
+          'likeStore/toggleLikedScene'
+        ),
+
+      setLoadingLikes: (loading) =>
+        set({ isLoadingLikes: loading }, false, 'likeStore/setLoadingLikes'),
+
+      resetLikeState: () =>
+        set(
+          {
+            likedSceneIds: new Set<string>(),
+            isLoadingLikes: false,
+          },
+          false,
+          'likeStore/resetLikeState'
+        ),
+    }),
+    {
+      name: 'like-store',
+    }
+  )
+)
+
+// Selectors
+export const useLikedSceneIds = () =>
+  useLikeStore((state) => state.likedSceneIds)
+export const useIsLoadingLikes = () =>
+  useLikeStore((state) => state.isLoadingLikes)


### PR DESCRIPTION
## 📋 개요
좋아요 상태를 zustand 전역 스토어로 이전하여 상태 관리를 개선합니다.

Closes #156

## 🔄 변경 사항
- `src/stores/likeStore.ts` 신규 생성
- `src/components/spot/SceneGallery.tsx` 리팩토링
- `src/components/spot/SceneImageModal.tsx` 리팩토링

## ✅ 체크리스트
- [x] 타입 체크 통과
- [x] 빌드 성공
- [x] 기존 기능 동작 확인

## 📌 관련 Requirements
- 1.1: 좋아요한 장면 ID를 전역 스토어에서 관리
- 1.2: SceneGallery에서 로컬 상태 대신 전역 스토어 사용
- 1.3: 좋아요 토글 시 전역 스토어 업데이트
