### PR TITLE
[Feat] Task 7 - 관리자 제보 검토 API 구현

### DIFF
--- a/src/app/api/admin/reports/[id]/review/route.ts
+++ b/src/app/api/admin/reports/[id]/review/route.ts
@@ -1,0 +1,186 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { validateReviewAction } from '@/lib/report-validation'
+import type { ReportStatus, ReviewHistory } from '@/types/report'
+import type { RelatedContent, SpotCategory } from '@/types/spot'
+
+/**
+ * 다음 스팟 ID 생성 (SPOT-{숫자} 형식)
+ */
+async function generateSpotId(): Promise<string> {
+  const collection = await getCollection(COLLECTIONS.SPOTS)
+
+  const spots = await collection
+    .find({ id: { $regex: /^SPOT-\d+$/ } })
+    .project({ id: 1 })
+    .sort({ id: -1 })
+    .limit(1)
+    .toArray()
+
+  if (spots.length === 0) {
+    return 'SPOT-001'
+  }
+
+  const match = spots[0].id.match(/^SPOT-(\d+)$/)
+  const nextNumber = match ? parseInt(match[1], 10) + 1 : 1
+  return `SPOT-${nextNumber.toString().padStart(3, '0')}`
+}
+
+/**
+ * PUT /api/admin/reports/[id]/review - 관리자 제보 검토
+ * Requirements: 5.2, 5.3, 1.5, 2.1
+ *
+ * - approve: 스팟 생성 + firstReporterId/Name 기록 + approvedSpotId 설정
+ * - reject: 사유 필수 검사 + 상태 변경
+ * - request_revision: 수정 요청 사유 기록 + 상태 변경
+ * - reviewHistory 배열에 이력 추가 + 최신 검토 정보 동시 업데이트
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    // 관리자 권한 검사
+    if (session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const { id } = await params
+    const body = await request.json()
+    const { action, comment } = body as {
+      action: string
+      comment?: string
+    }
+
+    // 검토 액션 유효성 검사
+    const validation = validateReviewAction(action, comment)
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: '유효성 검사 실패', details: validation.errors },
+        { status: 400 }
+      )
+    }
+
+    const reportsCollection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+    const report = await reportsCollection.findOne({ id })
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '제보를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // pending 상태의 제보만 검토 가능
+    if (report.status !== 'pending') {
+      return NextResponse.json(
+        { error: '이미 처리된 제보입니다' },
+        { status: 400 }
+      )
+    }
+
+    const statusMap: Record<string, ReportStatus> = {
+      approve: 'approved',
+      reject: 'rejected',
+      request_revision: 'revision_requested',
+    }
+
+    const newStatus = statusMap[action]
+    const now = new Date()
+    const adminId = session.user.id!
+
+    const historyEntry: ReviewHistory = {
+      status: newStatus,
+      comment: comment || '',
+      reviewedAt: now,
+      reviewedBy: adminId,
+    }
+
+    // 승인 시 스팟 생성 (Requirements 1.5, 2.1)
+    let approvedSpotId: string | undefined
+    if (action === 'approve') {
+      const spotsCollection = await getCollection(COLLECTIONS.SPOTS)
+      const spotId = await generateSpotId()
+
+      const newSpot = {
+        id: spotId,
+        name: report.name as string,
+        description: report.description as string,
+        photos: (report.evidencePairs as { realPhotoUrl: string }[]).map(
+          (pair) => pair.realPhotoUrl
+        ),
+        address: report.address as string,
+        coordinates: report.coordinates as { lat: number; lng: number },
+        category: report.category as SpotCategory,
+        relatedMedia: [],
+        relatedContent: (report.relatedContent || []) as RelatedContent[],
+        externalLinks: [],
+        authorId: report.reporterId as string,
+        authorName: report.reporterName as string,
+        isGuestSpot: false,
+        firstReporterId: report.reporterId as string,
+        firstReporterName: report.reporterName as string,
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      await spotsCollection.insertOne(newSpot)
+      approvedSpotId = spotId
+    }
+
+    // 제보 상태 업데이트 + reviewHistory 추가
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateFields: Record<string, any> = {
+      status: newStatus,
+      reviewedBy: adminId,
+      reviewedAt: now,
+      reviewComment: comment || '',
+      updatedAt: now,
+    }
+
+    if (approvedSpotId) {
+      updateFields.approvedSpotId = approvedSpotId
+    }
+
+    await reportsCollection.updateOne(
+      { id },
+      {
+        $set: updateFields,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        $push: { reviewHistory: historyEntry } as any,
+      }
+    )
+
+    const actionLabels: Record<string, string> = {
+      approve: '승인',
+      reject: '반려',
+      request_revision: '수정요청',
+    }
+
+    return NextResponse.json({
+      id,
+      status: newStatus,
+      approvedSpotId,
+      message: `제보가 ${actionLabels[action]}되었습니다`,
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error reviewing report:', error)
+    return NextResponse.json(
+      { error: '제보 검토에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+
+/**
+ * GET /api/admin/reports - 관리자 제보 목록 조회
+ * Requirements: 5.1
+ * - 기본 필터: status 'pending', 최신순 정렬
+ * - 관리자 권한 검사
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    // 관리자 권한 검사
+    if (session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const collection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status') || 'pending'
+    const page = parseInt(searchParams.get('page') || '1', 10)
+    const limit = parseInt(searchParams.get('limit') || '20', 10)
+    const skip = (page - 1) * limit
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query: Record<string, any> = {}
+    if (status !== 'all') {
+      query.status = status
+    }
+
+    const [reports, total] = await Promise.all([
+      collection
+        .find(query)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      collection.countDocuments(query),
+    ])
+
+    return NextResponse.json({
+      reports,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching admin reports:', error)
+    return NextResponse.json(
+      { error: '제보 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #236

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 관리자가 유저 제보를 조회하고 검토(승인/반려/수정요청)할 수 있는 API 구현

---

## 📋 변경 사항

- [x] `GET /api/admin/reports` - 관리자 제보 목록 조회 API (status 필터, 페이지네이션, 최신순 정렬)
- [x] `PUT /api/admin/reports/[id]/review` - 관리자 제보 검토 API (approve/reject/request_revision)
  - approve: 스팟 자동 생성 + firstReporterId/Name 기록 + approvedSpotId 설정
  - reject: 사유 필수 검사 + 상태 변경
  - request_revision: 수정 요청 사유 기록 + 상태 변경
  - reviewHistory 배열에 이력 추가 + 최신 검토 정보 동시 업데이트

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (tsc --noEmit)
- [x] 관리자 권한 검사 구현
- [x] 반려 시 사유 필수 유효성 검사

---

## 📝 추가 정보 (선택)

- Requirements: 5.1, 5.2, 5.3, 1.5, 2.1
- Task 7.2, 7.4, 7.5 (Property-Based Test)는 선택사항(*)으로 이 PR에 미포함
