### PR TITLE
[Feat] Task 2 - 코스 CRUD API 구현

### DIFF
--- a/src/app/api/routes/[id]/route.ts
+++ b/src/app/api/routes/[id]/route.ts
@@ -1,0 +1,285 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { Route, RouteDifficulty } from '@/types/route'
+import { calculateRouteDistances } from '@/lib/route-utils'
+
+const VALID_DIFFICULTIES: RouteDifficulty[] = ['easy', 'moderate', 'hard']
+
+/**
+ * GET /api/routes/[id] - 코스 상세 조회
+ * Requirements: 1.4, 2.3
+ * - spots 컬렉션과 대조하여 isAvailable 갱신
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id } = await params
+    const collection = await getCollection<Route>('routes')
+    const route = await collection.findOne({ id })
+
+    if (!route) {
+      return NextResponse.json(
+        { error: '코스를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 비공개 코스 타인 접근 차단
+    if (!route.isPublic) {
+      const session = await auth()
+      if (
+        !session?.user ||
+        (session.user.id !== route.authorId && session.user.role !== 'admin')
+      ) {
+        return NextResponse.json(
+          { error: '비공개 코스입니다' },
+          { status: 403 }
+        )
+      }
+    }
+
+    // spots 컬렉션과 대조하여 isAvailable 갱신
+    const spotsCollection = await getCollection('spots')
+    const spotIds = route.spots.map((s) => s.spotId)
+    const existingSpots = await spotsCollection
+      .find({ id: { $in: spotIds } })
+      .project({ id: 1, status: 1 })
+      .toArray()
+
+    const existingSpotMap = new Map(existingSpots.map((s) => [s.id, s]))
+
+    let hasChanges = false
+    const updatedSpots = route.spots.map((spot) => {
+      const dbSpot = existingSpotMap.get(spot.spotId)
+      // 스팟이 삭제되었거나 '소실됨' 상태인 경우
+      const isAvailable = dbSpot !== undefined && dbSpot.status !== 'lost'
+      if (spot.isAvailable !== isAvailable) {
+        hasChanges = true
+      }
+      return { ...spot, isAvailable }
+    })
+
+    // 변경사항이 있으면 DB 업데이트
+    if (hasChanges) {
+      await collection.updateOne(
+        { id },
+        { $set: { spots: updatedSpots, updatedAt: new Date() } }
+      )
+    }
+
+    return NextResponse.json({ ...route, spots: updatedSpots })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching route detail:', error)
+    return NextResponse.json(
+      { error: '코스 상세 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * PUT /api/routes/[id] - 코스 수정
+ * Requirements: 1.2, 1.3, 1.4
+ * - 작성자 권한 확인
+ * - 스팟 순서 변경 시 거리/시간 재계산
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const body = await request.json()
+    const collection = await getCollection<Route>('routes')
+
+    const route = await collection.findOne({ id })
+    if (!route) {
+      return NextResponse.json(
+        { error: '코스를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 작성자 또는 관리자만 수정 가능
+    if (session.user.id !== route.authorId && session.user.role !== 'admin') {
+      return NextResponse.json({ error: '권한이 없습니다' }, { status: 403 })
+    }
+
+    const errors: string[] = []
+    if (body.name !== undefined && !body.name?.trim())
+      errors.push('코스명은 필수입니다')
+    if (body.description !== undefined && !body.description?.trim())
+      errors.push('설명은 필수입니다')
+    if (body.estimatedDuration !== undefined && body.estimatedDuration <= 0)
+      errors.push('예상 소요시간은 0보다 커야 합니다')
+    if (
+      body.difficulty !== undefined &&
+      !VALID_DIFFICULTIES.includes(body.difficulty)
+    )
+      errors.push('유효하지 않은 난이도입니다')
+    if (
+      body.spots !== undefined &&
+      (!Array.isArray(body.spots) || body.spots.length < 2)
+    )
+      errors.push('코스에는 최소 2개의 스팟이 필요합니다')
+
+    if (errors.length > 0) {
+      return NextResponse.json(
+        { error: '유효성 검사 실패', fields: errors },
+        { status: 400 }
+      )
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateFields: Record<string, any> = { updatedAt: new Date() }
+
+    if (body.name) updateFields.name = body.name.trim()
+    if (body.description) updateFields.description = body.description.trim()
+    if (body.estimatedDuration !== undefined)
+      updateFields.estimatedDuration = body.estimatedDuration
+    if (body.difficulty) updateFields.difficulty = body.difficulty
+    if (body.relatedContentNames !== undefined)
+      updateFields.relatedContentNames = body.relatedContentNames
+    if (body.regionTag !== undefined) updateFields.regionTag = body.regionTag
+    if (body.isPublic !== undefined) updateFields.isPublic = body.isPublic
+
+    // 스팟 목록 변경 시 거리/시간 재계산
+    if (body.spots) {
+      const spotsCollection = await getCollection('spots')
+      const spotIds = body.spots.map((s: { spotId: string }) => s.spotId)
+      const existingSpots = await spotsCollection
+        .find({ id: { $in: spotIds } })
+        .project({ id: 1, name: 1, coordinates: 1, photos: 1 })
+        .toArray()
+
+      const existingSpotMap = new Map(existingSpots.map((s) => [s.id, s]))
+
+      const invalidSpotIds = spotIds.filter(
+        (sid: string) => !existingSpotMap.has(sid)
+      )
+      if (invalidSpotIds.length > 0) {
+        return NextResponse.json(
+          { error: '유효하지 않은 스팟이 포함되어 있습니다' },
+          { status: 400 }
+        )
+      }
+
+      const routeSpots = body.spots.map(
+        (s: { spotId: string; note?: string }) => {
+          const dbSpot = existingSpotMap.get(s.spotId)!
+          return {
+            spotId: s.spotId,
+            spotName: dbSpot.name,
+            coordinates: dbSpot.coordinates,
+            thumbnailUrl: dbSpot.photos?.[0] || '',
+            distanceFromPrev: null,
+            walkTimeFromPrev: null,
+            note: s.note || undefined,
+            isAvailable: true,
+          }
+        }
+      )
+
+      const distances = calculateRouteDistances(routeSpots)
+      routeSpots.forEach(
+        (
+          spot: {
+            distanceFromPrev: number | null
+            walkTimeFromPrev: number | null
+          },
+          i: number
+        ) => {
+          spot.distanceFromPrev = distances[i].distanceFromPrev
+          spot.walkTimeFromPrev = distances[i].walkTimeFromPrev
+        }
+      )
+
+      updateFields.spots = routeSpots
+      updateFields.totalDistance = distances.reduce(
+        (sum, d) => sum + (d.distanceFromPrev || 0),
+        0
+      )
+    }
+
+    await collection.updateOne({ id }, { $set: updateFields })
+
+    return NextResponse.json({ id, message: '코스가 수정되었습니다' })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error updating route:', error)
+    return NextResponse.json(
+      { error: '코스 수정에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/routes/[id] - 코스 삭제
+ * Requirements: 2.3
+ * - 작성자 권한 확인
+ * - 관련 북마크/완주 기록 정리
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const collection = await getCollection<Route>('routes')
+
+    const route = await collection.findOne({ id })
+    if (!route) {
+      return NextResponse.json(
+        { error: '코스를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 작성자 또는 관리자만 삭제 가능
+    if (session.user.id !== route.authorId && session.user.role !== 'admin') {
+      return NextResponse.json({ error: '권한이 없습니다' }, { status: 403 })
+    }
+
+    // 관련 북마크/완주 기록 삭제
+    const [bookmarksCollection, completionsCollection] = await Promise.all([
+      getCollection('route_bookmarks'),
+      getCollection('route_completions'),
+    ])
+
+    await Promise.all([
+      bookmarksCollection.deleteMany({ routeId: id }),
+      completionsCollection.deleteMany({ routeId: id }),
+      collection.deleteOne({ id }),
+    ])
+
+    return NextResponse.json({ message: '코스가 삭제되었습니다' })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error deleting route:', error)
+    return NextResponse.json(
+      { error: '코스 삭제에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -1,0 +1,271 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { Route, RouteDifficulty } from '@/types/route'
+import { calculateRouteDistances } from '@/lib/route-utils'
+
+/** 코스 ID 생성 (ROUTE-{숫자} 형식) */
+async function generateRouteId(): Promise<string> {
+  const collection = await getCollection<Route>('routes')
+  const routes = await collection
+    .find({ id: { $regex: /^ROUTE-\d+$/ } })
+    .project({ id: 1 })
+    .toArray()
+
+  if (routes.length === 0) return 'ROUTE-001'
+
+  const maxNumber = routes.reduce((max, route) => {
+    const match = route.id.match(/^ROUTE-(\d+)$/)
+    if (match) {
+      const num = parseInt(match[1], 10)
+      return num > max ? num : max
+    }
+    return max
+  }, 0)
+
+  return `ROUTE-${(maxNumber + 1).toString().padStart(3, '0')}`
+}
+
+const VALID_DIFFICULTIES: RouteDifficulty[] = ['easy', 'moderate', 'hard']
+
+/**
+ * POST /api/routes - 코스 생성
+ * Requirements: 1.1, 1.2, 1.3, 1.4, 1.5
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const body = await request.json()
+    const errors: string[] = []
+
+    // 필수 필드 검증
+    if (!body.name?.trim()) errors.push('코스명은 필수입니다')
+    if (!body.description?.trim()) errors.push('설명은 필수입니다')
+    if (!body.estimatedDuration || body.estimatedDuration <= 0)
+      errors.push('예상 소요시간은 필수입니다')
+    if (!body.difficulty || !VALID_DIFFICULTIES.includes(body.difficulty))
+      errors.push('난이도를 선택해주세요 (easy, moderate, hard)')
+    if (!Array.isArray(body.spots) || body.spots.length < 2)
+      errors.push('코스에는 최소 2개의 스팟이 필요합니다')
+
+    if (errors.length > 0) {
+      return NextResponse.json(
+        { error: '필수 항목을 입력해주세요', fields: errors },
+        { status: 400 }
+      )
+    }
+
+    // 스팟 ID 유효성 검증 (spots 컬렉션 대조)
+    const spotsCollection = await getCollection('spots')
+    const spotIds = body.spots.map((s: { spotId: string }) => s.spotId)
+    const existingSpots = await spotsCollection
+      .find({ id: { $in: spotIds } })
+      .project({ id: 1, name: 1, coordinates: 1, photos: 1 })
+      .toArray()
+
+    const existingSpotMap = new Map(existingSpots.map((s) => [s.id, s]))
+
+    const invalidSpotIds = spotIds.filter(
+      (id: string) => !existingSpotMap.has(id)
+    )
+    if (invalidSpotIds.length > 0) {
+      return NextResponse.json(
+        { error: '유효하지 않은 스팟이 포함되어 있습니다' },
+        { status: 400 }
+      )
+    }
+
+    // 스팟 데이터 구성 (비정규화 데이터 채우기)
+    const routeSpots = body.spots.map(
+      (s: { spotId: string; note?: string }) => {
+        const dbSpot = existingSpotMap.get(s.spotId)!
+        return {
+          spotId: s.spotId,
+          spotName: dbSpot.name,
+          coordinates: dbSpot.coordinates,
+          thumbnailUrl: dbSpot.photos?.[0] || '',
+          distanceFromPrev: null,
+          walkTimeFromPrev: null,
+          note: s.note || undefined,
+          isAvailable: true,
+        }
+      }
+    )
+
+    // 스팟 간 거리/시간 자동 계산
+    const distances = calculateRouteDistances(routeSpots)
+    routeSpots.forEach(
+      (
+        spot: {
+          distanceFromPrev: number | null
+          walkTimeFromPrev: number | null
+        },
+        i: number
+      ) => {
+        spot.distanceFromPrev = distances[i].distanceFromPrev
+        spot.walkTimeFromPrev = distances[i].walkTimeFromPrev
+      }
+    )
+
+    // 총 거리 계산
+    const totalDistance = distances.reduce(
+      (sum, d) => sum + (d.distanceFromPrev || 0),
+      0
+    )
+
+    const routesCollection = await getCollection<Route>('routes')
+    const now = new Date()
+    const routeId = await generateRouteId()
+
+    const newRoute: Route = {
+      id: routeId,
+      name: body.name.trim(),
+      description: body.description.trim(),
+      estimatedDuration: body.estimatedDuration,
+      difficulty: body.difficulty,
+      spots: routeSpots,
+      totalDistance,
+      relatedContentNames: body.relatedContentNames || [],
+      regionTag: body.regionTag || undefined,
+      isPublic: body.isPublic !== false,
+      isOfficial: false,
+      bookmarkCount: 0,
+      completionCount: 0,
+      authorId: session.user.id,
+      authorName:
+        session.user.name || session.user.email?.split('@')[0] || '익명',
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await routesCollection.insertOne(newRoute)
+
+    return NextResponse.json(
+      {
+        id: newRoute.id,
+        name: newRoute.name,
+        message: '코스가 생성되었습니다',
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error creating route:', error)
+    return NextResponse.json(
+      { error: '코스 생성에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/** 정렬 기준 타입 */
+type SortType = 'popular' | 'newest' | 'duration'
+
+/**
+ * GET /api/routes - 코스 목록 조회
+ * Requirements: 2.1, 2.2
+ * Query params:
+ *   - sort: popular | newest | duration (기본: popular)
+ *   - contentName: 작품명 필터
+ *   - regionTag: 지역 필터
+ *   - minDuration: 최소 소요시간 (분)
+ *   - maxDuration: 최대 소요시간 (분)
+ *   - page: 페이지 번호 (기본: 1)
+ *   - limit: 페이지당 항목 수 (기본: 12)
+ *   - authorId: 작성자 필터
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url)
+    const sort = (searchParams.get('sort') || 'popular') as SortType
+    const contentName = searchParams.get('contentName')
+    const regionTag = searchParams.get('regionTag')
+    const minDuration = searchParams.get('minDuration')
+    const maxDuration = searchParams.get('maxDuration')
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10))
+    const limit = Math.min(
+      50,
+      Math.max(1, parseInt(searchParams.get('limit') || '12', 10))
+    )
+    const authorId = searchParams.get('authorId')
+
+    // 현재 유저 확인 (비공개 코스 필터용)
+    const session = await auth()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query: Record<string, any> = {}
+
+    // 기본: 공개 코스만 표시 (본인 코스는 비공개도 포함)
+    if (authorId && session?.user?.id === authorId) {
+      query.authorId = authorId
+    } else if (authorId) {
+      query.authorId = authorId
+      query.isPublic = true
+    } else {
+      query.isPublic = true
+    }
+
+    // 작품별 필터
+    if (contentName) {
+      query.relatedContentNames = contentName
+    }
+
+    // 지역별 필터
+    if (regionTag) {
+      query.regionTag = regionTag
+    }
+
+    // 소요시간별 필터
+    if (minDuration || maxDuration) {
+      query.estimatedDuration = {}
+      if (minDuration) query.estimatedDuration.$gte = parseInt(minDuration, 10)
+      if (maxDuration) query.estimatedDuration.$lte = parseInt(maxDuration, 10)
+    }
+
+    const collection = await getCollection<Route>('routes')
+
+    // 정렬 기준 설정
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let sortOption: Record<string, any>
+    switch (sort) {
+      case 'newest':
+        sortOption = { createdAt: -1 }
+        break
+      case 'duration':
+        sortOption = { estimatedDuration: 1 }
+        break
+      case 'popular':
+      default:
+        sortOption = { bookmarkCount: -1, completionCount: -1, createdAt: -1 }
+        break
+    }
+
+    const skip = (page - 1) * limit
+    const [routes, total] = await Promise.all([
+      collection.find(query).sort(sortOption).skip(skip).limit(limit).toArray(),
+      collection.countDocuments(query),
+    ])
+
+    return NextResponse.json({
+      routes,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching routes:', error)
+    return NextResponse.json(
+      { error: '코스 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #252

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 성지순례 코스 시스템의 CRUD API 엔드포인트 구현 (생성/목록조회/상세/수정/삭제)

---

## 📋 변경 사항

- [x] `POST /api/routes` - 코스 생성 API (인증, 필수 필드 검증, 스팟 유효성 검증, 거리/시간 자동 계산)
- [x] `GET /api/routes` - 코스 목록 조회 API (인기순/최신순/소요시간순 정렬, 작품별/지역별/소요시간별 필터, 페이지네이션)
- [x] `GET /api/routes/[id]` - 코스 상세 조회 (spots 컬렉션 대조 isAvailable 갱신, 비공개 코스 접근 제어)
- [x] `PUT /api/routes/[id]` - 코스 수정 (작성자 권한 확인, 스팟 변경 시 거리/시간 재계산)
- [x] `DELETE /api/routes/[id]` - 코스 삭제 (작성자 권한 확인, 관련 북마크/완주 기록 정리)

**Requirements 대응:** 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] type-check 통과

---

## 📝 추가 정보

- 코스 ID는 `ROUTE-001` 형식으로 자동 생성
- 스팟 간 거리/시간은 `calculateRouteDistances` 유틸리티로 자동 계산
- 비공개 코스는 작성자/관리자만 상세 조회 가능
- 코스 삭제 시 route_bookmarks, route_completions 컬렉션도 함께 정리
