### PR TITLE
Feat/232  spot report api  add

### DIFF
--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { validateSpotReportInput } from '@/lib/report-validation'
+import type { ReportStatus } from '@/types/report'
+
+/**
+ * GET /api/reports/[id] - 제보 상세 조회
+ * Requirements: 1.6
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const collection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+    const report = await collection.findOne({ id })
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '제보를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 본인 제보 또는 관리자만 조회 가능
+    if (
+      report.reporterId !== session.user.id &&
+      session.user.role !== 'admin'
+    ) {
+      return NextResponse.json(
+        { error: '조회 권한이 없습니다' },
+        { status: 403 }
+      )
+    }
+
+    return NextResponse.json(report)
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching report detail:', error)
+    return NextResponse.json(
+      { error: '제보 상세 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * PUT /api/reports/[id] - 제보 수정
+ * Requirements: 1.6
+ * - 수정요청(revision_requested) 상태의 제보만 수정 가능
+ * - 수정 후 status를 'pending'으로 재설정
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const body = await request.json()
+    const collection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+
+    const report = await collection.findOne({ id })
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '제보를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 본인 제보만 수정 가능
+    if (report.reporterId !== session.user.id) {
+      return NextResponse.json(
+        { error: '수정 권한이 없습니다' },
+        { status: 403 }
+      )
+    }
+
+    // 수정요청 상태의 제보만 수정 가능
+    if (report.status !== 'revision_requested') {
+      return NextResponse.json(
+        { error: '수정요청 상태의 제보만 수정할 수 있습니다' },
+        { status: 400 }
+      )
+    }
+
+    // 유효성 검사
+    const validation = validateSpotReportInput(body)
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: '유효성 검사 실패', details: validation.errors },
+        { status: 400 }
+      )
+    }
+
+    const now = new Date()
+
+    await collection.updateOne(
+      { id },
+      {
+        $set: {
+          name: body.name.trim(),
+          description: body.description.trim(),
+          address: body.address.trim(),
+          coordinates: body.coordinates,
+          category: body.category,
+          relatedContent: body.relatedContent,
+          evidencePairs: body.evidencePairs,
+          episodeInfo: body.episodeInfo.trim(),
+          additionalPhotos: body.additionalPhotos,
+          status: 'pending' as ReportStatus, // 수정 후 pending으로 재설정
+          updatedAt: now,
+        },
+      }
+    )
+
+    return NextResponse.json({
+      id,
+      message: '제보가 수정되었습니다',
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error updating report:', error)
+    return NextResponse.json(
+      { error: '제보 수정에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/reports/nearby/route.ts
+++ b/src/app/api/reports/nearby/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { calculateDistance, getBoundingBox } from '@/lib/geo-utils'
+
+const NEARBY_RADIUS_METERS = 50
+
+/**
+ * GET /api/reports/nearby - 반경 50m 이내 기존 스팟/제보 검색
+ * Requirements: 1.3
+ * Query params:
+ *   - lat: 위도 (필수)
+ *   - lng: 경도 (필수)
+ *
+ * 바운딩 박스로 1차 필터 → Haversine으로 50m 이내 정밀 필터
+ * spots 컬렉션과 spot_reports(pending) 컬렉션 모두 검색
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const latStr = searchParams.get('lat')
+    const lngStr = searchParams.get('lng')
+
+    if (!latStr || !lngStr) {
+      return NextResponse.json(
+        { error: '위도(lat)와 경도(lng)는 필수입니다' },
+        { status: 400 }
+      )
+    }
+
+    const lat = parseFloat(latStr)
+    const lng = parseFloat(lngStr)
+
+    if (isNaN(lat) || isNaN(lng)) {
+      return NextResponse.json(
+        { error: '유효한 좌표를 입력해주세요' },
+        { status: 400 }
+      )
+    }
+
+    // 바운딩 박스 계산 (MongoDB 쿼리 최적화)
+    const bbox = getBoundingBox(lat, lng, NEARBY_RADIUS_METERS)
+
+    const bboxQuery = {
+      'coordinates.lat': { $gte: bbox.minLat, $lte: bbox.maxLat },
+      'coordinates.lng': { $gte: bbox.minLng, $lte: bbox.maxLng },
+    }
+
+    // 기존 스팟 검색
+    const spotsCollection = await getCollection(COLLECTIONS.SPOTS)
+    const nearbySpotCandidates = await spotsCollection
+      .find(bboxQuery)
+      .project({ id: 1, name: 1, coordinates: 1, category: 1, photos: 1 })
+      .toArray()
+
+    // 대기중 제보 검색
+    const reportsCollection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+    const nearbyReportCandidates = await reportsCollection
+      .find({ ...bboxQuery, status: 'pending' })
+      .project({ id: 1, name: 1, coordinates: 1, category: 1, status: 1 })
+      .toArray()
+
+    // Haversine으로 정밀 필터링
+    const nearbySpots = nearbySpotCandidates
+      .filter((spot) => {
+        const dist = calculateDistance(
+          lat,
+          lng,
+          spot.coordinates.lat,
+          spot.coordinates.lng
+        )
+        return dist <= NEARBY_RADIUS_METERS
+      })
+      .map((spot) => ({
+        id: spot.id,
+        name: spot.name,
+        coordinates: spot.coordinates,
+        category: spot.category,
+        thumbnailUrl: spot.photos?.[0] || '',
+        type: 'spot' as const,
+        distance: Math.round(
+          calculateDistance(
+            lat,
+            lng,
+            spot.coordinates.lat,
+            spot.coordinates.lng
+          )
+        ),
+      }))
+
+    const nearbyReports = nearbyReportCandidates
+      .filter((report) => {
+        const dist = calculateDistance(
+          lat,
+          lng,
+          report.coordinates.lat,
+          report.coordinates.lng
+        )
+        return dist <= NEARBY_RADIUS_METERS
+      })
+      .map((report) => ({
+        id: report.id,
+        name: report.name,
+        coordinates: report.coordinates,
+        category: report.category,
+        type: 'report' as const,
+        distance: Math.round(
+          calculateDistance(
+            lat,
+            lng,
+            report.coordinates.lat,
+            report.coordinates.lng
+          )
+        ),
+      }))
+
+    return NextResponse.json({
+      nearby: [...nearbySpots, ...nearbyReports],
+      total: nearbySpots.length + nearbyReports.length,
+      radius: NEARBY_RADIUS_METERS,
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error searching nearby:', error)
+    return NextResponse.json(
+      { error: '근처 검색에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { validateSpotReportInput } from '@/lib/report-validation'
+import type { CreateSpotReportInput, ReportStatus } from '@/types/report'
+
+/**
+ * SpotReport MongoDB Document
+ */
+interface SpotReportDocument {
+  id: string
+  reporterId: string
+  reporterName: string
+  status: ReportStatus
+  name: string
+  description: string
+  address: string
+  coordinates: { lat: number; lng: number }
+  category: string
+  relatedContent: {
+    name: string
+    type: string
+    year?: number
+    additionalInfo?: string
+  }[]
+  evidencePairs: {
+    captureImageUrl: string
+    realPhotoUrl: string
+    description?: string
+  }[]
+  episodeInfo: string
+  additionalPhotos?: string[]
+  reviewHistory?: []
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * 다음 제보 ID 생성 (REPORT-{숫자} 형식)
+ */
+async function generateReportId(): Promise<string> {
+  const collection = await getCollection<SpotReportDocument>(
+    COLLECTIONS.SPOT_REPORTS
+  )
+
+  const reports = await collection
+    .find({ id: { $regex: /^REPORT-\d+$/ } })
+    .project({ id: 1 })
+    .sort({ id: -1 })
+    .limit(1)
+    .toArray()
+
+  if (reports.length === 0) {
+    return 'REPORT-001'
+  }
+
+  const match = reports[0].id.match(/^REPORT-(\d+)$/)
+  const nextNumber = match ? parseInt(match[1], 10) + 1 : 1
+  return `REPORT-${nextNumber.toString().padStart(3, '0')}`
+}
+
+/**
+ * GET /api/reports - 내 제보 목록 조회
+ * Requirements: 1.6
+ * - 세션 유저의 reporterId로 필터링하여 목록 반환
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const collection = await getCollection<SpotReportDocument>(
+      COLLECTIONS.SPOT_REPORTS
+    )
+
+    const { searchParams } = new URL(request.url)
+    const page = parseInt(searchParams.get('page') || '1', 10)
+    const limit = parseInt(searchParams.get('limit') || '20', 10)
+    const skip = (page - 1) * limit
+
+    const query = { reporterId: session.user.id! }
+
+    const [reports, total] = await Promise.all([
+      collection
+        .find(query)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      collection.countDocuments(query),
+    ])
+
+    return NextResponse.json({
+      reports,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching reports:', error)
+    return NextResponse.json(
+      { error: '제보 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/reports - 신규 성지 제보 생성
+ * Requirements: 1.2, 1.4
+ * - 유효성 검사 → 인증 확인 → status 'pending'으로 저장
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const body: CreateSpotReportInput = await request.json()
+
+    // 유효성 검사 (Requirements 1.2)
+    const validation = validateSpotReportInput(body)
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: '유효성 검사 실패', details: validation.errors },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection<SpotReportDocument>(
+      COLLECTIONS.SPOT_REPORTS
+    )
+
+    const now = new Date()
+    const reportId = await generateReportId()
+
+    const newReport: SpotReportDocument = {
+      id: reportId,
+      reporterId: session.user.id!,
+      reporterName:
+        session.user.name || session.user.email?.split('@')[0] || '익명',
+      status: 'pending', // Requirements 1.4: 항상 pending으로 시작
+      name: body.name.trim(),
+      description: body.description.trim(),
+      address: body.address.trim(),
+      coordinates: {
+        lat: body.coordinates.lat,
+        lng: body.coordinates.lng,
+      },
+      category: body.category,
+      relatedContent: body.relatedContent,
+      evidencePairs: body.evidencePairs,
+      episodeInfo: body.episodeInfo.trim(),
+      additionalPhotos: body.additionalPhotos,
+      reviewHistory: [],
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await collection.insertOne(newReport)
+
+    return NextResponse.json(
+      {
+        id: newReport.id,
+        message: '제보가 접수되었습니다',
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error creating report:', error)
+    return NextResponse.json(
+      { error: '제보 생성에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/spots/[id]/supplements/route.ts
+++ b/src/app/api/spots/[id]/supplements/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import type { CreateSupplementInput, SupplementType } from '@/types/report'
+
+const VALID_SUPPLEMENT_TYPES: SupplementType[] = [
+  'scene_info',
+  'description',
+  'photo',
+  'other',
+]
+
+/**
+ * 다음 보완 제보 ID 생성 (SUPPLEMENT-{숫자} 형식)
+ */
+async function generateSupplementId(): Promise<string> {
+  const collection = await getCollection(COLLECTIONS.SPOT_SUPPLEMENTS)
+
+  const supplements = await collection
+    .find({ id: { $regex: /^SUPPLEMENT-\d+$/ } })
+    .project({ id: 1 })
+    .sort({ id: -1 })
+    .limit(1)
+    .toArray()
+
+  if (supplements.length === 0) {
+    return 'SUPPLEMENT-001'
+  }
+
+  const match = supplements[0].id.match(/^SUPPLEMENT-(\d+)$/)
+  const nextNumber = match ? parseInt(match[1], 10) + 1 : 1
+  return `SUPPLEMENT-${nextNumber.toString().padStart(3, '0')}`
+}
+
+/**
+ * GET /api/spots/[id]/supplements - 스팟 보완 기여자 목록 조회
+ * Requirements: 3.3
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: spotId } = await params
+    const collection = await getCollection(COLLECTIONS.SPOT_SUPPLEMENTS)
+
+    // 해당 스팟의 보완 기여자 목록 (중복 제거)
+    const supplements = await collection
+      .find({ spotId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    // 기여자 목록 추출 (중복 제거)
+    const contributorMap = new Map<
+      string,
+      { contributorId: string; contributorName: string; count: number }
+    >()
+
+    for (const supplement of supplements) {
+      const existing = contributorMap.get(supplement.contributorId)
+      if (existing) {
+        existing.count++
+      } else {
+        contributorMap.set(supplement.contributorId, {
+          contributorId: supplement.contributorId,
+          contributorName: supplement.contributorName,
+          count: 1,
+        })
+      }
+    }
+
+    return NextResponse.json({
+      contributors: Array.from(contributorMap.values()),
+      supplements,
+      total: supplements.length,
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching supplements:', error)
+    return NextResponse.json(
+      { error: '보완 기여자 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/spots/[id]/supplements - 기존 스팟 정보 보완 제보
+ * Requirements: 3.1, 3.2
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id: spotId } = await params
+    const body: CreateSupplementInput = await request.json()
+
+    // 스팟 존재 여부 확인
+    const spotsCollection = await getCollection(COLLECTIONS.SPOTS)
+    const spot = await spotsCollection.findOne({ id: spotId })
+    if (!spot) {
+      return NextResponse.json(
+        { error: '스팟을 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 유효성 검사
+    const errors: string[] = []
+
+    if (!body.type || !VALID_SUPPLEMENT_TYPES.includes(body.type)) {
+      errors.push('유효한 보완 유형을 선택해주세요')
+    }
+
+    if (!body.content?.trim()) {
+      errors.push('보완 내용을 입력해주세요')
+    }
+
+    // scene_info 타입일 때 추가 검증
+    if (body.type === 'scene_info') {
+      if (!body.sceneInfo?.animeTitle?.trim()) {
+        errors.push('작품명을 입력해주세요')
+      }
+    }
+
+    if (errors.length > 0) {
+      return NextResponse.json(
+        { error: '유효성 검사 실패', details: errors },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection(COLLECTIONS.SPOT_SUPPLEMENTS)
+    const now = new Date()
+    const supplementId = await generateSupplementId()
+
+    const newSupplement = {
+      id: supplementId,
+      spotId,
+      contributorId: session.user.id!,
+      contributorName:
+        session.user.name || session.user.email?.split('@')[0] || '익명',
+      type: body.type,
+      content: body.content.trim(),
+      sceneInfo: body.sceneInfo,
+      photos: body.photos || [],
+      approved: false,
+      createdAt: now,
+    }
+
+    await collection.insertOne(newSupplement)
+
+    return NextResponse.json(
+      {
+        id: newSupplement.id,
+        message: '정보 보완 제보가 접수되었습니다',
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error creating supplement:', error)
+    return NextResponse.json(
+      { error: '정보 보완 제보에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #232

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 성지 제보 시스템의 핵심 API 엔드포인트 4개 구현 (Task 4 + Task 5)

---

## 📋 변경 사항

- [x] `POST /api/reports` - 신규 성지 제보 생성 API
- [x] `GET /api/reports` - 내 제보 목록 조회 API
- [x] `GET /api/reports/[id]` - 제보 상세 조회 API
- [x] `PUT /api/reports/[id]` - 제보 수정 API (수정요청 상태만 수정 가능)
- [x] `GET /api/reports/nearby` - 반경 50m 이내 근처 스팟/제보 검색 API
- [x] `POST /api/spots/[id]/supplements` - 기존 스팟 정보 보완 제보 API
- [x] `GET /api/spots/[id]/supplements` - 스팟 보완 기여자 목록 조회 API

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 1.2, 1.3, 1.4, 1.6, 3.1, 3.2, 3.3 대응
- 인증 확인, 유효성 검사, 지오펜싱 중복 검사 로직 포함
- 기존 프로젝트 패턴(auth, getCollection, COLLECTIONS) 준수
