### PR TITLE
[Feat] Task 10.3~10.5 - 관리자 콘텐츠 이미지 관리 시스템 구현

### DIFF
--- a/.kiro/specs/multi-content-spot/tasks.md
+++ b/.kiro/specs/multi-content-spot/tasks.md
@@ -97,19 +97,19 @@
     - 이미지 없으면 기존 ContentTypeIcon 표시
     - _New Requirement_
 
-  - [ ] 10.3 관리자 전용 콘텐츠 이미지 관리 페이지 구현
+  - [x] 10.3 관리자 전용 콘텐츠 이미지 관리 페이지 구현
     - `src/app/admin/content-images/page.tsx` 생성
     - 콘텐츠 목록 조회 및 이미지 업로드 UI
     - 관리자 권한 체크 (role === 'admin')
     - _New Requirement_
 
-  - [ ] 10.4 콘텐츠 이미지 업로드 API 구현
+  - [x] 10.4 콘텐츠 이미지 업로드 API 구현
     - `src/app/api/admin/content-images/route.ts` 생성
     - 관리자 권한 검증
     - 이미지 업로드 및 콘텐츠 imageUrl 업데이트
     - _New Requirement_
 
-  - [ ] 10.5 콘텐츠 마스터 데이터 관리
+  - [x] 10.5 콘텐츠 마스터 데이터 관리
     - 콘텐츠 이름별 대표 이미지 저장 (MongoDB 컬렉션)
     - 스팟 등록 시 기존 콘텐츠 이미지 자동 적용
     - _New Requirement_

--- a/src/app/admin/content-images/page.tsx
+++ b/src/app/admin/content-images/page.tsx
@@ -1,0 +1,537 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import Image from 'next/image'
+import { ContentTypeIcon } from '@/components/common'
+import { ContentType, CONTENT_TYPE_CONFIG } from '@/types'
+
+interface ContentMaster {
+  id: string
+  normalizedName: string
+  displayName: string
+  imageUrl?: string
+  type?: ContentType
+  year?: number
+  spotCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+interface ContentMastersResponse {
+  items: ContentMaster[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+export default function AdminContentImagesPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+
+  const [contents, setContents] = useState<ContentMaster[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [syncing, setSyncing] = useState(false)
+
+  // 업로드 모달 상태
+  const [showUploadModal, setShowUploadModal] = useState(false)
+  const [selectedContent, setSelectedContent] = useState<ContentMaster | null>(
+    null
+  )
+  const [uploadFile, setUploadFile] = useState<File | null>(null)
+  const [uploadPreview, setUploadPreview] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+
+  // 새 콘텐츠 추가 상태
+  const [newContentName, setNewContentName] = useState('')
+  const [newContentType, setNewContentType] = useState<ContentType>('anime')
+  const [newContentYear, setNewContentYear] = useState('')
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // 콘텐츠 목록 조회
+  const fetchContents = useCallback(async () => {
+    try {
+      setLoading(true)
+      const params = new URLSearchParams({
+        page: page.toString(),
+        limit: '20',
+      })
+      if (search) {
+        params.set('search', search)
+      }
+
+      const res = await fetch(`/api/admin/content-images?${params}`)
+      if (!res.ok) throw new Error('Failed to fetch')
+
+      const data: ContentMastersResponse = await res.json()
+      setContents(data.items)
+      setTotalPages(data.totalPages)
+    } catch (error) {
+      console.error('Error fetching contents:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [page, search])
+
+  // 콘텐츠 마스터 동기화
+  const handleSync = async () => {
+    if (syncing) return
+
+    try {
+      setSyncing(true)
+      const res = await fetch('/api/admin/content-images/sync', {
+        method: 'POST',
+      })
+
+      if (!res.ok) throw new Error('Sync failed')
+
+      const data = await res.json()
+      alert(data.message)
+      fetchContents()
+    } catch (error) {
+      console.error('Error syncing:', error)
+      alert('동기화에 실패했습니다')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  // 이미지 업로드
+  const handleUpload = async () => {
+    if (uploading) return
+
+    const contentName = selectedContent?.displayName || newContentName.trim()
+    if (!contentName) {
+      alert('콘텐츠 이름을 입력해주세요')
+      return
+    }
+
+    if (!uploadFile && !selectedContent) {
+      alert('이미지를 선택해주세요')
+      return
+    }
+
+    try {
+      setUploading(true)
+      const formData = new FormData()
+      formData.append('contentName', contentName)
+
+      if (uploadFile) {
+        formData.append('file', uploadFile)
+      }
+
+      if (!selectedContent) {
+        formData.append('contentType', newContentType)
+        if (newContentYear) {
+          formData.append('year', newContentYear)
+        }
+      }
+
+      const res = await fetch('/api/admin/content-images', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!res.ok) {
+        const error = await res.json()
+        throw new Error(error.error || 'Upload failed')
+      }
+
+      alert('업로드 완료!')
+      closeUploadModal()
+      fetchContents()
+    } catch (error) {
+      console.error('Error uploading:', error)
+      alert(error instanceof Error ? error.message : '업로드에 실패했습니다')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  // 이미지 삭제
+  const handleDeleteImage = async (normalizedName: string) => {
+    if (!confirm('이미지를 삭제하시겠습니까?')) return
+
+    try {
+      const res = await fetch(
+        `/api/admin/content-images?normalizedName=${encodeURIComponent(normalizedName)}`,
+        { method: 'DELETE' }
+      )
+
+      if (!res.ok) throw new Error('Delete failed')
+
+      alert('이미지가 삭제되었습니다')
+      fetchContents()
+    } catch (error) {
+      console.error('Error deleting:', error)
+      alert('삭제에 실패했습니다')
+    }
+  }
+
+  // 파일 선택 핸들러
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setUploadFile(file)
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setUploadPreview(reader.result as string)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  // 업로드 모달 열기
+  const openUploadModal = (content?: ContentMaster) => {
+    setSelectedContent(content || null)
+    setUploadFile(null)
+    setUploadPreview(null)
+    setNewContentName('')
+    setNewContentType('anime')
+    setNewContentYear('')
+    setShowUploadModal(true)
+  }
+
+  // 업로드 모달 닫기
+  const closeUploadModal = () => {
+    setShowUploadModal(false)
+    setSelectedContent(null)
+    setUploadFile(null)
+    setUploadPreview(null)
+    setNewContentName('')
+    setNewContentType('anime')
+    setNewContentYear('')
+  }
+
+  // 권한 체크 및 데이터 로드
+  useEffect(() => {
+    if (status === 'loading') return
+
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
+      return
+    }
+
+    fetchContents()
+  }, [status, session, router, fetchContents])
+
+  // 검색 디바운스
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPage(1)
+      fetchContents()
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [search, fetchContents])
+
+  // 로딩 중
+  if (
+    status === 'loading' ||
+    (status === 'authenticated' && loading && contents.length === 0)
+  ) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    )
+  }
+
+  // 권한 없음
+  if (!session?.user || session.user.role !== 'admin') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="mb-2 text-2xl font-bold text-gray-800">
+            접근 권한 없음
+          </h1>
+          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        {/* 헤더 */}
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-800">
+              콘텐츠 이미지 관리
+            </h1>
+            <p className="mt-1 text-sm text-gray-600">
+              관련 콘텐츠의 대표 이미지를 관리합니다
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleSync}
+              disabled={syncing}
+              className="rounded-lg bg-gray-600 px-4 py-2 text-white hover:bg-gray-700 disabled:opacity-50"
+            >
+              {syncing ? '동기화 중...' : '스팟 데이터 동기화'}
+            </button>
+            <button
+              onClick={() => openUploadModal()}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            >
+              + 새 콘텐츠 추가
+            </button>
+          </div>
+        </div>
+
+        {/* 검색 */}
+        <div className="mb-6">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="콘텐츠 이름으로 검색..."
+            className="w-full max-w-md rounded-lg border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {/* 콘텐츠 목록 */}
+        {loading ? (
+          <div className="py-12 text-center text-gray-500">로딩 중...</div>
+        ) : contents.length === 0 ? (
+          <div className="py-12 text-center">
+            <p className="mb-4 text-gray-500">
+              {search ? '검색 결과가 없습니다' : '등록된 콘텐츠가 없습니다'}
+            </p>
+            {!search && (
+              <button
+                onClick={handleSync}
+                className="text-blue-600 hover:underline"
+              >
+                스팟 데이터에서 동기화하기
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {contents.map((content) => (
+              <div
+                key={content.id}
+                className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+              >
+                <div className="flex items-start gap-3">
+                  {/* 이미지 또는 아이콘 */}
+                  <div className="flex-shrink-0">
+                    {content.imageUrl ? (
+                      <div className="relative h-16 w-16 overflow-hidden rounded-full border-2 border-gray-200">
+                        <Image
+                          src={content.imageUrl}
+                          alt={content.displayName}
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
+                        <ContentTypeIcon
+                          type={content.type || 'other'}
+                          size="lg"
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 정보 */}
+                  <div className="min-w-0 flex-1">
+                    <h3 className="truncate font-medium text-gray-800">
+                      {content.displayName}
+                    </h3>
+                    <div className="mt-1 flex items-center gap-2 text-sm text-gray-500">
+                      {content.type && (
+                        <span>{CONTENT_TYPE_CONFIG[content.type]?.label}</span>
+                      )}
+                      {content.year && <span>({content.year})</span>}
+                    </div>
+                    <p className="mt-1 text-xs text-gray-400">
+                      {content.spotCount}개 스팟에서 사용
+                    </p>
+                  </div>
+                </div>
+
+                {/* 액션 버튼 */}
+                <div className="mt-3 flex gap-2 border-t border-gray-100 pt-3">
+                  <button
+                    onClick={() => openUploadModal(content)}
+                    className="flex-1 rounded bg-blue-50 px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-100"
+                  >
+                    {content.imageUrl ? '이미지 변경' : '이미지 추가'}
+                  </button>
+                  {content.imageUrl && (
+                    <button
+                      onClick={() => handleDeleteImage(content.normalizedName)}
+                      className="rounded bg-red-50 px-3 py-1.5 text-sm text-red-600 hover:bg-red-100"
+                    >
+                      삭제
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="mt-8 flex justify-center gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="rounded-lg border border-gray-300 px-4 py-2 disabled:opacity-50"
+            >
+              이전
+            </button>
+            <span className="px-4 py-2 text-gray-600">
+              {page} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="rounded-lg border border-gray-300 px-4 py-2 disabled:opacity-50"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 업로드 모달 */}
+      {showUploadModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+            <h2 className="mb-4 text-xl font-bold text-gray-800">
+              {selectedContent ? '이미지 업로드' : '새 콘텐츠 추가'}
+            </h2>
+
+            {/* 기존 콘텐츠 선택 시 */}
+            {selectedContent ? (
+              <div className="mb-4 rounded-lg bg-gray-50 p-3">
+                <p className="font-medium">{selectedContent.displayName}</p>
+                {selectedContent.type && (
+                  <p className="text-sm text-gray-500">
+                    {CONTENT_TYPE_CONFIG[selectedContent.type]?.label}
+                  </p>
+                )}
+              </div>
+            ) : (
+              /* 새 콘텐츠 입력 */
+              <div className="mb-4 space-y-4">
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    콘텐츠 이름 *
+                  </label>
+                  <input
+                    type="text"
+                    value={newContentName}
+                    onChange={(e) => setNewContentName(e.target.value)}
+                    placeholder="예: 도쿄 구울"
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    콘텐츠 타입
+                  </label>
+                  <select
+                    value={newContentType}
+                    onChange={(e) =>
+                      setNewContentType(e.target.value as ContentType)
+                    }
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    {Object.entries(CONTENT_TYPE_CONFIG).map(
+                      ([key, config]) => (
+                        <option key={key} value={key}>
+                          {config.label}
+                        </option>
+                      )
+                    )}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    연도 (선택)
+                  </label>
+                  <input
+                    type="number"
+                    value={newContentYear}
+                    onChange={(e) => setNewContentYear(e.target.value)}
+                    placeholder="예: 2014"
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* 이미지 업로드 */}
+            <div className="mb-6">
+              <label className="mb-2 block text-sm font-medium text-gray-700">
+                대표 이미지 {!selectedContent && '(선택)'}
+              </label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/gif,image/webp"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+              <div
+                onClick={() => fileInputRef.current?.click()}
+                className="cursor-pointer rounded-lg border-2 border-dashed border-gray-300 p-4 text-center transition-colors hover:border-blue-500"
+              >
+                {uploadPreview ? (
+                  <div className="relative mx-auto h-24 w-24 overflow-hidden rounded-full">
+                    <Image
+                      src={uploadPreview}
+                      alt="Preview"
+                      fill
+                      className="object-cover"
+                    />
+                  </div>
+                ) : (
+                  <div className="text-gray-500">
+                    <p>클릭하여 이미지 선택</p>
+                    <p className="mt-1 text-xs">
+                      JPG, PNG, GIF, WEBP (최대 5MB)
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* 버튼 */}
+            <div className="flex gap-3">
+              <button
+                onClick={closeUploadModal}
+                className="flex-1 rounded-lg border border-gray-300 px-4 py-2 hover:bg-gray-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleUpload}
+                disabled={
+                  uploading || (!selectedContent && !newContentName.trim())
+                }
+                className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {uploading ? '업로드 중...' : '저장'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/admin/content-images/route.ts
+++ b/src/app/api/admin/content-images/route.ts
@@ -1,0 +1,301 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { normalizeContentName } from '@/lib/content-utils'
+import { ContentType } from '@/types'
+import { writeFile, mkdir } from 'fs/promises'
+import path from 'path'
+import { existsSync } from 'fs'
+
+/**
+ * MongoDB ContentMaster 문서 인터페이스
+ */
+interface ContentMasterDocument {
+  _id?: string
+  normalizedName: string
+  displayName: string
+  imageUrl?: string
+  type?: ContentType
+  year?: number
+  spotCount: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * GET /api/admin/content-images - 콘텐츠 마스터 목록 조회
+ * 관리자 전용: 모든 콘텐츠 마스터 데이터 조회
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+
+    if (!session?.user || session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const search = searchParams.get('search')?.trim() || ''
+    const page = parseInt(searchParams.get('page') || '1', 10)
+    const limit = parseInt(searchParams.get('limit') || '20', 10)
+
+    const collection = await getCollection<ContentMasterDocument>(
+      COLLECTIONS.CONTENT_MASTERS
+    )
+
+    // 검색 필터 구성
+    const filter: Record<string, unknown> = {}
+    if (search) {
+      const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      filter.displayName = { $regex: escapedSearch, $options: 'i' }
+    }
+
+    // 전체 개수 조회
+    const total = await collection.countDocuments(filter)
+
+    // 페이지네이션 적용하여 조회
+    const items = await collection
+      .find(filter)
+      .sort({ spotCount: -1, displayName: 1 })
+      .skip((page - 1) * limit)
+      .limit(limit)
+      .toArray()
+
+    const formattedItems = items.map((item) => ({
+      id: item._id?.toString() || item.normalizedName,
+      normalizedName: item.normalizedName,
+      displayName: item.displayName,
+      imageUrl: item.imageUrl,
+      type: item.type,
+      year: item.year,
+      spotCount: item.spotCount,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    }))
+
+    return NextResponse.json({
+      items: formattedItems,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    })
+  } catch (error) {
+    console.error('Error fetching content masters:', error)
+    return NextResponse.json(
+      { error: '콘텐츠 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/admin/content-images - 콘텐츠 이미지 업로드/업데이트
+ * 관리자 전용: 콘텐츠 대표 이미지 설정
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+
+    if (!session?.user || session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const formData = await request.formData()
+    const file = formData.get('file') as File | null
+    const contentName = formData.get('contentName') as string | null
+    const contentType = formData.get('contentType') as ContentType | null
+    const year = formData.get('year') as string | null
+
+    if (!contentName) {
+      return NextResponse.json(
+        { error: '콘텐츠 이름이 필요합니다' },
+        { status: 400 }
+      )
+    }
+
+    const normalizedName = normalizeContentName(contentName)
+    const collection = await getCollection<ContentMasterDocument>(
+      COLLECTIONS.CONTENT_MASTERS
+    )
+
+    let imageUrl: string | undefined
+
+    // 파일이 있으면 업로드
+    if (file) {
+      const allowedTypes = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+      ]
+      if (!allowedTypes.includes(file.type)) {
+        return NextResponse.json(
+          {
+            error:
+              '지원하지 않는 파일 형식입니다. (JPG, PNG, GIF, WEBP만 가능)',
+          },
+          { status: 400 }
+        )
+      }
+
+      const maxSize = 5 * 1024 * 1024
+      if (file.size > maxSize) {
+        return NextResponse.json(
+          { error: '파일 크기는 5MB 이하여야 합니다' },
+          { status: 400 }
+        )
+      }
+
+      // 파일명 생성
+      const timestamp = Date.now()
+      const randomStr = Math.random().toString(36).substring(2, 8)
+      const ext = file.name.split('.').pop() || 'jpg'
+      const fileName = `content-${timestamp}-${randomStr}.${ext}`
+
+      // 업로드 디렉토리 확인 및 생성
+      const uploadDir = path.join(
+        process.cwd(),
+        'public',
+        'uploads',
+        'contents'
+      )
+      if (!existsSync(uploadDir)) {
+        await mkdir(uploadDir, { recursive: true })
+      }
+
+      // 파일 저장
+      const bytes = await file.arrayBuffer()
+      const buffer = Buffer.from(bytes)
+      const filePath = path.join(uploadDir, fileName)
+      await writeFile(filePath, buffer)
+
+      imageUrl = `/uploads/contents/${fileName}`
+    }
+
+    // 기존 콘텐츠 마스터 조회
+    const existing = await collection.findOne({ normalizedName })
+
+    const now = new Date()
+
+    if (existing) {
+      // 업데이트
+      const updateData: Partial<ContentMasterDocument> = {
+        displayName: contentName.trim(),
+        updatedAt: now,
+      }
+
+      if (imageUrl) {
+        updateData.imageUrl = imageUrl
+      }
+      if (contentType) {
+        updateData.type = contentType
+      }
+      if (year) {
+        updateData.year = parseInt(year, 10)
+      }
+
+      await collection.updateOne({ normalizedName }, { $set: updateData })
+
+      return NextResponse.json({
+        success: true,
+        message: '콘텐츠 이미지가 업데이트되었습니다',
+        contentMaster: {
+          ...existing,
+          ...updateData,
+          id: existing._id?.toString(),
+        },
+      })
+    } else {
+      // 새로 생성
+      const newContentMaster: ContentMasterDocument = {
+        normalizedName,
+        displayName: contentName.trim(),
+        imageUrl,
+        type: contentType || undefined,
+        year: year ? parseInt(year, 10) : undefined,
+        spotCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      const result = await collection.insertOne(newContentMaster)
+
+      return NextResponse.json({
+        success: true,
+        message: '콘텐츠 마스터가 생성되었습니다',
+        contentMaster: {
+          ...newContentMaster,
+          id: result.insertedId.toString(),
+        },
+      })
+    }
+  } catch (error) {
+    console.error('Error uploading content image:', error)
+    return NextResponse.json(
+      { error: '콘텐츠 이미지 업로드에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/admin/content-images - 콘텐츠 이미지 삭제
+ * 관리자 전용: 콘텐츠 대표 이미지 제거
+ */
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+
+    if (!session?.user || session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const normalizedName = searchParams.get('normalizedName')
+
+    if (!normalizedName) {
+      return NextResponse.json(
+        { error: '콘텐츠 이름이 필요합니다' },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<ContentMasterDocument>(
+      COLLECTIONS.CONTENT_MASTERS
+    )
+
+    // 이미지 URL만 제거 (콘텐츠 마스터 자체는 유지)
+    const result = await collection.updateOne(
+      { normalizedName },
+      { $unset: { imageUrl: '' }, $set: { updatedAt: new Date() } }
+    )
+
+    if (result.matchedCount === 0) {
+      return NextResponse.json(
+        { error: '콘텐츠를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: '콘텐츠 이미지가 삭제되었습니다',
+    })
+  } catch (error) {
+    console.error('Error deleting content image:', error)
+    return NextResponse.json(
+      { error: '콘텐츠 이미지 삭제에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/admin/content-images/sync/route.ts
+++ b/src/app/api/admin/content-images/sync/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { normalizeContentName } from '@/lib/content-utils'
+import { SpotCategory, ContentType } from '@/types'
+
+/**
+ * MongoDB Spot 문서 인터페이스 (필요한 필드만)
+ */
+interface SpotDocument {
+  _id?: string
+  category?: SpotCategory
+  relatedContent?: {
+    name: string
+    type: ContentType
+    year?: number
+    additionalInfo?: string
+    imageUrl?: string
+  }[]
+}
+
+/**
+ * MongoDB ContentMaster 문서 인터페이스
+ */
+interface ContentMasterDocument {
+  normalizedName: string
+  displayName: string
+  imageUrl?: string
+  type?: ContentType
+  year?: number
+  spotCount: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * POST /api/admin/content-images/sync - 콘텐츠 마스터 데이터 동기화
+ * 관리자 전용: 모든 스팟의 relatedContent에서 콘텐츠 마스터 데이터 생성/업데이트
+ */
+export async function POST(): Promise<NextResponse> {
+  try {
+    const session = await auth()
+
+    if (!session?.user || session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const spotsCollection = await getCollection<SpotDocument>(COLLECTIONS.SPOTS)
+    const contentMastersCollection = await getCollection<ContentMasterDocument>(
+      COLLECTIONS.CONTENT_MASTERS
+    )
+
+    // 모든 스팟에서 relatedContent 집계
+    const pipeline = [
+      { $match: { relatedContent: { $exists: true, $ne: [] } } },
+      { $unwind: '$relatedContent' },
+      {
+        $group: {
+          _id: {
+            normalizedName: {
+              $toLower: { $trim: { input: '$relatedContent.name' } },
+            },
+          },
+          displayName: { $first: '$relatedContent.name' },
+          type: { $first: '$relatedContent.type' },
+          year: { $first: '$relatedContent.year' },
+          spotCount: { $sum: 1 },
+        },
+      },
+    ]
+
+    const aggregatedContents = await spotsCollection
+      .aggregate(pipeline)
+      .toArray()
+
+    const now = new Date()
+    let created = 0
+    let updated = 0
+
+    for (const content of aggregatedContents) {
+      const normalizedName = content._id.normalizedName as string
+
+      const existing = await contentMastersCollection.findOne({
+        normalizedName,
+      })
+
+      if (existing) {
+        // spotCount만 업데이트 (이미지는 유지)
+        await contentMastersCollection.updateOne(
+          { normalizedName },
+          {
+            $set: {
+              spotCount: content.spotCount as number,
+              updatedAt: now,
+            },
+          }
+        )
+        updated++
+      } else {
+        // 새로 생성
+        await contentMastersCollection.insertOne({
+          normalizedName,
+          displayName: (content.displayName as string).trim(),
+          type: content.type as ContentType | undefined,
+          year: content.year as number | undefined,
+          spotCount: content.spotCount as number,
+          createdAt: now,
+          updatedAt: now,
+        })
+        created++
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `동기화 완료: ${created}개 생성, ${updated}개 업데이트`,
+      created,
+      updated,
+      total: aggregatedContents.length,
+    })
+  } catch (error) {
+    console.error('Error syncing content masters:', error)
+    return NextResponse.json(
+      { error: '콘텐츠 마스터 동기화에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/content-images/route.ts
+++ b/src/app/api/content-images/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { normalizeContentName } from '@/lib/content-utils'
+import { ContentType } from '@/types'
+
+/**
+ * MongoDB ContentMaster 문서 인터페이스
+ */
+interface ContentMasterDocument {
+  normalizedName: string
+  displayName: string
+  imageUrl?: string
+  type?: ContentType
+  year?: number
+  spotCount: number
+}
+
+/**
+ * GET /api/content-images - 콘텐츠 이미지 조회 (공개 API)
+ * 스팟 등록 시 기존 콘텐츠 이미지 자동 적용에 사용
+ *
+ * Query params:
+ *   - names: 콘텐츠 이름 목록 (쉼표로 구분)
+ *
+ * Response:
+ *   - images: { [normalizedName]: imageUrl } 형태의 맵
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url)
+    const namesParam = searchParams.get('names')
+
+    if (!namesParam) {
+      return NextResponse.json({ images: {} })
+    }
+
+    const names = namesParam
+      .split(',')
+      .map((n) => n.trim())
+      .filter(Boolean)
+
+    if (names.length === 0) {
+      return NextResponse.json({ images: {} })
+    }
+
+    // 정규화된 이름 목록 생성
+    const normalizedNames = names.map(normalizeContentName)
+
+    const collection = await getCollection<ContentMasterDocument>(
+      COLLECTIONS.CONTENT_MASTERS
+    )
+
+    // 이미지가 있는 콘텐츠만 조회
+    const contentMasters = await collection
+      .find({
+        normalizedName: { $in: normalizedNames },
+        imageUrl: { $exists: true, $ne: '' },
+      })
+      .toArray()
+
+    // 정규화된 이름 -> 이미지 URL 맵 생성
+    const images: Record<string, string> = {}
+    for (const cm of contentMasters) {
+      if (cm.imageUrl) {
+        images[cm.normalizedName] = cm.imageUrl
+      }
+    }
+
+    return NextResponse.json({ images })
+  } catch (error) {
+    console.error('Error fetching content images:', error)
+    return NextResponse.json(
+      { error: '콘텐츠 이미지 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, Suspense, useCallback } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useSession } from 'next-auth/react'
 import Link from 'next/link'
 import Image from 'next/image'
 import PostList from '@/components/community/PostList'
@@ -653,7 +654,9 @@ function SpotCard({
  * Requirements: 5.1
  */
 function MediaCategorySection() {
+  const { data: session } = useSession()
   const { data: mediaList, isLoading, error } = useMediaCommunitySummary()
+  const isAdmin = session?.user?.role === 'admin'
 
   if (isLoading) {
     return (
@@ -744,21 +747,46 @@ function MediaCategorySection() {
 
   return (
     <div className="rounded-lg bg-white p-6 shadow-sm">
-      <div className="mb-4 flex items-center gap-2">
-        <svg
-          className="h-5 w-5 text-navy-600"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
-          />
-        </svg>
-        <h2 className="text-lg font-semibold text-navy-800">작품별 커뮤니티</h2>
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <svg
+            className="h-5 w-5 text-navy-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"
+            />
+          </svg>
+          <h2 className="text-lg font-semibold text-navy-800">
+            작품별 커뮤니티
+          </h2>
+        </div>
+        {isAdmin && (
+          <Link
+            href="/admin/content-images"
+            className="flex items-center gap-1.5 rounded-lg bg-navy-100 px-3 py-1.5 text-sm font-medium text-navy-600 transition-colors hover:bg-navy-200"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            이미지 관리
+          </Link>
+        )}
       </div>
       <p className="mb-6 text-sm text-navy-500">
         애니메이션, 드라마, 영화 등 작품을 선택하여 관련 게시글을 확인하세요.

--- a/src/lib/content-utils.ts
+++ b/src/lib/content-utils.ts
@@ -77,3 +77,44 @@ export function removeContentAtIndex(
 
   return contents.filter((_, i) => i !== index)
 }
+
+/**
+ * 콘텐츠 마스터 데이터에서 이미지 URL 조회
+ * 스팟 등록 시 기존 콘텐츠 이미지 자동 적용에 사용
+ * @param contentMasters - 콘텐츠 마스터 데이터 맵 (정규화된 이름 -> imageUrl)
+ * @param contentName - 조회할 콘텐츠 이름
+ * @returns 이미지 URL 또는 undefined
+ */
+export function getContentImageUrl(
+  contentMasters: Map<string, string>,
+  contentName: string
+): string | undefined {
+  const normalizedName = normalizeContentName(contentName)
+  return contentMasters.get(normalizedName)
+}
+
+/**
+ * RelatedContent 배열에 마스터 이미지 자동 적용
+ * 스팟 등록/수정 시 기존 콘텐츠 이미지를 자동으로 적용
+ * @param contents - RelatedContent 배열
+ * @param contentMasters - 콘텐츠 마스터 데이터 맵 (정규화된 이름 -> imageUrl)
+ * @returns 이미지가 적용된 새 배열 (원본 불변)
+ */
+export function applyMasterImages(
+  contents: RelatedContent[],
+  contentMasters: Map<string, string>
+): RelatedContent[] {
+  return contents.map((content) => {
+    // 이미 이미지가 있으면 유지
+    if (content.imageUrl) {
+      return content
+    }
+
+    const imageUrl = getContentImageUrl(contentMasters, content.name)
+    if (imageUrl) {
+      return { ...content, imageUrl }
+    }
+
+    return content
+  })
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -86,6 +86,7 @@ export const COLLECTIONS = {
   SCENES: 'scenes',
   USERS: 'users',
   USER_LIKES: 'user_likes',
+  CONTENT_MASTERS: 'content_masters',
 } as const
 
 /**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -126,3 +126,25 @@ export interface UIStore {
   closePreview: () => void
   toggleMobileMenu: () => void
 }
+
+// ============================================
+// Content Master Types (콘텐츠 마스터 데이터)
+// ============================================
+
+export interface ContentMaster {
+  id: string
+  /** 정규화된 콘텐츠 이름 (소문자, 공백 제거) */
+  normalizedName: string
+  /** 원본 콘텐츠 이름 (표시용) */
+  displayName: string
+  /** 대표 이미지 URL */
+  imageUrl?: string
+  /** 콘텐츠 타입 */
+  type?: import('./spot').ContentType
+  /** 연도 */
+  year?: number
+  /** 등록된 스팟 수 */
+  spotCount: number
+  createdAt: Date
+  updatedAt: Date
+}

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -67,6 +67,50 @@ export type ContentType =
   | 'game'
   | 'other'
 
+export interface ContentTypeConfig {
+  icon: string
+  color: string
+  label: string
+}
+
+export const CONTENT_TYPE_CONFIG: Record<ContentType, ContentTypeConfig> = {
+  anime: {
+    icon: '/icons/content-types/anime.svg',
+    color: '#FF6B6B',
+    label: '애니메이션',
+  },
+  movie: {
+    icon: '/icons/content-types/movie.svg',
+    color: '#45B7D1',
+    label: '영화',
+  },
+  drama: {
+    icon: '/icons/content-types/drama.svg',
+    color: '#9B59B6',
+    label: '드라마',
+  },
+  sports_team: {
+    icon: '/icons/content-types/sports_team.svg',
+    color: '#4ECDC4',
+    label: '스포츠 팀',
+  },
+  artist: {
+    icon: '/icons/content-types/artist.svg',
+    color: '#96CEB4',
+    label: '아티스트',
+  },
+  game: {
+    icon: '/icons/content-types/game.svg',
+    color: '#DDA0DD',
+    label: '게임',
+  },
+  other: {
+    icon: '/icons/content-types/other.svg',
+    color: '#95A5A6',
+    label: '기타',
+  },
+}
+
 export interface CategoryConfig {
   icon: string
   color: string


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #199

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

관리자가 콘텐츠(작품)별 대표 이미지를 관리할 수 있는 시스템 구현

---

## 📋 변경 사항

- [x] ContentMaster 타입 및 컬렉션 추가 (src/types/api.ts, src/lib/db.ts)
- [x] CONTENT_TYPE_CONFIG 추가 (src/types/spot.ts)
- [x] 콘텐츠 마스터 이미지 자동 적용 유틸리티 함수 추가 (src/lib/content-utils.ts)
- [x] 관리자 콘텐츠 이미지 API 구현 (GET/POST/DELETE)
- [x] 콘텐츠 마스터 동기화 API 구현 (스팟 데이터에서 콘텐츠 추출)
- [x] 콘텐츠 이미지 조회 공개 API 추가 (스팟 등록 시 자동 적용용)
- [x] 관리자 콘텐츠 이미지 관리 페이지 구현 (/admin/content-images)
- [x] 커뮤니티 작품별 탭에 관리자용 "이미지 관리" 버튼 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

### 접근 방법
- 커뮤니티 페이지 → 작품별 탭 → "이미지 관리" 버튼 (관리자만 표시)
- 또는 직접 URL: `/admin/content-images`

### 주요 기능
- 스팟 데이터 동기화: 기존 스팟의 relatedContent에서 콘텐츠 마스터 데이터 자동 생성
- 콘텐츠별 대표 이미지 업로드/변경/삭제
- 관리자 권한 체크: session.user.role === 'admin'
