### PR TITLE
[Feat] 카테고리 필터 상태 전역 관리 (filterStore)

### DIFF
--- a/.kiro/specs/content-search-filter/design.md
+++ b/.kiro/specs/content-search-filter/design.md
@@ -1,0 +1,312 @@
+# Design Document: Content Search Filter
+
+## Overview
+
+콘텐츠 검색 필터 기능은 사용자가 작품명, 구단명, 아티스트명 등을 직접 검색하여 관련 스팟을 필터링할 수 있게 합니다. 기존 카테고리 필터와 함께 동작하며, 자동완성 기능을 통해 사용자 경험을 향상시킵니다.
+
+### 핵심 설계 원칙
+
+1. **기존 시스템 확장**: filterStore를 확장하여 검색 상태 관리
+2. **서버 사이드 필터링**: MongoDB 쿼리를 활용한 효율적인 검색
+3. **점진적 향상**: 자동완성은 UX 향상 기능으로, 기본 검색은 독립적으로 동작
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph UI["UI Layer"]
+        SI[SearchInput]
+        AD[AutocompleteDropdown]
+        CF[CategoryFilter]
+    end
+
+    subgraph Store["State Management"]
+        FS[filterStore]
+    end
+
+    subgraph Hooks["Custom Hooks"]
+        US[useContentSearch]
+        UA[useAutocomplete]
+    end
+
+    subgraph API["API Layer"]
+        SA["/api/spots"]
+        CA["/api/content-names"]
+    end
+
+    subgraph DB["Database"]
+        MC[(MongoDB)]
+    end
+
+    SI --> FS
+    SI --> UA
+    AD --> SI
+    CF --> FS
+
+    FS --> US
+    US --> SA
+    UA --> CA
+
+    SA --> MC
+    CA --> MC
+```
+
+### 데이터 흐름
+
+1. 사용자가 SearchInput에 검색어 입력
+2. 2글자 이상 입력 시 useAutocomplete가 자동완성 API 호출
+3. 검색어 확정 시 filterStore에 searchQuery 저장
+4. useSpots 훅이 filterStore 상태를 구독하여 API 호출
+5. API가 category + search 조건으로 MongoDB 쿼리 실행
+
+## Components and Interfaces
+
+### 1. SearchInput 컴포넌트
+
+```typescript
+interface SearchInputProps {
+  placeholder?: string
+  className?: string
+}
+
+// 주요 기능
+// - 검색어 입력 및 표시
+// - 자동완성 드롭다운 트리거
+// - 검색어 초기화 버튼
+// - 디바운스된 검색어 업데이트
+```
+
+### 2. AutocompleteDropdown 컴포넌트
+
+```typescript
+interface AutocompleteItem {
+  name: string
+  category: SpotCategory
+  count: number
+}
+
+interface AutocompleteDropdownProps {
+  items: AutocompleteItem[]
+  isLoading: boolean
+  onSelect: (item: AutocompleteItem) => void
+  onClose: () => void
+}
+
+// 주요 기능
+// - 자동완성 항목 목록 표시
+// - 카테고리 아이콘 및 스팟 개수 표시
+// - 키보드 네비게이션 지원
+// - 외부 클릭 시 닫기
+```
+
+### 3. ContentSearchFilter 컴포넌트 (통합)
+
+```typescript
+// SearchInput + AutocompleteDropdown을 결합한 컴포넌트
+// CategoryFilter와 나란히 배치
+```
+
+### 4. useContentSearch 훅
+
+```typescript
+interface UseContentSearchReturn {
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+  clearSearch: () => void
+  isSearchActive: boolean
+}
+```
+
+### 5. useAutocomplete 훅
+
+```typescript
+interface UseAutocompleteReturn {
+  suggestions: AutocompleteItem[]
+  isLoading: boolean
+  error: Error | null
+}
+
+// 디바운스된 API 호출 (300ms)
+// 2글자 미만 입력 시 빈 배열 반환
+```
+
+## Data Models
+
+### FilterStore 확장
+
+```typescript
+interface FilterStore {
+  // 기존 필드
+  selectedCategories: SpotCategory[]
+
+  // 새로운 필드
+  searchQuery: string
+
+  // 기존 액션
+  setSelectedCategories: (categories: SpotCategory[]) => void
+  toggleCategory: (category: SpotCategory) => void
+  selectAllCategories: () => void
+  clearCategories: () => void
+  resetFilterState: () => void
+
+  // 새로운 액션
+  setSearchQuery: (query: string) => void
+  clearSearchQuery: () => void
+}
+```
+
+### API 응답 타입
+
+```typescript
+// GET /api/content-names 응답
+interface ContentNamesResponse {
+  items: AutocompleteItem[]
+  total: number
+}
+
+// GET /api/spots 쿼리 파라미터 확장
+interface SpotsQueryParams {
+  category?: string // 기존
+  search?: string // 새로운 파라미터
+}
+```
+
+### MongoDB 쿼리 구조
+
+```typescript
+// 검색 쿼리 예시
+const query = {
+  // 카테고리 필터
+  ...(categories.length > 0 && { category: { $in: categories } }),
+
+  // 검색 필터 (relatedContent.name 부분 일치)
+  ...(search && {
+    'relatedContent.name': {
+      $regex: search,
+      $options: 'i', // 대소문자 무시
+    },
+  }),
+}
+```
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: 검색어 입력 실시간 반영
+
+_For any_ 문자열 입력, SearchInput 컴포넌트에 입력된 값은 즉시 내부 상태에 반영되어야 한다.
+
+**Validates: Requirements 1.3**
+
+### Property 2: 초기화 버튼 클릭 시 검색어 리셋
+
+_For any_ 비어있지 않은 검색어 상태에서, 초기화 버튼 클릭 시 검색어는 빈 문자열이 되고 filterStore의 searchQuery도 빈 문자열이 되어야 한다.
+
+**Validates: Requirements 1.5**
+
+### Property 3: 2글자 이상 입력 시 자동완성 활성화
+
+_For any_ 2글자 이상의 검색어 입력에 대해, useAutocomplete 훅은 API를 호출하고 결과를 반환해야 한다. 2글자 미만의 입력에 대해서는 API를 호출하지 않고 빈 배열을 반환해야 한다.
+
+**Validates: Requirements 2.1**
+
+### Property 4: 자동완성 최대 10개 제한
+
+_For any_ 자동완성 API 응답에 대해, 반환되는 항목 수는 항상 10개 이하여야 한다.
+
+**Validates: Requirements 2.2**
+
+### Property 5: 제안 항목 선택 시 검색어 설정 및 필터 적용
+
+_For any_ 자동완성 제안 항목 선택 시, SearchInput의 값은 선택된 항목의 name으로 설정되고, filterStore의 searchQuery도 동일한 값으로 업데이트되어야 한다.
+
+**Validates: Requirements 2.3, 2.4**
+
+### Property 6: 자동완성 항목 카테고리 정보 포함
+
+_For any_ 자동완성 API 응답의 각 항목에 대해, category 필드가 유효한 SpotCategory 값이어야 한다.
+
+**Validates: Requirements 2.6, 5.3**
+
+### Property 7: 부분 일치 검색 동작
+
+_For any_ 검색어와 스팟 데이터셋에 대해, API가 반환하는 모든 스팟의 relatedContent.name 중 하나 이상이 검색어를 부분 문자열로 포함해야 한다.
+
+**Validates: Requirements 3.1, 6.2**
+
+### Property 8: 대소문자 무시 검색
+
+_For any_ 검색어에 대해, 대문자/소문자 변형(예: "ABC", "abc", "Abc")은 동일한 검색 결과를 반환해야 한다.
+
+**Validates: Requirements 3.2**
+
+### Property 9: 카테고리와 검색어 AND 조건 결합
+
+_For any_ 카테고리 필터와 검색어 조합에 대해, API가 반환하는 모든 스팟은 선택된 카테고리에 속하면서 동시에 검색어와 매칭되는 relatedContent.name을 가져야 한다.
+
+**Validates: Requirements 3.5, 6.3**
+
+### Property 10: 스토어 검색어 상태 독립성
+
+_For any_ filterStore 상태 변경에 대해, searchQuery 변경은 selectedCategories에 영향을 주지 않고, selectedCategories 변경은 searchQuery에 영향을 주지 않아야 한다.
+
+**Validates: Requirements 4.1, 4.3, 4.4**
+
+### Property 11: 자동완성 API 중복 제거
+
+_For any_ 자동완성 API 응답에 대해, 반환되는 Content_Name 목록에 중복된 name 값이 없어야 한다.
+
+**Validates: Requirements 5.2**
+
+## Error Handling
+
+### 네트워크 오류
+
+- 자동완성 API 호출 실패 시 빈 배열 반환, 에러 로깅
+- 스팟 API 호출 실패 시 기존 데이터 유지, 사용자에게 에러 토스트 표시
+
+### 입력 유효성
+
+- 특수문자 포함 검색어: 정규식 이스케이프 처리
+- 매우 긴 검색어: 최대 100자 제한
+- XSS 방지: 검색어 sanitize 처리
+
+### 빈 상태 처리
+
+- 검색 결과 없음: "검색 결과가 없습니다" 메시지 표시
+- 자동완성 결과 없음: "일치하는 콘텐츠가 없습니다" 메시지 표시
+
+### 디바운스 처리
+
+- 자동완성 API 호출: 300ms 디바운스
+- 검색 필터 적용: 500ms 디바운스 (Enter 키 또는 제안 선택 시 즉시 적용)
+
+## Testing Strategy
+
+### 단위 테스트
+
+- SearchInput 컴포넌트: 입력, 초기화, 포커스 동작
+- AutocompleteDropdown 컴포넌트: 항목 렌더링, 선택, 닫기 동작
+- filterStore: 검색어 상태 관리 액션
+- useAutocomplete 훅: API 호출 조건, 디바운스 동작
+
+### 속성 기반 테스트
+
+테스트 라이브러리: **fast-check** (TypeScript/JavaScript용 PBT 라이브러리)
+
+각 속성 테스트는 최소 100회 반복 실행하며, 다음 형식의 태그를 포함합니다:
+
+```typescript
+// Feature: content-search-filter, Property N: {property_text}
+```
+
+### 통합 테스트
+
+- CategoryFilter + SearchInput 조합 동작
+- API 호출 및 지도 업데이트 흐름
+- 필터 초기화 시 전체 상태 리셋
+
+### E2E 테스트 (선택)
+
+- 검색어 입력 → 자동완성 표시 → 항목 선택 → 지도 필터링 전체 흐름

--- a/.kiro/specs/content-search-filter/requirements.md
+++ b/.kiro/specs/content-search-filter/requirements.md
@@ -1,0 +1,87 @@
+# Requirements Document
+
+## Introduction
+
+이 문서는 Not a Trip 플랫폼에 콘텐츠 검색 필터 기능을 추가하기 위한 요구사항을 정의합니다. 사용자가 작품명(애니메이션 제목, 영화/드라마 제목), 구단명(스포츠 팀), 아티스트명 등을 직접 검색하여 관련 스팟을 필터링할 수 있는 기능입니다. 기존 카테고리 필터와 함께 사용하여 더 정밀한 스팟 탐색이 가능합니다.
+
+## Glossary
+
+- **Search_Input**: 사용자가 검색어를 입력하는 텍스트 입력 컴포넌트
+- **Autocomplete_Dropdown**: 검색어 입력 시 표시되는 자동완성 제안 목록
+- **Content_Name**: relatedContent.name 필드에 저장된 작품명, 구단명, 아티스트명 등
+- **Search_Filter**: 검색어 기반으로 스팟을 필터링하는 기능
+- **Filter_Store**: 필터 상태를 관리하는 Zustand 스토어
+- **Spot_API**: 스팟 데이터를 조회하는 백엔드 API
+
+## Requirements
+
+### Requirement 1: 검색 입력 UI
+
+**User Story:** As a 사용자, I want to 검색창에 작품명이나 팀명을 입력, so that I can 관련 스팟을 빠르게 찾을 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Search_Input SHALL 지도 상단 필터 영역에 카테고리 필터와 함께 표시된다
+2. WHEN 사용자가 Search_Input에 포커스하면 THE Search_Input SHALL 플레이스홀더 텍스트를 표시한다
+3. WHEN 사용자가 검색어를 입력하면 THE Search_Input SHALL 입력값을 실시간으로 반영한다
+4. THE Search_Input SHALL 검색어 초기화 버튼(X)을 제공한다
+5. WHEN 초기화 버튼을 클릭하면 THE Search_Input SHALL 검색어를 비우고 필터를 해제한다
+
+### Requirement 2: 자동완성 기능
+
+**User Story:** As a 사용자, I want to 검색어 입력 시 자동완성 제안을 받고 싶다, so that I can 정확한 콘텐츠명을 쉽게 선택할 수 있다.
+
+#### Acceptance Criteria
+
+1. WHEN 사용자가 2글자 이상 입력하면 THE Autocomplete_Dropdown SHALL 매칭되는 Content_Name 목록을 표시한다
+2. THE Autocomplete_Dropdown SHALL 최대 10개의 제안 항목을 표시한다
+3. WHEN 제안 항목을 클릭하면 THE Search_Input SHALL 해당 Content_Name으로 채워진다
+4. WHEN 제안 항목을 클릭하면 THE Search_Filter SHALL 즉시 적용된다
+5. WHEN 매칭되는 결과가 없으면 THE Autocomplete_Dropdown SHALL "검색 결과 없음" 메시지를 표시한다
+6. THE Autocomplete_Dropdown SHALL 각 제안 항목에 해당 카테고리 아이콘을 표시한다
+7. WHEN Search_Input 외부를 클릭하면 THE Autocomplete_Dropdown SHALL 닫힌다
+
+### Requirement 3: 검색 필터링 로직
+
+**User Story:** As a 사용자, I want to 검색어로 스팟을 필터링하고 싶다, so that I can 특정 작품이나 팀 관련 장소만 볼 수 있다.
+
+#### Acceptance Criteria
+
+1. WHEN 검색어가 적용되면 THE Spot_API SHALL relatedContent.name 필드에서 부분 일치 검색을 수행한다
+2. THE Search_Filter SHALL 대소문자를 구분하지 않고 검색한다
+3. WHEN 검색 결과가 있으면 THE 지도 SHALL 필터링된 스팟만 표시한다
+4. WHEN 검색 결과가 없으면 THE 지도 SHALL 빈 상태 메시지를 표시한다
+5. THE Search_Filter SHALL 카테고리 필터와 AND 조건으로 결합된다
+
+### Requirement 4: 필터 상태 관리
+
+**User Story:** As a 개발자, I want to 검색 필터 상태를 전역으로 관리하고 싶다, so that I can 여러 컴포넌트에서 일관된 필터 상태를 사용할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Filter_Store SHALL 검색어 상태를 저장한다
+2. THE Filter_Store SHALL 검색어 설정, 초기화 액션을 제공한다
+3. WHEN 검색어가 변경되면 THE Filter_Store SHALL 구독 중인 컴포넌트에 변경을 알린다
+4. THE Filter_Store SHALL 카테고리 필터와 검색 필터를 독립적으로 관리한다
+
+### Requirement 5: 자동완성 데이터 조회
+
+**User Story:** As a 시스템, I want to 자동완성용 콘텐츠명 목록을 효율적으로 조회하고 싶다, so that I can 빠른 응답 속도를 제공할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Spot_API SHALL 자동완성용 콘텐츠명 목록 조회 엔드포인트를 제공한다
+2. WHEN 자동완성 API를 호출하면 THE Spot_API SHALL 중복 제거된 Content_Name 목록을 반환한다
+3. THE Spot_API SHALL 각 Content_Name에 해당 카테고리 정보를 포함하여 반환한다
+4. THE Spot_API SHALL 검색어 파라미터로 서버 사이드 필터링을 지원한다
+
+### Requirement 6: 검색 필터 API 통합
+
+**User Story:** As a 시스템, I want to 기존 스팟 조회 API에 검색 필터를 통합하고 싶다, so that I can 카테고리와 검색어를 함께 필터링할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Spot_API SHALL 검색어 쿼리 파라미터(search)를 지원한다
+2. WHEN search 파라미터가 제공되면 THE Spot_API SHALL relatedContent.name에서 부분 일치 검색을 수행한다
+3. WHEN category와 search 파라미터가 함께 제공되면 THE Spot_API SHALL 두 조건을 AND로 결합한다
+4. IF 검색어가 빈 문자열이면 THEN THE Spot_API SHALL 검색 필터를 적용하지 않는다

--- a/.kiro/specs/content-search-filter/tasks.md
+++ b/.kiro/specs/content-search-filter/tasks.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Content Search Filter
+
+## Overview
+
+콘텐츠 검색 필터 기능을 구현합니다. filterStore 확장 → API 구현 → UI 컴포넌트 순서로 진행하여 각 단계에서 동작을 검증할 수 있도록 합니다.
+
+## Tasks
+
+- [ ] 1. filterStore 검색 상태 확장
+  - [ ] 1.1 filterStore에 searchQuery 상태 및 액션 추가
+    - searchQuery: string 필드 추가
+    - setSearchQuery, clearSearchQuery 액션 추가
+    - useSearchQuery 셀렉터 추가
+    - _Requirements: 4.1, 4.2, 4.4_
+  - [ ]\* 1.2 filterStore 검색 상태 속성 테스트 작성
+    - **Property 10: 스토어 검색어 상태 독립성**
+    - **Validates: Requirements 4.1, 4.3, 4.4**
+
+- [ ] 2. 자동완성 API 구현
+  - [ ] 2.1 /api/content-names 엔드포인트 생성
+    - GET 메서드로 중복 제거된 콘텐츠명 목록 반환
+    - search 쿼리 파라미터로 서버 사이드 필터링
+    - 각 항목에 category, count 정보 포함
+    - 최대 10개 제한
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+  - [ ]\* 2.2 자동완성 API 속성 테스트 작성
+    - **Property 4: 자동완성 최대 10개 제한**
+    - **Property 6: 자동완성 항목 카테고리 정보 포함**
+    - **Property 11: 자동완성 API 중복 제거**
+    - **Validates: Requirements 2.2, 2.6, 5.2, 5.3**
+
+- [ ] 3. 스팟 API 검색 필터 통합
+  - [ ] 3.1 /api/spots에 search 쿼리 파라미터 추가
+    - relatedContent.name 부분 일치 검색 (대소문자 무시)
+    - category와 AND 조건 결합
+    - 빈 문자열 시 필터 미적용
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+  - [ ]\* 3.2 스팟 API 검색 필터 속성 테스트 작성
+    - **Property 7: 부분 일치 검색 동작**
+    - **Property 8: 대소문자 무시 검색**
+    - **Property 9: 카테고리와 검색어 AND 조건 결합**
+    - **Validates: Requirements 3.1, 3.2, 3.5, 6.2, 6.3**
+
+- [ ] 4. Checkpoint - API 및 스토어 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. useAutocomplete 훅 구현
+  - [ ] 5.1 useAutocomplete 커스텀 훅 생성
+    - 2글자 이상 입력 시 API 호출
+    - 300ms 디바운스 적용
+    - suggestions, isLoading, error 반환
+    - _Requirements: 2.1_
+  - [ ]\* 5.2 useAutocomplete 훅 속성 테스트 작성
+    - **Property 3: 2글자 이상 입력 시 자동완성 활성화**
+    - **Validates: Requirements 2.1**
+
+- [ ] 6. SearchInput 컴포넌트 구현
+  - [ ] 6.1 SearchInput 기본 컴포넌트 생성
+    - 검색어 입력 필드
+    - 초기화 버튼 (X)
+    - 플레이스홀더 텍스트
+    - filterStore 연동
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+  - [ ]\* 6.2 SearchInput 컴포넌트 속성 테스트 작성
+    - **Property 1: 검색어 입력 실시간 반영**
+    - **Property 2: 초기화 버튼 클릭 시 검색어 리셋**
+    - **Validates: Requirements 1.3, 1.5**
+
+- [ ] 7. AutocompleteDropdown 컴포넌트 구현
+  - [ ] 7.1 AutocompleteDropdown 컴포넌트 생성
+    - 제안 항목 목록 표시
+    - 카테고리 아이콘 및 스팟 개수 표시
+    - 항목 클릭 시 선택 처리
+    - 외부 클릭 시 닫기
+    - "검색 결과 없음" 메시지
+    - _Requirements: 2.2, 2.3, 2.4, 2.5, 2.6, 2.7_
+  - [ ]\* 7.2 AutocompleteDropdown 컴포넌트 속성 테스트 작성
+    - **Property 5: 제안 항목 선택 시 검색어 설정 및 필터 적용**
+    - **Validates: Requirements 2.3, 2.4**
+
+- [ ] 8. ContentSearchFilter 통합 컴포넌트 구현
+  - [ ] 8.1 ContentSearchFilter 컴포넌트 생성
+    - SearchInput + AutocompleteDropdown 결합
+    - 자동완성 드롭다운 표시/숨김 로직
+    - _Requirements: 1.1, 2.7_
+
+- [ ] 9. 지도 페이지 통합
+  - [ ] 9.1 CategoryFilter 옆에 ContentSearchFilter 배치
+    - 필터 영역 레이아웃 조정
+    - _Requirements: 1.1_
+  - [ ] 9.2 useSpots 훅에 searchQuery 연동
+    - filterStore의 searchQuery를 API 호출에 포함
+    - _Requirements: 3.3_
+
+- [ ] 10. 빈 상태 및 에러 처리
+  - [ ] 10.1 검색 결과 없음 UI 구현
+    - 지도에 빈 상태 메시지 표시
+    - _Requirements: 3.4_
+
+- [ ] 11. Final Checkpoint - 전체 기능 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- 각 task는 특정 requirements를 참조하여 추적 가능
+- Property tests는 fast-check 라이브러리 사용
+- 체크포인트에서 점진적 검증 수행

--- a/.kiro/specs/zustand-global-state/tasks.md
+++ b/.kiro/specs/zustand-global-state/tasks.md
@@ -43,19 +43,19 @@
     - 기존 인터페이스 유지 (하위 호환성)
     - _Requirements: 2.3_
 
-- [ ] 3. 카테고리 필터 상태 전역 관리
-  - [ ] 3.1 filterStore 생성
+- [x] 3. 카테고리 필터 상태 전역 관리
+  - [x] 3.1 filterStore 생성
     - `src/stores/filterStore.ts` 생성
     - selectedCategories 상태 정의
     - setSelectedCategories, toggleCategory, clearCategories 액션 구현
     - selector 함수 제공
     - _Requirements: 3.1_
-  - [ ] 3.2 CategoryFilter에 filterStore 적용
+  - [x] 3.2 CategoryFilter에 filterStore 적용
     - `src/components/map/CategoryFilter.tsx` 수정
     - props로 받던 selectedCategories를 filterStore로 교체
     - onChange 콜백 대신 filterStore.toggleCategory 직접 호출
     - _Requirements: 3.2_
-  - [ ] 3.3 PilgrimageMap에 filterStore 적용
+  - [x] 3.3 PilgrimageMap에 filterStore 적용
     - `src/components/map/PilgrimageMap.tsx` 수정
     - 로컬 상태 selectedCategories를 filterStore로 교체
     - useSpots 훅에 filterStore.selectedCategories 전달

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import { useSpots } from '@/hooks/useSpots'
 import SpotPreview from '@/components/map/SpotPreview'
 import CategoryFilter from '@/components/map/CategoryFilter'
-import { SpotCategory } from '@/types'
+import { useSelectedCategories } from '@/stores/filterStore'
 
 // Leaflet은 SSR을 지원하지 않으므로 dynamic import 사용
 const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
@@ -91,12 +90,11 @@ function SpotErrorDisplay({
  * - 반응형 레이아웃 지원
  * - 실제 API 데이터 연동 (Task 6.2)
  * - 카테고리 필터링 지원 (Requirements 2.2)
+ * - filterStore 전역 상태 사용 (Requirements 3.3)
  */
 export default function Home() {
-  // 카테고리 필터 상태 관리
-  const [selectedCategories, setSelectedCategories] = useState<SpotCategory[]>(
-    []
-  )
+  // filterStore에서 카테고리 필터 상태 가져오기
+  const selectedCategories = useSelectedCategories()
 
   // 실제 API에서 스팟 데이터 가져오기 (카테고리 필터 적용)
   const {
@@ -152,10 +150,7 @@ export default function Home() {
         {/* 카테고리 필터 (하단 중앙 플로팅 바) */}
         <div className="absolute bottom-6 left-1/2 z-[1000] -translate-x-1/2">
           <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
-            <CategoryFilter
-              selectedCategories={selectedCategories}
-              onChange={setSelectedCategories}
-            />
+            <CategoryFilter />
           </div>
         </div>
 

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -1,46 +1,31 @@
 'use client'
 
 import { SpotCategory, CATEGORY_CONFIG } from '@/types'
-
-interface CategoryFilterProps {
-  selectedCategories: SpotCategory[]
-  onChange: (categories: SpotCategory[]) => void
-}
-
-const ALL_CATEGORIES: SpotCategory[] = [
-  'animation',
-  'sports',
-  'movie_drama',
-  'music',
-  'game',
-  'other',
-]
+import {
+  useFilterStore,
+  useSelectedCategories,
+  ALL_CATEGORIES,
+} from '@/stores/filterStore'
 
 /**
  * 카테고리 필터 컴포넌트
  * Requirements 2.2: 카테고리별 스팟 필터링 UI
+ * Requirements 3.2: filterStore 전역 상태 사용
  */
-export default function CategoryFilter({
-  selectedCategories,
-  onChange,
-}: CategoryFilterProps) {
+export default function CategoryFilter() {
+  const selectedCategories = useSelectedCategories()
+  const { toggleCategory, selectAllCategories, clearCategories } =
+    useFilterStore()
+
   const handleCategoryToggle = (category: SpotCategory) => {
-    if (selectedCategories.includes(category)) {
-      // 카테고리 제거
-      onChange(selectedCategories.filter((c) => c !== category))
-    } else {
-      // 카테고리 추가
-      onChange([...selectedCategories, category])
-    }
+    toggleCategory(category)
   }
 
   const handleSelectAll = () => {
     if (selectedCategories.length === ALL_CATEGORIES.length) {
-      // 모두 선택된 상태면 전체 해제
-      onChange([])
+      clearCategories()
     } else {
-      // 전체 선택
-      onChange([...ALL_CATEGORIES])
+      selectAllCategories()
     }
   }
 

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -1,0 +1,82 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { SpotCategory } from '@/types'
+
+const ALL_CATEGORIES: SpotCategory[] = [
+  'animation',
+  'sports',
+  'movie_drama',
+  'music',
+  'game',
+  'other',
+]
+
+interface FilterStore {
+  selectedCategories: SpotCategory[]
+
+  setSelectedCategories: (categories: SpotCategory[]) => void
+  toggleCategory: (category: SpotCategory) => void
+  selectAllCategories: () => void
+  clearCategories: () => void
+  resetFilterState: () => void
+}
+
+export const useFilterStore = create<FilterStore>()(
+  devtools(
+    (set) => ({
+      selectedCategories: [...ALL_CATEGORIES],
+
+      setSelectedCategories: (categories) =>
+        set(
+          { selectedCategories: categories },
+          false,
+          'filterStore/setSelectedCategories'
+        ),
+
+      toggleCategory: (category) =>
+        set(
+          (state) => {
+            if (state.selectedCategories.includes(category)) {
+              return {
+                selectedCategories: state.selectedCategories.filter(
+                  (c) => c !== category
+                ),
+              }
+            }
+            return {
+              selectedCategories: [...state.selectedCategories, category],
+            }
+          },
+          false,
+          'filterStore/toggleCategory'
+        ),
+
+      selectAllCategories: () =>
+        set(
+          { selectedCategories: [...ALL_CATEGORIES] },
+          false,
+          'filterStore/selectAllCategories'
+        ),
+
+      clearCategories: () =>
+        set({ selectedCategories: [] }, false, 'filterStore/clearCategories'),
+
+      resetFilterState: () =>
+        set(
+          { selectedCategories: [...ALL_CATEGORIES] },
+          false,
+          'filterStore/resetFilterState'
+        ),
+    }),
+    {
+      name: 'filter-store',
+    }
+  )
+)
+
+// Selectors
+export const useSelectedCategories = () =>
+  useFilterStore((state) => state.selectedCategories)
+
+// Constants export
+export { ALL_CATEGORIES }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #160

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 카테고리 필터 상태를 zustand 전역 스토어(filterStore)로 이전하여 지도와 컴포넌트 간 필터 상태 동기화

---

## 📋 변경 사항

- [x] filterStore.ts 생성 (selectedCategories 상태, 액션, selector)
- [x] CategoryFilter 컴포넌트에서 props 대신 filterStore 사용
- [x] 메인 페이지에서 로컬 상태 대신 filterStore 사용

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- Requirements 3.1, 3.2, 3.3 대응
- 기존 mapStore, likeStore 패턴과 일관된 구조 유지
- devtools 미들웨어로 디버깅 용이성 확보
