### PR TITLE
[Feat] Task 2 - 인증 UI 상태 전역 관리 (authStore)

### DIFF
--- a/.kiro/specs/zustand-global-state/tasks.md
+++ b/.kiro/specs/zustand-global-state/tasks.md
@@ -30,14 +30,14 @@
     - props로 받던 likedSceneIds를 likeStore에서 직접 참조
     - _Requirements: 1.2_
 
-- [ ] 2. 인증 UI 상태 전역 관리
-  - [ ] 2.1 authStore 생성
+- [x] 2. 인증 UI 상태 전역 관리
+  - [x] 2.1 authStore 생성
     - `src/stores/authStore.ts` 생성
     - isLoggingOut, authError 상태 정의
     - setLoggingOut, setAuthError, clearAuthError 액션 구현
     - selector 함수 제공
     - _Requirements: 2.1, 2.2_
-  - [ ] 2.2 useAuth 훅에 authStore 적용
+  - [x] 2.2 useAuth 훅에 authStore 적용
     - `src/hooks/useAuth.ts` 수정
     - 로컬 상태 isLoggingOut, error를 authStore로 교체
     - 기존 인터페이스 유지 (하위 호환성)

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@
 import { useSession, signIn, signOut } from 'next-auth/react'
 import { useCallback, useState } from 'react'
 import { API_ROUTES } from '@/lib/api-routes'
+import { useAuthStore } from '@/stores/authStore'
 
 interface RegisterData {
   email: string
@@ -18,8 +19,13 @@ interface AuthError {
 export function useAuth() {
   const { data: session, status } = useSession()
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  // 전역 스토어에서 인증 UI 상태 가져오기
+  const isLoggingOut = useAuthStore((state) => state.isLoggingOut)
+  const error = useAuthStore((state) => state.authError)
+  const setLoggingOut = useAuthStore((state) => state.setLoggingOut)
+  const setAuthError = useAuthStore((state) => state.setAuthError)
+  const clearAuthError = useAuthStore((state) => state.clearAuthError)
 
   // 낙관적 업데이트: 로그아웃 중이면 인증되지 않은 것으로 처리
   const isAuthenticated = status === 'authenticated' && !isLoggingOut
@@ -29,7 +35,7 @@ export function useAuth() {
   const loginWithCredentials = useCallback(
     async (email: string, password: string) => {
       setIsLoading(true)
-      setError(null)
+      clearAuthError()
 
       try {
         const result = await signIn('credentials', {
@@ -39,43 +45,43 @@ export function useAuth() {
         })
 
         if (result?.error) {
-          setError('이메일 또는 비밀번호가 올바르지 않습니다.')
+          setAuthError('이메일 또는 비밀번호가 올바르지 않습니다.')
           return false
         }
 
         return true
       } catch {
-        setError('로그인 중 오류가 발생했습니다.')
+        setAuthError('로그인 중 오류가 발생했습니다.')
         return false
       } finally {
         setIsLoading(false)
       }
     },
-    []
+    [clearAuthError, setAuthError]
   )
 
   // 소셜 로그인
   const loginWithProvider = useCallback(
     async (provider: 'google' | 'kakao' | 'naver') => {
       setIsLoading(true)
-      setError(null)
+      clearAuthError()
 
       try {
         await signIn(provider, { callbackUrl: '/' })
       } catch {
-        setError('소셜 로그인 중 오류가 발생했습니다.')
+        setAuthError('소셜 로그인 중 오류가 발생했습니다.')
       } finally {
         setIsLoading(false)
       }
     },
-    []
+    [clearAuthError, setAuthError]
   )
 
   // 회원가입
   const register = useCallback(
     async (data: RegisterData) => {
       setIsLoading(true)
-      setError(null)
+      clearAuthError()
 
       try {
         const response = await fetch(API_ROUTES.AUTH.REGISTER, {
@@ -87,34 +93,36 @@ export function useAuth() {
         const result = await response.json()
 
         if (!response.ok) {
-          setError((result as AuthError).error || '회원가입에 실패했습니다.')
+          setAuthError(
+            (result as AuthError).error || '회원가입에 실패했습니다.'
+          )
           return false
         }
 
         // 회원가입 성공 후 자동 로그인
         return await loginWithCredentials(data.email, data.password)
       } catch {
-        setError('회원가입 중 오류가 발생했습니다.')
+        setAuthError('회원가입 중 오류가 발생했습니다.')
         return false
       } finally {
         setIsLoading(false)
       }
     },
-    [loginWithCredentials]
+    [loginWithCredentials, clearAuthError, setAuthError]
   )
 
   // 로그아웃 (낙관적 업데이트 적용)
   const logout = useCallback(async () => {
     // 즉시 로그아웃 상태로 전환하여 UI 업데이트
-    setIsLoggingOut(true)
+    setLoggingOut(true)
     // 백그라운드에서 실제 로그아웃 처리
     signOut({ callbackUrl: '/' })
-  }, [])
+  }, [setLoggingOut])
 
   // 에러 초기화
   const clearError = useCallback(() => {
-    setError(null)
-  }, [])
+    clearAuthError()
+  }, [clearAuthError])
 
   return {
     user: isLoggingOut ? null : session?.user,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+interface AuthStore {
+  isLoggingOut: boolean
+  authError: string | null
+
+  setLoggingOut: (value: boolean) => void
+  setAuthError: (error: string | null) => void
+  clearAuthError: () => void
+  resetAuthState: () => void
+}
+
+export const useAuthStore = create<AuthStore>()(
+  devtools(
+    (set) => ({
+      isLoggingOut: false,
+      authError: null,
+
+      setLoggingOut: (value) =>
+        set({ isLoggingOut: value }, false, 'authStore/setLoggingOut'),
+
+      setAuthError: (error) =>
+        set({ authError: error }, false, 'authStore/setAuthError'),
+
+      clearAuthError: () =>
+        set({ authError: null }, false, 'authStore/clearAuthError'),
+
+      resetAuthState: () =>
+        set(
+          {
+            isLoggingOut: false,
+            authError: null,
+          },
+          false,
+          'authStore/resetAuthState'
+        ),
+    }),
+    {
+      name: 'auth-store',
+    }
+  )
+)
+
+// Selectors
+export const useIsLoggingOut = () => useAuthStore((state) => state.isLoggingOut)
+export const useAuthError = () => useAuthStore((state) => state.authError)


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #158

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)

---

## ✨ 작업 개요

인증 UI 상태(isLoggingOut, authError)를 zustand 전역 스토어로 이전하여 상태 관리 개선

---

## 📋 변경 사항

- [x] `src/stores/authStore.ts` 생성
  - isLoggingOut, authError 상태 정의
  - setLoggingOut, setAuthError, clearAuthError, resetAuthState 액션 구현
  - useIsLoggingOut, useAuthError selector 제공
  - devtools 미들웨어 적용
- [x] `src/hooks/useAuth.ts` 수정
  - 로컬 상태를 authStore로 교체
  - 기존 인터페이스 유지 (하위 호환성)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 2.1, 2.2, 2.3 대응
- 기존 mapStore, likeStore 패턴과 일관성 유지
