### PR TITLE
[Feat] Task 9 - Zustand 스토어 및 커스텀 훅 구현

### DIFF
--- a/src/hooks/useMyReports.ts
+++ b/src/hooks/useMyReports.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import { reportKeys } from './useSpotReport'
+import type { SpotReport } from '@/types/report'
+
+/** 내 제보 목록 응답 */
+interface MyReportsResponse {
+  reports: SpotReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+/**
+ * 내 제보 목록 조회 훅
+ * GET /api/reports
+ * Requirements: 1.6, 2.2
+ */
+export function useMyReports(page: number = 1, limit: number = 20) {
+  return useQuery({
+    queryKey: [...reportKeys.lists(), { page, limit }],
+    queryFn: async (): Promise<MyReportsResponse> => {
+      const url = buildUrl(API_ROUTES.REPORTS.BASE, { page, limit })
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '제보 목록 조회에 실패했습니다')
+      }
+      return response.json()
+    },
+    staleTime: 2 * 60 * 1000,
+  })
+}

--- a/src/hooks/useNearbyCheck.ts
+++ b/src/hooks/useNearbyCheck.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import { reportKeys } from './useSpotReport'
+
+/** 근처 스팟/제보 항목 */
+export interface NearbyItem {
+  id: string
+  name: string
+  coordinates: { lat: number; lng: number }
+  category?: string
+  thumbnailUrl?: string
+  type: 'spot' | 'report'
+  distance: number
+}
+
+/** 근처 검색 응답 */
+interface NearbyResponse {
+  nearby: NearbyItem[]
+  total: number
+  radius: number
+}
+
+const DEBOUNCE_MS = 500
+
+/**
+ * 좌표 변경 시 50m 이내 기존 스팟/제보 검색 훅
+ * 디바운스 처리로 과도한 API 호출 방지
+ * Requirements: 1.3
+ */
+export function useNearbyCheck(
+  coordinates: { lat: number; lng: number } | null
+) {
+  const [debouncedCoords, setDebouncedCoords] = useState(coordinates)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+
+    timerRef.current = setTimeout(() => {
+      setDebouncedCoords(coordinates)
+    }, DEBOUNCE_MS)
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+    // coordinates 객체 참조가 아닌 lat/lng 값 변경 시에만 디바운스 재시작
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [coordinates?.lat, coordinates?.lng])
+
+  const query = useQuery({
+    queryKey: reportKeys.nearby(
+      debouncedCoords?.lat ?? 0,
+      debouncedCoords?.lng ?? 0
+    ),
+    queryFn: async (): Promise<NearbyResponse> => {
+      if (!debouncedCoords) throw new Error('좌표가 필요합니다')
+
+      const url = buildUrl(API_ROUTES.REPORTS.NEARBY, {
+        lat: debouncedCoords.lat,
+        lng: debouncedCoords.lng,
+      })
+
+      const response = await fetch(url)
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '근처 검색에 실패했습니다')
+      }
+      return response.json()
+    },
+    enabled: !!debouncedCoords,
+    staleTime: 30 * 1000,
+  })
+
+  return {
+    ...query,
+    nearbyItems: query.data?.nearby ?? [],
+    hasNearby: (query.data?.total ?? 0) > 0,
+  }
+}

--- a/src/hooks/useSpotReport.ts
+++ b/src/hooks/useSpotReport.ts
@@ -1,0 +1,115 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { API_ROUTES } from '@/lib/api-routes'
+import type { CreateSpotReportInput, SpotReport } from '@/types/report'
+
+/** 제보 생성 응답 */
+interface CreateReportResponse {
+  id: string
+  message: string
+}
+
+/** 제보 수정 응답 */
+interface UpdateReportResponse {
+  id: string
+  message: string
+}
+
+/** 제보 목록 쿼리 키 */
+export const reportKeys = {
+  all: ['reports'] as const,
+  lists: () => [...reportKeys.all, 'list'] as const,
+  detail: (id: string) => [...reportKeys.all, 'detail', id] as const,
+  nearby: (lat: number, lng: number) =>
+    [...reportKeys.all, 'nearby', lat, lng] as const,
+}
+
+/**
+ * 신규 성지 제보 제출 훅
+ * POST /api/reports
+ * Requirements: 1.2, 1.4
+ */
+export function useCreateReport() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (
+      input: CreateSpotReportInput
+    ): Promise<CreateReportResponse> => {
+      const response = await fetch(API_ROUTES.REPORTS.BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '제보 생성에 실패했습니다')
+      }
+
+      return response.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() })
+    },
+  })
+}
+
+/**
+ * 제보 수정 훅 (수정요청 상태 대응)
+ * PUT /api/reports/:id
+ * Requirements: 1.6
+ */
+export function useUpdateReport() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      input,
+    }: {
+      id: string
+      input: CreateSpotReportInput
+    }): Promise<UpdateReportResponse> => {
+      const response = await fetch(API_ROUTES.REPORTS.DETAIL(id), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '제보 수정에 실패했습니다')
+      }
+
+      return response.json()
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() })
+      queryClient.invalidateQueries({
+        queryKey: reportKeys.detail(variables.id),
+      })
+    },
+  })
+}
+
+/**
+ * 제보 상세 조회 훅
+ * GET /api/reports/:id
+ */
+export function useReportDetail(reportId: string | null) {
+  return useQuery({
+    queryKey: reportKeys.detail(reportId || ''),
+    queryFn: async (): Promise<SpotReport> => {
+      if (!reportId) throw new Error('Report ID is required')
+
+      const response = await fetch(API_ROUTES.REPORTS.DETAIL(reportId))
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '제보 조회에 실패했습니다')
+      }
+      return response.json()
+    },
+    enabled: !!reportId,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/hooks/useStatusReport.ts
+++ b/src/hooks/useStatusReport.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { API_ROUTES } from '@/lib/api-routes'
+import type { CreateStatusReportInput } from '@/types/report'
+import { spotKeys } from './useSpots'
+
+/** 상태 신고 응답 */
+interface StatusReportResponse {
+  id: string
+  message: string
+  statusUpdated: boolean
+}
+
+/**
+ * 스팟 상태 신고 훅
+ * POST /api/spots/:id/status-reports
+ * Requirements: 4.1
+ */
+export function useStatusReport(spotId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (
+      input: CreateStatusReportInput
+    ): Promise<StatusReportResponse> => {
+      const response = await fetch(API_ROUTES.STATUS_REPORTS.BASE(spotId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || '상태 신고에 실패했습니다')
+      }
+
+      return response.json()
+    },
+    onSuccess: () => {
+      // 스팟 상세 데이터 갱신 (상태가 변경되었을 수 있음)
+      queryClient.invalidateQueries({ queryKey: spotKeys.detail(spotId) })
+    },
+  })
+}

--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -37,6 +37,23 @@ export const API_ROUTES = {
     COMMUNITY_SUMMARY: '/api/media/community-summary',
   },
 
+  // Reports (성지 제보)
+  REPORTS: {
+    BASE: '/api/reports',
+    DETAIL: (id: string) => `/api/reports/${id}`,
+    NEARBY: '/api/reports/nearby',
+  },
+
+  // Spot Supplements (정보 보완)
+  SUPPLEMENTS: {
+    BASE: (spotId: string) => `/api/spots/${spotId}/supplements`,
+  },
+
+  // Spot Status Reports (상태 신고)
+  STATUS_REPORTS: {
+    BASE: (spotId: string) => `/api/spots/${spotId}/status-reports`,
+  },
+
   // Content Names (자동완성)
   CONTENT_NAMES: '/api/content-names',
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -57,6 +57,15 @@ export {
 } from './uploadQueueStore'
 export type { UploadItem, UploadStatus } from './uploadQueueStore'
 
+// Report Store - 제보 폼 상태 관리
+export {
+  useReportStore,
+  useReportCurrentStep,
+  useReportFormData,
+  useNearbyCheckPassed,
+} from './reportStore'
+export type { ReportFormStep, ReportFormData } from './reportStore'
+
 // Bottom Sheet Store - 바텀 시트 상태 관리
 export {
   useBottomSheetStore,

--- a/src/stores/reportStore.ts
+++ b/src/stores/reportStore.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { SpotCategory, RelatedContent } from '@/types/spot'
+import type { EvidencePair } from '@/types/report'
+
+/**
+ * 멀티스텝 제보 폼 단계
+ * 1: 위치 선택 → 2: 지오펜싱 검사 → 3: 장소 정보 입력 → 4: 증거 업로드 → 5: 확인/제출
+ */
+export type ReportFormStep = 1 | 2 | 3 | 4 | 5
+
+/** 제보 폼 임시 저장 데이터 */
+export interface ReportFormData {
+  /** 위치 정보 */
+  coordinates: { lat: number; lng: number } | null
+  address: string
+  /** 장소 정보 */
+  name: string
+  description: string
+  category: SpotCategory | null
+  /** 작품 정보 */
+  relatedContent: RelatedContent[]
+  episodeInfo: string
+  /** 증거 사진 쌍 */
+  evidencePairs: EvidencePair[]
+  /** 추가 사진 */
+  additionalPhotos: string[]
+}
+
+const INITIAL_FORM_DATA: ReportFormData = {
+  coordinates: null,
+  address: '',
+  name: '',
+  description: '',
+  category: null,
+  relatedContent: [],
+  episodeInfo: '',
+  evidencePairs: [],
+  additionalPhotos: [],
+}
+
+interface ReportStore {
+  /** 현재 폼 단계 */
+  currentStep: ReportFormStep
+  /** 임시 저장 데이터 */
+  formData: ReportFormData
+  /** 지오펜싱 검사 통과 여부 */
+  nearbyCheckPassed: boolean
+
+  /** 단계 이동 */
+  setStep: (step: ReportFormStep) => void
+  nextStep: () => void
+  prevStep: () => void
+  /** 폼 데이터 업데이트 */
+  updateFormData: (data: Partial<ReportFormData>) => void
+  /** 지오펜싱 검사 결과 설정 */
+  setNearbyCheckPassed: (passed: boolean) => void
+  /** 폼 초기화 */
+  resetForm: () => void
+}
+
+export const useReportStore = create<ReportStore>()(
+  devtools(
+    (set) => ({
+      currentStep: 1,
+      formData: { ...INITIAL_FORM_DATA },
+      nearbyCheckPassed: false,
+
+      setStep: (step) =>
+        set({ currentStep: step }, false, 'reportStore/setStep'),
+
+      nextStep: () =>
+        set(
+          (state) => ({
+            currentStep: Math.min(state.currentStep + 1, 5) as ReportFormStep,
+          }),
+          false,
+          'reportStore/nextStep'
+        ),
+
+      prevStep: () =>
+        set(
+          (state) => ({
+            currentStep: Math.max(state.currentStep - 1, 1) as ReportFormStep,
+          }),
+          false,
+          'reportStore/prevStep'
+        ),
+
+      updateFormData: (data) =>
+        set(
+          (state) => ({
+            formData: { ...state.formData, ...data },
+          }),
+          false,
+          'reportStore/updateFormData'
+        ),
+
+      setNearbyCheckPassed: (passed) =>
+        set(
+          { nearbyCheckPassed: passed },
+          false,
+          'reportStore/setNearbyCheckPassed'
+        ),
+
+      resetForm: () =>
+        set(
+          {
+            currentStep: 1,
+            formData: { ...INITIAL_FORM_DATA },
+            nearbyCheckPassed: false,
+          },
+          false,
+          'reportStore/resetForm'
+        ),
+    }),
+    { name: 'report-store' }
+  )
+)
+
+// Selectors
+export const useReportCurrentStep = () =>
+  useReportStore((state) => state.currentStep)
+export const useReportFormData = () => useReportStore((state) => state.formData)
+export const useNearbyCheckPassed = () =>
+  useReportStore((state) => state.nearbyCheckPassed)


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #238

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 성지 제보 시스템(09-spot-report-wiki)의 클라이언트 상태 관리 Zustand 스토어 및 API 연동 커스텀 훅 구현

---

## 📋 변경 사항

- [x] reportStore 멀티스텝 폼 상태 관리 구현 (Task 9.1)
- [x] 제보 관련 API 라우트 상수 추가 (api-routes.ts)
- [x] useSpotReport 제보 제출/수정/상세 조회 훅 구현 (Task 9.2)
- [x] useNearbyCheck 지오펜싱 중복 검사 훅 구현 (Task 9.3)
- [x] useMyReports 내 제보 목록 조회 훅 구현 (Task 9.4)
- [x] useStatusReport 상태 신고 훅 구현 (Task 9.5)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] `npm run type-check` 통과

---

## 📝 추가 정보

- Requirements: 1.1, 1.2, 1.3, 1.4, 1.6, 2.2, 4.1
- 기존 프로젝트 패턴(Zustand devtools, react-query)을 동일하게 따름
- useNearbyCheck는 500ms 디바운스로 과도한 API 호출 방지
