### PR TITLE
[Feat] SpotPin 호버 액션 추가(툴팁표기)

### DIFF
--- a/.kiro/specs/map-hover-tooltip/tasks.md
+++ b/.kiro/specs/map-hover-tooltip/tasks.md
@@ -18,13 +18,13 @@
     - 마커 위쪽 위치 및 화살표 스타일
     - _Requirements: 3.1, 3.2, 3.3, 5.1, 5.2, 5.4_
 
-- [ ] 2. SpotPin 컴포넌트 수정
-  - [ ] 2.1 HoverTooltip 통합
+- [x] 2. SpotPin 컴포넌트 수정
+  - [x] 2.1 HoverTooltip 통합
     - SpotPin에 HoverTooltip 조건부 렌더링 추가
     - isHovered 상태에 따라 툴팁 표시/숨김
     - 클릭 시 툴팁 숨김 처리
     - _Requirements: 1.1, 2.1, 2.2_
-  - [ ] 2.2 모바일 터치 로직 구현
+  - [x] 2.2 모바일 터치 로직 구현
     - 터치 디바이스 감지 로직 추가
     - 터치 카운트 상태 관리
     - 첫 터치: 툴팁 표시, 두 번째 터치: SpotPreview 열기

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import { useSpots } from '@/hooks/useSpots'
-import SpotPreview from '@/components/map/SpotPreview'
 import CategoryFilter from '@/components/map/CategoryFilter'
 import ContentSearchFilter from '@/components/map/ContentSearchFilter'
 import { useSelectedCategories, useSearchQuery } from '@/stores/filterStore'
@@ -262,9 +261,6 @@ export default function Home() {
             </div>
           </div>
         </div>
-
-        {/* 스팟 미리보기 툴팁 (지도 내부에 표시) */}
-        <SpotPreview />
       </div>
     </main>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -262,10 +262,10 @@ export default function Home() {
             </div>
           </div>
         </div>
-      </div>
 
-      {/* 스팟 미리보기 팝업 컴포넌트 */}
-      <SpotPreview />
+        {/* 스팟 미리보기 툴팁 (지도 내부에 표시) */}
+        <SpotPreview />
+      </div>
     </main>
   )
 }

--- a/src/components/map/HoverTooltip.tsx
+++ b/src/components/map/HoverTooltip.tsx
@@ -44,7 +44,7 @@ export default function HoverTooltip({ spot, isVisible }: HoverTooltipProps) {
     <Tooltip
       permanent
       direction="top"
-      offset={[0, -60]}
+      offset={[0, -10]}
       className="hover-tooltip"
     >
       <div className="hover-tooltip-content">

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -6,6 +6,7 @@ import { Map as LeafletMap } from 'leaflet'
 import { useMapStore } from '@/stores/mapStore'
 import { SpotPin as SpotPinType } from '@/types'
 import SpotPin from './SpotPin'
+import SpotPreview from './SpotPreview'
 import './map.css'
 
 interface PilgrimageMapProps {
@@ -158,6 +159,9 @@ export default function PilgrimageMap({
       <div className="absolute bottom-2 left-2 z-[1000] rounded bg-navy-800/80 px-2 py-1 text-xs text-white">
         Anime Pilgrim
       </div>
+
+      {/* 스팟 미리보기 툴팁 (지도 컨테이너 내부에 표시) */}
+      <SpotPreview />
     </div>
   )
 }

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -6,7 +6,6 @@ import L from 'leaflet'
 import { SpotPin as SpotPinType, CATEGORY_CONFIG, SpotCategory } from '@/types'
 import { useMapStore } from '@/stores/mapStore'
 import { useUIStore } from '@/stores/uiStore'
-import HoverTooltip from './HoverTooltip'
 
 interface SpotPinProps {
   spot: SpotPinType
@@ -223,7 +222,7 @@ const createImagePinIcon = (
 
 export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   const { selectedSpotId, setSelectedSpot } = useMapStore()
-  const { openPreview } = useUIStore()
+  const { openPreview, closePreview } = useUIStore()
   const [isHovered, setIsHovered] = useState(false)
 
   // 모바일 터치 관련 상태 (Requirements: 4.1, 4.2, 4.3)
@@ -314,36 +313,27 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
       }
 
       if (touchCount === 0) {
-        // 첫 번째 터치: 툴팁 표시
+        // 첫 번째 터치: SpotPreview 열기
         setTouchCount(1)
         setIsHovered(true)
+        setSelectedSpot(spot.id)
+        openPreview(spot.id)
 
-        // 3초 후 터치 카운트 리셋 (사용자가 다른 작업 중일 수 있음)
+        // 3초 후 터치 카운트 리셋
         touchResetTimeoutRef.current = setTimeout(() => {
           setTouchCount(0)
-          setIsHovered(false)
         }, 3000)
         return
       }
 
-      // 두 번째 터치: SpotPreview 열기
+      // 두 번째 터치: 추후 상세 모달 구현 예정
       setTouchCount(0)
       setIsHovered(false)
     }
 
-    // 클릭 시 호버 상태 해제 (툴팁 숨김)
-    setIsHovered(false)
-
-    // 기존 호버 타이머 취소
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current)
-    }
-
-    // 스팟 선택 상태 업데이트
+    // 데스크톱 클릭: 추후 상세 모달 구현 예정
+    // 현재는 스팟 선택만 처리
     setSelectedSpot(spot.id)
-
-    // 미리보기 팝업 열기 (SpotPreview 컴포넌트가 표시됨)
-    openPreview(spot.id)
 
     // 외부 콜백 호출
     onSelect?.(spot.id)
@@ -356,29 +346,38 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
     touchCount,
   ])
 
-  // Debounced 호버 핸들러 (50ms)
+  // Debounced 호버 핸들러 (50ms) - 호버 시 SpotPreview 열기
   const handleMouseOver = useCallback(() => {
+    // 터치 디바이스에서는 호버 이벤트 무시
+    if (isTouchDevice) return
+
     // 기존 타이머 취소
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
     }
-    // 50ms 후 호버 상태 설정
+    // 50ms 후 호버 상태 설정 및 SpotPreview 열기
     hoverTimeoutRef.current = setTimeout(() => {
       setIsHovered(true)
+      setSelectedSpot(spot.id)
+      openPreview(spot.id)
     }, 50)
-  }, [])
+  }, [isTouchDevice, spot.id, setSelectedSpot, openPreview])
 
-  // Debounced 호버 아웃 핸들러 (50ms)
+  // Debounced 호버 아웃 핸들러 (50ms) - 호버 아웃 시 SpotPreview 닫기
   const handleMouseOut = useCallback(() => {
+    // 터치 디바이스에서는 호버 이벤트 무시
+    if (isTouchDevice) return
+
     // 기존 타이머 취소
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
     }
-    // 50ms 후 호버 상태 해제
+    // 50ms 후 호버 상태 해제 및 SpotPreview 닫기
     hoverTimeoutRef.current = setTimeout(() => {
       setIsHovered(false)
+      closePreview()
     }, 50)
-  }, [])
+  }, [isTouchDevice, closePreview])
 
   return (
     <Marker
@@ -390,9 +389,6 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
         mouseover: handleMouseOver,
         mouseout: handleMouseOut,
       }}
-    >
-      {/* 호버 시 툴팁 표시 (Requirements: 1.1, 2.1, 2.2) */}
-      <HoverTooltip spot={spot} isVisible={isHovered && !isSelected} />
-    </Marker>
+    />
   )
 }

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -6,6 +6,7 @@ import L from 'leaflet'
 import { SpotPin as SpotPinType, CATEGORY_CONFIG, SpotCategory } from '@/types'
 import { useMapStore } from '@/stores/mapStore'
 import { useUIStore } from '@/stores/uiStore'
+import HoverTooltip from './HoverTooltip'
 
 interface SpotPinProps {
   spot: SpotPinType
@@ -260,6 +261,14 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   )
 
   const handleClick = useCallback(() => {
+    // 클릭 시 호버 상태 해제 (툴팁 숨김)
+    setIsHovered(false)
+
+    // 기존 호버 타이머 취소
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current)
+    }
+
     // 스팟 선택 상태 업데이트
     setSelectedSpot(spot.id)
 
@@ -304,6 +313,9 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
         mouseover: handleMouseOver,
         mouseout: handleMouseOut,
       }}
-    />
+    >
+      {/* 호버 시 툴팁 표시 (Requirements: 1.1, 2.1, 2.2) */}
+      <HoverTooltip spot={spot} isVisible={isHovered && !isSelected} />
+    </Marker>
   )
 }

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -227,6 +227,12 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   const isPreviewHovered = useIsPreviewHovered()
   const [isHovered, setIsHovered] = useState(false)
 
+  // isPreviewHovered의 최신 값을 참조하기 위한 ref
+  const isPreviewHoveredRef = useRef(isPreviewHovered)
+  useEffect(() => {
+    isPreviewHoveredRef.current = isPreviewHovered
+  }, [isPreviewHovered])
+
   // 마커의 화면 좌표 계산
   const getMarkerScreenPosition = useCallback(() => {
     const point = map.latLngToContainerPoint(spot.coordinates)
@@ -377,7 +383,7 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
     getMarkerScreenPosition,
   ])
 
-  // Debounced 호버 아웃 핸들러 (50ms) - 호버 아웃 시 SpotPreview 닫기
+  // Debounced 호버 아웃 핸들러 - 호버 아웃 시 SpotPreview 닫기
   const handleMouseOut = useCallback(() => {
     // 터치 디바이스에서는 호버 이벤트 무시
     if (isTouchDevice) return
@@ -386,14 +392,14 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
     }
-    // 100ms 후 호버 상태 해제 (툴팁 위로 마우스 이동 시간 확보)
+    // 150ms 후 호버 상태 해제 (툴팁 위로 마우스 이동 시간 확보)
     hoverTimeoutRef.current = setTimeout(() => {
-      // 툴팁 위에 마우스가 있으면 닫지 않음
-      if (isPreviewHovered) return
+      // 툴팁 위에 마우스가 있으면 닫지 않음 (ref로 최신 값 참조)
+      if (isPreviewHoveredRef.current) return
       setIsHovered(false)
       closePreview()
-    }, 100)
-  }, [isTouchDevice, closePreview, isPreviewHovered])
+    }, 150)
+  }, [isTouchDevice, closePreview])
 
   return (
     <Marker

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
-import { Marker } from 'react-leaflet'
+import { Marker, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import { SpotPin as SpotPinType, CATEGORY_CONFIG, SpotCategory } from '@/types'
 import { useMapStore } from '@/stores/mapStore'
-import { useUIStore } from '@/stores/uiStore'
+import { useUIStore, useIsPreviewHovered } from '@/stores/uiStore'
 
 interface SpotPinProps {
   spot: SpotPinType
@@ -221,9 +221,17 @@ const createImagePinIcon = (
 }
 
 export default function SpotPin({ spot, onSelect }: SpotPinProps) {
+  const map = useMap()
   const { selectedSpotId, setSelectedSpot } = useMapStore()
   const { openPreview, closePreview } = useUIStore()
+  const isPreviewHovered = useIsPreviewHovered()
   const [isHovered, setIsHovered] = useState(false)
+
+  // 마커의 화면 좌표 계산
+  const getMarkerScreenPosition = useCallback(() => {
+    const point = map.latLngToContainerPoint(spot.coordinates)
+    return { x: point.x, y: point.y }
+  }, [map, spot.coordinates])
 
   // 모바일 터치 관련 상태 (Requirements: 4.1, 4.2, 4.3)
   const [touchCount, setTouchCount] = useState(0)
@@ -317,7 +325,7 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
         setTouchCount(1)
         setIsHovered(true)
         setSelectedSpot(spot.id)
-        openPreview(spot.id)
+        openPreview(spot.id, getMarkerScreenPosition())
 
         // 3초 후 터치 카운트 리셋
         touchResetTimeoutRef.current = setTimeout(() => {
@@ -359,9 +367,15 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
     hoverTimeoutRef.current = setTimeout(() => {
       setIsHovered(true)
       setSelectedSpot(spot.id)
-      openPreview(spot.id)
+      openPreview(spot.id, getMarkerScreenPosition())
     }, 50)
-  }, [isTouchDevice, spot.id, setSelectedSpot, openPreview])
+  }, [
+    isTouchDevice,
+    spot.id,
+    setSelectedSpot,
+    openPreview,
+    getMarkerScreenPosition,
+  ])
 
   // Debounced 호버 아웃 핸들러 (50ms) - 호버 아웃 시 SpotPreview 닫기
   const handleMouseOut = useCallback(() => {
@@ -372,12 +386,14 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
     }
-    // 50ms 후 호버 상태 해제 및 SpotPreview 닫기
+    // 100ms 후 호버 상태 해제 (툴팁 위로 마우스 이동 시간 확보)
     hoverTimeoutRef.current = setTimeout(() => {
+      // 툴팁 위에 마우스가 있으면 닫지 않음
+      if (isPreviewHovered) return
       setIsHovered(false)
       closePreview()
-    }, 50)
-  }, [isTouchDevice, closePreview])
+    }, 100)
+  }, [isTouchDevice, closePreview, isPreviewHovered])
 
   return (
     <Marker

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -226,8 +226,31 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   const { openPreview } = useUIStore()
   const [isHovered, setIsHovered] = useState(false)
 
+  // 모바일 터치 관련 상태 (Requirements: 4.1, 4.2, 4.3)
+  const [touchCount, setTouchCount] = useState(0)
+  const [isTouchDevice, setIsTouchDevice] = useState(false)
+
   // Debounce를 위한 타이머 ref
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  // 터치 리셋 타이머 ref
+  const touchResetTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // 터치 디바이스 감지
+  useEffect(() => {
+    const checkTouchDevice = () => {
+      const hasTouch =
+        'ontouchstart' in window ||
+        window.matchMedia('(hover: none)').matches ||
+        navigator.maxTouchPoints > 0
+      setIsTouchDevice(hasTouch)
+    }
+
+    checkTouchDevice()
+
+    // 윈도우 리사이즈 시 재확인 (태블릿 등 하이브리드 디바이스 대응)
+    window.addEventListener('resize', checkTouchDevice)
+    return () => window.removeEventListener('resize', checkTouchDevice)
+  }, [])
 
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
@@ -235,10 +258,32 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
       if (hoverTimeoutRef.current) {
         clearTimeout(hoverTimeoutRef.current)
       }
+      if (touchResetTimeoutRef.current) {
+        clearTimeout(touchResetTimeoutRef.current)
+      }
     }
   }, [])
 
   const isSelected = selectedSpotId === spot.id
+
+  // 다른 곳 터치 시 툴팁 숨김 및 터치 카운트 리셋 (Requirements: 4.2)
+  useEffect(() => {
+    if (!isTouchDevice) return
+
+    const handleOutsideTouch = (e: TouchEvent) => {
+      // 마커 외부 터치 시 상태 리셋
+      const target = e.target as HTMLElement
+      const isMarkerTouch = target.closest('.custom-image-spot-pin')
+
+      if (!isMarkerTouch && touchCount > 0) {
+        setTouchCount(0)
+        setIsHovered(false)
+      }
+    }
+
+    document.addEventListener('touchstart', handleOutsideTouch)
+    return () => document.removeEventListener('touchstart', handleOutsideTouch)
+  }, [isTouchDevice, touchCount])
 
   // Z-Index 계산: 호버 > 선택 > 기본
   const getZIndexOffset = () => {
@@ -261,6 +306,31 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   )
 
   const handleClick = useCallback(() => {
+    // 모바일 터치 디바이스 처리 (Requirements: 4.1, 4.3)
+    if (isTouchDevice) {
+      // 기존 터치 리셋 타이머 취소
+      if (touchResetTimeoutRef.current) {
+        clearTimeout(touchResetTimeoutRef.current)
+      }
+
+      if (touchCount === 0) {
+        // 첫 번째 터치: 툴팁 표시
+        setTouchCount(1)
+        setIsHovered(true)
+
+        // 3초 후 터치 카운트 리셋 (사용자가 다른 작업 중일 수 있음)
+        touchResetTimeoutRef.current = setTimeout(() => {
+          setTouchCount(0)
+          setIsHovered(false)
+        }, 3000)
+        return
+      }
+
+      // 두 번째 터치: SpotPreview 열기
+      setTouchCount(0)
+      setIsHovered(false)
+    }
+
     // 클릭 시 호버 상태 해제 (툴팁 숨김)
     setIsHovered(false)
 
@@ -277,7 +347,14 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
 
     // 외부 콜백 호출
     onSelect?.(spot.id)
-  }, [spot.id, setSelectedSpot, openPreview, onSelect])
+  }, [
+    spot.id,
+    setSelectedSpot,
+    openPreview,
+    onSelect,
+    isTouchDevice,
+    touchCount,
+  ])
 
   // Debounced 호버 핸들러 (50ms)
   const handleMouseOver = useCallback(() => {

--- a/src/components/map/SpotPreview.tsx
+++ b/src/components/map/SpotPreview.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useRef } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import {
@@ -17,11 +17,11 @@ interface SpotPreviewProps {
 /**
  * SpotPreview 컴포넌트
  *
- * 스팟 핀 클릭 시 표시되는 미리보기 팝업입니다.
+ * 스팟 핀 호버 시 표시되는 미리보기 툴팁입니다.
+ * 지도 우측 하단에 고정되어 표시됩니다.
  *
  * Requirements:
  * - 2.2: 스팟 이름, 사진, 설명, 주소 표시
- * - 2.3: 외부 클릭 시 팝업 닫기
  * - 2.4: 상세보기 버튼으로 Spot_Detail 페이지 이동
  */
 export default function SpotPreview({ className = '' }: SpotPreviewProps) {
@@ -34,41 +34,6 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
 
   // 스팟 미리보기 데이터 조회
   const { data: spot, isLoading, error } = useSpotPreview(previewSpotId)
-
-  // 외부 클릭 시 팝업 닫기 (Requirements 2.3)
-  const handleClickOutside = useCallback(
-    (event: MouseEvent) => {
-      if (
-        previewRef.current &&
-        !previewRef.current.contains(event.target as Node)
-      ) {
-        closePreview()
-      }
-    },
-    [closePreview]
-  )
-
-  // ESC 키로 팝업 닫기
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closePreview()
-      }
-    },
-    [closePreview]
-  )
-
-  useEffect(() => {
-    if (isPreviewOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-      document.addEventListener('keydown', handleKeyDown)
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [isPreviewOpen, handleClickOutside, handleKeyDown])
 
   // 상세 페이지로 이동 (Requirements 2.4)
   const handleDetailClick = () => {
@@ -84,52 +49,89 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
 
   return (
     <div
-      className={`fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 backdrop-blur-sm ${className}`}
-      role="dialog"
-      aria-modal="true"
+      ref={previewRef}
+      className={`animate-fade-in-up absolute bottom-4 right-4 z-[900] w-80 rounded-xl bg-white shadow-xl ${className}`}
+      role="tooltip"
       aria-labelledby="spot-preview-title"
+      onMouseEnter={(e) => e.stopPropagation()}
     >
-      <div
-        ref={previewRef}
-        className="animate-fade-in-up mx-4 w-full max-w-md rounded-2xl bg-white shadow-2xl"
-      >
-        {/* 로딩 상태 */}
-        {isLoading && (
-          <div className="flex h-64 items-center justify-center">
-            <div className="text-center">
-              <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-navy-200 border-t-navy-600"></div>
-              <p className="mt-3 text-sm text-navy-600">스팟 정보 로딩 중...</p>
-            </div>
+      {/* 로딩 상태 */}
+      {isLoading && (
+        <div className="flex h-32 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-6 w-6 animate-spin rounded-full border-2 border-navy-200 border-t-navy-600"></div>
+            <p className="mt-2 text-xs text-navy-600">로딩 중...</p>
           </div>
-        )}
+        </div>
+      )}
 
-        {/* 에러 상태 */}
-        {error && (
-          <div className="flex h-64 flex-col items-center justify-center p-6">
-            <div className="mb-3 text-4xl">😢</div>
-            <p className="text-center text-navy-600">
-              스팟 정보를 불러오는데 실패했습니다.
-            </p>
-            <button
-              onClick={closePreview}
-              className="mt-4 rounded-lg bg-navy-600 px-4 py-2 text-sm text-white hover:bg-navy-700"
+      {/* 에러 상태 */}
+      {error && (
+        <div className="flex h-32 flex-col items-center justify-center p-4">
+          <div className="mb-2 text-2xl">😢</div>
+          <p className="text-center text-sm text-navy-600">
+            정보를 불러올 수 없습니다
+          </p>
+        </div>
+      )}
+
+      {/* 스팟 미리보기 콘텐츠 (Requirements 2.2) */}
+      {spot && !isLoading && !error && (
+        <>
+          {/* 닫기 버튼 */}
+          <button
+            onClick={closePreview}
+            className="absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-black/40 text-white transition-colors hover:bg-black/60"
+            aria-label="닫기"
+          >
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
             >
-              닫기
-            </button>
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+
+          {/* 스팟 사진 */}
+          <div className="relative h-32 w-full overflow-hidden rounded-t-xl">
+            {spot.photoUrl ? (
+              <Image
+                src={spot.photoUrl}
+                alt={spot.name}
+                fill
+                className="object-cover"
+                sizes="320px"
+                priority
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-navy-100">
+                <span className="text-3xl">🗾</span>
+              </div>
+            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
           </div>
-        )}
 
-        {/* 스팟 미리보기 콘텐츠 (Requirements 2.2) */}
-        {spot && !isLoading && !error && (
-          <>
-            {/* 닫기 버튼 */}
-            <button
-              onClick={closePreview}
-              className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/30 text-white backdrop-blur-sm transition-colors hover:bg-black/50"
-              aria-label="닫기"
+          {/* 스팟 정보 */}
+          <div className="p-3">
+            {/* 스팟 이름 */}
+            <h2
+              id="spot-preview-title"
+              className="mb-1 truncate text-base font-bold text-navy-800"
             >
+              {spot.name}
+            </h2>
+
+            {/* 스팟 주소 */}
+            <div className="mb-2 flex items-start space-x-1 text-xs text-navy-600">
               <svg
-                className="h-5 w-5"
+                className="mt-0.5 h-3 w-3 flex-shrink-0"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -138,120 +140,46 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              <span className="line-clamp-1">{spot.address}</span>
+            </div>
+
+            {/* 스팟 설명 */}
+            <p className="mb-3 line-clamp-2 text-xs leading-relaxed text-navy-700">
+              {spot.description}
+            </p>
+
+            {/* 상세보기 버튼 (Requirements 2.4) */}
+            <button
+              onClick={handleDetailClick}
+              className="flex w-full items-center justify-center space-x-1 rounded-lg bg-navy-600 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-navy-700"
+            >
+              <span>자세히 보기</span>
+              <svg
+                className="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
                 />
               </svg>
             </button>
-
-            {/* 스팟 사진 */}
-            <div className="relative h-48 w-full overflow-hidden rounded-t-2xl">
-              {spot.photoUrl ? (
-                <Image
-                  src={spot.photoUrl}
-                  alt={spot.name}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 768px) 100vw, 400px"
-                  priority
-                />
-              ) : (
-                <div className="flex h-full w-full items-center justify-center bg-navy-100">
-                  <span className="text-4xl">🗾</span>
-                </div>
-              )}
-              <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
-
-              {/* 배지 */}
-              <div className="absolute bottom-3 left-3">
-                <span className="inline-flex items-center rounded-full bg-navy-600/90 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm">
-                  📍 특별한 여행지
-                </span>
-              </div>
-            </div>
-
-            {/* 스팟 정보 */}
-            <div className="p-5">
-              {/* 스팟 이름 */}
-              <h2
-                id="spot-preview-title"
-                className="mb-2 text-xl font-bold text-navy-800"
-              >
-                {spot.name}
-              </h2>
-
-              {/* 스팟 주소 */}
-              <div className="mb-3 flex items-start space-x-2 text-sm text-navy-600">
-                <svg
-                  className="mt-0.5 h-4 w-4 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-                <span>{spot.address}</span>
-              </div>
-
-              {/* 스팟 설명 */}
-              <p className="mb-4 line-clamp-3 text-sm leading-relaxed text-navy-700">
-                {spot.description}
-              </p>
-
-              {/* 액션 버튼 영역 */}
-              <div className="flex items-center justify-between border-t border-navy-100 pt-4">
-                <div className="flex space-x-3">
-                  <button
-                    className="flex items-center space-x-1 text-sm text-navy-500 transition-colors hover:text-navy-700"
-                    aria-label="좋아요"
-                  >
-                    <span>❤️</span>
-                    <span>좋아요</span>
-                  </button>
-                  <button
-                    className="flex items-center space-x-1 text-sm text-navy-500 transition-colors hover:text-navy-700"
-                    aria-label="공유하기"
-                  >
-                    <span>🔗</span>
-                    <span>공유</span>
-                  </button>
-                </div>
-
-                {/* 상세보기 버튼 (Requirements 2.4) */}
-                <button
-                  onClick={handleDetailClick}
-                  className="flex items-center space-x-2 rounded-lg bg-navy-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-navy-700"
-                >
-                  <span>자세히 보기</span>
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/map/SpotPreview.tsx
+++ b/src/components/map/SpotPreview.tsx
@@ -7,6 +7,7 @@ import {
   useUIStore,
   useIsPreviewOpen,
   usePreviewSpotId,
+  usePreviewPosition,
 } from '@/stores/uiStore'
 import { useSpotPreview } from '@/hooks/useSpots'
 
@@ -14,11 +15,15 @@ interface SpotPreviewProps {
   className?: string
 }
 
+// 툴팁 크기 상수
+const TOOLTIP_WIDTH = 384 // w-96
+const TOOLTIP_HEIGHT = 340 // 대략적인 높이
+
 /**
  * SpotPreview 컴포넌트
  *
  * 스팟 핀 호버 시 표시되는 미리보기 툴팁입니다.
- * 지도 우측 하단에 고정되어 표시됩니다.
+ * 핀 위치 근처에 동적으로 표시됩니다.
  *
  * Requirements:
  * - 2.2: 스팟 이름, 사진, 설명, 주소 표시
@@ -30,6 +35,7 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
 
   const isPreviewOpen = useIsPreviewOpen()
   const previewSpotId = usePreviewSpotId()
+  const previewPosition = usePreviewPosition()
   const { closePreview } = useUIStore()
 
   // 스팟 미리보기 데이터 조회
@@ -47,10 +53,59 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
     return null
   }
 
+  // 툴팁 위치 계산 (핀 오른쪽에 표시, 화면 밖으로 나가면 조정)
+  const calculatePosition = () => {
+    if (!previewPosition) {
+      return { left: 16, top: 100 } // 기본 위치
+    }
+
+    const { x, y } = previewPosition
+    const padding = 16
+    const pinOffset = 30 // 핀에서 떨어진 거리
+
+    // 부모 컨테이너 크기 (지도 컨테이너)
+    const containerWidth =
+      previewRef.current?.parentElement?.clientWidth || window.innerWidth
+    const containerHeight =
+      previewRef.current?.parentElement?.clientHeight || window.innerHeight
+
+    // 기본: 핀 오른쪽에 표시
+    let left = x + pinOffset
+    let top = y - TOOLTIP_HEIGHT / 2
+
+    // 오른쪽 화면 밖으로 나가면 왼쪽에 표시
+    if (left + TOOLTIP_WIDTH > containerWidth - padding) {
+      left = x - TOOLTIP_WIDTH - pinOffset
+    }
+
+    // 왼쪽 화면 밖으로 나가면 최소 padding 유지
+    if (left < padding) {
+      left = padding
+    }
+
+    // 위쪽 화면 밖으로 나가면 조정
+    if (top < padding) {
+      top = padding
+    }
+
+    // 아래쪽 화면 밖으로 나가면 조정
+    if (top + TOOLTIP_HEIGHT > containerHeight - padding) {
+      top = containerHeight - TOOLTIP_HEIGHT - padding
+    }
+
+    return { left, top }
+  }
+
+  const position = calculatePosition()
+
   return (
     <div
       ref={previewRef}
-      className={`animate-fade-in-up absolute bottom-20 left-4 z-[900] w-96 rounded-xl bg-white shadow-xl ${className}`}
+      className={`animate-fade-in-up absolute z-[900] w-96 rounded-xl bg-white shadow-xl ${className}`}
+      style={{
+        left: position.left,
+        top: position.top,
+      }}
       role="tooltip"
       aria-labelledby="spot-preview-title"
       onMouseEnter={(e) => e.stopPropagation()}

--- a/src/components/map/SpotPreview.tsx
+++ b/src/components/map/SpotPreview.tsx
@@ -36,7 +36,7 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
   const isPreviewOpen = useIsPreviewOpen()
   const previewSpotId = usePreviewSpotId()
   const previewPosition = usePreviewPosition()
-  const { closePreview } = useUIStore()
+  const { closePreview, setPreviewHovered } = useUIStore()
 
   // 스팟 미리보기 데이터 조회
   const { data: spot, isLoading, error } = useSpotPreview(previewSpotId)
@@ -98,6 +98,16 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
 
   const position = calculatePosition()
 
+  // 툴팁 위에 마우스가 올라가면 닫히지 않도록 처리
+  const handleMouseEnter = () => {
+    setPreviewHovered(true)
+  }
+
+  const handleMouseLeave = () => {
+    setPreviewHovered(false)
+    closePreview()
+  }
+
   return (
     <div
       ref={previewRef}
@@ -108,7 +118,8 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
       }}
       role="tooltip"
       aria-labelledby="spot-preview-title"
-      onMouseEnter={(e) => e.stopPropagation()}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       {/* 로딩 상태 */}
       {isLoading && (

--- a/src/components/map/SpotPreview.tsx
+++ b/src/components/map/SpotPreview.tsx
@@ -50,25 +50,25 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
   return (
     <div
       ref={previewRef}
-      className={`animate-fade-in-up absolute bottom-4 right-4 z-[900] w-80 rounded-xl bg-white shadow-xl ${className}`}
+      className={`animate-fade-in-up absolute bottom-20 left-4 z-[900] w-96 rounded-xl bg-white shadow-xl ${className}`}
       role="tooltip"
       aria-labelledby="spot-preview-title"
       onMouseEnter={(e) => e.stopPropagation()}
     >
       {/* 로딩 상태 */}
       {isLoading && (
-        <div className="flex h-32 items-center justify-center">
+        <div className="flex h-40 items-center justify-center">
           <div className="text-center">
-            <div className="mx-auto h-6 w-6 animate-spin rounded-full border-2 border-navy-200 border-t-navy-600"></div>
-            <p className="mt-2 text-xs text-navy-600">로딩 중...</p>
+            <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-navy-200 border-t-navy-600"></div>
+            <p className="mt-2 text-sm text-navy-600">로딩 중...</p>
           </div>
         </div>
       )}
 
       {/* 에러 상태 */}
       {error && (
-        <div className="flex h-32 flex-col items-center justify-center p-4">
-          <div className="mb-2 text-2xl">😢</div>
+        <div className="flex h-40 flex-col items-center justify-center p-4">
+          <div className="mb-2 text-3xl">😢</div>
           <p className="text-center text-sm text-navy-600">
             정보를 불러올 수 없습니다
           </p>
@@ -81,11 +81,11 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
           {/* 닫기 버튼 */}
           <button
             onClick={closePreview}
-            className="absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-black/40 text-white transition-colors hover:bg-black/60"
+            className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/40 text-white transition-colors hover:bg-black/60"
             aria-label="닫기"
           >
             <svg
-              className="h-3.5 w-3.5"
+              className="h-4 w-4"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -100,38 +100,38 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
           </button>
 
           {/* 스팟 사진 */}
-          <div className="relative h-32 w-full overflow-hidden rounded-t-xl">
+          <div className="relative h-44 w-full overflow-hidden rounded-t-xl">
             {spot.photoUrl ? (
               <Image
                 src={spot.photoUrl}
                 alt={spot.name}
                 fill
                 className="object-cover"
-                sizes="320px"
+                sizes="384px"
                 priority
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center bg-navy-100">
-                <span className="text-3xl">🗾</span>
+                <span className="text-4xl">🗾</span>
               </div>
             )}
             <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
           </div>
 
           {/* 스팟 정보 */}
-          <div className="p-3">
+          <div className="p-4">
             {/* 스팟 이름 */}
             <h2
               id="spot-preview-title"
-              className="mb-1 truncate text-base font-bold text-navy-800"
+              className="mb-2 truncate text-lg font-bold text-navy-800"
             >
               {spot.name}
             </h2>
 
             {/* 스팟 주소 */}
-            <div className="mb-2 flex items-start space-x-1 text-xs text-navy-600">
+            <div className="mb-2 flex items-start space-x-1.5 text-sm text-navy-600">
               <svg
-                className="mt-0.5 h-3 w-3 flex-shrink-0"
+                className="mt-0.5 h-4 w-4 flex-shrink-0"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -153,18 +153,18 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
             </div>
 
             {/* 스팟 설명 */}
-            <p className="mb-3 line-clamp-2 text-xs leading-relaxed text-navy-700">
+            <p className="mb-4 line-clamp-2 text-sm leading-relaxed text-navy-700">
               {spot.description}
             </p>
 
             {/* 상세보기 버튼 (Requirements 2.4) */}
             <button
               onClick={handleDetailClick}
-              className="flex w-full items-center justify-center space-x-1 rounded-lg bg-navy-600 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-navy-700"
+              className="flex w-full items-center justify-center space-x-1.5 rounded-lg bg-navy-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
             >
               <span>자세히 보기</span>
               <svg
-                className="h-3 w-3"
+                className="h-4 w-4"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/src/components/map/__tests__/spot-pin-coordinates.test.tsx
+++ b/src/components/map/__tests__/spot-pin-coordinates.test.tsx
@@ -76,7 +76,9 @@ jest.mock('@/stores/mapStore', () => ({
 jest.mock('@/stores/uiStore', () => ({
   useUIStore: () => ({
     openPreview: jest.fn(),
+    closePreview: jest.fn(),
   }),
+  useIsPreviewHovered: () => false,
 }))
 
 /**
@@ -100,6 +102,9 @@ jest.mock('react-leaflet', () => ({
   MapContainer: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="map-container">{children}</div>
   ),
+  useMap: () => ({
+    latLngToContainerPoint: jest.fn(() => ({ x: 100, y: 100 })),
+  }),
 }))
 
 jest.mock('leaflet', () => ({

--- a/src/components/map/__tests__/spot-preview-required-info.test.tsx
+++ b/src/components/map/__tests__/spot-preview-required-info.test.tsx
@@ -76,9 +76,11 @@ function containsRequiredInfo(
 jest.mock('@/stores/uiStore', () => ({
   useUIStore: () => ({
     closePreview: jest.fn(),
+    setPreviewHovered: jest.fn(),
   }),
   useIsPreviewOpen: () => true, // Always open for testing
   usePreviewSpotId: () => 'test-spot-id', // Mock spot ID
+  usePreviewPosition: () => ({ x: 100, y: 100 }), // Mock position
 }))
 
 /**

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,14 +1,22 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
+interface PreviewPosition {
+  x: number
+  y: number
+}
+
 interface UIStore {
   isPreviewOpen: boolean
   previewSpotId: string | null
+  previewPosition: PreviewPosition | null
+  isPreviewHovered: boolean
   isMobileMenuOpen: boolean
   isMapLoading: boolean
 
-  openPreview: (spotId: string) => void
+  openPreview: (spotId: string, position?: PreviewPosition) => void
   closePreview: () => void
+  setPreviewHovered: (hovered: boolean) => void
   toggleMobileMenu: () => void
   closeMobileMenu: () => void
   setMapLoading: (loading: boolean) => void
@@ -20,14 +28,17 @@ export const useUIStore = create<UIStore>()(
     (set) => ({
       isPreviewOpen: false,
       previewSpotId: null,
+      previewPosition: null,
+      isPreviewHovered: false,
       isMobileMenuOpen: false,
       isMapLoading: true,
 
-      openPreview: (spotId) =>
+      openPreview: (spotId, position) =>
         set(
           {
             isPreviewOpen: true,
             previewSpotId: spotId,
+            previewPosition: position || null,
             isMobileMenuOpen: false,
           },
           false,
@@ -39,10 +50,15 @@ export const useUIStore = create<UIStore>()(
           {
             isPreviewOpen: false,
             previewSpotId: null,
+            previewPosition: null,
+            isPreviewHovered: false,
           },
           false,
           'uiStore/closePreview'
         ),
+
+      setPreviewHovered: (hovered) =>
+        set({ isPreviewHovered: hovered }, false, 'uiStore/setPreviewHovered'),
 
       toggleMobileMenu: () =>
         set(
@@ -66,6 +82,8 @@ export const useUIStore = create<UIStore>()(
           {
             isPreviewOpen: false,
             previewSpotId: null,
+            previewPosition: null,
+            isPreviewHovered: false,
             isMobileMenuOpen: false,
             isMapLoading: true,
           },
@@ -82,6 +100,10 @@ export const useUIStore = create<UIStore>()(
 // Selectors
 export const useIsPreviewOpen = () => useUIStore((state) => state.isPreviewOpen)
 export const usePreviewSpotId = () => useUIStore((state) => state.previewSpotId)
+export const usePreviewPosition = () =>
+  useUIStore((state) => state.previewPosition)
+export const useIsPreviewHovered = () =>
+  useUIStore((state) => state.isPreviewHovered)
 export const useIsMobileMenuOpen = () =>
   useUIStore((state) => state.isMobileMenuOpen)
 export const useIsMapLoading = () => useUIStore((state) => state.isMapLoading)


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #185

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 스팟 핀 호버 시 SpotPreview 툴팁이 핀 근처에 표시되도록 구현

---

## 📋 변경 사항

- [x] SpotPin 호버 시 SpotPreview 툴팁 표시
- [x] 툴팁 위치를 핀 오른쪽에 동적으로 계산 (화면 밖 나가면 왼쪽으로 조정)
- [x] 툴팁 위에 마우스 호버 시 닫히지 않도록 처리
- [x] 모바일 터치 디바이스 지원 (첫 터치: 툴팁 표시)
- [x] uiStore에 previewPosition, isPreviewHovered 상태 추가
- [x] SpotPreview를 PilgrimageMap 내부로 이동 (좌표계 일치)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<img width="1002" height="753" alt="image" src="https://github.com/user-attachments/assets/bf18de27-0faa-436b-b7d8-3c73780c65b7" />

---

## 📝 추가 정보 (선택)

- Requirements: 1.1, 2.1, 2.2, 4.1, 4.2, 4.3 대응
- 핀 클릭 시 상세 모달은 별도 Task에서 구현 예정
