### PR TITLE
Feat/168  spots api search filter add

### DIFF
--- a/.kiro/specs/content-search-filter/tasks.md
+++ b/.kiro/specs/content-search-filter/tasks.md
@@ -6,8 +6,8 @@
 
 ## Tasks
 
-- [ ] 1. filterStore 검색 상태 확장
-  - [ ] 1.1 filterStore에 searchQuery 상태 및 액션 추가
+- [x] 1. filterStore 검색 상태 확장
+  - [x] 1.1 filterStore에 searchQuery 상태 및 액션 추가
     - searchQuery: string 필드 추가
     - setSearchQuery, clearSearchQuery 액션 추가
     - useSearchQuery 셀렉터 추가
@@ -16,8 +16,8 @@
     - **Property 10: 스토어 검색어 상태 독립성**
     - **Validates: Requirements 4.1, 4.3, 4.4**
 
-- [ ] 2. 자동완성 API 구현
-  - [ ] 2.1 /api/content-names 엔드포인트 생성
+- [x] 2. 자동완성 API 구현
+  - [x] 2.1 /api/content-names 엔드포인트 생성
     - GET 메서드로 중복 제거된 콘텐츠명 목록 반환
     - search 쿼리 파라미터로 서버 사이드 필터링
     - 각 항목에 category, count 정보 포함
@@ -29,8 +29,8 @@
     - **Property 11: 자동완성 API 중복 제거**
     - **Validates: Requirements 2.2, 2.6, 5.2, 5.3**
 
-- [ ] 3. 스팟 API 검색 필터 통합
-  - [ ] 3.1 /api/spots에 search 쿼리 파라미터 추가
+- [x] 3. 스팟 API 검색 필터 통합
+  - [x] 3.1 /api/spots에 search 쿼리 파라미터 추가
     - relatedContent.name 부분 일치 검색 (대소문자 무시)
     - category와 AND 조건 결합
     - 빈 문자열 시 필터 미적용

--- a/.kiro/specs/zustand-global-state/tasks.md
+++ b/.kiro/specs/zustand-global-state/tasks.md
@@ -61,17 +61,17 @@
     - useSpots 훅에 filterStore.selectedCategories 전달
     - _Requirements: 3.3_
 
-- [ ] 4. 코드 정리 및 검증
-  - [ ] 4.1 불필요한 로컬 상태 코드 제거
+- [x] 4. 코드 정리 및 검증
+  - [x] 4.1 불필요한 로컬 상태 코드 제거
     - 마이그레이션 완료된 컴포넌트에서 사용하지 않는 로컬 상태 제거
     - 불필요한 props 제거
     - _Requirements: 코드 품질_
-  - [ ] 4.2 스토어 index.ts 생성
+  - [x] 4.2 스토어 index.ts 생성
     - `src/stores/index.ts` 생성
     - 모든 스토어 re-export
     - _Requirements: 코드 품질_
 
-- [ ] 5. Checkpoint - 전역 상태 관리 검증
+- [x] 5. Checkpoint - 전역 상태 관리 검증
   - 좋아요 상태가 페이지 이동 후에도 유지되는지 확인
   - 카테고리 필터가 지도와 동기화되는지 확인
   - 로그아웃 상태가 전역으로 관리되는지 확인

--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -11,6 +11,14 @@ import {
 import { validateExternalLinks } from '@/lib/external-link-validation'
 
 /**
+ * 정규식 특수문자 이스케이프 처리
+ * MongoDB $regex에서 안전하게 사용하기 위함
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, (match) => '\\' + match)
+}
+
+/**
  * 다음 스팟 ID 생성 (SPOT-{숫자} 형식)
  * 기존 스팟 중 가장 큰 번호를 찾아서 +1
  */
@@ -71,25 +79,42 @@ interface SpotDocument {
 /**
  * GET /api/spots - 모든 스팟 목록 조회 (핀 표시용)
  * Requirements: 1.2, 6.2, 2.2 (카테고리 필터링)
+ * Requirements: 6.1, 6.2, 6.3, 6.4 (검색 필터링)
  * Query params:
  *   - category: 카테고리 필터 (쉼표로 구분, 예: animation,sports)
+ *   - search: 검색어 필터 (relatedContent.name 부분 일치, 대소문자 무시)
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const collection = await getCollection<SpotDocument>('spots')
 
-    // 카테고리 필터 파라미터 파싱
+    // 쿼리 파라미터 파싱
     const { searchParams } = new URL(request.url)
     const categoryParam = searchParams.get('category')
+    const searchParam = searchParams.get('search')
 
     // MongoDB 쿼리 조건 생성
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const query: Record<string, any> = {}
 
+    // 카테고리 필터 (Requirements 2.2)
     if (categoryParam) {
       const categories = categoryParam.split(',').filter(Boolean)
       if (categories.length > 0) {
         query.category = { $in: categories }
+      }
+    }
+
+    // 검색 필터 (Requirements 6.1, 6.2, 6.3, 6.4)
+    // - 빈 문자열이 아닌 경우에만 필터 적용 (6.4)
+    // - relatedContent.name 부분 일치 검색 (6.2)
+    // - 대소문자 무시 (6.2)
+    // - category와 AND 조건 결합 (6.3)
+    if (searchParam && searchParam.trim() !== '') {
+      const escapedSearch = escapeRegex(searchParam.trim())
+      query['relatedContent.name'] = {
+        $regex: escapedSearch,
+        $options: 'i', // 대소문자 무시
       }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #168

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> /api/spots 엔드포인트에 search 쿼리 파라미터를 추가하여 콘텐츠명 기반 스팟 검색 기능 지원

---

## 📋 변경 사항

- [x] `search` 쿼리 파라미터 추가 (Requirements 6.1)
- [x] `relatedContent.name` 필드에서 부분 일치 검색 구현 (Requirements 6.2)
- [x] 대소문자 무시 검색 (`$options: 'i'`)
- [x] `category`와 `search` 파라미터 AND 조건 결합 (Requirements 6.3)
- [x] 빈 문자열 시 필터 미적용 처리 (Requirements 6.4)
- [x] 정규식 특수문자 이스케이프 처리 (`escapeRegex` 함수 추가)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

### API 사용 예시
GET /api/spots?search=귀멸의칼날 GET /api/spots?category=animation&search=귀멸 GET /api/spots?category=animation,sports&search=도쿄


### 관련 Requirements

- 6.1: search 쿼리 파라미터 지원
- 6.2: relatedContent.name 부분 일치 검색
- 6.3: category와 search AND 조건 결합
- 6.4: 빈 문자열 시 필터 미적용

