### PR TITLE
Feat/222  push notification  add

### DIFF
--- a/.kiro/specs/08-mobile-first-ux/tasks.md
+++ b/.kiro/specs/08-mobile-first-ux/tasks.md
@@ -278,8 +278,8 @@
     - 오프라인 상태에서 저장된 데이터 표시
     - _Requirements: 4.2_
 
-- [ ] 17. 푸시 알림 설정
-  - [ ] 17.1 푸시 알림 유틸리티 구현 (src/lib/push-notifications.ts)
+- [x] 17. 푸시 알림 설정
+  - [x] 17.1 푸시 알림 유틸리티 구현 (src/lib/push-notifications.ts)
     - 알림 권한 요청
     - 구독 등록/해제
     - 알림 페이로드 생성
@@ -289,7 +289,7 @@
     - **Property 9: 푸시 알림 페이로드 구조**
     - **Validates: Requirements 4.3**
 
-  - [ ] 17.3 푸시 알림 API 엔드포인트 구현
+  - [x] 17.3 푸시 알림 API 엔드포인트 구현
     - 구독 저장 API
     - 알림 발송 API (뱃지 획득, 제보 승인)
     - _Requirements: 4.3_

--- a/public/sw.js
+++ b/public/sw.js
@@ -228,3 +228,56 @@ async function getCacheStats() {
   }
   return stats
 }
+
+// ============================================
+// 푸시 알림 이벤트 처리
+// @requirements 4.3
+// ============================================
+
+// push: 푸시 알림 수신 시 알림 표시
+self.addEventListener('push', (event) => {
+  if (!event.data) return
+
+  try {
+    const data = event.data.json()
+    const options = {
+      body: data.body || '',
+      icon: data.icon || '/icons/icon-192x192.png',
+      badge: data.badge || '/icons/icon-192x192.png',
+      tag: data.tag || 'default',
+      data: data.data || {},
+      actions: [],
+      vibrate: [200, 100, 200],
+    }
+
+    event.waitUntil(self.registration.showNotification(data.title, options))
+  } catch {
+    // JSON 파싱 실패 시 텍스트로 표시
+    const text = event.data.text()
+    event.waitUntil(
+      self.registration.showNotification('Not a Trip', { body: text })
+    )
+  }
+})
+
+// notificationclick: 알림 클릭 시 해당 페이지로 이동
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const url = event.notification.data?.url || '/'
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window' }).then((clientList) => {
+      // 이미 열린 탭이 있으면 포커스
+      for (const client of clientList) {
+        if (client.url.includes(url) && 'focus' in client) {
+          return client.focus()
+        }
+      }
+      // 없으면 새 탭 열기
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(url)
+      }
+    })
+  )
+})

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import type { PushNotificationPayload } from '@/lib/push-notifications'
+
+/**
+ * 푸시 구독 MongoDB Document
+ */
+interface PushSubscriptionDocument {
+  endpoint: string
+  keys: {
+    p256dh: string
+    auth: string
+  }
+  userId?: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * 알림 발송 요청 Body
+ */
+interface SendNotificationBody {
+  /** 특정 유저에게만 발송 (없으면 전체) */
+  userId?: string
+  /** 알림 페이로드 */
+  payload: PushNotificationPayload
+}
+
+/**
+ * POST /api/push/send - 푸시 알림 발송
+ * Requirements: 4.3
+ *
+ * web-push 라이브러리 미설치 시 구독 정보만 조회하고
+ * 실제 발송은 web-push 설정 후 활성화
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body: SendNotificationBody = await request.json()
+    const { userId, payload } = body
+
+    if (!payload?.type || !payload?.title || !payload?.body) {
+      return NextResponse.json(
+        { error: '유효하지 않은 알림 페이로드입니다 (type, title, body 필수)' },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<PushSubscriptionDocument>(
+      COLLECTIONS.PUSH_SUBSCRIPTIONS
+    )
+
+    // 대상 구독 조회
+    const query = userId ? { userId } : {}
+    const subscriptions = await collection.find(query).toArray()
+
+    if (subscriptions.length === 0) {
+      return NextResponse.json({
+        success: true,
+        sent: 0,
+        message: '발송 대상 구독이 없습니다',
+      })
+    }
+
+    const notificationPayload = JSON.stringify({
+      title: payload.title,
+      body: payload.body,
+      icon: payload.icon || '/icons/icon-192x192.png',
+      badge: '/icons/icon-192x192.png',
+      url: payload.url || '/',
+      tag: payload.tag,
+      data: {
+        type: payload.type,
+        url: payload.url || '/',
+        ...payload.data,
+      },
+    })
+
+    // web-push 라이브러리를 통한 실제 발송
+    let sent = 0
+    const failed: string[] = []
+
+    for (const sub of subscriptions) {
+      try {
+        await sendWebPush(sub, notificationPayload)
+        sent++
+      } catch (error) {
+        console.error(`푸시 발송 실패 (${sub.endpoint}):`, error)
+        failed.push(sub.endpoint)
+
+        // 410 Gone 또는 404 응답 시 구독 삭제
+        if (isExpiredSubscription(error)) {
+          await collection.deleteOne({ endpoint: sub.endpoint })
+        }
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      sent,
+      failed: failed.length,
+      total: subscriptions.length,
+    })
+  } catch (error) {
+    console.error('푸시 알림 발송 실패:', error)
+    return NextResponse.json(
+      { error: '알림 발송에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * Web Push 발송 (web-push 라이브러리 래핑)
+ * VAPID 키가 설정되지 않으면 스킵
+ */
+async function sendWebPush(
+  subscription: PushSubscriptionDocument,
+  payload: string
+): Promise<void> {
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY
+  const vapidEmail = process.env.VAPID_EMAIL
+
+  if (!vapidPublicKey || !vapidPrivateKey || !vapidEmail) {
+    console.warn('VAPID 키가 설정되지 않아 푸시 발송을 스킵합니다')
+    return
+  }
+
+  // web-push 동적 import (서버 전용)
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const webpush = require('web-push') as {
+      setVapidDetails: (
+        subject: string,
+        publicKey: string,
+        privateKey: string
+      ) => void
+      sendNotification: (
+        sub: { endpoint: string; keys: { p256dh: string; auth: string } },
+        payload: string
+      ) => Promise<unknown>
+    }
+
+    webpush.setVapidDetails(
+      `mailto:${vapidEmail}`,
+      vapidPublicKey,
+      vapidPrivateKey
+    )
+
+    await webpush.sendNotification(
+      {
+        endpoint: subscription.endpoint,
+        keys: subscription.keys,
+      },
+      payload
+    )
+  } catch (error) {
+    // web-push 미설치 시 경고만 출력
+    if (
+      error instanceof Error &&
+      error.message.includes('Cannot find module')
+    ) {
+      console.warn(
+        'web-push 패키지가 설치되지 않았습니다. npm install web-push로 설치해주세요.'
+      )
+      return
+    }
+    throw error
+  }
+}
+
+/**
+ * 만료된 구독인지 확인
+ */
+function isExpiredSubscription(error: unknown): boolean {
+  if (error && typeof error === 'object' && 'statusCode' in error) {
+    const statusCode = (error as { statusCode: number }).statusCode
+    return statusCode === 404 || statusCode === 410
+  }
+  return false
+}

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * 푸시 구독 MongoDB Document
+ */
+interface PushSubscriptionDocument {
+  endpoint: string
+  keys: {
+    p256dh: string
+    auth: string
+  }
+  userId?: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * POST /api/push/subscribe - 푸시 알림 구독 등록
+ * Requirements: 4.3
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json()
+    const { endpoint, keys } = body
+
+    if (!endpoint || !keys?.p256dh || !keys?.auth) {
+      return NextResponse.json(
+        { error: '유효하지 않은 구독 정보입니다' },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<PushSubscriptionDocument>(
+      COLLECTIONS.PUSH_SUBSCRIPTIONS
+    )
+
+    // 기존 구독이 있으면 업데이트, 없으면 생성
+    await collection.updateOne(
+      { endpoint },
+      {
+        $set: {
+          endpoint,
+          keys: { p256dh: keys.p256dh, auth: keys.auth },
+          updatedAt: new Date(),
+        },
+        $setOnInsert: {
+          createdAt: new Date(),
+        },
+      },
+      { upsert: true }
+    )
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('푸시 구독 등록 실패:', error)
+    return NextResponse.json(
+      { error: '구독 등록에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/push/subscribe - 푸시 알림 구독 해제
+ * Requirements: 4.3
+ */
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json()
+    const { endpoint } = body
+
+    if (!endpoint) {
+      return NextResponse.json(
+        { error: 'endpoint가 필요합니다' },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<PushSubscriptionDocument>(
+      COLLECTIONS.PUSH_SUBSCRIPTIONS
+    )
+
+    await collection.deleteOne({ endpoint })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('푸시 구독 해제 실패:', error)
+    return NextResponse.json(
+      { error: '구독 해제에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -92,6 +92,8 @@ export const COLLECTIONS = {
   BADGES: 'badges',
   USER_BADGES: 'user_badges',
   USER_STATS: 'user_stats',
+  // 푸시 알림 컬렉션 (08-mobile-first-ux)
+  PUSH_SUBSCRIPTIONS: 'push_subscriptions',
 } as const
 
 /**

--- a/src/lib/push-notifications.ts
+++ b/src/lib/push-notifications.ts
@@ -5,4 +5,256 @@
  * @requirements 4.3
  */
 
-// TODO: Task 17.1에서 구현
+// ============================================
+// 타입 정의
+// ============================================
+
+/** 푸시 알림 유형 */
+export type PushNotificationType =
+  | 'badge_earned'
+  | 'spot_approved'
+  | 'comment_reply'
+  | 'new_checkin'
+
+/** 푸시 알림 페이로드 */
+export interface PushNotificationPayload {
+  type: PushNotificationType
+  title: string
+  body: string
+  icon?: string
+  url?: string
+  data?: Record<string, unknown>
+  tag?: string
+}
+
+/** 알림 권한 상태 */
+export type NotificationPermissionState = 'granted' | 'denied' | 'default'
+
+/** 구독 결과 */
+export interface SubscriptionResult {
+  success: boolean
+  subscription?: PushSubscription
+  error?: string
+}
+
+// ============================================
+// 알림 권한 요청
+// ============================================
+
+/**
+ * 브라우저가 푸시 알림을 지원하는지 확인
+ */
+export function isPushSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'Notification' in window &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window
+  )
+}
+
+/**
+ * 현재 알림 권한 상태 조회
+ */
+export function getNotificationPermission(): NotificationPermissionState {
+  if (!isPushSupported()) return 'denied'
+  return Notification.permission as NotificationPermissionState
+}
+
+/**
+ * 알림 권한 요청
+ * @returns 권한 상태 ('granted' | 'denied' | 'default')
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermissionState> {
+  if (!isPushSupported()) {
+    return 'denied'
+  }
+
+  try {
+    const permission = await Notification.requestPermission()
+    return permission as NotificationPermissionState
+  } catch {
+    return 'denied'
+  }
+}
+
+// ============================================
+// 구독 등록/해제
+// ============================================
+
+/**
+ * VAPID 공개키를 Uint8Array로 변환
+ */
+function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray.buffer as ArrayBuffer
+}
+
+/**
+ * 푸시 알림 구독 등록
+ * @returns 구독 결과
+ */
+export async function subscribeToPush(): Promise<SubscriptionResult> {
+  if (!isPushSupported()) {
+    return { success: false, error: '푸시 알림이 지원되지 않는 브라우저입니다' }
+  }
+
+  const permission = await requestNotificationPermission()
+  if (permission !== 'granted') {
+    return { success: false, error: '알림 권한이 거부되었습니다' }
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+
+    if (!vapidPublicKey) {
+      return { success: false, error: 'VAPID 공개키가 설정되지 않았습니다' }
+    }
+
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+    })
+
+    // 서버에 구독 정보 저장
+    const response = await fetch('/api/push/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(subscription.toJSON()),
+    })
+
+    if (!response.ok) {
+      throw new Error('구독 정보 저장 실패')
+    }
+
+    return { success: true, subscription }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : '구독 등록에 실패했습니다'
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * 푸시 알림 구독 해제
+ */
+export async function unsubscribeFromPush(): Promise<boolean> {
+  if (!isPushSupported()) return false
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    const subscription = await registration.pushManager.getSubscription()
+
+    if (!subscription) return true
+
+    // 서버에서 구독 정보 삭제
+    await fetch('/api/push/subscribe', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint: subscription.endpoint }),
+    })
+
+    await subscription.unsubscribe()
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 현재 구독 상태 확인
+ */
+export async function getCurrentSubscription(): Promise<PushSubscription | null> {
+  if (!isPushSupported()) return null
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    return await registration.pushManager.getSubscription()
+  } catch {
+    return null
+  }
+}
+
+// ============================================
+// 알림 페이로드 생성
+// ============================================
+
+/**
+ * 뱃지 획득 알림 페이로드 생성
+ */
+export function createBadgeEarnedPayload(
+  badgeName: string,
+  badgeIcon?: string
+): PushNotificationPayload {
+  return {
+    type: 'badge_earned',
+    title: '🏆 새로운 뱃지 획득!',
+    body: `"${badgeName}" 뱃지를 획득했습니다!`,
+    icon: badgeIcon || '/icons/badge-default.png',
+    url: '/profile',
+    tag: 'badge-earned',
+    data: { badgeName },
+  }
+}
+
+/**
+ * 제보 승인 알림 페이로드 생성
+ */
+export function createSpotApprovedPayload(
+  spotName: string,
+  spotId: string
+): PushNotificationPayload {
+  return {
+    type: 'spot_approved',
+    title: '✅ 스팟 제보 승인!',
+    body: `"${spotName}" 스팟이 승인되었습니다!`,
+    icon: '/icons/spot-approved.png',
+    url: `/spots/${spotId}`,
+    tag: `spot-approved-${spotId}`,
+    data: { spotId, spotName },
+  }
+}
+
+/**
+ * 댓글 답글 알림 페이로드 생성
+ */
+export function createCommentReplyPayload(
+  authorName: string,
+  postId: string
+): PushNotificationPayload {
+  return {
+    type: 'comment_reply',
+    title: '💬 새 답글',
+    body: `${authorName}님이 답글을 남겼습니다`,
+    icon: '/icons/comment-reply.png',
+    url: `/community?postId=${postId}`,
+    tag: `comment-reply-${postId}`,
+    data: { authorName, postId },
+  }
+}
+
+/**
+ * 새 인증 알림 페이로드 생성
+ */
+export function createNewCheckInPayload(
+  userName: string,
+  spotName: string,
+  spotId: string
+): PushNotificationPayload {
+  return {
+    type: 'new_checkin',
+    title: '📸 새 인증샷',
+    body: `${userName}님이 "${spotName}"에서 인증했습니다`,
+    icon: '/icons/new-checkin.png',
+    url: `/spots/${spotId}`,
+    tag: `new-checkin-${spotId}`,
+    data: { userName, spotName, spotId },
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #222

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 푸시 알림 유틸리티 및 API 엔드포인트 구현 (Requirements 4.3)

---

## 📋 변경 사항

- [x] `src/lib/push-notifications.ts` - 알림 권한 요청, 구독 등록/해제, 4가지 알림 타입별 페이로드 생성
- [x] `src/app/api/push/subscribe/route.ts` - 구독 등록(POST)/해제(DELETE) API
- [x] `src/app/api/push/send/route.ts` - 알림 발송 API (web-push 선택적 의존성)
- [x] `public/sw.js` - push/notificationclick 이벤트 핸들러 추가
- [x] `src/lib/db.ts` - PUSH_SUBSCRIPTIONS 컬렉션 상수 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- web-push 패키지는 선택적 의존성으로 처리. VAPID 키 미설정 시 graceful skip
- 실제 푸시 발송을 위해서는 VAPID 키 생성 및 환경변수 설정 필요:
  - `NEXT_PUBLIC_VAPID_PUBLIC_KEY`
  - `VAPID_PRIVATE_KEY`
  - `VAPID_EMAIL`
