### PR TITLE
Feat/197  icon image convert  add

### DIFF
--- a/.kiro/specs/multi-content-spot/requirements.md
+++ b/.kiro/specs/multi-content-spot/requirements.md
@@ -76,3 +76,15 @@
 1. WHEN 사용자가 관련 콘텐츠 없이 스팟을 등록할 때 THEN THE SpotForm SHALL 정상적으로 스팟을 저장한다
 2. WHEN 스팟에 관련 콘텐츠가 없을 때 THEN THE SpotDetailPage SHALL "관련 콘텐츠" 섹션을 표시하지 않는다
 3. WHEN 스팟에 관련 콘텐츠가 없을 때 THEN THE RelatedContentForm SHALL 콘텐츠 추가를 유도하는 안내 메시지를 표시한다
+
+### Requirement 7: 관련 콘텐츠 대표 이미지 관리
+
+**User Story:** As a 관리자, I want 관련 콘텐츠에 대표 이미지를 설정할 수 있기를, so that 사용자가 콘텐츠를 시각적으로 쉽게 인식할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관련 콘텐츠에 대표 이미지가 설정되어 있을 때 THEN THE SpotDetailPage SHALL 기본 아이콘 대신 원형 뱃지 형태로 대표 이미지를 표시한다
+2. WHEN 관련 콘텐츠에 대표 이미지가 없을 때 THEN THE SpotDetailPage SHALL 기존 ContentType 아이콘을 표시한다
+3. WHEN 관리자가 콘텐츠 이미지 관리 페이지에 접근할 때 THEN THE System SHALL 관리자 권한을 확인한다
+4. WHEN 관리자가 콘텐츠 대표 이미지를 업로드할 때 THEN THE System SHALL 해당 콘텐츠 이름에 이미지를 연결하여 저장한다
+5. WHEN 사용자가 스팟에 콘텐츠를 추가할 때 THEN THE System SHALL 기존에 등록된 콘텐츠 이미지가 있으면 자동으로 적용한다

--- a/.kiro/specs/multi-content-spot/tasks.md
+++ b/.kiro/specs/multi-content-spot/tasks.md
@@ -33,8 +33,8 @@
 
 ## 진행 중인 Tasks
 
-- [ ] 5. RelatedContentSection 컴포넌트 구현
-  - [ ] 5.1 RelatedContentSection 컴포넌트 생성
+- [x] 5. RelatedContentSection 컴포넌트 구현
+  - [x] 5.1 RelatedContentSection 컴포넌트 생성
     - `src/components/spot/RelatedContentSection.tsx` 파일 생성
     - 관련 콘텐츠 그리드 레이아웃 구현
     - 초기 3개 표시 및 "더보기" 버튼 구현
@@ -42,46 +42,46 @@
     - 빈 배열일 때 섹션 숨김
     - _Requirements: 3.1, 3.2, 3.3, 6.2_
 
-- [ ] 6. 스팟 상세 페이지 연동
-  - [ ] 6.1 SpotDetailPage에 RelatedContentSection 통합
+- [x] 6. 스팟 상세 페이지 연동
+  - [x] 6.1 SpotDetailPage에 RelatedContentSection 통합
     - 스팟 상세 페이지에 RelatedContentSection 추가
     - relatedContent 배열 전달
     - 기존 단일 콘텐츠 표시 로직 제거
     - _Requirements: 3.1, 3.4_
 
-- [ ] 7. 빈 콘텐츠 처리
-  - [ ] 7.1 빈 relatedContent 배열 처리 구현
+- [x] 7. 빈 콘텐츠 처리
+  - [x] 7.1 빈 relatedContent 배열 처리 구현
     - 스팟 등록 시 빈 배열 허용
     - 스팟 상세 페이지에서 빈 배열 시 섹션 숨김
     - _Requirements: 6.1, 6.2_
 
-- [ ] 8. 콘텐츠 타입 아이콘 이미지 전환
-  - [ ] 8.1 아이콘 이미지 에셋 준비
+- [x] 8. 콘텐츠 타입 아이콘 이미지 전환
+  - [x] 8.1 아이콘 이미지 에셋 준비
     - `public/icons/content-types/` 디렉토리 생성
     - 각 ContentType별 SVG 아이콘 파일 생성 (anime, movie, drama, sports_team, artist, game, other)
     - 각 SpotCategory별 SVG 아이콘 파일 생성 (animation, sports, movie_drama, music, game, other)
     - 각 ExternalLinkType별 SVG 아이콘 파일 생성 (official, ticket, schedule, sns, other)
     - _New Requirement_
 
-  - [ ] 8.2 ContentTypeIcon 컴포넌트 생성
+  - [x] 8.2 ContentTypeIcon 컴포넌트 생성
     - `src/components/common/ContentTypeIcon.tsx` 파일 생성
     - ContentType을 받아 해당 SVG 아이콘을 렌더링
     - size prop으로 크기 조절 가능
     - fallback으로 기존 이모티콘 표시
     - _New Requirement_
 
-  - [ ] 8.3 기존 이모티콘 사용 부분 교체
+  - [x] 8.3 기존 이모티콘 사용 부분 교체
     - `RelatedContentItem.tsx`의 이모티콘을 ContentTypeIcon으로 교체
     - `RelatedContentForm.tsx`의 이모티콘을 ContentTypeIcon으로 교체
     - `CATEGORY_CONFIG`, `CONTENT_TYPE_CONFIG`, `LINK_TYPE_CONFIG`의 icon 필드를 이미지 경로로 변경
     - _New Requirement_
 
-  - [ ] 8.4 SpotCategory 아이콘 이미지 적용
+  - [x] 8.4 SpotCategory 아이콘 이미지 적용
     - 지도 마커, 카테고리 필터 등에서 사용하는 카테고리 아이콘 교체
     - CategoryIcon 컴포넌트 생성 또는 ContentTypeIcon 확장
     - _New Requirement_
 
-- [ ] 9. Checkpoint - 전체 기능 검증
+- [x] 9. Checkpoint - 전체 기능 검증
   - 스팟 등록/수정/상세 페이지 전체 플로우 확인
   - 아이콘 이미지 렌더링 확인
   - 사용자에게 질문이 있으면 문의

--- a/.kiro/specs/multi-content-spot/tasks.md
+++ b/.kiro/specs/multi-content-spot/tasks.md
@@ -86,6 +86,34 @@
   - 아이콘 이미지 렌더링 확인
   - 사용자에게 질문이 있으면 문의
 
+- [ ] 10. 관련 콘텐츠 대표 이미지 기능
+  - [x] 10.1 RelatedContent 타입에 imageUrl 필드 추가
+    - `src/types/spot.ts`의 RelatedContent 인터페이스에 imageUrl 필드 추가
+    - _New Requirement_
+
+  - [x] 10.2 대표 이미지 원형 뱃지 표시 구현
+    - RelatedContentSection에서 이미지가 있으면 원형 뱃지로 표시
+    - RelatedContentItem에서도 이미지 표시 지원
+    - 이미지 없으면 기존 ContentTypeIcon 표시
+    - _New Requirement_
+
+  - [ ] 10.3 관리자 전용 콘텐츠 이미지 관리 페이지 구현
+    - `src/app/admin/content-images/page.tsx` 생성
+    - 콘텐츠 목록 조회 및 이미지 업로드 UI
+    - 관리자 권한 체크 (role === 'admin')
+    - _New Requirement_
+
+  - [ ] 10.4 콘텐츠 이미지 업로드 API 구현
+    - `src/app/api/admin/content-images/route.ts` 생성
+    - 관리자 권한 검증
+    - 이미지 업로드 및 콘텐츠 imageUrl 업데이트
+    - _New Requirement_
+
+  - [ ] 10.5 콘텐츠 마스터 데이터 관리
+    - 콘텐츠 이름별 대표 이미지 저장 (MongoDB 컬렉션)
+    - 스팟 등록 시 기존 콘텐츠 이미지 자동 적용
+    - _New Requirement_
+
 ## 선택적 테스트 Tasks
 
 - [ ]\* T1. 유틸리티 함수 속성 테스트 작성

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'cdn.myanimelist.net',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 }

--- a/public/icons/categories/animation.svg
+++ b/public/icons/categories/animation.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Animation category - TV with play button -->
+  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+  <polygon points="10 8 10 14 15 11 10 8"/>
+  <line x1="8" y1="21" x2="16" y2="21"/>
+  <line x1="12" y1="17" x2="12" y2="21"/>
+</svg>

--- a/public/icons/categories/game.svg
+++ b/public/icons/categories/game.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Game category - Gamepad -->
+  <line x1="6" y1="12" x2="10" y2="12"/>
+  <line x1="8" y1="10" x2="8" y2="14"/>
+  <line x1="15" y1="13" x2="15.01" y2="13"/>
+  <line x1="18" y1="11" x2="18.01" y2="11"/>
+  <rect x="2" y="6" width="20" height="12" rx="2"/>
+</svg>

--- a/public/icons/categories/movie_drama.svg
+++ b/public/icons/categories/movie_drama.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Movie/Drama category - Film strip -->
+  <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18"/>
+  <line x1="7" y1="2" x2="7" y2="22"/>
+  <line x1="17" y1="2" x2="17" y2="22"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <line x1="2" y1="7" x2="7" y2="7"/>
+  <line x1="2" y1="17" x2="7" y2="17"/>
+  <line x1="17" y1="7" x2="22" y2="7"/>
+  <line x1="17" y1="17" x2="22" y2="17"/>
+</svg>

--- a/public/icons/categories/music.svg
+++ b/public/icons/categories/music.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Music category - Music note -->
+  <path d="M9 18V5l12-2v13"/>
+  <circle cx="6" cy="18" r="3"/>
+  <circle cx="18" cy="16" r="3"/>
+</svg>

--- a/public/icons/categories/other.svg
+++ b/public/icons/categories/other.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Other category - Map pin -->
+  <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+  <circle cx="12" cy="10" r="3"/>
+</svg>

--- a/public/icons/categories/sports.svg
+++ b/public/icons/categories/sports.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Sports category - Soccer ball -->
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+  <path d="M2 12h20"/>
+</svg>

--- a/public/icons/content-types/anime.svg
+++ b/public/icons/content-types/anime.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- TV/Monitor icon for anime -->
+  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+  <line x1="8" y1="21" x2="16" y2="21"/>
+  <line x1="12" y1="17" x2="12" y2="21"/>
+</svg>

--- a/public/icons/content-types/artist.svg
+++ b/public/icons/content-types/artist.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Microphone icon for artist -->
+  <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
+  <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+  <line x1="12" y1="19" x2="12" y2="22"/>
+</svg>

--- a/public/icons/content-types/drama.svg
+++ b/public/icons/content-types/drama.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Clapperboard icon for drama -->
+  <path d="M4 11v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
+  <path d="M4 11l16-8"/>
+  <path d="M4 11h16"/>
+  <path d="M8 11V3"/>
+  <path d="M12 11V5"/>
+  <path d="M16 11V7"/>
+</svg>

--- a/public/icons/content-types/game.svg
+++ b/public/icons/content-types/game.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Gamepad icon for game -->
+  <line x1="6" y1="12" x2="10" y2="12"/>
+  <line x1="8" y1="10" x2="8" y2="14"/>
+  <line x1="15" y1="13" x2="15.01" y2="13"/>
+  <line x1="18" y1="11" x2="18.01" y2="11"/>
+  <rect x="2" y="6" width="20" height="12" rx="2"/>
+</svg>

--- a/public/icons/content-types/movie.svg
+++ b/public/icons/content-types/movie.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Film reel icon for movie -->
+  <circle cx="12" cy="12" r="10"/>
+  <circle cx="12" cy="12" r="3"/>
+  <circle cx="12" cy="5" r="1"/>
+  <circle cx="12" cy="19" r="1"/>
+  <circle cx="5" cy="12" r="1"/>
+  <circle cx="19" cy="12" r="1"/>
+</svg>

--- a/public/icons/content-types/other.svg
+++ b/public/icons/content-types/other.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Star icon for other -->
+  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+</svg>

--- a/public/icons/content-types/sports_team.svg
+++ b/public/icons/content-types/sports_team.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Trophy icon for sports team -->
+  <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/>
+  <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/>
+  <path d="M4 22h16"/>
+  <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/>
+  <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/>
+  <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z"/>
+</svg>

--- a/public/icons/link-types/official.svg
+++ b/public/icons/link-types/official.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Globe icon for official website -->
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+</svg>

--- a/public/icons/link-types/other.svg
+++ b/public/icons/link-types/other.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Link icon for other -->
+  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+</svg>

--- a/public/icons/link-types/schedule.svg
+++ b/public/icons/link-types/schedule.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Calendar icon for schedule -->
+  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+  <line x1="16" y1="2" x2="16" y2="6"/>
+  <line x1="8" y1="2" x2="8" y2="6"/>
+  <line x1="3" y1="10" x2="21" y2="10"/>
+</svg>

--- a/public/icons/link-types/sns.svg
+++ b/public/icons/link-types/sns.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Share icon for SNS -->
+  <circle cx="18" cy="5" r="3"/>
+  <circle cx="6" cy="12" r="3"/>
+  <circle cx="18" cy="19" r="3"/>
+  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+</svg>

--- a/public/icons/link-types/ticket.svg
+++ b/public/icons/link-types/ticket.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Ticket icon -->
+  <path d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"/>
+  <path d="M13 5v2"/>
+  <path d="M13 17v2"/>
+  <path d="M13 11v2"/>
+</svg>

--- a/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
+++ b/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
@@ -5,7 +5,12 @@
 import fc from 'fast-check'
 import { render, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { SpotDetailData, MediaInfo, NearbyFacility } from '@/types'
+import {
+  SpotDetailData,
+  RelatedContent,
+  NearbyFacility,
+  ContentType,
+} from '@/types'
 import SpotDetailPage from '../page'
 
 // Cleanup after each test to prevent DOM element accumulation
@@ -20,15 +25,24 @@ afterEach(() => {
  * Generators for property-based testing
  */
 
-// Generate valid MediaInfo objects
-const mediaInfoArbitrary = fc.record({
-  title: fc
+// Generate valid RelatedContent objects
+const relatedContentArbitrary = fc.record({
+  name: fc
     .string({ minLength: 1, maxLength: 100 })
     .filter((s) => s.trim().length > 0),
-  type: fc.constantFrom('anime', 'drama', 'movie', 'other') as fc.Arbitrary<
-    MediaInfo['type']
-  >,
+  type: fc.constantFrom(
+    'anime',
+    'movie',
+    'drama',
+    'sports_team',
+    'artist',
+    'game',
+    'other'
+  ) as fc.Arbitrary<ContentType>,
   year: fc.option(fc.integer({ min: 1900, max: 2030 }), { nil: undefined }),
+  additionalInfo: fc.option(fc.string({ minLength: 1, maxLength: 100 }), {
+    nil: undefined,
+  }),
 })
 
 // Generate valid SpotDetailData objects
@@ -50,13 +64,16 @@ const spotDetailDataArbitrary = fc.record({
     fc.double({ min: -90, max: 90, noNaN: true }),
     fc.double({ min: -180, max: 180, noNaN: true })
   ) as fc.Arbitrary<[number, number]>,
-  relatedMedia: fc.array(mediaInfoArbitrary, { minLength: 1, maxLength: 5 }),
+  relatedContent: fc.array(relatedContentArbitrary, {
+    minLength: 1,
+    maxLength: 5,
+  }),
   nearbyFacilities: fc.constant([]) as fc.Arbitrary<NearbyFacility[]>, // Not tested in this property
 })
 
 /**
  * Helper function to check if rendered content contains required information
- * Requirements 3.2: 스팟 이름, 사진들, 전체 설명, 주소, 관련 미디어 정보 표시
+ * Requirements 3.2: 스팟 이름, 사진들, 전체 설명, 주소, 관련 콘텐츠 정보 표시
  */
 function containsRequiredInfo(
   container: HTMLElement,
@@ -81,14 +98,16 @@ function containsRequiredInfo(
     container.querySelector('img') !== null ||
     content.includes('사진')
 
-  // Check if related media information is present
-  const hasRelatedMedia =
-    !spotData.relatedMedia ||
-    spotData.relatedMedia.length === 0 ||
-    spotData.relatedMedia.some((media) => content.includes(media.title)) ||
-    content.includes('관련 작품')
+  // Check if related content information is present
+  const hasRelatedContent =
+    !spotData.relatedContent ||
+    spotData.relatedContent.length === 0 ||
+    spotData.relatedContent.some((c) => content.includes(c.name)) ||
+    content.includes('관련 콘텐츠')
 
-  return hasName && hasAddress && hasDescription && hasPhotos && hasRelatedMedia
+  return (
+    hasName && hasAddress && hasDescription && hasPhotos && hasRelatedContent
+  )
 }
 
 /**
@@ -277,7 +296,7 @@ describe('SpotDetail Required Information Property Tests', () => {
             fc.double({ min: -90, max: 90, noNaN: true }),
             fc.double({ min: -180, max: 180, noNaN: true })
           ) as fc.Arbitrary<[number, number]>,
-          relatedMedia: fc.array(mediaInfoArbitrary, {
+          relatedContent: fc.array(relatedContentArbitrary, {
             minLength: 1,
             maxLength: 3,
           }),
@@ -299,13 +318,13 @@ describe('SpotDetail Required Information Property Tests', () => {
 
           const content = container.textContent || ''
 
-          // Even with empty photos, name, address, description, and related media should still be present
+          // Even with empty photos, name, address, description, and related content should still be present
           const hasName = content.includes(spotData.name)
           const hasAddress = content.includes(spotData.address)
           const hasDescription = content.includes(spotData.description)
-          const hasRelatedMedia =
-            !spotData.relatedMedia ||
-            spotData.relatedMedia.some((media) => content.includes(media.title))
+          const hasRelatedContent =
+            !spotData.relatedContent ||
+            spotData.relatedContent.some((c) => content.includes(c.name))
 
           // Photos section should not be rendered when photos array is empty
           const photosSection = container.querySelector('h2')
@@ -316,7 +335,7 @@ describe('SpotDetail Required Information Property Tests', () => {
             hasName &&
             hasAddress &&
             hasDescription &&
-            hasRelatedMedia &&
+            hasRelatedContent &&
             !hasPhotosSection
           )
         }
@@ -325,7 +344,7 @@ describe('SpotDetail Required Information Property Tests', () => {
     )
   })
 
-  test('Property 3 Edge Case: Empty related media array handling', () => {
+  test('Property 3 Edge Case: Empty related content array handling', () => {
     fc.assert(
       fc.property(
         fc.record({
@@ -342,7 +361,7 @@ describe('SpotDetail Required Information Property Tests', () => {
             fc.double({ min: -90, max: 90, noNaN: true }),
             fc.double({ min: -180, max: 180, noNaN: true })
           ) as fc.Arbitrary<[number, number]>,
-          relatedMedia: fc.constant([]) as fc.Arbitrary<MediaInfo[]>, // Empty related media array
+          relatedContent: fc.constant([]) as fc.Arbitrary<RelatedContent[]>, // Empty related content array
           nearbyFacilities: fc.constant([]) as fc.Arbitrary<NearbyFacility[]>,
         }),
         (spotData: SpotDetailData) => {
@@ -361,7 +380,7 @@ describe('SpotDetail Required Information Property Tests', () => {
 
           const pageContent = container.textContent || ''
 
-          // Even with empty related media, name, address, description, and photos should still be present
+          // Even with empty related content, name, address, description, and photos should still be present
           const hasName = pageContent.includes(spotData.name)
           const hasAddress = pageContent.includes(spotData.address)
           const hasDescription = pageContent.includes(spotData.description)
@@ -370,15 +389,15 @@ describe('SpotDetail Required Information Property Tests', () => {
           const hasPhotos =
             spotData.photos.length === 0 || pageContent.includes('사진')
 
-          // Related media section should not be rendered when relatedMedia array is empty
-          const hasRelatedMediaSection = pageContent.includes('관련 작품')
+          // Related content section should not be rendered when relatedContent array is empty
+          const hasRelatedContentSection = pageContent.includes('관련 콘텐츠')
 
           return (
             hasName &&
             hasAddress &&
             hasDescription &&
             hasPhotos &&
-            !hasRelatedMediaSection
+            !hasRelatedContentSection
           )
         }
       ),
@@ -405,10 +424,10 @@ describe('SpotDetail Required Information Property Tests', () => {
             fc.double({ min: -90, max: 90, noNaN: true }),
             fc.double({ min: -180, max: 180, noNaN: true })
           ) as fc.Arbitrary<[number, number]>,
-          relatedMedia: fc.array(mediaInfoArbitrary, {
+          relatedContent: fc.array(relatedContentArbitrary, {
             minLength: 3,
             maxLength: 5,
-          }), // Many related media
+          }), // Many related content
           nearbyFacilities: fc.constant([]) as fc.Arbitrary<NearbyFacility[]>,
         }),
         (spotData: SpotDetailData) => {
@@ -455,21 +474,28 @@ describe('SpotDetail Required Information Property Tests', () => {
             fc.double({ min: -90, max: 90, noNaN: true }),
             fc.double({ min: -180, max: 180, noNaN: true })
           ) as fc.Arbitrary<[number, number]>,
-          relatedMedia: fc.array(
+          relatedContent: fc.array(
             fc.record({
-              title: fc
+              name: fc
                 .string({ minLength: 1 })
                 .filter((s) => s.trim().length > 0)
                 .map((s) => s + ' アニメ & < > " \''), // Add Japanese and special characters
               type: fc.constantFrom(
                 'anime',
-                'drama',
                 'movie',
+                'drama',
+                'sports_team',
+                'artist',
+                'game',
                 'other'
-              ) as fc.Arbitrary<MediaInfo['type']>,
+              ) as fc.Arbitrary<ContentType>,
               year: fc.option(fc.integer({ min: 1900, max: 2030 }), {
                 nil: undefined,
               }),
+              additionalInfo: fc.option(
+                fc.string({ minLength: 1, maxLength: 50 }),
+                { nil: undefined }
+              ),
             }),
             { minLength: 1, maxLength: 3 }
           ),

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -14,6 +14,8 @@ import dynamic from 'next/dynamic'
 import NearbyFacilities from '@/components/spot/NearbyFacilities'
 import SpotCommunitySection from '@/components/spot/SpotCommunitySection'
 import { SpotContentSection } from '@/components/spot/SpotContentSection'
+import { RelatedContentSection } from '@/components/spot/RelatedContentSection'
+import { CategoryIcon } from '@/components/common'
 
 // 지도 컴포넌트를 동적으로 로드 (SSR 방지)
 const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
@@ -182,7 +184,10 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
                   color: categoryConfig.color,
                 }}
               >
-                <span>{categoryConfig.icon}</span>
+                <CategoryIcon
+                  category={spot.category as SpotCategory}
+                  size="sm"
+                />
                 <span>{categoryConfig.label}</span>
               </span>
             </div>
@@ -274,113 +279,9 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
         <SpotCommunitySection spotId={spot.id} spotName={spot.name} />
       </div>
 
-      {/* Related Content - 맨 아래 (Requirements 3.3) */}
-      {/* relatedContent 우선, 없으면 relatedMedia 표시 (하위 호환성) */}
-      {((spot.relatedContent && spot.relatedContent.length > 0) ||
-        (spot.relatedMedia && spot.relatedMedia.length > 0)) && (
-        <div className="overflow-hidden rounded-lg bg-white shadow-md">
-          <div className="p-6">
-            <h2 className="mb-4 text-2xl font-bold text-gray-900">
-              관련 콘텐츠
-            </h2>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {/* relatedContent 표시 (새로운 형식) */}
-              {spot.relatedContent && spot.relatedContent.length > 0
-                ? spot.relatedContent.map((content, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="text-lg">
-                            {getContentTypeIcon(content.type)}
-                          </span>
-                          <h3 className="font-semibold text-gray-900">
-                            {content.name}
-                          </h3>
-                        </div>
-                        <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-                          {getContentTypeLabel(content.type)}
-                        </span>
-                      </div>
-                      {(content.year || content.additionalInfo) && (
-                        <p className="mt-1 text-sm text-gray-600">
-                          {content.year && `${content.year}년`}
-                          {content.year && content.additionalInfo && ' · '}
-                          {content.additionalInfo}
-                        </p>
-                      )}
-                      <Link
-                        href={`/community/media/${encodeURIComponent(content.name)}`}
-                        className="mt-3 inline-flex items-center gap-1 text-sm text-navy-600 transition-colors hover:text-navy-800"
-                      >
-                        <span>커뮤니티 보기</span>
-                        <svg
-                          className="h-4 w-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M9 5l7 7-7 7"
-                          />
-                        </svg>
-                      </Link>
-                    </div>
-                  ))
-                : /* relatedMedia 표시 (기존 형식 - 하위 호환성) */
-                  spot.relatedMedia?.map((media, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="text-lg">
-                            {getContentTypeIcon(media.type)}
-                          </span>
-                          <h3 className="font-semibold text-gray-900">
-                            {media.title}
-                          </h3>
-                        </div>
-                        <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-                          {getMediaTypeLabel(media.type)}
-                        </span>
-                      </div>
-                      {media.year && (
-                        <p className="mt-1 text-sm text-gray-600">
-                          {media.year}년
-                        </p>
-                      )}
-                      <Link
-                        href={`/community/media/${encodeURIComponent(media.title)}`}
-                        className="mt-3 inline-flex items-center gap-1 text-sm text-navy-600 transition-colors hover:text-navy-800"
-                      >
-                        <span>커뮤니티 보기</span>
-                        <svg
-                          className="h-4 w-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M9 5l7 7-7 7"
-                          />
-                        </svg>
-                      </Link>
-                    </div>
-                  ))}
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Related Content - 맨 아래 (Requirements 3.1, 3.4) */}
+      {/* RelatedContentSection 컴포넌트 사용 - 빈 배열일 때 자동으로 섹션 숨김 */}
+      <RelatedContentSection contents={spot.relatedContent || []} />
     </div>
   )
 }
@@ -503,42 +404,4 @@ function SpotNotFound() {
       </div>
     </div>
   )
-}
-
-function getMediaTypeLabel(type: string): string {
-  const labels: Record<string, string> = {
-    anime: '애니메이션',
-    drama: '드라마',
-    movie: '영화',
-    other: '기타',
-  }
-  return labels[type] || type
-}
-
-// 콘텐츠 타입별 아이콘 (Requirements 3.3)
-function getContentTypeIcon(type: string): string {
-  const icons: Record<string, string> = {
-    anime: '🎬',
-    movie: '🎥',
-    drama: '📺',
-    sports_team: '⚽',
-    artist: '🎵',
-    game: '🎮',
-    other: '📍',
-  }
-  return icons[type] || '📍'
-}
-
-// 콘텐츠 타입별 라벨 (Requirements 3.3)
-function getContentTypeLabel(type: string): string {
-  const labels: Record<string, string> = {
-    anime: '애니메이션',
-    movie: '영화',
-    drama: '드라마',
-    sports_team: '스포츠 팀',
-    artist: '아티스트',
-    game: '게임',
-    other: '기타',
-  }
-  return labels[type] || type
 }

--- a/src/app/test/related-content-section/page.tsx
+++ b/src/app/test/related-content-section/page.tsx
@@ -6,7 +6,20 @@ import { RelatedContent } from '@/types'
 
 // 테스트용 샘플 데이터
 const SAMPLE_CONTENTS: RelatedContent[] = [
-  { name: '도쿄구울', type: 'anime', year: 2014, additionalInfo: '시즌 1' },
+  {
+    name: '청춘 돼지는 바니걸 선배의 꿈을 꾸지 않는다',
+    type: 'anime',
+    year: 2018,
+    additionalInfo: '시즌 1',
+    imageUrl: 'https://cdn.myanimelist.net/images/anime/1301/93586.jpg',
+  },
+  {
+    name: '도쿄구울',
+    type: 'anime',
+    year: 2014,
+    additionalInfo: '시즌 1',
+    imageUrl: 'https://cdn.myanimelist.net/images/anime/5/64449.jpg',
+  },
   { name: '원피스', type: 'anime', year: 1999 },
   { name: '너의 이름은', type: 'movie', year: 2016 },
   { name: 'FC 도쿄', type: 'sports_team', additionalInfo: 'J리그' },
@@ -58,10 +71,10 @@ export default function RelatedContentSectionTestPage() {
               4개 (더보기 표시)
             </button>
             <button
-              onClick={() => setContentCount(6)}
-              className={`rounded px-3 py-1.5 text-sm ${contentCount === 6 ? 'bg-navy-600 text-white' : 'bg-navy-100 text-navy-700 hover:bg-navy-200'}`}
+              onClick={() => setContentCount(7)}
+              className={`rounded px-3 py-1.5 text-sm ${contentCount === 7 ? 'bg-navy-600 text-white' : 'bg-navy-100 text-navy-700 hover:bg-navy-200'}`}
             >
-              6개 (전체)
+              7개 (전체)
             </button>
           </div>
           <p className="mt-3 text-sm text-navy-500">

--- a/src/components/common/ContentTypeIcon.tsx
+++ b/src/components/common/ContentTypeIcon.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import Image from 'next/image'
+import { ContentType, SpotCategory, ExternalLinkType } from '@/types'
+
+// ============================================
+// 아이콘 경로 매핑
+// ============================================
+
+const CONTENT_TYPE_ICON_PATH: Record<ContentType, string> = {
+  anime: '/icons/content-types/anime.svg',
+  movie: '/icons/content-types/movie.svg',
+  drama: '/icons/content-types/drama.svg',
+  sports_team: '/icons/content-types/sports_team.svg',
+  artist: '/icons/content-types/artist.svg',
+  game: '/icons/content-types/game.svg',
+  other: '/icons/content-types/other.svg',
+}
+
+const CATEGORY_ICON_PATH: Record<SpotCategory, string> = {
+  animation: '/icons/categories/animation.svg',
+  sports: '/icons/categories/sports.svg',
+  movie_drama: '/icons/categories/movie_drama.svg',
+  music: '/icons/categories/music.svg',
+  game: '/icons/categories/game.svg',
+  other: '/icons/categories/other.svg',
+}
+
+const LINK_TYPE_ICON_PATH: Record<ExternalLinkType, string> = {
+  official: '/icons/link-types/official.svg',
+  ticket: '/icons/link-types/ticket.svg',
+  schedule: '/icons/link-types/schedule.svg',
+  sns: '/icons/link-types/sns.svg',
+  other: '/icons/link-types/other.svg',
+}
+
+// ============================================
+// Fallback 이모티콘 매핑
+// ============================================
+
+const CONTENT_TYPE_FALLBACK: Record<ContentType, string> = {
+  anime: '🎬',
+  movie: '🎥',
+  drama: '📺',
+  sports_team: '⚽',
+  artist: '🎵',
+  game: '🎮',
+  other: '📍',
+}
+
+const CATEGORY_FALLBACK: Record<SpotCategory, string> = {
+  animation: '🎬',
+  sports: '⚽',
+  movie_drama: '🎥',
+  music: '🎵',
+  game: '🎮',
+  other: '📍',
+}
+
+const LINK_TYPE_FALLBACK: Record<ExternalLinkType, string> = {
+  official: '🏠',
+  ticket: '🎫',
+  schedule: '📅',
+  sns: '📱',
+  other: '🔗',
+}
+
+// ============================================
+// 사이즈 설정
+// ============================================
+
+type IconSize = 'sm' | 'md' | 'lg'
+
+const SIZE_MAP: Record<IconSize, number> = {
+  sm: 16,
+  md: 20,
+  lg: 24,
+}
+
+// ============================================
+// ContentTypeIcon 컴포넌트
+// ============================================
+
+interface ContentTypeIconProps {
+  type: ContentType
+  size?: IconSize
+  className?: string
+}
+
+/**
+ * ContentType에 해당하는 SVG 아이콘을 렌더링하는 컴포넌트
+ * SVG 로드 실패 시 fallback으로 이모티콘을 표시합니다.
+ */
+export function ContentTypeIcon({
+  type,
+  size = 'md',
+  className = '',
+}: ContentTypeIconProps) {
+  const iconPath = CONTENT_TYPE_ICON_PATH[type] || CONTENT_TYPE_ICON_PATH.other
+  const fallback = CONTENT_TYPE_FALLBACK[type] || CONTENT_TYPE_FALLBACK.other
+  const pixelSize = SIZE_MAP[size]
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center ${className}`}
+      style={{ width: pixelSize, height: pixelSize }}
+    >
+      <Image
+        src={iconPath}
+        alt={type}
+        width={pixelSize}
+        height={pixelSize}
+        className="h-full w-full"
+        onError={(e) => {
+          // SVG 로드 실패 시 fallback 이모티콘으로 대체
+          const target = e.currentTarget
+          target.style.display = 'none'
+          const parent = target.parentElement
+          if (parent) {
+            const fallbackSpan = document.createElement('span')
+            fallbackSpan.textContent = fallback
+            fallbackSpan.style.fontSize = `${pixelSize}px`
+            fallbackSpan.style.lineHeight = '1'
+            parent.appendChild(fallbackSpan)
+          }
+        }}
+      />
+    </span>
+  )
+}
+
+// ============================================
+// CategoryIcon 컴포넌트
+// ============================================
+
+interface CategoryIconProps {
+  category: SpotCategory
+  size?: IconSize
+  className?: string
+}
+
+/**
+ * SpotCategory에 해당하는 SVG 아이콘을 렌더링하는 컴포넌트
+ * SVG 로드 실패 시 fallback으로 이모티콘을 표시합니다.
+ */
+export function CategoryIcon({
+  category,
+  size = 'md',
+  className = '',
+}: CategoryIconProps) {
+  const iconPath = CATEGORY_ICON_PATH[category] || CATEGORY_ICON_PATH.other
+  const fallback = CATEGORY_FALLBACK[category] || CATEGORY_FALLBACK.other
+  const pixelSize = SIZE_MAP[size]
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center ${className}`}
+      style={{ width: pixelSize, height: pixelSize }}
+    >
+      <Image
+        src={iconPath}
+        alt={category}
+        width={pixelSize}
+        height={pixelSize}
+        className="h-full w-full"
+        onError={(e) => {
+          // SVG 로드 실패 시 fallback 이모티콘으로 대체
+          const target = e.currentTarget
+          target.style.display = 'none'
+          const parent = target.parentElement
+          if (parent) {
+            const fallbackSpan = document.createElement('span')
+            fallbackSpan.textContent = fallback
+            fallbackSpan.style.fontSize = `${pixelSize}px`
+            fallbackSpan.style.lineHeight = '1'
+            parent.appendChild(fallbackSpan)
+          }
+        }}
+      />
+    </span>
+  )
+}
+
+// ============================================
+// LinkTypeIcon 컴포넌트
+// ============================================
+
+interface LinkTypeIconProps {
+  linkType: ExternalLinkType
+  size?: IconSize
+  className?: string
+}
+
+/**
+ * ExternalLinkType에 해당하는 SVG 아이콘을 렌더링하는 컴포넌트
+ * SVG 로드 실패 시 fallback으로 이모티콘을 표시합니다.
+ */
+export function LinkTypeIcon({
+  linkType,
+  size = 'md',
+  className = '',
+}: LinkTypeIconProps) {
+  const iconPath = LINK_TYPE_ICON_PATH[linkType] || LINK_TYPE_ICON_PATH.other
+  const fallback = LINK_TYPE_FALLBACK[linkType] || LINK_TYPE_FALLBACK.other
+  const pixelSize = SIZE_MAP[size]
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center ${className}`}
+      style={{ width: pixelSize, height: pixelSize }}
+    >
+      <Image
+        src={iconPath}
+        alt={linkType}
+        width={pixelSize}
+        height={pixelSize}
+        className="h-full w-full"
+        onError={(e) => {
+          // SVG 로드 실패 시 fallback 이모티콘으로 대체
+          const target = e.currentTarget
+          target.style.display = 'none'
+          const parent = target.parentElement
+          if (parent) {
+            const fallbackSpan = document.createElement('span')
+            fallbackSpan.textContent = fallback
+            fallbackSpan.style.fontSize = `${pixelSize}px`
+            fallbackSpan.style.lineHeight = '1'
+            parent.appendChild(fallbackSpan)
+          }
+        }}
+      />
+    </span>
+  )
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,2 @@
 export { LoginRequiredModal } from './LoginRequiredModal'
+export { ContentTypeIcon, CategoryIcon, LinkTypeIcon } from './ContentTypeIcon'

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -6,6 +6,7 @@ import {
   useSelectedCategories,
   ALL_CATEGORIES,
 } from '@/stores/filterStore'
+import { CategoryIcon } from '@/components/common'
 
 /**
  * 카테고리 필터 컴포넌트
@@ -63,7 +64,7 @@ export default function CategoryFilter() {
               backgroundColor: isSelected ? config.color : undefined,
             }}
           >
-            <span>{config.icon}</span>
+            <CategoryIcon category={category} size="sm" />
             <span>{config.label}</span>
           </button>
         )

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -32,10 +32,24 @@ const getCategoryColor = (category?: SpotCategory): string => {
   return CATEGORY_CONFIG[category]?.color || '#2d4a6f'
 }
 
-// 카테고리별 아이콘 가져오기
-const getCategoryIcon = (category?: SpotCategory): string => {
-  if (!category) return '📍' // 기본 아이콘
-  return CATEGORY_CONFIG[category]?.icon || '📍'
+// 카테고리별 아이콘 가져오기 (SVG 이미지 경로 또는 fallback 이모티콘)
+const getCategoryIcon = (
+  category?: SpotCategory
+): { path: string; fallback: string } => {
+  const fallbackIcons: Record<SpotCategory, string> = {
+    animation: '🎬',
+    sports: '⚽',
+    movie_drama: '🎥',
+    music: '🎵',
+    game: '🎮',
+    other: '📍',
+  }
+
+  if (!category) return { path: '/icons/categories/other.svg', fallback: '📍' }
+  return {
+    path: CATEGORY_CONFIG[category]?.icon || '/icons/categories/other.svg',
+    fallback: fallbackIcons[category] || '📍',
+  }
 }
 
 // 작품 이미지 핀 아이콘 생성
@@ -55,7 +69,7 @@ const createImagePinIcon = (
 
   // 카테고리별 색상 적용
   const categoryColor = getCategoryColor(category)
-  const categoryIcon = getCategoryIcon(category)
+  const categoryIconData = getCategoryIcon(category)
 
   // 테두리 색상 및 스타일 (카테고리 색상 적용)
   const getBorderColor = () => {
@@ -101,9 +115,13 @@ const createImagePinIcon = (
         border-radius: 50%;
         align-items: center;
         justify-content: center;
-        font-size: 24px;
       ">
-        ${categoryIcon}
+        <img 
+          src="${categoryIconData.path}" 
+          alt="category" 
+          style="width: 24px; height: 24px;"
+          onerror="this.style.display='none'; this.parentElement.innerHTML='<span style=font-size:24px>${categoryIconData.fallback}</span>';"
+        />
       </div>`
     : `<div style="
         width: 100%;
@@ -113,9 +131,13 @@ const createImagePinIcon = (
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 24px;
       ">
-        ${categoryIcon}
+        <img 
+          src="${categoryIconData.path}" 
+          alt="category" 
+          style="width: 24px; height: 24px;"
+          onerror="this.style.display='none'; this.parentElement.innerHTML+='<span style=font-size:24px>${categoryIconData.fallback}</span>';"
+        />
       </div>`
 
   // 호버 상태 클래스

--- a/src/components/spot/RelatedContentForm.tsx
+++ b/src/components/spot/RelatedContentForm.tsx
@@ -15,18 +15,15 @@ interface RelatedContentFormProps {
   maxItems?: number
 }
 
-// 콘텐츠 타입 설정
-const CONTENT_TYPE_CONFIG: Record<
-  ContentType,
-  { label: string; icon: string }
-> = {
-  anime: { label: '애니메이션', icon: '🎬' },
-  movie: { label: '영화', icon: '🎥' },
-  drama: { label: '드라마', icon: '📺' },
-  sports_team: { label: '스포츠 팀', icon: '⚽' },
-  artist: { label: '아티스트', icon: '🎵' },
-  game: { label: '게임', icon: '🎮' },
-  other: { label: '기타', icon: '📍' },
+// 콘텐츠 타입 라벨 설정
+const CONTENT_TYPE_LABELS: Record<ContentType, string> = {
+  anime: '애니메이션',
+  movie: '영화',
+  drama: '드라마',
+  sports_team: '스포츠 팀',
+  artist: '아티스트',
+  game: '게임',
+  other: '기타',
 }
 
 /**
@@ -185,11 +182,10 @@ export function RelatedContentForm({
                 }
                 className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm text-navy-800 focus:border-navy-500 focus:outline-none focus:ring-2 focus:ring-navy-500/20"
               >
-                {(Object.keys(CONTENT_TYPE_CONFIG) as ContentType[]).map(
+                {(Object.keys(CONTENT_TYPE_LABELS) as ContentType[]).map(
                   (type) => (
                     <option key={type} value={type}>
-                      {CONTENT_TYPE_CONFIG[type].icon}{' '}
-                      {CONTENT_TYPE_CONFIG[type].label}
+                      {CONTENT_TYPE_LABELS[type]}
                     </option>
                   )
                 )}

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -1,19 +1,17 @@
 'use client'
 
 import { RelatedContent, ContentType } from '@/types'
+import { ContentTypeIcon } from '@/components/common'
 
-// 콘텐츠 타입 설정
-const CONTENT_TYPE_CONFIG: Record<
-  ContentType,
-  { label: string; icon: string }
-> = {
-  anime: { label: '애니메이션', icon: '🎬' },
-  movie: { label: '영화', icon: '🎥' },
-  drama: { label: '드라마', icon: '📺' },
-  sports_team: { label: '스포츠 팀', icon: '⚽' },
-  artist: { label: '아티스트', icon: '🎵' },
-  game: { label: '게임', icon: '🎮' },
-  other: { label: '기타', icon: '📍' },
+// 콘텐츠 타입 라벨 설정
+const CONTENT_TYPE_LABELS: Record<ContentType, string> = {
+  anime: '애니메이션',
+  movie: '영화',
+  drama: '드라마',
+  sports_team: '스포츠 팀',
+  artist: '아티스트',
+  game: '게임',
+  other: '기타',
 }
 
 interface RelatedContentItemProps {
@@ -46,8 +44,8 @@ export function RelatedContentItem({
   isDragging,
   isDragOver,
 }: RelatedContentItemProps) {
-  const typeConfig =
-    CONTENT_TYPE_CONFIG[content.type] || CONTENT_TYPE_CONFIG.other
+  const typeLabel =
+    CONTENT_TYPE_LABELS[content.type] || CONTENT_TYPE_LABELS.other
 
   return (
     <div
@@ -82,13 +80,11 @@ export function RelatedContentItem({
 
       {/* 콘텐츠 정보 */}
       <div className="flex flex-1 items-center gap-3">
-        <span className="text-lg" role="img" aria-label={typeConfig.label}>
-          {typeConfig.icon}
-        </span>
+        <ContentTypeIcon type={content.type} size="lg" />
         <div className="min-w-0 flex-1">
           <p className="truncate font-medium text-navy-800">{content.name}</p>
           <p className="truncate text-xs text-navy-500">
-            {typeConfig.label}
+            {typeLabel}
             {content.year && ` · ${content.year}년`}
             {content.additionalInfo && ` · ${content.additionalInfo}`}
           </p>

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { RelatedContent, ContentType } from '@/types'
 import { ContentTypeIcon } from '@/components/common'
 
@@ -80,7 +81,19 @@ export function RelatedContentItem({
 
       {/* 콘텐츠 정보 */}
       <div className="flex flex-1 items-center gap-3">
-        <ContentTypeIcon type={content.type} size="lg" />
+        {/* 대표 이미지가 있으면 원형 뱃지로 표시, 없으면 기본 아이콘 */}
+        {content.imageUrl ? (
+          <div className="relative h-8 w-8 flex-shrink-0 overflow-hidden rounded-full border-2 border-navy-200">
+            <Image
+              src={content.imageUrl}
+              alt={content.name}
+              fill
+              className="object-cover"
+            />
+          </div>
+        ) : (
+          <ContentTypeIcon type={content.type} size="lg" />
+        )}
         <div className="min-w-0 flex-1">
           <p className="truncate font-medium text-navy-800">{content.name}</p>
           <p className="truncate text-xs text-navy-500">

--- a/src/components/spot/RelatedContentSection.tsx
+++ b/src/components/spot/RelatedContentSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { RelatedContent, ContentType } from '@/types'
 import { ContentTypeIcon } from '@/components/common'
 
@@ -125,8 +126,20 @@ function RelatedContentCard({ content }: RelatedContentCardProps) {
   return (
     <div className="rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <ContentTypeIcon type={content.type} size="lg" />
+        <div className="flex items-center gap-3">
+          {/* 대표 이미지가 있으면 원형 뱃지로 표시, 없으면 기본 아이콘 */}
+          {content.imageUrl ? (
+            <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-full border-2 border-gray-200">
+              <Image
+                src={content.imageUrl}
+                alt={content.name}
+                fill
+                className="object-cover"
+              />
+            </div>
+          ) : (
+            <ContentTypeIcon type={content.type} size="lg" />
+          )}
           <h3 className="font-semibold text-gray-900">{content.name}</h3>
         </div>
         <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">

--- a/src/components/spot/RelatedContentSection.tsx
+++ b/src/components/spot/RelatedContentSection.tsx
@@ -3,19 +3,17 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { RelatedContent, ContentType } from '@/types'
+import { ContentTypeIcon } from '@/components/common'
 
-// 콘텐츠 타입 설정
-const CONTENT_TYPE_CONFIG: Record<
-  ContentType,
-  { label: string; icon: string }
-> = {
-  anime: { label: '애니메이션', icon: '🎬' },
-  movie: { label: '영화', icon: '🎥' },
-  drama: { label: '드라마', icon: '📺' },
-  sports_team: { label: '스포츠 팀', icon: '⚽' },
-  artist: { label: '아티스트', icon: '🎵' },
-  game: { label: '게임', icon: '🎮' },
-  other: { label: '기타', icon: '📍' },
+// 콘텐츠 타입 라벨 설정
+const CONTENT_TYPE_LABELS: Record<ContentType, string> = {
+  anime: '애니메이션',
+  movie: '영화',
+  drama: '드라마',
+  sports_team: '스포츠 팀',
+  artist: '아티스트',
+  game: '게임',
+  other: '기타',
 }
 
 interface RelatedContentSectionProps {
@@ -121,20 +119,18 @@ interface RelatedContentCardProps {
  * Requirements 3.4: 타입 아이콘, 이름, 연도, 추가정보 표시
  */
 function RelatedContentCard({ content }: RelatedContentCardProps) {
-  const typeConfig =
-    CONTENT_TYPE_CONFIG[content.type] || CONTENT_TYPE_CONFIG.other
+  const typeLabel =
+    CONTENT_TYPE_LABELS[content.type] || CONTENT_TYPE_LABELS.other
 
   return (
     <div className="rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-lg" role="img" aria-label={typeConfig.label}>
-            {typeConfig.icon}
-          </span>
+          <ContentTypeIcon type={content.type} size="lg" />
           <h3 className="font-semibold text-gray-900">{content.name}</h3>
         </div>
         <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-          {typeConfig.label}
+          {typeLabel}
         </span>
       </div>
       {(content.year || content.additionalInfo) && (

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -162,6 +162,8 @@ export interface RelatedContent {
   type: ContentType
   year?: number
   additionalInfo?: string
+  /** 대표 이미지 URL (관리자만 설정 가능) */
+  imageUrl?: string
 }
 
 export interface Spot {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -23,11 +23,27 @@ export interface LinkTypeConfig {
 }
 
 export const LINK_TYPE_CONFIG: Record<ExternalLinkType, LinkTypeConfig> = {
-  official: { label: '공식 홈페이지', icon: '🏠', color: '#3B82F6' },
-  ticket: { label: '티켓 예매', icon: '🎫', color: '#10B981' },
-  schedule: { label: '일정 확인', icon: '📅', color: '#F59E0B' },
-  sns: { label: 'SNS', icon: '📱', color: '#8B5CF6' },
-  other: { label: '기타', icon: '🔗', color: '#6B7280' },
+  official: {
+    label: '공식 홈페이지',
+    icon: '/icons/link-types/official.svg',
+    color: '#3B82F6',
+  },
+  ticket: {
+    label: '티켓 예매',
+    icon: '/icons/link-types/ticket.svg',
+    color: '#10B981',
+  },
+  schedule: {
+    label: '일정 확인',
+    icon: '/icons/link-types/schedule.svg',
+    color: '#F59E0B',
+  },
+  sns: { label: 'SNS', icon: '/icons/link-types/sns.svg', color: '#8B5CF6' },
+  other: {
+    label: '기타',
+    icon: '/icons/link-types/other.svg',
+    color: '#6B7280',
+  },
 }
 
 // ============================================
@@ -58,12 +74,32 @@ export interface CategoryConfig {
 }
 
 export const CATEGORY_CONFIG: Record<SpotCategory, CategoryConfig> = {
-  animation: { icon: '🎬', color: '#FF6B6B', label: '애니메이션' },
-  sports: { icon: '⚽', color: '#4ECDC4', label: '스포츠' },
-  movie_drama: { icon: '🎥', color: '#45B7D1', label: '영화/드라마' },
-  music: { icon: '🎵', color: '#96CEB4', label: '음악/콘서트' },
-  game: { icon: '🎮', color: '#DDA0DD', label: '게임' },
-  other: { icon: '📍', color: '#95A5A6', label: '기타' },
+  animation: {
+    icon: '/icons/categories/animation.svg',
+    color: '#FF6B6B',
+    label: '애니메이션',
+  },
+  sports: {
+    icon: '/icons/categories/sports.svg',
+    color: '#4ECDC4',
+    label: '스포츠',
+  },
+  movie_drama: {
+    icon: '/icons/categories/movie_drama.svg',
+    color: '#45B7D1',
+    label: '영화/드라마',
+  },
+  music: {
+    icon: '/icons/categories/music.svg',
+    color: '#96CEB4',
+    label: '음악/콘서트',
+  },
+  game: { icon: '/icons/categories/game.svg', color: '#DDA0DD', label: '게임' },
+  other: {
+    icon: '/icons/categories/other.svg',
+    color: '#95A5A6',
+    label: '기타',
+  },
 }
 
 // ============================================


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #197

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [x] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 기존 이모티콘 기반 아이콘을 SVG 이미지로 전환하여 일관된 디자인 시스템 구축

---

## 📋 변경 사항

- [x] SVG 아이콘 에셋 18개 추가 (content-types 7개, categories 6개, link-types 5개)
- [x] ContentTypeIcon, CategoryIcon, LinkTypeIcon 컴포넌트 구현
- [x] CATEGORY_CONFIG, LINK_TYPE_CONFIG icon 필드 이미지 경로로 변경
- [x] RelatedContentItem, RelatedContentSection, RelatedContentForm 이모티콘 교체
- [x] CategoryFilter, SpotPin 카테고리 아이콘 SVG로 교체
- [x] SpotDetailPage 카테고리 배지 CategoryIcon 적용
- [x] multi-content-spot tasks 완료 상태 업데이트

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

- 아이콘 컴포넌트는 size prop으로 sm(16px), md(20px), lg(24px) 크기 조절 가능
- SVG 로드 실패 시 fallback 이모티콘 자동 표시
- Task 8.1 ~ 8.4 및 Task 9 (전체 기능 검증) 완료
