### PR TITLE
[Feat] Task 13 - 기존 스팟 정보 보완 UI 구현

### DIFF
--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -15,6 +15,9 @@ import NearbyFacilities from '@/components/spot/NearbyFacilities'
 import { SpotContentSection } from '@/components/spot/SpotContentSection'
 import { RelatedContentSection } from '@/components/spot/RelatedContentSection'
 import { SpotCheckInSection } from '@/components/spot/SpotCheckInSection'
+import { SupplementForm } from '@/components/report/SupplementForm'
+import { ContributorList } from '@/components/report/ContributorList'
+import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import { CategoryIcon } from '@/components/common'
 import { SpotDetailSkeleton as SpotDetailSkeletonUI } from '@/components/common/SkeletonUI'
 import SwipeableGallery from '@/components/mobile/SwipeableGallery'
@@ -168,10 +171,30 @@ interface SpotDetailContentProps {
 }
 
 function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+  const [showSupplementForm, setShowSupplementForm] = useState(false)
+  const [showLoginModal, setShowLoginModal] = useState(false)
+  const [supplementKey, setSupplementKey] = useState(0)
+
   // 카테고리 정보 가져오기 (Requirements 2.3)
   const categoryConfig = spot.category
     ? CATEGORY_CONFIG[spot.category as SpotCategory]
     : null
+
+  const handleSupplementClick = () => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true)
+      return
+    }
+    setShowSupplementForm((prev) => !prev)
+  }
+
+  const handleSupplementSuccess = () => {
+    setShowSupplementForm(false)
+    // ContributorList 리프레시를 위해 key 변경
+    setSupplementKey((prev) => prev + 1)
+  }
 
   return (
     <div className="space-y-8">
@@ -311,6 +334,43 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
           sceneImageUrl={spot.photos?.[0]}
         />
       </div>
+
+      {/* 정보 보완 섹션 - Requirements 3.1, 3.3 */}
+      <div className="overflow-hidden rounded-lg bg-white shadow-md">
+        <div className="p-4 md:p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-900 md:text-xl">
+              정보 보완
+            </h2>
+            <button
+              onClick={handleSupplementClick}
+              className="rounded-lg bg-navy-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+            >
+              {showSupplementForm ? '닫기' : '정보 수정 제안'}
+            </button>
+          </div>
+
+          {showSupplementForm && (
+            <div className="mb-4 rounded-lg border border-navy-100 p-4">
+              <SupplementForm
+                spotId={spot.id}
+                onSuccess={handleSupplementSuccess}
+                onCancel={() => setShowSupplementForm(false)}
+              />
+            </div>
+          )}
+
+          <ContributorList key={supplementKey} spotId={spot.id} />
+        </div>
+      </div>
+
+      {/* 로그인 필요 모달 */}
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        title="로그인이 필요합니다"
+        description="정보 보완 제보를 하려면 로그인이 필요합니다."
+        onConfirm={() => router.push('/auth/login')}
+      />
 
       {/* Related Content - 맨 아래 (Requirements 3.1, 3.4) */}
       <RelatedContentSection contents={spot.relatedContent || []} />

--- a/src/components/report/ContributorList.tsx
+++ b/src/components/report/ContributorList.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { API_ROUTES } from '@/lib/api-routes'
+
+interface Contributor {
+  contributorId: string
+  contributorName: string
+  count: number
+}
+
+interface ContributorListProps {
+  spotId: string
+}
+
+/**
+ * 스팟 정보 보완 기여자 목록 컴포넌트
+ * Requirements: 3.3
+ */
+export function ContributorList({ spotId }: ContributorListProps) {
+  const [contributors, setContributors] = useState<Contributor[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchContributors = async () => {
+      try {
+        const res = await fetch(API_ROUTES.SUPPLEMENTS.BASE(spotId))
+        if (!res.ok) return
+        const data = await res.json()
+        setContributors(data.contributors || [])
+      } catch {
+        // 조용히 실패
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchContributors()
+  }, [spotId])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-2">
+        <div className="h-4 w-4 animate-spin rounded-full border-2 border-navy-400 border-t-transparent" />
+        <span className="text-xs text-navy-400">기여자 로딩 중...</span>
+      </div>
+    )
+  }
+
+  if (contributors.length === 0) return null
+
+  return (
+    <div>
+      <h3 className="mb-2 text-sm font-medium text-navy-700">📋 정보 기여자</h3>
+      <div className="flex flex-wrap gap-2">
+        {contributors.map((c) => (
+          <span
+            key={c.contributorId}
+            className="inline-flex items-center gap-1 rounded-full bg-navy-50 px-2.5 py-1 text-xs text-navy-600"
+          >
+            <svg
+              className="h-3 w-3"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
+            </svg>
+            {c.contributorName}
+            {c.count > 1 && (
+              <span className="text-navy-400">({c.count}건)</span>
+            )}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/report/SupplementForm.tsx
+++ b/src/components/report/SupplementForm.tsx
@@ -1,0 +1,454 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import Image from 'next/image'
+import type { SupplementType, CreateSupplementInput } from '@/types/report'
+import { API_ROUTES } from '@/lib/api-routes'
+
+interface SupplementFormProps {
+  spotId: string
+  onSuccess?: () => void
+  onCancel?: () => void
+}
+
+const SUPPLEMENT_TYPES: {
+  value: SupplementType
+  label: string
+  icon: string
+  description: string
+}[] = [
+  {
+    value: 'scene_info',
+    label: '씬 정보',
+    icon: '🎬',
+    description: '작품명, 에피소드, 캡처 이미지 추가',
+  },
+  {
+    value: 'description',
+    label: '설명 보완',
+    icon: '📝',
+    description: '장소 설명이나 방문 팁 추가',
+  },
+  {
+    value: 'photo',
+    label: '사진 추가',
+    icon: '📸',
+    description: '씬 비교 사진이나 대표 사진 추가',
+  },
+  {
+    value: 'other',
+    label: '기타',
+    icon: '💡',
+    description: '기타 정보 보완',
+  },
+]
+
+/**
+ * 기존 스팟 정보 보완 제보 폼
+ * Requirements: 3.1, 3.2
+ */
+export function SupplementForm({
+  spotId,
+  onSuccess,
+  onCancel,
+}: SupplementFormProps) {
+  const [type, setType] = useState<SupplementType | null>(null)
+  const [content, setContent] = useState('')
+  const [animeTitle, setAnimeTitle] = useState('')
+  const [episodeInfo, setEpisodeInfo] = useState('')
+  const [captureImageUrl, setCaptureImageUrl] = useState('')
+  const [capturePreview, setCapturePreview] = useState<string | null>(null)
+  const [photos, setPhotos] = useState<string[]>([])
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const captureRef = useRef<HTMLInputElement>(null)
+  const photoRef = useRef<HTMLInputElement>(null)
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const formData = new FormData()
+    formData.append('file', file)
+    const res = await fetch(API_ROUTES.UPLOAD, {
+      method: 'POST',
+      body: formData,
+    })
+    if (!res.ok) throw new Error('업로드 실패')
+    const data = await res.json()
+    return data.imageUrl
+  }
+
+  const handleCaptureUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (ev) => setCapturePreview(ev.target?.result as string)
+    reader.readAsDataURL(file)
+
+    setIsUploading(true)
+    try {
+      const url = await uploadImage(file)
+      setCaptureImageUrl(url)
+    } catch {
+      setCapturePreview(null)
+      setCaptureImageUrl('')
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (ev) => setPhotoPreview(ev.target?.result as string)
+    reader.readAsDataURL(file)
+
+    setIsUploading(true)
+    try {
+      const url = await uploadImage(file)
+      setPhotos([url])
+    } catch {
+      setPhotoPreview(null)
+      setPhotos([])
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!type || !content.trim()) return
+
+    if (type === 'scene_info' && !animeTitle.trim()) {
+      setError('작품명을 입력해주세요')
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+
+    const input: CreateSupplementInput = {
+      type,
+      content: content.trim(),
+      ...(type === 'scene_info' && {
+        sceneInfo: {
+          animeTitle: animeTitle.trim(),
+          episodeInfo: episodeInfo.trim() || undefined,
+          captureImageUrl: captureImageUrl || undefined,
+        },
+      }),
+      ...(photos.length > 0 && { photos }),
+    }
+
+    try {
+      const res = await fetch(API_ROUTES.SUPPLEMENTS.BASE(spotId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '제보에 실패했습니다')
+      }
+
+      setSuccess(true)
+      onSuccess?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '제보에 실패했습니다')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const canSubmit =
+    type &&
+    content.trim() &&
+    !isSubmitting &&
+    !isUploading &&
+    (type !== 'scene_info' || animeTitle.trim())
+
+  if (success) {
+    return (
+      <div className="rounded-lg bg-green-50 p-4 text-center">
+        <p className="text-sm font-medium text-green-700">
+          ✅ 정보 보완 제보가 접수되었습니다
+        </p>
+        <p className="mt-1 text-xs text-green-600">
+          검토 후 반영됩니다. 감사합니다!
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 보완 유형 선택 */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-navy-800">
+          보완 유형 <span className="text-red-500">*</span>
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {SUPPLEMENT_TYPES.map((st) => (
+            <button
+              key={st.value}
+              type="button"
+              onClick={() => setType(st.value)}
+              className={`rounded-lg border p-3 text-left transition-colors ${
+                type === st.value
+                  ? 'border-navy-500 bg-navy-50'
+                  : 'border-navy-100 hover:border-navy-300'
+              }`}
+            >
+              <span className="text-lg">{st.icon}</span>
+              <p className="mt-1 text-xs font-medium text-navy-700">
+                {st.label}
+              </p>
+              <p className="text-[10px] text-navy-400">{st.description}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* scene_info 전용 필드 */}
+      {type === 'scene_info' && (
+        <div className="space-y-3 rounded-lg border border-navy-100 bg-navy-50/30 p-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-navy-700">
+              작품명 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={animeTitle}
+              onChange={(e) => setAnimeTitle(e.target.value)}
+              placeholder="예: 너의 이름은"
+              className="w-full rounded-md border border-navy-200 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-navy-700">
+              에피소드/타임스탬프
+            </label>
+            <input
+              type="text"
+              value={episodeInfo}
+              onChange={(e) => setEpisodeInfo(e.target.value)}
+              placeholder="예: 1화 12:30"
+              className="w-full rounded-md border border-navy-200 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-navy-700">
+              캡처 이미지
+            </label>
+            <input
+              ref={captureRef}
+              type="file"
+              accept="image/*"
+              onChange={handleCaptureUpload}
+              className="hidden"
+            />
+            {capturePreview ? (
+              <div className="relative aspect-video w-full max-w-xs overflow-hidden rounded-lg">
+                <Image
+                  src={capturePreview}
+                  alt="캡처 이미지"
+                  fill
+                  className="object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCapturePreview(null)
+                    setCaptureImageUrl('')
+                    if (captureRef.current) captureRef.current.value = ''
+                  }}
+                  className="absolute right-1 top-1 rounded-full bg-black/50 p-0.5 text-white hover:bg-black/70"
+                >
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => captureRef.current?.click()}
+                disabled={isUploading}
+                className="flex aspect-video w-full max-w-xs flex-col items-center justify-center rounded-lg border-2 border-dashed border-navy-200 hover:border-navy-400 hover:bg-navy-50"
+              >
+                {isUploading ? (
+                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-navy-600 border-t-transparent" />
+                ) : (
+                  <>
+                    <svg
+                      className="mb-1 h-6 w-6 text-navy-300"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                      />
+                    </svg>
+                    <span className="text-xs text-navy-400">
+                      캡처 이미지 업로드
+                    </span>
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* photo 타입 전용 사진 업로드 */}
+      {type === 'photo' && (
+        <div>
+          <label className="mb-1 block text-xs font-medium text-navy-700">
+            사진 첨부
+          </label>
+          <input
+            ref={photoRef}
+            type="file"
+            accept="image/*"
+            onChange={handlePhotoUpload}
+            className="hidden"
+          />
+          {photoPreview ? (
+            <div className="relative aspect-video w-full max-w-xs overflow-hidden rounded-lg">
+              <Image
+                src={photoPreview}
+                alt="첨부 사진"
+                fill
+                className="object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  setPhotoPreview(null)
+                  setPhotos([])
+                  if (photoRef.current) photoRef.current.value = ''
+                }}
+                className="absolute right-1 top-1 rounded-full bg-black/50 p-0.5 text-white hover:bg-black/70"
+              >
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => photoRef.current?.click()}
+              disabled={isUploading}
+              className="flex aspect-video w-full max-w-xs flex-col items-center justify-center rounded-lg border-2 border-dashed border-navy-200 hover:border-navy-400 hover:bg-navy-50"
+            >
+              {isUploading ? (
+                <div className="h-6 w-6 animate-spin rounded-full border-2 border-navy-600 border-t-transparent" />
+              ) : (
+                <>
+                  <svg
+                    className="mb-1 h-6 w-6 text-navy-300"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                    />
+                  </svg>
+                  <span className="text-xs text-navy-400">사진 업로드</span>
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* 보완 내용 */}
+      {type && (
+        <div>
+          <label className="mb-1 block text-sm font-medium text-navy-800">
+            보완 내용 <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder={
+              type === 'scene_info'
+                ? '해당 장면에 대한 설명을 입력해주세요'
+                : type === 'description'
+                  ? '보완할 설명이나 방문 팁을 입력해주세요'
+                  : type === 'photo'
+                    ? '사진에 대한 설명을 입력해주세요'
+                    : '보완할 내용을 입력해주세요'
+            }
+            rows={3}
+            maxLength={500}
+            className="w-full rounded-md border border-navy-200 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none"
+          />
+          <p className="mt-1 text-right text-xs text-navy-400">
+            {content.length}/500
+          </p>
+        </div>
+      )}
+
+      {/* 에러 메시지 */}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      {/* 버튼 */}
+      <div className="flex gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-lg border border-navy-200 py-2.5 text-sm font-medium text-navy-600 transition-colors hover:bg-navy-50"
+          >
+            취소
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="flex-1 rounded-lg bg-navy-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? '제출 중...' : '정보 보완 제출'}
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #244

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 기존 스팟의 부족한 정보를 유저가 직접 보완할 수 있는 UI 컴포넌트 구현 및 스팟 상세 페이지 통합

---

## 📋 변경 사항

- [x] SupplementForm 컴포넌트 구현 (보완 유형 선택, scene_info 전용 필드, 사진 업로드)
- [x] ContributorList 컴포넌트 구현 (기여자 목록 표시)
- [x] 스팟 상세 페이지에 "정보 수정 제안" 버튼 및 보완 UI 통합
- [x] 미인증 유저 접근 시 로그인 모달 표시

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 3.1, 3.2, 3.3 대응
- Task 13.1, 13.2, 13.3 완료
- 기존 `/api/spots/:id/supplements` API와 연동
