### PR TITLE
[Fix] 검색 자동완성 카테고리 아이콘 버그 수정

### DIFF
--- a/src/components/map/AutocompleteDropdown.tsx
+++ b/src/components/map/AutocompleteDropdown.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useEffect, useRef, useCallback } from 'react'
-import { CATEGORY_CONFIG, SpotCategory } from '@/types'
+import { SpotCategory } from '@/types'
+import { CategoryIcon } from '@/components/common'
 import type { AutocompleteItem } from '@/hooks/useAutocomplete'
 
 /**
@@ -17,17 +18,18 @@ interface AutocompleteDropdownProps {
 }
 
 /**
- * 카테고리 아이콘 가져오기
- */
-function getCategoryIcon(category: SpotCategory): string {
-  return CATEGORY_CONFIG[category]?.icon || '📍'
-}
-
-/**
  * 카테고리 라벨 가져오기
  */
 function getCategoryLabel(category: SpotCategory): string {
-  return CATEGORY_CONFIG[category]?.label || '기타'
+  const labels: Record<SpotCategory, string> = {
+    animation: '애니메이션',
+    sports: '스포츠',
+    movie_drama: '영화/드라마',
+    music: '음악/콘서트',
+    game: '게임',
+    other: '기타',
+  }
+  return labels[category] || '기타'
 }
 
 /**
@@ -138,13 +140,11 @@ export default function AutocompleteDropdown({
             >
               <div className="flex items-center gap-2">
                 {/* 카테고리 아이콘 (Requirements 2.6) */}
-                <span
-                  className="text-base"
-                  role="img"
-                  aria-label={getCategoryLabel(item.category)}
-                >
-                  {getCategoryIcon(item.category)}
-                </span>
+                <CategoryIcon
+                  category={item.category}
+                  size="md"
+                  className="flex-shrink-0"
+                />
                 {/* 콘텐츠명 */}
                 <span className="text-sm font-medium text-gray-900">
                   {item.name}


### PR DESCRIPTION
## 🔗 관련 이슈

- 검색 자동완성에서 아이콘 경로가 텍스트로 표시되는 버그
- Closes: #201

---

## 📋 PR 타입

- [x] 🐛 **fix**: 버그 수정

---

## ✨ 작업 개요

검색 자동완성 드롭다운에서 카테고리 아이콘이 경로 문자열로 표시되던 버그 수정

---

## 📋 변경 사항

- [x] AutocompleteDropdown에서 CATEGORY_CONFIG.icon 대신 CategoryIcon 컴포넌트 사용

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

CATEGORY_CONFIG의 icon 필드가 이모티콘에서 SVG 경로로 변경되면서 발생한 버그
