### PR TITLE
스팟 상태 신고 UI 구현 및 최초 제보자 표시/프로필 연동

### DIFF
--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -93,6 +93,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const { searchParams } = new URL(request.url)
     const categoryParam = searchParams.get('category')
     const searchParam = searchParams.get('search')
+    const firstReporterIdParam = searchParams.get('firstReporterId')
 
     // MongoDB 쿼리 조건 생성
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -117,6 +118,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         { name: { $regex: escapedSearch, $options: 'i' } },
         { 'relatedContent.name': { $regex: escapedSearch, $options: 'i' } },
       ]
+    }
+
+    // 최초 제보자 필터 (Requirements 2.2)
+    if (firstReporterIdParam) {
+      query.firstReporterId = firstReporterIdParam
     }
 
     // Get spots from database with filter

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -7,6 +7,7 @@ import { UserStats, UserBadge, ContentProgress } from '@/types'
 import { CheckInGallery } from '@/components/checkin'
 import { TrophyRoom } from '@/components/profile/TrophyRoom'
 import { ContentProgressCard } from '@/components/profile/ContentProgressCard'
+import { API_ROUTES } from '@/lib/api-routes'
 
 interface UserProfilePageProps {
   params: Promise<{ id: string }>
@@ -26,12 +27,15 @@ interface UserInfo {
 export default function UserProfilePage({ params }: UserProfilePageProps) {
   const { id: userId } = use(params)
   const [activeTab, setActiveTab] = useState<
-    'checkins' | 'badges' | 'progress'
+    'checkins' | 'badges' | 'progress' | 'reports'
   >('checkins')
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null)
   const [stats, setStats] = useState<UserStats | null>(null)
   const [badges, setBadges] = useState<UserBadge[]>([])
   const [progress, setProgress] = useState<ContentProgress[]>([])
+  const [reportedSpots, setReportedSpots] = useState<
+    { id: string; name: string; address: string }[]
+  >([])
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -65,6 +69,23 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
           name: '순례자',
           image: undefined,
         })
+
+        // 제보한 스팟 목록 조회 (firstReporterId로 필터)
+        const spotsRes = await fetch(
+          `${API_ROUTES.SPOTS.BASE}?firstReporterId=${userId}`
+        )
+        if (spotsRes.ok) {
+          const spotsData = await spotsRes.json()
+          setReportedSpots(
+            (spotsData.spots || []).map(
+              (s: { id: string; name: string; address?: string }) => ({
+                id: s.id,
+                name: s.name,
+                address: s.address || '',
+              })
+            )
+          )
+        }
       } catch (error) {
         console.error('Error fetching profile data:', error)
       } finally {
@@ -180,6 +201,16 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
           >
             진행 현황
           </button>
+          <button
+            onClick={() => setActiveTab('reports')}
+            className={`rounded-lg px-4 py-2 font-medium ${
+              activeTab === 'reports'
+                ? 'bg-blue-600 text-white'
+                : 'bg-white text-gray-600 hover:bg-gray-50'
+            }`}
+          >
+            제보한 스팟
+          </button>
         </div>
 
         {/* 탭 콘텐츠 */}
@@ -206,6 +237,37 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
                     className="mt-2 inline-block text-blue-600 hover:underline"
                   >
                     성지 탐색하러 가기
+                  </Link>
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'reports' && (
+            <div className="space-y-3">
+              {reportedSpots.length > 0 ? (
+                reportedSpots.map((spot) => (
+                  <Link
+                    key={spot.id}
+                    href={`/spots/${spot.id}`}
+                    className="block rounded-lg border border-gray-200 p-4 transition-colors hover:bg-gray-50"
+                  >
+                    <p className="font-medium text-gray-900">{spot.name}</p>
+                    {spot.address && (
+                      <p className="mt-1 text-sm text-gray-500">
+                        📍 {spot.address}
+                      </p>
+                    )}
+                  </Link>
+                ))
+              ) : (
+                <div className="py-12 text-center">
+                  <p className="text-gray-500">아직 제보한 스팟이 없습니다</p>
+                  <Link
+                    href="/reports/new"
+                    className="mt-2 inline-block text-blue-600 hover:underline"
+                  >
+                    성지 제보하러 가기
                   </Link>
                 </div>
               )}

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -17,6 +17,8 @@ import { RelatedContentSection } from '@/components/spot/RelatedContentSection'
 import { SpotCheckInSection } from '@/components/spot/SpotCheckInSection'
 import { SupplementForm } from '@/components/report/SupplementForm'
 import { ContributorList } from '@/components/report/ContributorList'
+import { StatusReportForm } from '@/components/report/StatusReportForm'
+import { SpotStatusIndicator } from '@/components/report/SpotStatusIndicator'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import { CategoryIcon } from '@/components/common'
 import { SpotDetailSkeleton as SpotDetailSkeletonUI } from '@/components/common/SkeletonUI'
@@ -174,7 +176,11 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
   const { isAuthenticated } = useAuth()
   const router = useRouter()
   const [showSupplementForm, setShowSupplementForm] = useState(false)
+  const [showStatusReportForm, setShowStatusReportForm] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
+  const [loginModalContext, setLoginModalContext] = useState<
+    'supplement' | 'status'
+  >('supplement')
   const [supplementKey, setSupplementKey] = useState(0)
 
   // 카테고리 정보 가져오기 (Requirements 2.3)
@@ -184,10 +190,20 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
 
   const handleSupplementClick = () => {
     if (!isAuthenticated) {
+      setLoginModalContext('supplement')
       setShowLoginModal(true)
       return
     }
     setShowSupplementForm((prev) => !prev)
+  }
+
+  const handleStatusReportClick = () => {
+    if (!isAuthenticated) {
+      setLoginModalContext('status')
+      setShowLoginModal(true)
+      return
+    }
+    setShowStatusReportForm((prev) => !prev)
   }
 
   const handleSupplementSuccess = () => {
@@ -229,6 +245,13 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
           <h1 className="mb-2 text-2xl font-bold text-gray-900 md:mb-4 md:text-3xl">
             {spot.name}
           </h1>
+
+          {/* 스팟 상태 표시 - Requirements 4.4 */}
+          {spot.spotStatus && spot.spotStatus !== 'normal' && (
+            <div className="mb-2 md:mb-3">
+              <SpotStatusIndicator status={spot.spotStatus} size="md" />
+            </div>
+          )}
 
           {/* 주소 + 길찾기 버튼 (Requirements 2.3) */}
           <div className="mb-3 flex items-center justify-between gap-2 md:mb-4">
@@ -364,11 +387,50 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
         </div>
       </div>
 
+      {/* 스팟 상태 신고 섹션 - Requirements 4.1, 4.4 */}
+      <div className="overflow-hidden rounded-lg bg-white shadow-md">
+        <div className="p-4 md:p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-900 md:text-xl">
+              현재 상태 신고
+            </h2>
+            <button
+              onClick={handleStatusReportClick}
+              className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600"
+            >
+              {showStatusReportForm ? '닫기' : '상태 신고'}
+            </button>
+          </div>
+
+          {/* 현재 상태 표시 */}
+          {spot.spotStatus && (
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-sm text-gray-600">현재 상태:</span>
+              <SpotStatusIndicator status={spot.spotStatus} />
+            </div>
+          )}
+
+          {showStatusReportForm && (
+            <div className="rounded-lg border border-amber-100 p-4">
+              <StatusReportForm
+                spotId={spot.id}
+                onSuccess={() => setShowStatusReportForm(false)}
+                onCancel={() => setShowStatusReportForm(false)}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
       {/* 로그인 필요 모달 */}
       <LoginRequiredModal
         isOpen={showLoginModal}
         title="로그인이 필요합니다"
-        description="정보 보완 제보를 하려면 로그인이 필요합니다."
+        description={
+          loginModalContext === 'status'
+            ? '상태 신고를 하려면 로그인이 필요합니다.'
+            : '정보 보완 제보를 하려면 로그인이 필요합니다.'
+        }
         onConfirm={() => router.push('/auth/login')}
       />
 

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -253,6 +253,19 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
             </div>
           )}
 
+          {/* 최초 제보자 표시 - Requirements 2.1 */}
+          {spot.firstReporterId && spot.firstReporterName && (
+            <p className="mb-2 text-sm text-navy-500 md:mb-3">
+              📍 최초 제보:{' '}
+              <Link
+                href={`/profile/${spot.firstReporterId}`}
+                className="font-medium text-navy-600 hover:underline"
+              >
+                @{spot.firstReporterName}
+              </Link>
+            </p>
+          )}
+
           {/* 주소 + 길찾기 버튼 (Requirements 2.3) */}
           <div className="mb-3 flex items-center justify-between gap-2 md:mb-4">
             <div className="flex min-w-0 items-center text-gray-600">

--- a/src/app/test/status-report/page.tsx
+++ b/src/app/test/status-report/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+import { StatusReportForm } from '@/components/report/StatusReportForm'
+import { SpotStatusIndicator } from '@/components/report/SpotStatusIndicator'
+import type { SpotStatus } from '@/types/report'
+
+const STATUSES: SpotStatus[] = [
+  'normal',
+  'partially_changed',
+  'under_construction',
+  'demolished',
+  'inaccessible',
+]
+
+/**
+ * 🧪 상태 신고 UI 테스트 페이지
+ */
+export default function StatusReportTestPage() {
+  const [selectedStatus, setSelectedStatus] = useState<SpotStatus>('normal')
+
+  return (
+    <div className="mx-auto max-w-lg space-y-8 p-4">
+      <h1 className="text-xl font-bold text-navy-800">
+        🧪 상태 신고 UI 테스트
+      </h1>
+
+      {/* SpotStatusIndicator 테스트 */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-navy-600">
+          SpotStatusIndicator
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {STATUSES.map((s) => (
+            <button key={s} onClick={() => setSelectedStatus(s)}>
+              <SpotStatusIndicator
+                status={s}
+                size={selectedStatus === s ? 'md' : 'sm'}
+              />
+            </button>
+          ))}
+        </div>
+        <p className="text-xs text-navy-400">선택된 상태: {selectedStatus}</p>
+        <div className="text-xs text-navy-400">
+          status 없을 때: <SpotStatusIndicator status={undefined} />
+          (아무것도 안 보여야 함)
+        </div>
+      </section>
+
+      {/* StatusReportForm 테스트 */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-navy-600">
+          StatusReportForm (mock spotId)
+        </h2>
+        <div className="rounded-lg border border-navy-100 p-4">
+          <StatusReportForm
+            spotId="test-spot-id"
+            onSuccess={() => alert('성공!')}
+            onCancel={() => alert('취소!')}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -35,7 +35,7 @@ export function Header() {
             스팟 등록
           </Link>
           <Link
-            href="/test/report-ui"
+            href="/test/status-report"
             className="text-sm text-yellow-400 transition hover:text-yellow-300"
           >
             🧪 테스트

--- a/src/components/report/SpotStatusIndicator.tsx
+++ b/src/components/report/SpotStatusIndicator.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import type { SpotStatus } from '@/types/report'
+
+interface SpotStatusIndicatorProps {
+  status?: SpotStatus
+  size?: 'sm' | 'md'
+}
+
+const STATUS_CONFIG: Record<
+  SpotStatus,
+  { label: string; icon: string; bgColor: string; textColor: string }
+> = {
+  normal: {
+    label: '정상',
+    icon: '✅',
+    bgColor: 'bg-green-100',
+    textColor: 'text-green-700',
+  },
+  partially_changed: {
+    label: '일부 변경',
+    icon: '🔄',
+    bgColor: 'bg-yellow-100',
+    textColor: 'text-yellow-700',
+  },
+  under_construction: {
+    label: '공사중',
+    icon: '🚧',
+    bgColor: 'bg-orange-100',
+    textColor: 'text-orange-700',
+  },
+  demolished: {
+    label: '소실됨',
+    icon: '🏚️',
+    bgColor: 'bg-red-100',
+    textColor: 'text-red-700',
+  },
+  inaccessible: {
+    label: '접근 불가',
+    icon: '🚫',
+    bgColor: 'bg-gray-100',
+    textColor: 'text-gray-700',
+  },
+}
+
+/**
+ * 스팟 상태 시각적 표시 컴포넌트
+ * 지도 및 스팟 상세에서 상태별 아이콘/색상 구분
+ * Requirements: 4.4
+ */
+export function SpotStatusIndicator({
+  status,
+  size = 'sm',
+}: SpotStatusIndicatorProps) {
+  if (!status) return null
+
+  const config = STATUS_CONFIG[status]
+  if (!config) return null
+
+  const sizeClass = size === 'sm' ? 'px-2 py-0.5 text-xs' : 'px-3 py-1 text-sm'
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full font-medium ${config.bgColor} ${config.textColor} ${sizeClass}`}
+    >
+      <span>{config.icon}</span>
+      <span>{config.label}</span>
+    </span>
+  )
+}

--- a/src/components/report/StatusReportForm.tsx
+++ b/src/components/report/StatusReportForm.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import Image from 'next/image'
+import { useStatusReport } from '@/hooks/useStatusReport'
+import type { SpotStatus, CreateStatusReportInput } from '@/types/report'
+import { API_ROUTES } from '@/lib/api-routes'
+
+interface StatusReportFormProps {
+  spotId: string
+  onSuccess?: () => void
+  onCancel?: () => void
+}
+
+const SPOT_STATUSES: {
+  value: SpotStatus
+  label: string
+  icon: string
+  description: string
+}[] = [
+  {
+    value: 'normal',
+    label: '정상',
+    icon: '✅',
+    description: '문제 없이 방문 가능',
+  },
+  {
+    value: 'partially_changed',
+    label: '일부 변경',
+    icon: '🔄',
+    description: '일부 모습이 변경됨',
+  },
+  {
+    value: 'under_construction',
+    label: '공사중',
+    icon: '🚧',
+    description: '현재 공사가 진행 중',
+  },
+  {
+    value: 'demolished',
+    label: '소실됨',
+    icon: '🏚️',
+    description: '건물/장소가 철거됨',
+  },
+  {
+    value: 'inaccessible',
+    label: '접근 불가',
+    icon: '🚫',
+    description: '출입이 제한된 상태',
+  },
+]
+
+/**
+ * 스팟 상태 신고 폼 컴포넌트
+ * Requirements: 4.1, 4.2
+ */
+export function StatusReportForm({
+  spotId,
+  onSuccess,
+  onCancel,
+}: StatusReportFormProps) {
+  const [selectedStatus, setSelectedStatus] = useState<SpotStatus | null>(null)
+  const [description, setDescription] = useState('')
+  const [photoUrl, setPhotoUrl] = useState<string | null>(null)
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null)
+  const [isUploading, setIsUploading] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const photoRef = useRef<HTMLInputElement>(null)
+
+  const { mutate: submitReport, isPending } = useStatusReport(spotId)
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const formData = new FormData()
+    formData.append('file', file)
+    const res = await fetch(API_ROUTES.UPLOAD, {
+      method: 'POST',
+      body: formData,
+    })
+    if (!res.ok) throw new Error('업로드 실패')
+    const data = await res.json()
+    return data.imageUrl
+  }
+
+  const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (ev) => setPhotoPreview(ev.target?.result as string)
+    reader.readAsDataURL(file)
+
+    setIsUploading(true)
+    try {
+      const url = await uploadImage(file)
+      setPhotoUrl(url)
+    } catch {
+      setPhotoPreview(null)
+      setPhotoUrl(null)
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  const removePhoto = () => {
+    setPhotoPreview(null)
+    setPhotoUrl(null)
+    if (photoRef.current) photoRef.current.value = ''
+  }
+
+  const handleSubmit = () => {
+    if (!selectedStatus || !description.trim()) return
+
+    const input: CreateStatusReportInput = {
+      status: selectedStatus,
+      description: description.trim(),
+      photoUrl: photoUrl || undefined,
+    }
+
+    submitReport(input, {
+      onSuccess: () => {
+        setSuccess(true)
+        onSuccess?.()
+      },
+    })
+  }
+
+  const canSubmit =
+    selectedStatus && description.trim() && !isPending && !isUploading
+
+  if (success) {
+    return (
+      <div className="rounded-lg bg-green-50 p-4 text-center">
+        <p className="text-sm font-medium text-green-700">
+          ✅ 상태 신고가 접수되었습니다
+        </p>
+        <p className="mt-1 text-xs text-green-600">
+          검토 후 반영됩니다. 감사합니다!
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 상태 선택 */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-navy-800">
+          현재 상태 <span className="text-red-500">*</span>
+        </p>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {SPOT_STATUSES.map((s) => (
+            <button
+              key={s.value}
+              type="button"
+              onClick={() => setSelectedStatus(s.value)}
+              className={`rounded-lg border p-3 text-left transition-colors ${
+                selectedStatus === s.value
+                  ? 'border-navy-500 bg-navy-50'
+                  : 'border-navy-100 hover:border-navy-300'
+              }`}
+            >
+              <span className="text-lg">{s.icon}</span>
+              <p className="mt-1 text-xs font-medium text-navy-700">
+                {s.label}
+              </p>
+              <p className="text-[10px] text-navy-400">{s.description}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 설명 입력 */}
+      {selectedStatus && (
+        <div>
+          <label className="mb-1 block text-sm font-medium text-navy-800">
+            상세 설명 <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="현재 상태에 대해 자세히 설명해주세요"
+            rows={3}
+            maxLength={500}
+            className="w-full rounded-md border border-navy-200 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none"
+          />
+          <p className="mt-1 text-right text-xs text-navy-400">
+            {description.length}/500
+          </p>
+        </div>
+      )}
+
+      {/* 사진 첨부 */}
+      {selectedStatus && (
+        <div>
+          <label className="mb-1 block text-xs font-medium text-navy-700">
+            증거 사진 (선택)
+          </label>
+          <input
+            ref={photoRef}
+            type="file"
+            accept="image/*"
+            onChange={handlePhotoUpload}
+            className="hidden"
+          />
+          {photoPreview ? (
+            <div className="relative aspect-video w-full max-w-xs overflow-hidden rounded-lg">
+              <Image
+                src={photoPreview}
+                alt="증거 사진"
+                fill
+                className="object-cover"
+              />
+              <button
+                type="button"
+                onClick={removePhoto}
+                className="absolute right-1 top-1 rounded-full bg-black/50 p-0.5 text-white hover:bg-black/70"
+              >
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => photoRef.current?.click()}
+              disabled={isUploading}
+              className="flex aspect-video w-full max-w-xs flex-col items-center justify-center rounded-lg border-2 border-dashed border-navy-200 hover:border-navy-400 hover:bg-navy-50"
+            >
+              {isUploading ? (
+                <div className="h-6 w-6 animate-spin rounded-full border-2 border-navy-600 border-t-transparent" />
+              ) : (
+                <>
+                  <svg
+                    className="mb-1 h-6 w-6 text-navy-300"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                    />
+                  </svg>
+                  <span className="text-xs text-navy-400">사진 업로드</span>
+                </>
+              )}
+            </button>
+          )}
+          {/* 사진 넛지 안내 */}
+          <p className="mt-1.5 text-xs text-blue-600">
+            💡 사진 증거를 첨부하면 더 빠르게 처리됩니다
+          </p>
+        </div>
+      )}
+
+      {/* 경고 문구 (심리적 허들) */}
+      {selectedStatus && (
+        <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          ⚠️ 허위 신고 시 서비스 이용이 제한될 수 있습니다
+        </p>
+      )}
+
+      {/* 버튼 */}
+      <div className="flex gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-lg border border-navy-200 py-2.5 text-sm font-medium text-navy-600 transition-colors hover:bg-navy-50"
+          >
+            취소
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="flex-1 rounded-lg bg-navy-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-navy-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isPending ? '제출 중...' : '상태 신고'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -45,6 +45,10 @@ export interface SpotDetailData {
   isGuestSpot?: boolean
   /** 현재 스팟 상태 (09-spot-report-wiki) */
   spotStatus?: SpotStatus
+  /** 최초 제보자 ID (09-spot-report-wiki) */
+  firstReporterId?: string
+  /** 최초 제보자 이름 (09-spot-report-wiki) */
+  firstReporterName?: string
 }
 
 // API response types

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { SpotCategory, RelatedContent, ExternalLink } from '@/types'
+import type { SpotStatus } from '@/types/report'
 import { API_ROUTES, buildUrl } from '@/lib/api-routes'
 
 // Types for spot data
@@ -42,6 +43,8 @@ export interface SpotDetailData {
   authorId?: string
   authorName?: string
   isGuestSpot?: boolean
+  /** 현재 스팟 상태 (09-spot-report-wiki) */
+  spotStatus?: SpotStatus
 }
 
 // API response types

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -6,6 +6,7 @@ import type {
   Coordinates,
   NearbyFacility,
 } from './spot'
+import type { SpotStatus } from './report'
 
 // ============================================
 // API Response Types
@@ -49,6 +50,8 @@ export interface SpotDetailData {
   authorId?: string
   authorName?: string
   isGuestSpot?: boolean
+  /** 현재 스팟 상태 (09-spot-report-wiki) */
+  spotStatus?: SpotStatus
 }
 
 export interface CreateSpotInput {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -52,6 +52,10 @@ export interface SpotDetailData {
   isGuestSpot?: boolean
   /** 현재 스팟 상태 (09-spot-report-wiki) */
   spotStatus?: SpotStatus
+  /** 최초 제보자 ID (09-spot-report-wiki) */
+  firstReporterId?: string
+  /** 최초 제보자 이름 (09-spot-report-wiki) */
+  firstReporterName?: string
 }
 
 export interface CreateSpotInput {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #246

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 스팟 상태 신고 UI 구현 및 최초 제보자 표시/프로필 연동

---

## 📋 변경 사항

- [x] StatusReportForm 컴포넌트 구현 (상태 선택, 설명, 사진 첨부, 경고 문구, 넛지 UI)
- [x] SpotStatusIndicator 컴포넌트 구현 (상태별 아이콘/색상/라벨)
- [x] SpotDetailData에 spotStatus 필드 추가
- [x] 스팟 상세 페이지에 상태 신고 UI 통합
- [x] 스팟 상세 페이지에 최초 제보자 표시 추가
- [x] SpotDetailData에 firstReporter 필드 추가
- [x] spots API에 firstReporterId 필터 추가
- [x] 프로필 페이지에 제보한 스팟 탭 추가
- [x] 상태 신고 테스트 페이지 추가 및 header 링크 갱신

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Task 14 (스팟 상태 신고 UI 구현) - Requirements 4.1, 4.2, 4.4
- Task 15 (최초 제보자 표시 및 프로필 연동) - Requirements 2.1, 2.2
