### PR TITLE
[Feat] Task 9 - 지도 페이지 통합

### DIFF
--- a/.kiro/specs/content-search-filter/tasks.md
+++ b/.kiro/specs/content-search-filter/tasks.md
@@ -84,11 +84,11 @@
     - 자동완성 드롭다운 표시/숨김 로직
     - _Requirements: 1.1, 2.7_
 
-- [ ] 9. 지도 페이지 통합
-  - [ ] 9.1 CategoryFilter 옆에 ContentSearchFilter 배치
+- [x] 9. 지도 페이지 통합
+  - [x] 9.1 CategoryFilter 옆에 ContentSearchFilter 배치
     - 필터 영역 레이아웃 조정
     - _Requirements: 1.1_
-  - [ ] 9.2 useSpots 훅에 searchQuery 연동
+  - [x] 9.2 useSpots 훅에 searchQuery 연동
     - filterStore의 searchQuery를 API 호출에 포함
     - _Requirements: 3.3_
 

--- a/.kiro/specs/multi-content-spot/design.md
+++ b/.kiro/specs/multi-content-spot/design.md
@@ -1,0 +1,226 @@
+# Design Document: Multi-Content Spot (다중 작품 연결 스팟)
+
+## Overview
+
+이 기능은 하나의 스팟에 여러 관련 콘텐츠(작품)를 연결할 수 있도록 UI/UX를 개선합니다. 기존 `RelatedContentForm` 컴포넌트를 확장하여 다중 콘텐츠 추가, 순서 변경, 중복 방지 기능을 구현하고, 스팟 상세 페이지에서 모든 연결된 콘텐츠를 효과적으로 표시합니다.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "스팟 등록/수정 폼"
+        SF[SpotForm]
+        RCF[RelatedContentForm]
+        RCI[RelatedContentItem]
+        RCA[RelatedContentAddForm]
+    end
+
+    subgraph "스팟 상세 페이지"
+        SDP[SpotDetailPage]
+        RCS[RelatedContentSection]
+        RCG[RelatedContentGrid]
+    end
+
+    subgraph "데이터 흐름"
+        RC[RelatedContent[]]
+    end
+
+    SF --> RCF
+    RCF --> RCI
+    RCF --> RCA
+    RCF --> RC
+
+    SDP --> RCS
+    RCS --> RCG
+    RC --> RCS
+```
+
+## Components and Interfaces
+
+### 1. RelatedContentForm (확장)
+
+기존 컴포넌트를 확장하여 다음 기능을 추가합니다:
+
+```typescript
+interface RelatedContentFormProps {
+  value: RelatedContent[]
+  onChange: (contents: RelatedContent[]) => void
+  maxItems?: number // 최대 추가 가능 개수 (기본값: 20)
+}
+
+// 내부 상태
+interface RelatedContentFormState {
+  isAdding: boolean
+  newContent: Partial<RelatedContent>
+  draggedIndex: number | null
+  duplicateWarning: string | null
+}
+```
+
+### 2. RelatedContentItem (신규)
+
+개별 콘텐츠 항목을 표시하고 드래그 앤 드롭을 지원하는 컴포넌트:
+
+```typescript
+interface RelatedContentItemProps {
+  content: RelatedContent
+  index: number
+  onRemove: () => void
+  onDragStart: (index: number) => void
+  onDragOver: (index: number) => void
+  onDragEnd: () => void
+  isDragging: boolean
+  isDragOver: boolean
+}
+```
+
+### 3. RelatedContentSection (신규)
+
+스팟 상세 페이지에서 관련 콘텐츠를 표시하는 섹션 컴포넌트:
+
+```typescript
+interface RelatedContentSectionProps {
+  contents: RelatedContent[]
+  initialDisplayCount?: number // 기본값: 3
+}
+
+interface RelatedContentSectionState {
+  isExpanded: boolean
+}
+```
+
+## Data Models
+
+기존 데이터 모델을 그대로 사용합니다:
+
+```typescript
+// 기존 타입 (변경 없음)
+interface RelatedContent {
+  name: string
+  type: ContentType
+  year?: number
+  additionalInfo?: string
+}
+
+type ContentType =
+  | 'anime'
+  | 'movie'
+  | 'drama'
+  | 'sports_team'
+  | 'artist'
+  | 'game'
+  | 'other'
+```
+
+### 중복 검사 유틸리티
+
+```typescript
+/**
+ * 콘텐츠 이름 정규화 (중복 검사용)
+ */
+function normalizeContentName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+/**
+ * 중복 콘텐츠 검사
+ */
+function isDuplicateContent(
+  contents: RelatedContent[],
+  newName: string
+): boolean {
+  const normalizedNew = normalizeContentName(newName)
+  return contents.some((c) => normalizeContentName(c.name) === normalizedNew)
+}
+```
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system-essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: 콘텐츠 추가 불변성
+
+_For any_ 기존 RelatedContent 배열과 새로운 유효한 RelatedContent 항목에 대해, 추가 연산 후 결과 배열은 기존의 모든 항목과 새 항목을 포함해야 한다.
+
+**Validates: Requirements 1.2, 5.3**
+
+### Property 2: 콘텐츠 삭제 정확성
+
+_For any_ RelatedContent 배열과 유효한 인덱스에 대해, 해당 인덱스의 항목을 삭제하면 결과 배열의 길이는 1 감소하고, 삭제된 항목을 제외한 모든 항목이 원래 순서대로 유지되어야 한다.
+
+**Validates: Requirements 1.3**
+
+### Property 3: 순서 변경 불변성
+
+_For any_ RelatedContent 배열과 두 개의 유효한 인덱스에 대해, 순서 변경(reorder) 연산 후 결과 배열은 원본과 동일한 항목들을 포함하고 길이가 동일해야 한다 (내용물 보존, 순서만 변경).
+
+**Validates: Requirements 2.1**
+
+### Property 4: 콘텐츠 표시 개수 제한 및 확장
+
+_For any_ 4개 이상의 RelatedContent 배열에 대해, 초기 표시 상태에서는 정확히 3개만 표시되고, 확장 상태에서는 모든 항목이 표시되어야 한다.
+
+**Validates: Requirements 3.2, 3.3**
+
+### Property 5: 콘텐츠 렌더링 완전성
+
+_For any_ RelatedContent 항목에 대해, 렌더링 결과는 해당 항목의 name, type을 포함해야 하고, year와 additionalInfo가 존재하면 이들도 포함해야 한다.
+
+**Validates: Requirements 3.4**
+
+### Property 6: 중복 검사 정규화
+
+_For any_ 문자열 name에 대해, 대소문자를 변경하거나 앞뒤에 공백을 추가해도 정규화 함수는 동일한 결과를 반환해야 한다. 또한, 정규화된 이름이 기존 배열에 존재하면 중복으로 감지되어야 한다.
+
+**Validates: Requirements 4.1, 4.3**
+
+### Property 7: 데이터 로드 라운드트립
+
+_For any_ 유효한 Spot 데이터에 대해, 수정 폼에 로드한 후 변경 없이 저장하면 원본 relatedContent 배열과 동일한 데이터가 유지되어야 한다.
+
+**Validates: Requirements 5.1, 5.2**
+
+## Error Handling
+
+### 입력 검증 오류
+
+| 오류 상황            | 처리 방법                             |
+| -------------------- | ------------------------------------- |
+| 빈 콘텐츠 이름       | 추가 버튼 비활성화, 에러 메시지 표시  |
+| 중복 콘텐츠          | 경고 메시지 표시, 강제 추가 옵션 제공 |
+| 최대 개수 초과       | 추가 버튼 비활성화, 안내 메시지 표시  |
+| 잘못된 드래그 인덱스 | 연산 무시, 원본 상태 유지             |
+
+### API 오류
+
+| 오류 상황      | 처리 방법                          |
+| -------------- | ---------------------------------- |
+| 스팟 로드 실패 | 에러 메시지 표시, 재시도 버튼 제공 |
+| 스팟 저장 실패 | 에러 메시지 표시, 입력 데이터 유지 |
+
+## Testing Strategy
+
+### 단위 테스트
+
+- `normalizeContentName` 함수: 다양한 입력에 대한 정규화 결과 확인
+- `isDuplicateContent` 함수: 중복 검사 로직 확인
+- `RelatedContentItem` 컴포넌트: 렌더링 및 이벤트 핸들링 확인
+- `RelatedContentSection` 컴포넌트: 초기 표시 개수 및 확장 기능 확인
+
+### 속성 기반 테스트
+
+- **Property 1-3**: 배열 연산의 정확성 검증 (fast-check 사용)
+- **Property 6**: 문자열 정규화 함수의 멱등성 검증
+- **Property 7**: 데이터 라운드트립 검증
+
+### 통합 테스트
+
+- 스팟 등록 플로우: 여러 콘텐츠 추가 후 저장
+- 스팟 수정 플로우: 기존 콘텐츠 로드, 수정, 저장
+- 스팟 상세 페이지: 다중 콘텐츠 표시 및 확장
+
+### 테스트 라이브러리
+
+- **단위 테스트**: Jest + React Testing Library
+- **속성 기반 테스트**: fast-check (최소 100회 반복)
+- **E2E 테스트**: Playwright (선택적)

--- a/.kiro/specs/multi-content-spot/requirements.md
+++ b/.kiro/specs/multi-content-spot/requirements.md
@@ -1,0 +1,78 @@
+# Requirements Document
+
+## Introduction
+
+이 문서는 "다중 작품 연결 스팟" 기능의 요구사항을 정의합니다. 현재 스팟에는 relatedContent 배열이 존재하지만, UI에서 여러 작품을 효과적으로 추가/관리하는 기능이 부족합니다. 예를 들어, 도쿄타워는 도쿄구울, 원피스타워, 그 외 여러 작품에 등장하지만 현재는 하나의 작품만 쉽게 추가할 수 있습니다. 이 기능을 통해 사용자가 스팟 등록/수정 시 여러 작품을 쉽게 추가하고 관리할 수 있도록 합니다.
+
+## Glossary
+
+- **Spot**: 특별한 여행지 정보를 담은 데이터 엔티티
+- **RelatedContent**: 스팟과 연결된 작품/콘텐츠 정보 (이름, 타입, 연도, 추가정보 포함)
+- **ContentType**: 콘텐츠의 종류 (anime, movie, drama, sports_team, artist, game, other)
+- **RelatedContentForm**: 관련 콘텐츠를 입력하는 폼 컴포넌트
+- **SpotForm**: 스팟 등록/수정을 위한 메인 폼 컴포넌트
+- **SpotDetailPage**: 스팟 상세 정보를 표시하는 페이지
+
+## Requirements
+
+### Requirement 1: 다중 콘텐츠 추가 UI 개선
+
+**User Story:** As a 사용자, I want 스팟 등록 시 여러 관련 콘텐츠를 연속으로 쉽게 추가할 수 있기를, so that 하나의 스팟에 여러 작품을 빠르게 연결할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 사용자가 관련 콘텐츠를 추가한 후 THEN THE RelatedContentForm SHALL 추가 완료 후 즉시 새로운 콘텐츠 추가 버튼을 표시한다
+2. WHEN 사용자가 여러 콘텐츠를 추가했을 때 THEN THE RelatedContentForm SHALL 추가된 모든 콘텐츠를 목록으로 표시한다
+3. WHEN 사용자가 추가된 콘텐츠 목록에서 특정 항목을 삭제하려 할 때 THEN THE RelatedContentForm SHALL 해당 항목만 삭제하고 나머지는 유지한다
+4. THE RelatedContentForm SHALL 추가된 콘텐츠 개수를 표시한다
+
+### Requirement 2: 콘텐츠 순서 관리
+
+**User Story:** As a 사용자, I want 추가한 관련 콘텐츠의 순서를 변경할 수 있기를, so that 가장 중요한 작품을 먼저 표시할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 사용자가 콘텐츠 목록에서 드래그 앤 드롭을 수행할 때 THEN THE RelatedContentForm SHALL 콘텐츠의 순서를 변경한다
+2. WHEN 콘텐츠 순서가 변경되었을 때 THEN THE RelatedContentForm SHALL 변경된 순서를 즉시 반영하여 표시한다
+3. THE RelatedContentForm SHALL 각 콘텐츠 항목에 순서 변경을 위한 드래그 핸들을 표시한다
+
+### Requirement 3: 스팟 상세 페이지 다중 콘텐츠 표시
+
+**User Story:** As a 사용자, I want 스팟 상세 페이지에서 연결된 모든 작품을 볼 수 있기를, so that 해당 장소와 관련된 모든 콘텐츠를 확인할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 스팟에 여러 relatedContent가 있을 때 THEN THE SpotDetailPage SHALL 모든 관련 콘텐츠를 그리드 형태로 표시한다
+2. WHEN 관련 콘텐츠가 4개 이상일 때 THEN THE SpotDetailPage SHALL 처음 3개만 표시하고 "더보기" 버튼을 제공한다
+3. WHEN 사용자가 "더보기" 버튼을 클릭할 때 THEN THE SpotDetailPage SHALL 나머지 모든 콘텐츠를 표시한다
+4. THE SpotDetailPage SHALL 각 콘텐츠의 타입 아이콘, 이름, 연도, 추가정보를 표시한다
+
+### Requirement 4: 콘텐츠 중복 방지
+
+**User Story:** As a 사용자, I want 동일한 작품을 중복으로 추가하지 않도록 안내받기를, so that 데이터의 일관성을 유지할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 사용자가 이미 추가된 콘텐츠와 동일한 이름의 콘텐츠를 추가하려 할 때 THEN THE RelatedContentForm SHALL 중복 경고 메시지를 표시한다
+2. WHEN 중복 경고가 표시될 때 THEN THE RelatedContentForm SHALL 사용자가 그래도 추가할 수 있는 옵션을 제공한다
+3. THE RelatedContentForm SHALL 콘텐츠 이름 비교 시 대소문자를 무시하고 앞뒤 공백을 제거하여 비교한다
+
+### Requirement 5: 스팟 수정 시 기존 콘텐츠 유지
+
+**User Story:** As a 사용자, I want 스팟 수정 시 기존에 등록된 관련 콘텐츠가 유지되기를, so that 실수로 데이터를 잃지 않습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 스팟 수정 페이지가 로드될 때 THEN THE SpotForm SHALL 기존에 등록된 모든 relatedContent를 표시한다
+2. WHEN 사용자가 기존 콘텐츠를 수정하지 않고 저장할 때 THEN THE SpotForm SHALL 기존 콘텐츠를 그대로 유지한다
+3. WHEN 사용자가 새 콘텐츠를 추가하고 저장할 때 THEN THE SpotForm SHALL 기존 콘텐츠와 새 콘텐츠를 모두 저장한다
+
+### Requirement 6: 빈 콘텐츠 목록 처리
+
+**User Story:** As a 사용자, I want 관련 콘텐츠가 없는 스팟도 등록할 수 있기를, so that 나중에 콘텐츠를 추가할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 사용자가 관련 콘텐츠 없이 스팟을 등록할 때 THEN THE SpotForm SHALL 정상적으로 스팟을 저장한다
+2. WHEN 스팟에 관련 콘텐츠가 없을 때 THEN THE SpotDetailPage SHALL "관련 콘텐츠" 섹션을 표시하지 않는다
+3. WHEN 스팟에 관련 콘텐츠가 없을 때 THEN THE RelatedContentForm SHALL 콘텐츠 추가를 유도하는 안내 메시지를 표시한다

--- a/.kiro/specs/multi-content-spot/tasks.md
+++ b/.kiro/specs/multi-content-spot/tasks.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Multi-Content Spot (다중 작품 연결 스팟)
+
+## Overview
+
+기존 `RelatedContentForm` 컴포넌트를 확장하여 다중 콘텐츠 추가, 순서 변경, 중복 방지 기능을 구현하고, 스팟 상세 페이지에서 모든 연결된 콘텐츠를 효과적으로 표시합니다.
+
+## Tasks
+
+- [ ] 1. 유틸리티 함수 및 타입 정의
+  - [ ] 1.1 콘텐츠 관련 유틸리티 함수 구현
+    - `src/lib/content-utils.ts` 파일 생성
+    - `normalizeContentName` 함수 구현 (대소문자 무시, 공백 제거)
+    - `isDuplicateContent` 함수 구현 (중복 검사)
+    - `reorderContents` 함수 구현 (순서 변경)
+    - `removeContentAtIndex` 함수 구현 (삭제)
+    - _Requirements: 4.3, 2.1, 1.3_
+
+  - [ ]\* 1.2 유틸리티 함수 속성 테스트 작성
+    - **Property 6: 중복 검사 정규화**
+    - **Property 2: 콘텐츠 삭제 정확성**
+    - **Property 3: 순서 변경 불변성**
+    - **Validates: Requirements 4.1, 4.3, 1.3, 2.1**
+
+- [ ] 2. RelatedContentItem 컴포넌트 구현
+  - [ ] 2.1 RelatedContentItem 컴포넌트 생성
+    - `src/components/spot/RelatedContentItem.tsx` 파일 생성
+    - 개별 콘텐츠 항목 표시 (타입 아이콘, 이름, 연도, 추가정보)
+    - 삭제 버튼 구현
+    - 드래그 핸들 구현
+    - 드래그 앤 드롭 이벤트 핸들러 연결
+    - _Requirements: 1.3, 2.3, 3.4_
+
+  - [ ]\* 2.2 RelatedContentItem 단위 테스트 작성
+    - 렌더링 테스트 (모든 필드 표시 확인)
+    - 삭제 버튼 클릭 이벤트 테스트
+    - **Property 5: 콘텐츠 렌더링 완전성**
+    - **Validates: Requirements 3.4**
+
+- [ ] 3. RelatedContentForm 컴포넌트 확장
+  - [ ] 3.1 다중 콘텐츠 목록 표시 기능 구현
+    - 기존 `RelatedContentForm` 컴포넌트 수정
+    - 추가된 콘텐츠 목록을 `RelatedContentItem`으로 렌더링
+    - 콘텐츠 개수 표시
+    - 빈 상태 안내 메시지 표시
+    - _Requirements: 1.2, 1.4, 6.3_
+
+  - [ ] 3.2 콘텐츠 추가 기능 구현
+    - 새 콘텐츠 추가 폼 구현
+    - 추가 완료 후 폼 초기화 및 추가 버튼 표시
+    - 중복 검사 및 경고 메시지 표시
+    - 강제 추가 옵션 제공
+    - _Requirements: 1.1, 4.1, 4.2_
+
+  - [ ] 3.3 콘텐츠 삭제 기능 구현
+    - 삭제 버튼 클릭 시 해당 항목만 삭제
+    - 삭제 확인 없이 즉시 삭제 (되돌리기 가능하도록 상태 관리)
+    - _Requirements: 1.3_
+
+  - [ ] 3.4 드래그 앤 드롭 순서 변경 기능 구현
+    - HTML5 Drag and Drop API 사용
+    - 드래그 시작/종료 상태 관리
+    - 드롭 위치에 따른 순서 변경
+    - 시각적 피드백 (드래그 중인 항목 표시)
+    - _Requirements: 2.1, 2.2_
+
+  - [ ]\* 3.5 RelatedContentForm 속성 테스트 작성
+    - **Property 1: 콘텐츠 추가 불변성**
+    - **Validates: Requirements 1.2, 5.3**
+
+- [ ] 4. Checkpoint - 폼 컴포넌트 검증
+  - 모든 테스트 통과 확인
+  - 스팟 등록 페이지에서 다중 콘텐츠 추가 동작 확인
+  - 사용자에게 질문이 있으면 문의
+
+- [ ] 5. 스팟 수정 페이지 연동
+  - [ ] 5.1 기존 콘텐츠 로드 기능 구현
+    - 스팟 수정 페이지에서 기존 relatedContent 배열 로드
+    - RelatedContentForm에 초기값으로 전달
+    - _Requirements: 5.1_
+
+  - [ ] 5.2 수정 저장 기능 구현
+    - 기존 콘텐츠 유지 및 새 콘텐츠 추가 저장
+    - API 호출 시 전체 relatedContent 배열 전송
+    - _Requirements: 5.2, 5.3_
+
+  - [ ]\* 5.3 데이터 라운드트립 테스트 작성
+    - **Property 7: 데이터 로드 라운드트립**
+    - **Validates: Requirements 5.1, 5.2**
+
+- [ ] 6. RelatedContentSection 컴포넌트 구현
+  - [ ] 6.1 RelatedContentSection 컴포넌트 생성
+    - `src/components/spot/RelatedContentSection.tsx` 파일 생성
+    - 관련 콘텐츠 그리드 레이아웃 구현
+    - 초기 3개 표시 및 "더보기" 버튼 구현
+    - 확장 시 모든 콘텐츠 표시
+    - 빈 배열일 때 섹션 숨김
+    - _Requirements: 3.1, 3.2, 3.3, 6.2_
+
+  - [ ]\* 6.2 RelatedContentSection 속성 테스트 작성
+    - **Property 4: 콘텐츠 표시 개수 제한 및 확장**
+    - **Validates: Requirements 3.2, 3.3**
+
+- [ ] 7. 스팟 상세 페이지 연동
+  - [ ] 7.1 SpotDetailPage에 RelatedContentSection 통합
+    - 스팟 상세 페이지에 RelatedContentSection 추가
+    - relatedContent 배열 전달
+    - 기존 단일 콘텐츠 표시 로직 제거
+    - _Requirements: 3.1, 3.4_
+
+- [ ] 8. 빈 콘텐츠 처리
+  - [ ] 8.1 빈 relatedContent 배열 처리 구현
+    - 스팟 등록 시 빈 배열 허용
+    - 스팟 상세 페이지에서 빈 배열 시 섹션 숨김
+    - _Requirements: 6.1, 6.2_
+
+- [ ] 9. Final Checkpoint - 전체 기능 검증
+  - 모든 테스트 통과 확인
+  - 스팟 등록/수정/상세 페이지 전체 플로우 확인
+  - 사용자에게 질문이 있으면 문의
+
+## Notes
+
+- `*` 표시된 태스크는 선택적 테스트 태스크입니다
+- 각 태스크는 특정 요구사항을 참조하여 추적 가능합니다
+- 체크포인트에서 점진적 검증을 수행합니다
+- 속성 테스트는 fast-check 라이브러리를 사용하여 최소 100회 반복 실행합니다

--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -107,15 +107,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // 검색 필터 (Requirements 6.1, 6.2, 6.3, 6.4)
     // - 빈 문자열이 아닌 경우에만 필터 적용 (6.4)
-    // - relatedContent.name 부분 일치 검색 (6.2)
+    // - name 또는 relatedContent.name 부분 일치 검색 (6.2)
     // - 대소문자 무시 (6.2)
     // - category와 AND 조건 결합 (6.3)
     if (searchParam && searchParam.trim() !== '') {
       const escapedSearch = escapeRegex(searchParam.trim())
-      query['relatedContent.name'] = {
-        $regex: escapedSearch,
-        $options: 'i', // 대소문자 무시
-      }
+      query.$or = [
+        { name: { $regex: escapedSearch, $options: 'i' } },
+        { 'relatedContent.name': { $regex: escapedSearch, $options: 'i' } },
+      ]
     }
 
     // Get spots from database with filter

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import { useSpots } from '@/hooks/useSpots'
 import SpotPreview from '@/components/map/SpotPreview'
@@ -97,6 +98,7 @@ export default function Home() {
   // filterStore에서 필터 상태 가져오기
   const selectedCategories = useSelectedCategories()
   const searchQuery = useSearchQuery()
+  const [isSearchExpanded, setIsSearchExpanded] = useState(false)
 
   // 실제 API에서 스팟 데이터 가져오기 (카테고리 + 검색 필터 적용)
   const {
@@ -156,11 +158,13 @@ export default function Home() {
         <div className="absolute bottom-6 left-1/2 z-[1000] -translate-x-1/2">
           <div className="flex items-center gap-2">
             {/* 콘텐츠 검색 필터 (토글 버튼) */}
-            <ContentSearchFilter />
-            {/* 카테고리 필터 */}
-            <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
-              <CategoryFilter />
-            </div>
+            <ContentSearchFilter onExpandChange={setIsSearchExpanded} />
+            {/* 카테고리 필터 - 검색창이 열리면 숨김 */}
+            {!isSearchExpanded && (
+              <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
+                <CategoryFilter />
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,8 @@ import dynamic from 'next/dynamic'
 import { useSpots } from '@/hooks/useSpots'
 import SpotPreview from '@/components/map/SpotPreview'
 import CategoryFilter from '@/components/map/CategoryFilter'
-import { useSelectedCategories } from '@/stores/filterStore'
+import ContentSearchFilter from '@/components/map/ContentSearchFilter'
+import { useSelectedCategories, useSearchQuery } from '@/stores/filterStore'
 
 // Leaflet은 SSR을 지원하지 않으므로 dynamic import 사용
 const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
@@ -93,16 +94,20 @@ function SpotErrorDisplay({
  * - filterStore 전역 상태 사용 (Requirements 3.3)
  */
 export default function Home() {
-  // filterStore에서 카테고리 필터 상태 가져오기
+  // filterStore에서 필터 상태 가져오기
   const selectedCategories = useSelectedCategories()
+  const searchQuery = useSearchQuery()
 
-  // 실제 API에서 스팟 데이터 가져오기 (카테고리 필터 적용)
+  // 실제 API에서 스팟 데이터 가져오기 (카테고리 + 검색 필터 적용)
   const {
     data: spots,
     isLoading,
     error,
     refetch,
-  } = useSpots(selectedCategories.length > 0 ? selectedCategories : undefined)
+  } = useSpots(
+    selectedCategories.length > 0 ? selectedCategories : undefined,
+    searchQuery || undefined
+  )
 
   /**
    * 스팟 선택 핸들러
@@ -147,10 +152,17 @@ export default function Home() {
           onSpotSelect={handleSpotSelect}
         />
 
-        {/* 카테고리 필터 (하단 중앙 플로팅 바) */}
+        {/* 필터 영역 (하단 중앙 플로팅 바) */}
         <div className="absolute bottom-6 left-1/2 z-[1000] -translate-x-1/2">
-          <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
-            <CategoryFilter />
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+            {/* 콘텐츠 검색 필터 */}
+            <div className="w-64 sm:w-72">
+              <ContentSearchFilter />
+            </div>
+            {/* 카테고리 필터 */}
+            <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
+              <CategoryFilter />
+            </div>
           </div>
         </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,11 +154,9 @@ export default function Home() {
 
         {/* 필터 영역 (하단 중앙 플로팅 바) */}
         <div className="absolute bottom-6 left-1/2 z-[1000] -translate-x-1/2">
-          <div className="flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
-            {/* 콘텐츠 검색 필터 */}
-            <div className="w-64 sm:w-72">
-              <ContentSearchFilter />
-            </div>
+          <div className="flex items-center gap-2">
+            {/* 콘텐츠 검색 필터 (토글 버튼) */}
+            <ContentSearchFilter />
             {/* 카테고리 필터 */}
             <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
               <CategoryFilter />

--- a/src/components/map/AutocompleteDropdown.tsx
+++ b/src/components/map/AutocompleteDropdown.tsx
@@ -104,7 +104,7 @@ export default function AutocompleteDropdown({
     <div
       id={id}
       ref={dropdownRef}
-      className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg"
+      className="absolute bottom-full left-0 z-50 mb-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg"
       role="listbox"
       aria-label="자동완성 제안 목록"
     >

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -8,11 +8,13 @@ import AutocompleteDropdown from './AutocompleteDropdown'
 interface ContentSearchFilterProps {
   placeholder?: string
   className?: string
+  onExpandChange?: (expanded: boolean) => void
 }
 
 export default function ContentSearchFilter({
   placeholder = '작품명, 팀명, 아티스트명 검색...',
   className = '',
+  onExpandChange,
 }: ContentSearchFilterProps) {
   const dropdownId = useId()
   const searchQuery = useSearchQuery()
@@ -26,22 +28,21 @@ export default function ContentSearchFilter({
 
   useEffect(() => {
     setInputValue(searchQuery)
-    // 검색어가 있으면 확장 상태 유지
     if (searchQuery) {
       setIsExpanded(true)
+      onExpandChange?.(true)
     }
-  }, [searchQuery])
+  }, [searchQuery, onExpandChange])
 
-  // 외부 클릭 시 검색창 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
         containerRef.current &&
         !containerRef.current.contains(event.target as Node)
       ) {
-        // 검색어가 없으면 접기
-        if (!inputValue) {
+        if (!inputValue && !searchQuery) {
           setIsExpanded(false)
+          onExpandChange?.(false)
         }
         setIsDropdownOpen(false)
       }
@@ -49,16 +50,16 @@ export default function ContentSearchFilter({
 
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [inputValue])
+  }, [inputValue, searchQuery, onExpandChange])
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
       setInputValue(value)
-      setSearchQuery(value)
+      // 입력 시에는 자동완성만 열고, 실제 검색은 하지 않음
       setIsDropdownOpen(value.length >= 2)
     },
-    [setSearchQuery]
+    []
   )
 
   const handleClear = useCallback(() => {
@@ -66,7 +67,8 @@ export default function ContentSearchFilter({
     clearSearchQuery()
     setIsDropdownOpen(false)
     setIsExpanded(false)
-  }, [clearSearchQuery])
+    onExpandChange?.(false)
+  }, [clearSearchQuery, onExpandChange])
 
   const handleSelect = useCallback(
     (item: AutocompleteItem) => {
@@ -91,26 +93,31 @@ export default function ContentSearchFilter({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Escape') {
         if (inputValue) {
-          handleClear()
+          setInputValue('')
+          setIsDropdownOpen(false)
         } else {
-          setIsExpanded(false)
+          handleClear()
         }
       } else if (e.key === 'Enter') {
+        // Enter 키 입력 시에만 검색 적용
+        if (inputValue.trim()) {
+          setSearchQuery(inputValue.trim())
+        }
         setIsDropdownOpen(false)
       }
     },
-    [handleClear, inputValue]
+    [handleClear, inputValue, setSearchQuery]
   )
 
   const handleToggleExpand = useCallback(() => {
-    setIsExpanded((prev) => !prev)
-    // 확장 시 input에 포커스
-    if (!isExpanded) {
+    const newExpanded = !isExpanded
+    setIsExpanded(newExpanded)
+    onExpandChange?.(newExpanded)
+    if (newExpanded) {
       setTimeout(() => inputRef.current?.focus(), 100)
     }
-  }, [isExpanded])
+  }, [isExpanded, onExpandChange])
 
-  // 접힌 상태: 돋보기 버튼만 표시
   if (!isExpanded) {
     return (
       <button
@@ -136,7 +143,6 @@ export default function ContentSearchFilter({
     )
   }
 
-  // 확장된 상태: 검색 입력창 표시
   return (
     <div ref={containerRef} className={`relative ${className}`}>
       <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -19,12 +19,37 @@ export default function ContentSearchFilter({
   const { setSearchQuery, clearSearchQuery } = useFilterStore()
   const [inputValue, setInputValue] = useState(searchQuery)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
   const { suggestions, isLoading } = useAutocomplete(inputValue)
   const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     setInputValue(searchQuery)
+    // 검색어가 있으면 확장 상태 유지
+    if (searchQuery) {
+      setIsExpanded(true)
+    }
   }, [searchQuery])
+
+  // 외부 클릭 시 검색창 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        // 검색어가 없으면 접기
+        if (!inputValue) {
+          setIsExpanded(false)
+        }
+        setIsDropdownOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [inputValue])
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,6 +65,7 @@ export default function ContentSearchFilter({
     setInputValue('')
     clearSearchQuery()
     setIsDropdownOpen(false)
+    setIsExpanded(false)
   }, [clearSearchQuery])
 
   const handleSelect = useCallback(
@@ -64,14 +90,53 @@ export default function ContentSearchFilter({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Escape') {
-        handleClear()
+        if (inputValue) {
+          handleClear()
+        } else {
+          setIsExpanded(false)
+        }
       } else if (e.key === 'Enter') {
         setIsDropdownOpen(false)
       }
     },
-    [handleClear]
+    [handleClear, inputValue]
   )
 
+  const handleToggleExpand = useCallback(() => {
+    setIsExpanded((prev) => !prev)
+    // 확장 시 input에 포커스
+    if (!isExpanded) {
+      setTimeout(() => inputRef.current?.focus(), 100)
+    }
+  }, [isExpanded])
+
+  // 접힌 상태: 돋보기 버튼만 표시
+  if (!isExpanded) {
+    return (
+      <button
+        onClick={handleToggleExpand}
+        className={`flex h-10 w-10 items-center justify-center rounded-full bg-white/95 shadow-lg backdrop-blur-sm transition-all hover:bg-white ${className}`}
+        aria-label="검색 열기"
+      >
+        <svg
+          className="h-5 w-5 text-navy-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      </button>
+    )
+  }
+
+  // 확장된 상태: 검색 입력창 표시
   return (
     <div ref={containerRef} className={`relative ${className}`}>
       <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
@@ -91,13 +156,14 @@ export default function ContentSearchFilter({
         </svg>
       </div>
       <input
+        ref={inputRef}
         type="text"
         value={inputValue}
         onChange={handleInputChange}
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full rounded-full border border-gray-200 bg-white/90 py-2 pl-10 pr-10 text-sm text-gray-900 placeholder-gray-500 shadow-sm transition-all focus:border-navy-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-navy-500"
+        className="w-64 rounded-full border border-gray-200 bg-white/95 py-2 pl-10 pr-10 text-sm text-gray-900 placeholder-gray-500 shadow-lg backdrop-blur-sm transition-all focus:border-navy-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-navy-500"
         role="combobox"
         aria-label="콘텐츠 검색"
         aria-expanded={isDropdownOpen}
@@ -105,29 +171,27 @@ export default function ContentSearchFilter({
         aria-haspopup="listbox"
         aria-autocomplete="list"
       />
-      {inputValue && (
-        <button
-          type="button"
-          onClick={handleClear}
-          className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 transition-colors hover:text-gray-600"
-          aria-label="검색어 초기화"
+      <button
+        type="button"
+        onClick={handleClear}
+        className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 transition-colors hover:text-gray-600"
+        aria-label="검색어 초기화"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
         >
-          <svg
-            className="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
-      )}
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
       <AutocompleteDropdown
         id={dropdownId}
         items={suggestions}

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -95,13 +95,16 @@ export const mediaKeys = {
 /**
  * Hook to fetch all spots for map pins
  * @param categories - 필터링할 카테고리 배열 (선택사항)
+ * @param search - 검색어 (선택사항) - relatedContent.name 부분 일치 검색
+ * Requirements: 3.3 - filterStore의 searchQuery를 API 호출에 포함
  */
-export function useSpots(categories?: SpotCategory[]) {
+export function useSpots(categories?: SpotCategory[], search?: string) {
   return useQuery({
-    queryKey: spotKeys.list({ categories }),
+    queryKey: spotKeys.list({ categories, search }),
     queryFn: async (): Promise<SpotPin[]> => {
       const url = buildUrl(API_ROUTES.SPOTS.BASE, {
         category: categories?.length ? categories.join(',') : undefined,
+        search: search || undefined,
       })
       const response = await fetch(url)
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #179

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정

---

## ✨ 작업 개요

> 콘텐츠 검색 필터 기능을 지도 페이지에 통합하여 사용자가 작품명/스팟명으로 스팟을 필터링할 수 있도록 합니다.

---

## 📋 변경 사항

- [x] 지도 페이지에 ContentSearchFilter 컴포넌트 배치
- [x] useSpots 훅에 searchQuery 파라미터 연동
- [x] 검색 필터를 토글 버튼 방식으로 변경 (돋보기 버튼 클릭 시 확장)
- [x] 검색창 열림 시 카테고리 필터 숨김 처리
- [x] 검색 시 리렌더링 문제 수정 (Enter 또는 자동완성 선택 시에만 검색 적용)
- [x] 자동완성 드롭다운을 위로 표시되도록 변경
- [x] 스팟 검색 시 스팟명과 작품명 모두 검색하도록 수정

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)
<img width="839" height="589" alt="image" src="https://github.com/user-attachments/assets/7cff17b6-70fa-4013-874a-cb5b1a6a314d" />

---

## 📝 추가 정보 (선택)

- **Task 번호**: Task 9, 9.1, 9.2
- **Requirements**: 1.1, 3.3
- 다중 작품 연결 스팟 기능은 별도 spec으로 분리됨 (`.kiro/specs/multi-content-spot/`)
