### PR TITLE
[Feat] Task 17 - 관리자 제보 검토 UI 구현

### DIFF
--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { AdminReportList } from '@/components/admin/AdminReportList'
+import { AdminReportReview } from '@/components/admin/AdminReportReview'
+import type { SpotReport } from '@/types/report'
+
+/**
+ * 관리자 제보 관리 페이지
+ * Requirements: 5.1, 5.2
+ * - AdminReportList + AdminReportReview 통합
+ * - 관리자 권한 검사 (미인증/비관리자 접근 차단)
+ */
+export default function AdminReportsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [selectedReport, setSelectedReport] = useState<SpotReport | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  // 권한 체크
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
+    }
+  }, [status, session, router])
+
+  const handleSelectReport = useCallback((report: SpotReport) => {
+    setSelectedReport(report)
+  }, [])
+
+  const handleReviewComplete = useCallback(() => {
+    setSelectedReport(null)
+    setRefreshKey((k) => k + 1)
+  }, [])
+
+  // 로딩
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    )
+  }
+
+  // 권한 없음
+  if (!session?.user || session.user.role !== 'admin') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="mb-2 text-2xl font-bold text-gray-800">
+            접근 권한 없음
+          </h1>
+          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* 헤더 */}
+      <div className="border-b border-gray-200 bg-white px-6 py-4">
+        <h1 className="text-xl font-bold text-gray-800">제보 관리</h1>
+        <p className="mt-0.5 text-sm text-gray-500">
+          유저 제보를 검토하고 승인/반려할 수 있습니다
+        </p>
+      </div>
+
+      {/* 메인 레이아웃: 좌측 목록 + 우측 상세 */}
+      <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
+        {/* 좌측: 제보 목록 */}
+        <div className="w-96 flex-shrink-0 border-r border-gray-200 bg-white">
+          <AdminReportList
+            onSelectReport={handleSelectReport}
+            selectedReportId={selectedReport?.id}
+            refreshKey={refreshKey}
+          />
+        </div>
+
+        {/* 우측: 제보 상세/검토 */}
+        <div className="flex-1 bg-gray-50">
+          {selectedReport ? (
+            <AdminReportReview
+              key={selectedReport.id}
+              report={selectedReport}
+              onReviewComplete={handleReviewComplete}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <div className="text-center text-gray-400">
+                <p className="text-4xl">📋</p>
+                <p className="mt-2 text-sm">좌측 목록에서 제보를 선택하세요</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/AdminReportList.tsx
+++ b/src/components/admin/AdminReportList.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Image from 'next/image'
+import { ReportStatusBadge } from '@/components/report/ReportStatusBadge'
+import { CATEGORY_CONFIG } from '@/types/spot'
+import type { SpotReport } from '@/types/report'
+
+interface AdminReportsResponse {
+  reports: SpotReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+const STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'pending', label: '대기중' },
+  { value: 'all', label: '전체' },
+  { value: 'approved', label: '승인' },
+  { value: 'rejected', label: '반려' },
+  { value: 'revision_requested', label: '수정요청' },
+]
+
+interface AdminReportListProps {
+  onSelectReport: (report: SpotReport) => void
+  selectedReportId?: string
+  /** 외부에서 목록 새로고침을 트리거하기 위한 카운터 */
+  refreshKey?: number
+}
+
+/**
+ * 관리자 제보 목록 컴포넌트
+ * Requirements: 5.1
+ * - 대기중 제보 목록 (상태 필터, 최신순 정렬)
+ * - 제보 요약 카드 (장소명, 카테고리, 제보자, 제출일)
+ */
+export function AdminReportList({
+  onSelectReport,
+  selectedReportId,
+  refreshKey = 0,
+}: AdminReportListProps) {
+  const [reports, setReports] = useState<SpotReport[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [statusFilter, setStatusFilter] = useState('pending')
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [total, setTotal] = useState(0)
+
+  const fetchReports = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const params = new URLSearchParams({
+        status: statusFilter,
+        page: page.toString(),
+        limit: '20',
+      })
+
+      const res = await fetch(`/api/admin/reports?${params}`)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '제보 목록 조회 실패')
+      }
+
+      const data: AdminReportsResponse = await res.json()
+      setReports(data.reports)
+      setTotalPages(data.totalPages)
+      setTotal(data.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }, [statusFilter, page])
+
+  useEffect(() => {
+    fetchReports()
+  }, [fetchReports, refreshKey])
+
+  // 필터 변경 시 페이지 초기화
+  const handleFilterChange = (value: string) => {
+    setStatusFilter(value)
+    setPage(1)
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 p-4 text-center text-sm text-red-600">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* 상태 필터 */}
+      <div className="border-b border-gray-200 p-3">
+        <div className="flex flex-wrap gap-1.5">
+          {STATUS_FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              onClick={() => handleFilterChange(filter.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                statusFilter === filter.value
+                  ? 'bg-navy-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-gray-400">총 {total}건</p>
+      </div>
+
+      {/* 제보 목록 */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="space-y-2 p-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="h-20 animate-pulse rounded-lg bg-gray-100"
+              />
+            ))}
+          </div>
+        ) : reports.length === 0 ? (
+          <div className="py-12 text-center text-sm text-gray-400">
+            {statusFilter === 'pending'
+              ? '대기중인 제보가 없습니다'
+              : '해당 상태의 제보가 없습니다'}
+          </div>
+        ) : (
+          <div className="space-y-1 p-2">
+            {reports.map((report) => (
+              <ReportSummaryCard
+                key={report.id}
+                report={report}
+                isSelected={selectedReportId === report.id}
+                onClick={() => onSelectReport(report)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 border-t border-gray-200 p-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-30"
+          >
+            이전
+          </button>
+          <span className="text-xs text-gray-500">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page >= totalPages}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-30"
+          >
+            다음
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReportSummaryCard({
+  report,
+  isSelected,
+  onClick,
+}: {
+  report: SpotReport
+  isSelected: boolean
+  onClick: () => void
+}) {
+  const categoryConfig = report.category
+    ? CATEGORY_CONFIG[report.category]
+    : null
+  const thumbnail = report.evidencePairs?.[0]?.realPhotoUrl
+
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full rounded-lg border p-3 text-left transition-colors ${
+        isSelected
+          ? 'border-navy-400 bg-navy-50'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      }`}
+    >
+      <div className="flex gap-3">
+        {/* 썸네일 */}
+        {thumbnail ? (
+          <div className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg">
+            <Image
+              src={thumbnail}
+              alt={report.name}
+              fill
+              className="object-cover"
+            />
+          </div>
+        ) : (
+          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 text-xl">
+            📍
+          </div>
+        )}
+
+        {/* 정보 */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <p className="truncate text-sm font-medium text-gray-800">
+              {report.name}
+            </p>
+            <ReportStatusBadge status={report.status} />
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+            {categoryConfig && <span>{categoryConfig.label}</span>}
+            <span>·</span>
+            <span>{report.reporterName}</span>
+          </div>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {new Date(report.createdAt).toLocaleDateString('ko-KR')}
+          </p>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/src/components/admin/AdminReportReview.tsx
+++ b/src/components/admin/AdminReportReview.tsx
@@ -1,0 +1,305 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { ReportStatusBadge } from '@/components/report/ReportStatusBadge'
+import { CATEGORY_CONFIG } from '@/types/spot'
+import type { SpotReport, ReviewHistory } from '@/types/report'
+
+interface AdminReportReviewProps {
+  report: SpotReport
+  onReviewComplete: () => void
+}
+
+/**
+ * 관리자 제보 검토 컴포넌트
+ * Requirements: 5.2, 5.3
+ * - 제보 상세 정보 표시 (증거 사진 쌍, 지도 위치, 작품 정보)
+ * - 승인/반려/수정요청 버튼 + 코멘트 입력
+ * - 검토 히스토리(reviewHistory) 타임라인 표시
+ */
+export function AdminReportReview({
+  report,
+  onReviewComplete,
+}: AdminReportReviewProps) {
+  const [comment, setComment] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const categoryConfig = report.category
+    ? CATEGORY_CONFIG[report.category]
+    : null
+  const isPending = report.status === 'pending'
+
+  const handleReview = async (
+    action: 'approve' | 'reject' | 'request_revision'
+  ) => {
+    if (action === 'reject' && !comment.trim()) {
+      setError('반려 사유를 입력해주세요')
+      return
+    }
+    if (action === 'request_revision' && !comment.trim()) {
+      setError('수정 요청 사유를 입력해주세요')
+      return
+    }
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const res = await fetch(`/api/admin/reports/${report.id}/review`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, comment: comment.trim() }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '검토 처리 실패')
+      }
+
+      setComment('')
+      onReviewComplete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="space-y-6 p-6">
+        {/* 헤더 */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-800">{report.name}</h2>
+            <p className="mt-1 text-sm text-gray-500">{report.address}</p>
+          </div>
+          <ReportStatusBadge status={report.status} size="md" />
+        </div>
+
+        {/* 기본 정보 */}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">
+            기본 정보
+          </h3>
+          <dl className="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <dt className="text-gray-400">카테고리</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {categoryConfig?.label || '미분류'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">제보자</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {report.reporterName}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">제출일</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {new Date(report.createdAt).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">좌표</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {report.coordinates.lat.toFixed(5)},{' '}
+                {report.coordinates.lng.toFixed(5)}
+              </dd>
+            </div>
+          </dl>
+          {report.description && (
+            <div className="mt-3 border-t border-gray-100 pt-3">
+              <dt className="text-sm text-gray-400">설명</dt>
+              <dd className="mt-1 whitespace-pre-wrap text-sm text-gray-700">
+                {report.description}
+              </dd>
+            </div>
+          )}
+        </section>
+
+        {/* 작품 정보 */}
+        {report.relatedContent && report.relatedContent.length > 0 && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">
+              작품 정보
+            </h3>
+            <div className="space-y-2">
+              {report.relatedContent.map((content, idx) => (
+                <div
+                  key={idx}
+                  className="flex items-center gap-2 rounded-md bg-gray-50 px-3 py-2 text-sm"
+                >
+                  <span className="font-medium text-gray-700">
+                    {content.name}
+                  </span>
+                  {content.year && (
+                    <span className="text-gray-400">({content.year})</span>
+                  )}
+                </div>
+              ))}
+            </div>
+            {report.episodeInfo && (
+              <p className="mt-2 text-sm text-gray-500">
+                에피소드: {report.episodeInfo}
+              </p>
+            )}
+          </section>
+        )}
+
+        {/* 증거 사진 쌍 */}
+        {report.evidencePairs && report.evidencePairs.length > 0 && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">
+              증거 사진 ({report.evidencePairs.length}쌍)
+            </h3>
+            <div className="space-y-4">
+              {report.evidencePairs.map((pair, idx) => (
+                <div key={idx} className="rounded-lg bg-gray-50 p-3">
+                  <p className="mb-2 text-xs font-medium text-gray-500">
+                    #{idx + 1}
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <p className="mb-1 text-xs text-gray-400">작품 캡처</p>
+                      <div className="relative aspect-video overflow-hidden rounded-lg">
+                        <Image
+                          src={pair.captureImageUrl}
+                          alt={`캡처 ${idx + 1}`}
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <p className="mb-1 text-xs text-gray-400">현장 사진</p>
+                      <div className="relative aspect-video overflow-hidden rounded-lg">
+                        <Image
+                          src={pair.realPhotoUrl}
+                          alt={`현장 ${idx + 1}`}
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  {pair.description && (
+                    <p className="mt-2 text-xs text-gray-500">
+                      {pair.description}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* 검토 히스토리 */}
+        {report.reviewHistory && report.reviewHistory.length > 0 && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">
+              검토 히스토리
+            </h3>
+            <div className="relative space-y-3 pl-4">
+              {/* 타임라인 라인 */}
+              <div className="absolute bottom-0 left-1.5 top-0 w-px bg-gray-200" />
+              {report.reviewHistory.map(
+                (history: ReviewHistory, idx: number) => (
+                  <div key={idx} className="relative">
+                    {/* 타임라인 도트 */}
+                    <div className="absolute -left-4 top-1.5 h-3 w-3 rounded-full border-2 border-white bg-gray-400" />
+                    <div className="rounded-md bg-gray-50 p-3">
+                      <div className="flex items-center gap-2">
+                        <ReportStatusBadge status={history.status} />
+                        <span className="text-xs text-gray-400">
+                          {new Date(history.reviewedAt).toLocaleDateString(
+                            'ko-KR',
+                            {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            }
+                          )}
+                        </span>
+                      </div>
+                      {history.comment && (
+                        <p className="mt-1.5 text-sm text-gray-600">
+                          {history.comment}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* 검토 액션 (pending 상태일 때만) */}
+        {isPending && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">검토</h3>
+
+            {/* 코멘트 입력 */}
+            <textarea
+              value={comment}
+              onChange={(e) => {
+                setComment(e.target.value)
+                setError(null)
+              }}
+              placeholder="코멘트를 입력하세요 (반려/수정요청 시 필수)"
+              rows={3}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none focus:ring-1 focus:ring-navy-400"
+            />
+
+            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+
+            {/* 액션 버튼 */}
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={() => handleReview('approve')}
+                disabled={loading}
+                className="flex-1 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+              >
+                {loading ? '처리중...' : '✅ 승인'}
+              </button>
+              <button
+                onClick={() => handleReview('request_revision')}
+                disabled={loading}
+                className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+              >
+                {loading ? '처리중...' : '✏️ 수정요청'}
+              </button>
+              <button
+                onClick={() => handleReview('reject')}
+                disabled={loading}
+                className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+              >
+                {loading ? '처리중...' : '❌ 반려'}
+              </button>
+            </div>
+          </section>
+        )}
+
+        {/* 이미 처리된 제보 안내 */}
+        {!isPending && (
+          <div className="rounded-lg bg-gray-50 p-4 text-center text-sm text-gray-500">
+            이미 처리된 제보입니다
+            {report.reviewComment && (
+              <p className="mt-1 text-gray-600">💬 {report.reviewComment}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈
## 🔗 관련 이슈

- Closes #248

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 관리자가 유저 제보를 검토(승인/반려/수정요청)할 수 있는 UI 구현

---

## 📋 변경 사항

- [x] AdminReportList 컴포넌트 (상태 필터, 최신순 정렬, 제보 요약 카드)
- [x] AdminReportReview 컴포넌트 (증거 사진 쌍, 작품 정보, 검토 히스토리 타임라인, 승인/반려/수정요청)
- [x] 관리자 제보 관리 페이지 (좌측 목록 + 우측 상세 레이아웃, 권한 검사)

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 5.1, 5.2, 5.3 대응
- 기존 API (GET /api/admin/reports, PUT /api/admin/reports/:id/review) 활용
- 총 3개 커밋, 644줄 추가

- Closes #이슈번호

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

---

## 📋 변경 사항

- [ ] 변경 항목 1
- [ ] 변경 항목 2

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

<!-- 리뷰어가 알아야 할 특별한 사항 -->
