### PR TITLE
[Feat] 코스 북마크, 완주 기록, 추천 코스 API 구현

### DIFF
--- a/.kiro/specs/08-mobile-first-ux/tasks.md
+++ b/.kiro/specs/08-mobile-first-ux/tasks.md
@@ -299,33 +299,33 @@
   - 오프라인 페이지 고도화 확인
   - 푸시 알림 권한 요청 확인
 
-- [ ] 19. 성능 최적화
-  - [ ] 19.1 스켈레톤 UI 컴포넌트 구현 (src/components/common/SkeletonUI.tsx)
+- [x] 19. 성능 최적화
+  - [x] 19.1 스켈레톤 UI 컴포넌트 구현 (src/components/common/SkeletonUI.tsx)
     - 스팟 카드 스켈레톤
     - 갤러리 스켈레톤
     - 지도 스켈레톤
     - _Requirements: 5.4_
 
-  - [ ] 19.2 기존 컴포넌트에 스켈레톤 UI 적용
+  - [x] 19.2 기존 컴포넌트에 스켈레톤 UI 적용
     - 스팟 상세 페이지
     - 갤러리 페이지
     - 메인 지도 페이지
     - _Requirements: 5.4_
 
-  - [ ] 19.3 이미지 최적화 설정 확인
+  - [x] 19.3 이미지 최적화 설정 확인
     - Next.js Image 컴포넌트 WebP 변환 확인
     - 이미지 크기 최적화 확인
     - blur placeholder 적용
     - _Requirements: 5.1_
 
-- [ ] 20. SafeAreaWrapper 컴포넌트 구현
-  - [ ] 20.1 SafeAreaWrapper 컴포넌트 구현 (src/components/mobile/SafeAreaWrapper.tsx)
+- [x] 20. SafeAreaWrapper 컴포넌트 구현
+  - [x] 20.1 SafeAreaWrapper 컴포넌트 구현 (src/components/mobile/SafeAreaWrapper.tsx)
     - env(safe-area-inset-\*) CSS 변수 활용
     - 방향별 패딩 적용 옵션
     - 추가 패딩 옵션
     - _Requirements: 4.4_
 
-  - [ ] 20.2 하단 네비게이션에 Safe Area 적용
+  - [x] 20.2 하단 네비게이션에 Safe Area 적용
     - Header 컴포넌트 Safe Area 적용
     - Bottom Sheet Safe Area 적용
     - _Requirements: 4.4_

--- a/.kiro/specs/09-spot-report-wiki/.config.kiro
+++ b/.kiro/specs/09-spot-report-wiki/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "7e71efb2-42be-4baa-94a9-89fb1bb5a1bb", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/09-spot-report-wiki/design.md
+++ b/.kiro/specs/09-spot-report-wiki/design.md
@@ -1,0 +1,630 @@
+# Design Document: 성지 제보 시스템 (Spot Report Wiki)
+
+## Overview
+
+성지 제보 시스템은 유저들이 새로운 성지를 제보하고, 기존 성지 정보를 보완하며, 스팟 상태 변경을 신고할 수 있는 집단지성 위키 시스템입니다. 관리자 검토 워크플로우를 통해 데이터 품질을 유지하면서, 최초 제보자 명예 시스템으로 참여 동기를 부여합니다.
+
+### 핵심 설계 원칙
+
+1. **증거 기반 제보**: 애니메이션 캡처 + 현장 사진 쌍을 필수로 요구하여 제보 품질 보장
+2. **지오펜싱 중복 방지**: 반경 50m 이내 기존 스팟/대기 제보 검사로 중복 제보 방지
+3. **관리자 게이트키핑**: 모든 신규 제보는 관리자 승인 후 공개
+4. **남용 방지**: 상태 신고 시 사진 증거 또는 3회 이상 누적 조건으로 자동 전환
+
+## Architecture
+
+### 시스템 아키텍처
+
+```mermaid
+graph TB
+    subgraph Client["클라이언트 (Next.js App Router)"]
+        ReportForm["제보 폼 컴포넌트"]
+        SupplementForm["정보 보완 폼"]
+        StatusReportForm["상태 신고 폼"]
+        AdminPanel["관리자 제보 관리"]
+        SpotDetail["스팟 상세 (제보자 표시)"]
+        Profile["프로필 (제보 목록)"]
+    end
+
+    subgraph API["API Routes"]
+        ReportAPI["POST /api/reports"]
+        ReportListAPI["GET /api/reports"]
+        ReportDetailAPI["GET/PUT /api/reports/:id"]
+        AdminReviewAPI["PUT /api/admin/reports/:id/review"]
+        SupplementAPI["POST /api/spots/:id/supplements"]
+        StatusReportAPI["POST /api/spots/:id/status-reports"]
+        NearbyCheckAPI["GET /api/reports/nearby"]
+    end
+
+    subgraph DB["MongoDB Collections"]
+        ReportsCol["spot_reports"]
+        SupplementsCol["spot_supplements"]
+        StatusReportsCol["spot_status_reports"]
+        SpotsCol["spots (기존)"]
+        UsersCol["users (기존)"]
+    end
+
+    ReportForm --> ReportAPI
+    ReportForm --> NearbyCheckAPI
+    SupplementForm --> SupplementAPI
+    StatusReportForm --> StatusReportAPI
+    AdminPanel --> ReportListAPI
+    AdminPanel --> AdminReviewAPI
+
+    ReportAPI --> ReportsCol
+    NearbyCheckAPI --> ReportsCol
+    NearbyCheckAPI --> SpotsCol
+    SupplementAPI --> SupplementsCol
+    StatusReportAPI --> StatusReportsCol
+    AdminReviewAPI --> ReportsCol
+    AdminReviewAPI --> SpotsCol
+```
+
+### 제보 워크플로우
+
+```mermaid
+stateDiagram-v2
+    [*] --> 작성중: 유저가 제보 폼 열기
+    작성중 --> 지오펜싱검사: 위치 핀 등록
+    지오펜싱검사 --> 중복경고: 50m 이내 기존 스팟 존재
+    지오펜싱검사 --> 증거업로드: 중복 없음
+    중복경고 --> 증거업로드: 유저가 계속 진행
+    중복경고 --> 기존스팟보완: 유저가 기존 스팟 선택
+    증거업로드 --> 대기중: 제출 (필수: 캡처+현장사진 쌍)
+    대기중 --> 승인: 관리자 승인
+    대기중 --> 반려: 관리자 반려
+    대기중 --> 수정요청: 관리자 수정 요청
+    수정요청 --> 대기중: 유저 수정 후 재제출
+    승인 --> 지도표시: 스팟 생성 + 최초 제보자 기록
+    반려 --> [*]: 사유 알림
+    기존스팟보완 --> [*]: 보완 정보 추가
+```
+
+
+
+## Components and Interfaces
+
+### API 엔드포인트
+
+| 메서드 | 경로 | 설명 | 인증 |
+|--------|------|------|------|
+| `POST` | `/api/reports` | 신규 성지 제보 제출 | 필수 |
+| `GET` | `/api/reports` | 내 제보 목록 조회 | 필수 |
+| `GET` | `/api/reports/:id` | 제보 상세 조회 | 필수 |
+| `PUT` | `/api/reports/:id` | 제보 수정 (수정요청 대응) | 필수 |
+| `GET` | `/api/reports/nearby` | 반경 50m 이내 기존 스팟/제보 검색 | 필수 |
+| `POST` | `/api/spots/:id/supplements` | 기존 스팟 정보 보완 제보 | 필수 |
+| `GET` | `/api/spots/:id/supplements` | 스팟 보완 기여자 목록 조회 | 없음 |
+| `POST` | `/api/spots/:id/status-reports` | 스팟 상태 신고 | 필수 |
+| `GET` | `/api/spots/:id/status-reports` | 스팟 상태 신고 이력 조회 | 없음 |
+| `GET` | `/api/admin/reports` | 관리자 제보 목록 (대기중 필터) | 관리자 |
+| `PUT` | `/api/admin/reports/:id/review` | 관리자 제보 검토 (승인/반려/수정요청) | 관리자 |
+
+> **SupplementType `photo` vs CheckIn(07-pilgrimage-checkin) 구분 기준:**
+> - `photo` 타입 보완 제보: 스팟의 **위키 대표 사진** 또는 **씬 비교 사진**으로 사용. 작품 속 장면과 실제 장소의 대응 관계를 보여주는 증거 사진이며, 스팟 상세 페이지의 정보 섹션에 표시됨.
+> - CheckIn 사진 (07 스펙): 유저 개인의 **방문 인증샷**. 갤러리/피드에 표시되며 스팟 정보 자체를 보완하지 않음.
+> - 판단 기준: "이 사진이 스팟 정보의 정확성/풍부함을 높이는가?" → 보완 제보, "유저의 방문 경험을 공유하는가?" → CheckIn
+
+### 클라이언트 컴포넌트
+
+#### 제보 관련 컴포넌트
+
+| 컴포넌트 | 경로 | 설명 |
+|----------|------|------|
+| `SpotReportForm` | `src/components/report/SpotReportForm.tsx` | 신규 성지 제보 폼 (위치 핀, 증거 사진 쌍 업로드) |
+| `EvidencePairUpload` | `src/components/report/EvidencePairUpload.tsx` | 애니메이션 캡처 + 현장 사진 쌍 업로드 UI |
+| `NearbySpotWarning` | `src/components/report/NearbySpotWarning.tsx` | 50m 이내 기존 스팟 경고 및 목록 표시 |
+| `ReportStatusBadge` | `src/components/report/ReportStatusBadge.tsx` | 제보 상태 뱃지 (대기중/승인/반려/수정요청) |
+| `MyReportList` | `src/components/report/MyReportList.tsx` | 내 제보 목록 |
+
+#### 정보 보완 컴포넌트
+
+| 컴포넌트 | 경로 | 설명 |
+|----------|------|------|
+| `SupplementForm` | `src/components/report/SupplementForm.tsx` | 기존 스팟 정보 수정 제안 폼 |
+| `ContributorList` | `src/components/report/ContributorList.tsx` | 스팟 정보 보완 기여자 목록 |
+
+#### 상태 신고 컴포넌트
+
+| 컴포넌트 | 경로 | 설명 |
+|----------|------|------|
+| `StatusReportForm` | `src/components/report/StatusReportForm.tsx` | 스팟 상태 신고 폼 (상태 선택 + 사진 첨부) |
+| `SpotStatusIndicator` | `src/components/report/SpotStatusIndicator.tsx` | 지도/상세에서 스팟 상태 시각적 표시 |
+
+#### 관리자 컴포넌트
+
+| 컴포넌트 | 경로 | 설명 |
+|----------|------|------|
+| `AdminReportList` | `src/components/admin/AdminReportList.tsx` | 대기중 제보 목록 (필터/정렬) |
+| `AdminReportReview` | `src/components/admin/AdminReportReview.tsx` | 제보 검토 UI (승인/반려/수정요청) |
+
+#### 페이지
+
+| 페이지 | 경로 | 설명 |
+|--------|------|------|
+| 성지 제보 페이지 | `src/app/reports/new/page.tsx` | 신규 제보 폼 페이지 |
+| 내 제보 목록 | `src/app/reports/page.tsx` | 내 제보 현황 페이지 |
+| 제보 상세 | `src/app/reports/[id]/page.tsx` | 제보 상세/수정 페이지 |
+| 관리자 제보 관리 | `src/app/admin/reports/page.tsx` | 관리자 제보 검토 페이지 |
+
+### 커스텀 훅
+
+| 훅 | 경로 | 설명 |
+|----|------|------|
+| `useSpotReport` | `src/hooks/useSpotReport.ts` | 제보 제출/수정 로직 |
+| `useNearbyCheck` | `src/hooks/useNearbyCheck.ts` | 50m 반경 중복 검사 |
+| `useMyReports` | `src/hooks/useMyReports.ts` | 내 제보 목록 조회 |
+| `useStatusReport` | `src/hooks/useStatusReport.ts` | 상태 신고 로직 |
+
+### Zustand 스토어
+
+| 스토어 | 경로 | 설명 |
+|--------|------|------|
+| `reportStore` | `src/stores/reportStore.ts` | 제보 폼 상태 관리 (멀티스텝 폼 진행 상태, 임시 저장) |
+
+
+## Data Models
+
+### MongoDB 컬렉션 추가
+
+기존 `COLLECTIONS` 상수에 다음 컬렉션을 추가합니다:
+
+```typescript
+// src/lib/db.ts - COLLECTIONS에 추가
+SPOT_REPORTS: 'spot_reports',
+SPOT_SUPPLEMENTS: 'spot_supplements',
+SPOT_STATUS_REPORTS: 'spot_status_reports',
+```
+
+### 타입 정의
+
+```typescript
+// src/types/report.ts
+
+// ============================================
+// 제보 상태 타입
+// ============================================
+
+export type ReportStatus = 'pending' | 'approved' | 'rejected' | 'revision_requested'
+
+// ============================================
+// 검토 히스토리 (상태 변경 추적)
+// ============================================
+
+/** 관리자 검토 이력 (반려/수정요청/승인 히스토리 추적) */
+export interface ReviewHistory {
+  /** 변경된 상태 */
+  status: ReportStatus
+  /** 관리자 코멘트 (반려 사유, 수정 요청 내용 등) */
+  comment: string
+  /** 검토 시각 */
+  reviewedAt: Date
+  /** 검토자 ID */
+  reviewedBy: string
+}
+
+// ============================================
+// 증거 사진 쌍 (필수)
+// ============================================
+
+/** 애니메이션 캡처 + 현장 사진 쌍 */
+export interface EvidencePair {
+  /** 애니메이션/작품 원본 캡처 이미지 URL */
+  captureImageUrl: string
+  /** 현장 사진 또는 로드뷰 캡처 URL */
+  realPhotoUrl: string
+  /** 설명 (선택) */
+  description?: string
+}
+
+// ============================================
+// 성지 제보 (SpotReport)
+// ============================================
+
+export interface SpotReport {
+  id: string
+  /** 제보자 정보 */
+  reporterId: string
+  reporterName: string
+  /** 제보 상태 */
+  status: ReportStatus
+  /** 장소 정보 */
+  name: string
+  description: string
+  address: string
+  coordinates: {
+    lat: number
+    lng: number
+  }
+  category: SpotCategory
+  /** 작품 정보 */
+  relatedContent: RelatedContent[]
+  /** 증거 사진 쌍 (최소 1쌍 필수) */
+  evidencePairs: EvidencePair[]
+  /** 에피소드/타임스탬프 정보 */
+  episodeInfo: string
+  /** 추가 사진 (선택) */
+  additionalPhotos?: string[]
+  /** 관리자 검토 (최신 검토 정보 - 빠른 조회용) */
+  reviewedBy?: string
+  reviewedAt?: Date
+  reviewComment?: string
+  /** 검토 히스토리 (반려/수정요청/재제출 전체 이력 추적) */
+  reviewHistory?: ReviewHistory[]
+  /** 승인 시 생성된 스팟 ID */
+  approvedSpotId?: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface CreateSpotReportInput {
+  name: string
+  description: string
+  address: string
+  coordinates: {
+    lat: number
+    lng: number
+  }
+  category: SpotCategory
+  relatedContent: RelatedContent[]
+  evidencePairs: EvidencePair[]
+  episodeInfo: string
+  additionalPhotos?: string[]
+}
+
+// ============================================
+// 정보 보완 제보 (SpotSupplement)
+// ============================================
+
+export type SupplementType = 'scene_info' | 'description' | 'photo' | 'other'
+
+export interface SpotSupplement {
+  id: string
+  spotId: string
+  /** 기여자 정보 */
+  contributorId: string
+  contributorName: string
+  /** 보완 유형 */
+  type: SupplementType
+  /** 보완 내용 */
+  content: string
+  /** 추가 씬 정보 (scene_info 타입일 때) */
+  sceneInfo?: {
+    animeTitle: string
+    episodeInfo?: string
+    captureImageUrl?: string
+  }
+  /** 추가 사진 */
+  photos?: string[]
+  /** 승인 여부 */
+  approved: boolean
+  createdAt: Date
+}
+
+export interface CreateSupplementInput {
+  type: SupplementType
+  content: string
+  sceneInfo?: {
+    animeTitle: string
+    episodeInfo?: string
+    captureImageUrl?: string
+  }
+  photos?: string[]
+}
+
+// ============================================
+// 스팟 상태 신고 (SpotStatusReport)
+// ============================================
+
+export type SpotStatus = 'normal' | 'partially_changed' | 'under_construction' | 'demolished' | 'inaccessible'
+
+export interface SpotStatusReport {
+  id: string
+  spotId: string
+  /** 신고자 정보 */
+  reporterId: string
+  reporterName: string
+  /** 신고 상태 */
+  status: SpotStatus
+  /** 설명 */
+  description: string
+  /** 증거 사진 (선택, 있으면 즉시 '검토 중' 전환 트리거) */
+  photoUrl?: string
+  createdAt: Date
+}
+
+export interface CreateStatusReportInput {
+  status: SpotStatus
+  description: string
+  photoUrl?: string
+}
+
+// ============================================
+// 스팟 확장 필드 (기존 Spot 인터페이스에 추가)
+// ============================================
+
+/** 기존 Spot 인터페이스에 추가할 필드 */
+export interface SpotReportExtension {
+  /** 최초 제보자 ID */
+  firstReporterId?: string
+  /** 최초 제보자 이름 */
+  firstReporterName?: string
+  /** 현재 스팟 상태 */
+  spotStatus?: SpotStatus
+  /** 상태 신고 누적 수 */
+  statusReportCount?: number
+}
+```
+
+### MongoDB 인덱스
+
+```javascript
+// spot_reports 컬렉션
+db.spot_reports.createIndex({ "coordinates.lat": 1, "coordinates.lng": 1 })
+db.spot_reports.createIndex({ reporterId: 1 })
+db.spot_reports.createIndex({ status: 1 })
+db.spot_reports.createIndex({ createdAt: -1 })
+db.spot_reports.createIndex({ status: 1, createdAt: -1 }) // 관리자 대기 목록 조회 최적화
+
+// spot_supplements 컬렉션
+db.spot_supplements.createIndex({ spotId: 1 })
+db.spot_supplements.createIndex({ contributorId: 1 })
+
+// spot_status_reports 컬렉션
+db.spot_status_reports.createIndex({ spotId: 1 })
+db.spot_status_reports.createIndex({ spotId: 1, createdAt: -1 })
+
+// spots 컬렉션 (기존에 추가)
+db.spots.createIndex({ "coordinates.lat": 1, "coordinates.lng": 1 })
+```
+
+### 지오펜싱 검사 로직
+
+반경 50m 이내 중복 검사를 위한 Haversine 거리 계산:
+
+```typescript
+// src/lib/geo-utils.ts
+
+/**
+ * Haversine 공식으로 두 좌표 간 거리 계산 (미터 단위)
+ */
+export function calculateDistance(
+  lat1: number, lng1: number,
+  lat2: number, lng2: number
+): number {
+  const R = 6371000 // 지구 반지름 (미터)
+  const dLat = toRad(lat2 - lat1)
+  const dLng = toRad(lng2 - lng1)
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLng / 2) * Math.sin(dLng / 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}
+
+function toRad(deg: number): number {
+  return deg * (Math.PI / 180)
+}
+
+/**
+ * 반경 내 근처 스팟/제보 검색을 위한 바운딩 박스 계산
+ * MongoDB 쿼리 최적화용 (정확한 거리는 Haversine으로 후처리)
+ */
+export function getBoundingBox(lat: number, lng: number, radiusMeters: number) {
+  const latDelta = radiusMeters / 111320
+  const lngDelta = radiusMeters / (111320 * Math.cos(toRad(lat)))
+  return {
+    minLat: lat - latDelta,
+    maxLat: lat + latDelta,
+    minLng: lng - lngDelta,
+    maxLng: lng + lngDelta,
+  }
+}
+```
+
+### 상태 신고 자동 전환 로직
+
+```typescript
+// 상태 신고 처리 시 자동 전환 조건:
+// 1. 사진 증거가 첨부된 경우 → 즉시 '검토 중(경고)' 전환
+// 2. 동일 스팟에 대한 신고가 3회 이상 누적 → '검토 중(경고)' 전환
+
+async function processStatusReport(spotId: string, report: CreateStatusReportInput) {
+  const shouldAutoFlag =
+    report.photoUrl != null ||  // 사진 증거 있음
+    (await getStatusReportCount(spotId)) + 1 >= 3  // 3회 이상 누적
+
+  if (shouldAutoFlag) {
+    await updateSpotStatus(spotId, report.status) // 스팟 상태 업데이트
+  }
+}
+```
+
+### 관리자 검토 히스토리 기록 로직
+
+```typescript
+// 관리자 검토 시 reviewHistory 배열에 이력 추가
+// 최신 검토 정보는 reviewedBy/reviewedAt/reviewComment에도 동시 업데이트 (빠른 조회용)
+
+async function processAdminReview(
+  reportId: string,
+  action: 'approve' | 'reject' | 'request_revision',
+  comment: string,
+  adminId: string
+) {
+  const statusMap = {
+    approve: 'approved',
+    reject: 'rejected',
+    request_revision: 'revision_requested',
+  } as const
+
+  const newStatus = statusMap[action]
+  const now = new Date()
+
+  const historyEntry: ReviewHistory = {
+    status: newStatus,
+    comment,
+    reviewedAt: now,
+    reviewedBy: adminId,
+  }
+
+  await db.collection(COLLECTIONS.SPOT_REPORTS).updateOne(
+    { _id: new ObjectId(reportId) },
+    {
+      $set: {
+        status: newStatus,
+        reviewedBy: adminId,
+        reviewedAt: now,
+        reviewComment: comment,
+        updatedAt: now,
+      },
+      $push: { reviewHistory: historyEntry },
+    }
+  )
+}
+```
+
+
+## Correctness Properties
+
+*속성(Property)은 시스템의 모든 유효한 실행에서 참이어야 하는 특성 또는 동작입니다. 속성은 사람이 읽을 수 있는 명세와 기계가 검증할 수 있는 정확성 보장 사이의 다리 역할을 합니다.*
+
+### Property 1: 제보 필수 필드 유효성 검사
+
+*For any* 제보 입력에서, 장소명, 설명, 주소, 좌표, 카테고리, 작품 정보, 에피소드 정보 중 하나라도 누락되거나, evidencePairs가 비어있거나, evidencePairs 내 captureImageUrl 또는 realPhotoUrl이 누락된 경우, 제보 생성은 거부되어야 하고 에러를 반환해야 한다.
+
+**Validates: Requirements 1.2**
+
+### Property 2: 지오펜싱 거리 계산 정확성
+
+*For any* 두 좌표 쌍 (lat1, lng1)과 (lat2, lng2)에 대해, calculateDistance 함수가 반환하는 거리가 50m 이하이면 nearby 검색 결과에 포함되어야 하고, 50m 초과이면 포함되지 않아야 한다.
+
+**Validates: Requirements 1.3**
+
+### Property 3: 제보 초기 상태 불변성
+
+*For any* 유효한 제보 입력에 대해, 새로 생성된 제보의 status는 항상 'pending'이어야 한다.
+
+**Validates: Requirements 1.4**
+
+### Property 4: 승인 시 스팟 생성 및 제보자 귀속
+
+*For any* 'pending' 상태의 제보에 대해, 관리자가 승인하면 새 스팟이 생성되고, 해당 스팟의 firstReporterId는 원래 제보자의 ID와 일치하며, firstReporterName은 제보자의 이름과 일치해야 한다.
+
+**Validates: Requirements 1.5, 2.1**
+
+### Property 5: 유저별 제보 목록 필터링
+
+*For any* 유저 ID에 대해, 해당 유저의 제보 목록 API가 반환하는 모든 제보의 reporterId는 요청한 유저 ID와 일치해야 한다.
+
+**Validates: Requirements 2.2**
+
+### Property 6: 보완 제보 기여자 추적
+
+*For any* 스팟과 보완 제보에 대해, 보완 제보가 성공적으로 추가되면 해당 스팟의 기여자 목록에 보완 제보자가 포함되어야 한다.
+
+**Validates: Requirements 3.2, 3.3**
+
+### Property 7: 상태 값 유효성
+
+*For any* 상태 신고 입력에서, status 값이 'normal', 'partially_changed', 'under_construction', 'demolished', 'inaccessible' 중 하나가 아니면 신고가 거부되어야 한다.
+
+**Validates: Requirements 4.2**
+
+### Property 8: 상태 신고 자동 전환 조건
+
+*For any* 스팟에 대해, (1) 사진 증거가 첨부된 상태 신고가 제출되면 즉시 스팟 상태가 업데이트되어야 하고, (2) 사진 없는 신고가 3회 이상 누적되면 스팟 상태가 업데이트되어야 한다. 사진 없는 신고가 3회 미만이면 스팟 상태는 변경되지 않아야 한다.
+
+**Validates: Requirements 4.3**
+
+### Property 9: 관리자 제보 목록 필터링
+
+*For any* 관리자 제보 목록 API 응답에서, 기본 필터 적용 시 반환되는 모든 제보의 status는 'pending'이어야 한다.
+
+**Validates: Requirements 5.1**
+
+### Property 10: 관리자 검토 상태 전이
+
+*For any* 'pending' 상태의 제보에 대해, 관리자가 'approve' 액션을 수행하면 status는 'approved'로, 'reject' 액션을 수행하면 status는 'rejected'로, 'request_revision' 액션을 수행하면 status는 'revision_requested'로 변경되어야 한다.
+
+**Validates: Requirements 5.2**
+
+### Property 11: 반려 시 사유 필수
+
+*For any* 제보 반려 요청에서, reviewComment가 비어있거나 누락된 경우 반려가 거부되어야 한다.
+
+**Validates: Requirements 5.3**
+
+## Error Handling
+
+### API 에러 처리
+
+| 상황 | HTTP 상태 | 에러 메시지 |
+|------|-----------|-------------|
+| 미인증 유저의 제보 시도 | 401 | "로그인이 필요합니다" |
+| 필수 필드 누락 | 400 | "유효성 검사 실패" + 상세 에러 목록 |
+| 증거 사진 쌍 누락 | 400 | "애니메이션 캡처와 현장 사진을 쌍으로 등록해주세요" |
+| 존재하지 않는 제보 ID | 404 | "제보를 찾을 수 없습니다" |
+| 권한 없는 제보 수정 | 403 | "수정 권한이 없습니다" |
+| 관리자가 아닌 유저의 검토 시도 | 403 | "관리자 권한이 필요합니다" |
+| 이미 검토된 제보 재검토 | 400 | "이미 처리된 제보입니다" |
+| 반려 시 사유 미입력 | 400 | "반려 사유를 입력해주세요" |
+| 유효하지 않은 상태 값 | 400 | "유효하지 않은 상태입니다" |
+| 이미지 업로드 실패 | 500 | "이미지 업로드에 실패했습니다" |
+| DB 연결 실패 | 500 | "서버 오류가 발생했습니다" |
+
+### 클라이언트 에러 처리
+
+- 네트워크 오류 시 재시도 안내 토스트 표시
+- 제보 폼 작성 중 페이지 이탈 시 확인 다이얼로그 표시
+- 이미지 업로드 실패 시 개별 재시도 가능
+- 지오펜싱 검사 실패 시 (위치 서비스 비활성화) 수동 주소 입력 안내
+
+## Testing Strategy
+
+### 속성 기반 테스트 (Property-Based Testing)
+
+- **라이브러리**: `fast-check` (TypeScript/JavaScript용 PBT 라이브러리)
+- **최소 반복 횟수**: 각 속성 테스트당 100회 이상
+- **태그 형식**: `Feature: 09-spot-report-wiki, Property {번호}: {속성 설명}`
+
+각 Correctness Property는 하나의 속성 기반 테스트로 구현합니다:
+
+| 속성 | 테스트 대상 | 생성기 |
+|------|-------------|--------|
+| Property 1 | 제보 유효성 검사 함수 | 임의의 제보 입력 (일부 필드 누락) |
+| Property 2 | calculateDistance + nearby 검색 | 임의의 좌표 쌍 |
+| Property 3 | 제보 생성 함수 | 임의의 유효한 제보 입력 |
+| Property 4 | 승인 처리 함수 | 임의의 pending 제보 |
+| Property 5 | 유저별 제보 목록 API | 임의의 유저 ID + 여러 유저의 제보 |
+| Property 6 | 보완 제보 + 기여자 목록 | 임의의 스팟 + 보완 입력 |
+| Property 7 | 상태 신고 유효성 검사 | 임의의 문자열 상태 값 |
+| Property 8 | 상태 신고 자동 전환 로직 | 임의의 스팟 + 신고 시퀀스 |
+| Property 9 | 관리자 제보 목록 API | 다양한 상태의 제보 혼합 |
+| Property 10 | 관리자 검토 상태 전이 | 임의의 pending 제보 + 액션 |
+| Property 11 | 반려 유효성 검사 | 임의의 반려 요청 (사유 유무) |
+
+### 단위 테스트
+
+단위 테스트는 속성 테스트를 보완하여 구체적인 예제와 엣지 케이스를 검증합니다:
+
+- **지오펜싱**: 정확히 50m 경계값, 적도/극지방 좌표, 동일 좌표
+- **상태 전환**: 정확히 3회째 신고, 사진 있는 첫 번째 신고
+- **승인 워크플로우**: 승인 후 스팟 데이터 정합성
+- **뱃지 부여**: 제보 수 경계값 (1개, 5개, 10개 등)
+- **증거 사진 쌍**: 캡처만 있고 현장 사진 없는 경우, 빈 URL 문자열
+
+### 테스트 파일 구조
+
+```
+src/lib/__tests__/
+├── geo-utils.test.ts              # 거리 계산 단위 테스트
+├── geo-utils.property.test.ts     # Property 2
+├── report-validation.test.ts      # 유효성 검사 단위 테스트
+├── report-validation.property.test.ts  # Property 1, 3, 7, 11
+├── report-review.property.test.ts # Property 4, 9, 10
+├── report-query.property.test.ts  # Property 5
+├── supplement.property.test.ts    # Property 6
+└── status-report.property.test.ts # Property 8
+```

--- a/.kiro/specs/09-spot-report-wiki/requirements.md
+++ b/.kiro/specs/09-spot-report-wiki/requirements.md
@@ -20,10 +20,11 @@
 #### Acceptance Criteria
 
 1. WHEN 유저가 지도에서 특정 위치를 길게 누르거나 "성지 제보" 버튼을 클릭할 때 THEN THE System SHALL 제보 폼을 표시한다
-2. WHEN 유저가 제보 폼을 작성할 때 THEN THE System SHALL 다음 정보를 입력받는다: 위치(핀), 장소명, 작품명, 에피소드/타임스탬프, 설명, 참고 이미지
-3. WHEN 제보가 제출되면 THEN THE System SHALL 관리자 검토 대기 상태로 저장한다
-4. WHEN 관리자가 제보를 승인하면 THEN THE System SHALL 해당 스팟을 지도에 추가하고 최초 제보자 정보를 표시한다
-5. THE System SHALL 제보 상태(대기중/승인/반려)를 유저에게 알린다
+2. WHEN 유저가 제보 폼을 작성할 때 THEN THE System SHALL 다음 정보를 필수로 입력받는다: 정확한 위치(핀), 장소명, 작품명, 에피소드/타임스탬프, 설명, **애니메이션 원본 캡처 이미지와 현장 사진(또는 로드뷰 캡처)을 반드시 쌍으로 등록**하도록 강제한다
+3. WHEN 유저가 지도에 제보 핀을 등록할 때 THEN THE System SHALL 반경 50m 이내에 이미 등록된 스팟이나 대기 중인 제보가 있는지 검사하여, 있을 경우 "근처에 이미 등록된 스팟이 있습니다"라는 경고와 함께 기존 스팟 목록을 보여준다
+4. WHEN 제보가 제출되면 THEN THE System SHALL 관리자 검토 대기 상태로 저장한다
+5. WHEN 관리자가 제보를 승인하면 THEN THE System SHALL 해당 스팟을 지도에 추가하고 최초 제보자 정보를 표시한다
+6. THE System SHALL 제보 상태(대기중/승인/반려)를 유저에게 알린다
 
 ### Requirement 2: 최초 제보자 명예 시스템
 
@@ -53,7 +54,7 @@
 
 1. WHEN 유저가 "현재 상태 신고" 버튼을 클릭할 때 THEN THE System SHALL 상태 신고 폼을 표시한다
 2. THE System SHALL 다음 상태를 선택할 수 있도록 한다: 정상, 일부 변경, 공사중, 소실됨, 접근 불가
-3. WHEN 상태 신고가 일정 수 이상 누적되면 THEN THE System SHALL 해당 스팟에 경고 표시를 추가한다
+3. WHEN 상태 신고가 일정 수(예: 3회) 이상 누적되거나, **신고 시 현장 사진(소실/공사중임을 증명하는 사진)을 첨부한 경우** THEN THE System SHALL 해당 스팟을 자동으로 '검토 중(경고)' 상태로 전환하여 지도에 시각적으로 표시한다
 4. THE System SHALL 지도에서 소실/변경된 스팟을 시각적으로 구분하여 표시한다
 
 ### Requirement 5: 제보 검토 시스템 (관리자)

--- a/.kiro/specs/09-spot-report-wiki/tasks.md
+++ b/.kiro/specs/09-spot-report-wiki/tasks.md
@@ -1,0 +1,281 @@
+# Implementation Plan: 성지 제보 시스템 (Spot Report Wiki)
+
+## Overview
+
+유저들이 새로운 성지를 제보하고, 기존 스팟 정보를 보완하며, 스팟 상태 변경을 신고할 수 있는 집단지성 위키 시스템을 구현합니다. 증거 사진 쌍 업로드, 지오펜싱 중복 검사, 관리자 검토 워크플로우, 상태 신고 자동 전환 로직을 포함합니다.
+
+## Tasks
+
+- [x] 1. 타입 정의 및 데이터 모델 설정
+  - [x] 1.1 제보 관련 타입 정의
+    - `src/types/report.ts` 생성
+    - ReportStatus, ReviewHistory, EvidencePair, SpotReport, CreateSpotReportInput 타입 정의
+    - SupplementType, SpotSupplement, CreateSupplementInput 타입 정의
+    - SpotStatus, SpotStatusReport, CreateStatusReportInput 타입 정의
+    - SpotReportExtension 타입 정의 (기존 Spot 인터페이스 확장용)
+    - _Requirements: 1.2, 4.2_
+  - [x] 1.2 MongoDB 컬렉션 상수 추가
+    - `src/lib/db.ts`의 COLLECTIONS에 SPOT_REPORTS, SPOT_SUPPLEMENTS, SPOT_STATUS_REPORTS 추가
+    - _Requirements: 1.4_
+  - [x] 1.3 기존 Spot 타입에 SpotReportExtension 필드 추가
+    - `src/types/spot.ts`에 firstReporterId, firstReporterName, spotStatus, statusReportCount 필드 추가
+    - _Requirements: 2.1, 4.4_
+
+- [x] 2. 지오펜싱 유틸리티 및 유효성 검사 구현
+  - [x] 2.1 Haversine 거리 계산 유틸리티 구현
+    - `src/lib/geo-utils.ts` 생성
+    - calculateDistance 함수 구현 (두 좌표 간 미터 단위 거리 계산)
+    - getBoundingBox 함수 구현 (MongoDB 쿼리 최적화용 바운딩 박스)
+    - _Requirements: 1.3_
+  - [ ]* 2.2 Property 2 테스트: 지오펜싱 거리 계산 정확성
+    - **Property 2: 지오펜싱 거리 계산 정확성**
+    - calculateDistance 반환값이 50m 이하이면 nearby 결과에 포함, 초과이면 미포함 검증
+    - **Validates: Requirements 1.3**
+  - [x] 2.3 제보 입력 유효성 검사 함수 구현
+    - `src/lib/report-validation.ts` 생성
+    - validateSpotReportInput: 필수 필드 검사, evidencePairs 쌍 검증
+    - validateStatusReportInput: 상태 값 유효성 검사
+    - validateReviewAction: 반려 시 사유 필수 검사
+    - _Requirements: 1.2, 4.2, 5.3_
+  - [ ]* 2.4 Property 1 테스트: 제보 필수 필드 유효성 검사
+    - **Property 1: 제보 필수 필드 유효성 검사**
+    - 필수 필드 누락 또는 evidencePairs 비어있으면 거부 검증
+    - **Validates: Requirements 1.2**
+  - [ ]* 2.5 Property 7 테스트: 상태 값 유효성
+    - **Property 7: 상태 값 유효성**
+    - 유효하지 않은 status 값이면 신고 거부 검증
+    - **Validates: Requirements 4.2**
+  - [ ]* 2.6 Property 11 테스트: 반려 시 사유 필수
+    - **Property 11: 반려 시 사유 필수**
+    - reviewComment 비어있거나 누락 시 반려 거부 검증
+    - **Validates: Requirements 5.3**
+
+- [x] 3. Checkpoint - 기본 유틸리티 검증
+  - 타입 정의, 거리 계산, 유효성 검사 함수가 올바르게 동작하는지 확인
+  - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
+
+- [x] 4. 신규 성지 제보 API 구현
+  - [x] 4.1 제보 생성 API 구현
+    - `src/app/api/reports/route.ts` 생성 (POST: 제보 생성, GET: 내 제보 목록)
+    - POST: 유효성 검사 → 인증 확인 → status 'pending'으로 저장
+    - GET: 세션 유저의 reporterId로 필터링하여 목록 반환
+    - _Requirements: 1.2, 1.4, 1.6_
+  - [ ]* 4.2 Property 3 테스트: 제보 초기 상태 불변성
+    - **Property 3: 제보 초기 상태 불변성**
+    - 새로 생성된 제보의 status는 항상 'pending' 검증
+    - **Validates: Requirements 1.4**
+  - [ ]* 4.3 Property 5 테스트: 유저별 제보 목록 필터링
+    - **Property 5: 유저별 제보 목록 필터링**
+    - 반환되는 모든 제보의 reporterId가 요청 유저 ID와 일치 검증
+    - **Validates: Requirements 2.2**
+  - [x] 4.4 제보 상세/수정 API 구현
+    - `src/app/api/reports/[id]/route.ts` 생성 (GET: 상세 조회, PUT: 수정)
+    - PUT: 수정요청 상태의 제보만 수정 가능, 수정 후 status를 'pending'으로 재설정
+    - _Requirements: 1.6_
+  - [x] 4.5 근처 스팟/제보 검색 API 구현
+    - `src/app/api/reports/nearby/route.ts` 생성 (GET)
+    - 바운딩 박스로 1차 필터 → Haversine으로 50m 이내 정밀 필터
+    - spots 컬렉션과 spot_reports(pending) 컬렉션 모두 검색
+    - _Requirements: 1.3_
+
+- [x] 5. 기존 스팟 정보 보완 API 구현
+  - [x] 5.1 보완 제보 API 구현
+    - `src/app/api/spots/[id]/supplements/route.ts` 생성 (POST: 보완 제보, GET: 기여자 목록)
+    - POST: 보완 유형별 데이터 저장 (scene_info, description, photo, other)
+    - GET: 해당 스팟의 보완 기여자 목록 반환
+    - _Requirements: 3.1, 3.2, 3.3_
+  - [ ]* 5.2 Property 6 테스트: 보완 제보 기여자 추적
+    - **Property 6: 보완 제보 기여자 추적**
+    - 보완 제보 추가 후 기여자 목록에 해당 기여자 포함 검증
+    - **Validates: Requirements 3.2, 3.3**
+
+- [x] 6. 스팟 상태 신고 API 구현
+  - [x] 6.1 상태 신고 API 구현
+    - `src/app/api/spots/[id]/status-reports/route.ts` 생성 (POST: 상태 신고, GET: 신고 이력)
+    - POST: 상태 유효성 검사 → 저장 → 자동 전환 조건 평가
+    - 자동 전환 로직: 사진 증거 첨부 시 즉시 전환, 3회 이상 누적 시 전환
+    - _Requirements: 4.1, 4.2, 4.3_
+  - [ ]* 6.2 Property 8 테스트: 상태 신고 자동 전환 조건
+    - **Property 8: 상태 신고 자동 전환 조건**
+    - 사진 첨부 시 즉시 전환, 사진 없이 3회 이상 누적 시 전환, 3회 미만이면 미변경 검증
+    - **Validates: Requirements 4.3**
+
+- [x] 7. 관리자 제보 검토 API 구현
+  - [x] 7.1 관리자 제보 목록 API 구현
+    - `src/app/api/admin/reports/route.ts` 생성 (GET)
+    - 기본 필터: status 'pending', 최신순 정렬
+    - 관리자 권한 검사
+    - _Requirements: 5.1_
+  - [ ]* 7.2 Property 9 테스트: 관리자 제보 목록 필터링
+    - **Property 9: 관리자 제보 목록 필터링**
+    - 기본 필터 적용 시 반환되는 모든 제보의 status가 'pending' 검증
+    - **Validates: Requirements 5.1**
+  - [x] 7.3 관리자 제보 검토 API 구현
+    - `src/app/api/admin/reports/[id]/review/route.ts` 생성 (PUT)
+    - approve: 스팟 생성 + firstReporterId/Name 기록 + approvedSpotId 설정
+    - reject: 사유 필수 검사 + 상태 변경
+    - request_revision: 수정 요청 사유 기록 + 상태 변경
+    - reviewHistory 배열에 이력 추가 + 최신 검토 정보 동시 업데이트
+    - _Requirements: 5.2, 5.3, 1.5, 2.1_
+  - [ ]* 7.4 Property 4 테스트: 승인 시 스팟 생성 및 제보자 귀속
+    - **Property 4: 승인 시 스팟 생성 및 제보자 귀속**
+    - 승인 시 생성된 스팟의 firstReporterId/Name이 원래 제보자와 일치 검증
+    - **Validates: Requirements 1.5, 2.1**
+  - [ ]* 7.5 Property 10 테스트: 관리자 검토 상태 전이
+    - **Property 10: 관리자 검토 상태 전이**
+    - approve → 'approved', reject → 'rejected', request_revision → 'revision_requested' 검증
+    - **Validates: Requirements 5.2**
+
+- [x] 8. Checkpoint - API 전체 검증
+  - 모든 API 엔드포인트가 올바르게 동작하는지 확인
+  - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
+
+- [x] 9. Zustand 스토어 및 커스텀 훅 구현
+  - [x] 9.1 reportStore 구현
+    - `src/stores/reportStore.ts` 생성
+    - 멀티스텝 폼 진행 상태 관리 (현재 단계, 임시 저장 데이터)
+    - 폼 초기화, 단계 이동, 임시 저장 액션
+    - _Requirements: 1.1, 1.2_
+  - [x] 9.2 useSpotReport 훅 구현
+    - `src/hooks/useSpotReport.ts` 생성
+    - 제보 제출 (POST /api/reports), 제보 수정 (PUT /api/reports/:id) 로직
+    - 로딩/에러 상태 관리
+    - _Requirements: 1.2, 1.4_
+  - [x] 9.3 useNearbyCheck 훅 구현
+    - `src/hooks/useNearbyCheck.ts` 생성
+    - 좌표 변경 시 GET /api/reports/nearby 호출
+    - 디바운스 처리로 과도한 API 호출 방지
+    - _Requirements: 1.3_
+  - [x] 9.4 useMyReports 훅 구현
+    - `src/hooks/useMyReports.ts` 생성
+    - GET /api/reports로 내 제보 목록 조회
+    - _Requirements: 1.6, 2.2_
+  - [x] 9.5 useStatusReport 훅 구현
+    - `src/hooks/useStatusReport.ts` 생성
+    - POST /api/spots/:id/status-reports 호출 로직
+    - _Requirements: 4.1_
+
+- [x] 10. 신규 성지 제보 UI 컴포넌트 구현
+  - [x] 10.1 EvidencePairUpload 컴포넌트 구현
+    - `src/components/report/EvidencePairUpload.tsx` 생성
+    - 애니메이션 캡처 + 현장 사진 쌍 업로드 UI
+    - 쌍이 완성되지 않으면 제출 불가 처리
+    - 08-mobile-first-ux의 이미지 압축 파이프라인 활용: `useImageCompression` 훅 + `browser-image-compression`으로 업로드 전 클라이언트 단 리사이징 및 WebP 압축 필수 적용
+    - _Requirements: 1.2_
+  - [x] 10.2 NearbySpotWarning 컴포넌트 구현
+    - `src/components/report/NearbySpotWarning.tsx` 생성
+    - 50m 이내 기존 스팟 경고 메시지 및 기존 스팟 목록 표시
+    - "계속 진행" / "기존 스팟 보완" 선택 옵션
+    - _Requirements: 1.3_
+  - [x] 10.3 SpotReportForm 컴포넌트 구현
+    - `src/components/report/SpotReportForm.tsx` 생성
+    - 멀티스텝 폼: 위치 선택 → 지오펜싱 검사 → 장소 정보 입력 → 증거 업로드 → 확인/제출
+    - reportStore와 연동하여 폼 상태 관리
+    - _Requirements: 1.1, 1.2, 1.3_
+  - [x] 10.4 ReportStatusBadge 컴포넌트 구현
+    - `src/components/report/ReportStatusBadge.tsx` 생성
+    - 대기중/승인/반려/수정요청 상태별 색상 및 텍스트 표시
+    - _Requirements: 1.6_
+  - [x] 10.5 MyReportList 컴포넌트 구현
+    - `src/components/report/MyReportList.tsx` 생성
+    - 내 제보 목록 카드 형태 표시 (상태 뱃지 포함)
+    - _Requirements: 1.6, 2.2_
+
+- [x] 11. 제보 관련 페이지 구현
+  - [x] 11.1 신규 제보 페이지 구현
+    - `src/app/reports/new/page.tsx` 생성
+    - SpotReportForm 컴포넌트 렌더링
+    - 인증 확인 (미인증 시 로그인 리다이렉트)
+    - _Requirements: 1.1_
+  - [x] 11.2 내 제보 목록 페이지 구현
+    - `src/app/reports/page.tsx` 생성
+    - MyReportList 컴포넌트 렌더링
+    - _Requirements: 1.6, 2.2_
+  - [x] 11.3 제보 상세/수정 페이지 구현
+    - `src/app/reports/[id]/page.tsx` 생성
+    - 제보 상세 정보 표시 + 수정요청 상태일 때 수정 폼 표시
+    - 관리자 코멘트(reviewComment) 표시
+    - _Requirements: 1.6_
+
+- [x] 12. Checkpoint - 제보 플로우 검증
+  - 신규 제보 폼 → 지오펜싱 검사 → 제출 → 내 제보 목록 확인 플로우 검증
+  - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
+
+- [x] 13. 기존 스팟 정보 보완 UI 구현
+  - [x] 13.1 SupplementForm 컴포넌트 구현
+    - `src/components/report/SupplementForm.tsx` 생성
+    - 보완 유형 선택 (scene_info, description, photo, other)
+    - scene_info 선택 시 작품명/에피소드/캡처 이미지 입력 필드 표시
+    - _Requirements: 3.1, 3.2_
+  - [x] 13.2 ContributorList 컴포넌트 구현
+    - `src/components/report/ContributorList.tsx` 생성
+    - 스팟 상세 페이지에 보완 기여자 목록 표시
+    - _Requirements: 3.3_
+  - [x] 13.3 스팟 상세 페이지에 보완 제보 UI 통합
+    - 기존 `src/app/spots/[id]/page.tsx`에 "정보 수정 제안" 버튼 추가
+    - SupplementForm 모달/섹션 연결
+    - ContributorList 섹션 추가
+    - _Requirements: 3.1, 3.3_
+
+- [x] 14. 스팟 상태 신고 UI 구현
+  - [x] 14.1 StatusReportForm 컴포넌트 구현
+    - `src/components/report/StatusReportForm.tsx` 생성
+    - 상태 선택 (정상/일부 변경/공사중/소실됨/접근 불가) + 설명 + 사진 첨부
+    - "허위 신고 시 서비스 이용이 제한될 수 있습니다" 경고 문구 표시 (심리적 허들)
+    - "사진 증거를 첨부하면 더 빠르게 처리됩니다" 안내 넛지 UI 추가
+    - _Requirements: 4.1, 4.2_
+  - [x] 14.2 SpotStatusIndicator 컴포넌트 구현
+    - `src/components/report/SpotStatusIndicator.tsx` 생성
+    - 지도 및 스팟 상세에서 상태별 시각적 표시 (아이콘/색상 구분)
+    - _Requirements: 4.4_
+  - [x] 14.3 스팟 상세 페이지에 상태 신고 UI 통합
+    - 기존 `src/app/spots/[id]/page.tsx`에 "현재 상태 신고" 버튼 추가
+    - StatusReportForm 모달/섹션 연결
+    - SpotStatusIndicator 표시
+    - _Requirements: 4.1, 4.4_
+
+- [x] 15. 최초 제보자 표시 및 프로필 연동
+  - [x] 15.1 스팟 상세 페이지에 최초 제보자 표시
+    - 기존 `src/app/spots/[id]/page.tsx`에 "최초 제보: @username" 표시 추가
+    - firstReporterId가 있는 경우에만 표시
+    - _Requirements: 2.1_
+  - [x] 15.2 유저 프로필에 제보 스팟 목록 표시
+    - 기존 프로필 페이지에 "제보한 스팟" 섹션 추가
+    - 승인된 제보 목록 표시
+    - _Requirements: 2.2_
+
+- [x] 16. Checkpoint - 유저 기능 전체 검증
+  - 정보 보완, 상태 신고, 최초 제보자 표시, 프로필 연동 검증
+  - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
+
+- [x] 17. 관리자 제보 검토 UI 구현
+  - [x] 17.1 AdminReportList 컴포넌트 구현
+    - `src/components/admin/AdminReportList.tsx` 생성
+    - 대기중 제보 목록 (상태 필터, 최신순 정렬)
+    - 제보 요약 카드 (장소명, 카테고리, 제보자, 제출일)
+    - _Requirements: 5.1_
+  - [x] 17.2 AdminReportReview 컴포넌트 구현
+    - `src/components/admin/AdminReportReview.tsx` 생성
+    - 제보 상세 정보 표시 (증거 사진 쌍, 지도 위치, 작품 정보)
+    - 승인/반려/수정요청 버튼 + 코멘트 입력
+    - 검토 히스토리(reviewHistory) 타임라인 표시
+    - _Requirements: 5.2, 5.3_
+  - [x] 17.3 관리자 제보 관리 페이지 구현
+    - `src/app/admin/reports/page.tsx` 생성
+    - AdminReportList + AdminReportReview 통합
+    - 관리자 권한 검사 (미인증/비관리자 접근 차단)
+    - _Requirements: 5.1, 5.2_
+
+- [x] 18. Final Checkpoint - 전체 기능 검증
+  - 전체 제보 워크플로우 (제보 → 검토 → 승인 → 지도 표시) 검증
+  - 관리자 검토 플로우 (승인/반려/수정요청) 검증
+  - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
+
+## Notes
+
+- `*` 표시된 태스크는 선택사항이며 빠른 MVP를 위해 건너뛸 수 있습니다
+- 각 태스크는 특정 요구사항을 참조하여 추적 가능합니다
+- 체크포인트에서 점진적 검증을 수행합니다
+- 속성 테스트는 `fast-check` 라이브러리를 사용하여 보편적 정확성 속성을 검증합니다
+- 단위 테스트는 특정 예제와 엣지 케이스를 검증합니다
+- SupplementType `photo`는 스팟 위키 대표 사진/씬 비교 사진용이며, CheckIn 사진(07 스펙)과 구분됩니다

--- a/.kiro/specs/10-pilgrimage-route/.config.kiro
+++ b/.kiro/specs/10-pilgrimage-route/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "ca5157d5-e1f7-43b2-bd53-71f0ac18c112", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/10-pilgrimage-route/design.md
+++ b/.kiro/specs/10-pilgrimage-route/design.md
@@ -1,0 +1,594 @@
+# Design Document: 성지순례 코스/루트 시스템 (Pilgrimage Route)
+
+## Overview
+
+성지순례 코스 시스템은 유저가 여러 스팟을 순서대로 묶어 코스를 생성하고, 다른 유저들이 이를 탐색·따라가기할 수 있는 기능이다. 핵심은 스팟의 **순서 보장**, 현장에서의 **따라가기 모드(네비게이션)**, 그리고 **오프라인 캐싱**을 통한 네트워크 없는 환경에서의 사용성 확보이다.
+
+### 주요 설계 결정
+
+1. **순서 보장 배열(Ordered Array)**: MongoDB 문서 내 `spots` 배열의 인덱스 순서를 코스 순서로 사용한다. 별도 `order` 필드 없이 배열 인덱스 자체가 순서를 의미하며, 순서 변경 시 배열을 재배치한다.
+2. **Haversine 기반 거리 계산**: 기존 `geo-utils.ts`의 `calculateDistance`를 재활용하여 스팟 간 직선거리를 계산하고, 도보 시간은 `직선거리 × 1.3 / 평균보행속도(4km/h)`로 추정한다. 정확한 경로는 외부 지도 앱(구글맵/야후재팬맵)으로 연결한다.
+3. **Service Worker 프리패치**: 08번 스펙의 PWA 인프라(`public/sw.js`)를 확장하여, 코스 시작/저장 시 해당 코스 내 스팟 데이터와 썸네일을 `CacheStorage`에 프리패치한다.
+4. **Zustand 진행 상태 관리**: `courseProgressStore`로 현재 진행 중인 코스, 현재 목표 스팟 인덱스, 인증 완료 스팟 목록을 관리한다.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Client ["클라이언트 (Next.js App Router)"]
+        RP[코스 목록 페이지<br/>/routes]
+        RD[코스 상세 페이지<br/>/routes/[id]]
+        RC[코스 생성 페이지<br/>/routes/create]
+        NM[따라가기 모드<br/>NavigationMode]
+        
+        subgraph Stores ["Zustand Stores"]
+            CPS[courseProgressStore]
+            MS[mapStore]
+        end
+        
+        subgraph Hooks ["Custom Hooks"]
+            UG[useGeolocation]
+            UCR[useRouteNavigation]
+            URC[useRouteCache]
+        end
+        
+        subgraph SW ["Service Worker"]
+            SWC[Route Cache<br/>ROUTE_CACHE]
+        end
+    end
+    
+    subgraph Server ["서버 (API Routes)"]
+        AR[/api/routes]
+        ARD[/api/routes/[id]]
+        ARB[/api/routes/[id]/bookmark]
+        ARC[/api/routes/[id]/complete]
+    end
+    
+    subgraph DB ["MongoDB"]
+        RC_DB[(routes)]
+        RB_DB[(route_bookmarks)]
+        RCO_DB[(route_completions)]
+    end
+    
+    RP --> AR
+    RD --> ARD
+    RC --> AR
+    NM --> CPS
+    NM --> UG
+    NM --> UCR
+    UCR --> CPS
+    URC --> SWC
+    
+    AR --> RC_DB
+    ARD --> RC_DB
+    ARB --> RB_DB
+    ARC --> RCO_DB
+```
+
+### 페이지 구조
+
+| 경로 | 설명 |
+|------|------|
+| `/routes` | 코스 목록 (탐색, 필터, 정렬) |
+| `/routes/create` | 코스 생성 |
+| `/routes/[id]` | 코스 상세 (지도 + 스팟 목록) |
+| `/routes/[id]/edit` | 코스 수정 (작성자만) |
+
+### API 엔드포인트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| `GET` | `/api/routes` | 코스 목록 조회 (필터, 정렬, 페이지네이션) |
+| `POST` | `/api/routes` | 코스 생성 |
+| `GET` | `/api/routes/[id]` | 코스 상세 조회 |
+| `PUT` | `/api/routes/[id]` | 코스 수정 |
+| `DELETE` | `/api/routes/[id]` | 코스 삭제 |
+| `POST` | `/api/routes/[id]/bookmark` | 코스 저장/해제 |
+| `POST` | `/api/routes/[id]/complete` | 코스 완주 기록 |
+| `GET` | `/api/routes/recommended` | 추천 코스 조회 |
+
+
+## Components and Interfaces
+
+### 1. 페이지 컴포넌트
+
+#### `RouteListPage` (`src/app/routes/page.tsx`)
+- 코스 목록 표시 (카드 형태)
+- 정렬: 인기순(북마크+완주), 최신순, 소요시간순
+- 필터: 작품별, 지역별, 소요시간별
+- 무한 스크롤 페이지네이션
+
+#### `RouteDetailPage` (`src/app/routes/[id]/page.tsx`)
+- 지도에 전체 동선 표시 (Polyline)
+- 스팟 목록을 순서대로 표시
+- 스팟 간 이동 거리/시간 표시
+- "코스 시작" / "코스 저장" 버튼
+- 코스 제작자 정보
+
+#### `RouteCreatePage` (`src/app/routes/create/page.tsx`)
+- 코스 기본 정보 입력 (이름, 설명, 예상 소요시간, 난이도)
+- 스팟 검색/선택 UI
+- 드래그 앤 드롭으로 스팟 순서 변경
+- 지도에서 직접 스팟 선택
+- 공개/비공개 설정
+- 미리보기
+
+### 2. 핵심 컴포넌트
+
+#### `RouteCard` (`src/components/route/RouteCard.tsx`)
+- 코스 카드 (목록용)
+- 코스명, 스팟 수, 예상 시간, 난이도, 북마크 수 표시
+
+#### `RouteMap` (`src/components/route/RouteMap.tsx`)
+- Leaflet 기반 코스 지도
+- 스팟 마커 + 순서 번호 표시
+- 스팟 간 Polyline 연결
+- 현재 위치 표시 (따라가기 모드)
+
+#### `SpotOrderList` (`src/components/route/SpotOrderList.tsx`)
+- 스팟 순서 목록 (생성/수정 시 드래그 앤 드롭)
+- 스팟 간 거리/시간 표시
+- 외부 지도 앱 연결 버튼
+
+#### `NavigationPanel` (`src/components/route/NavigationPanel.tsx`)
+- 따라가기 모드 하단 패널
+- 현재 목표 스팟 정보
+- 다음 스팟까지 거리/시간
+- 진행률 바
+- 인증(Check-in) 버튼
+- 코스 종료 버튼
+
+#### `RouteFilterBar` (`src/components/route/RouteFilterBar.tsx`)
+- 작품별, 지역별, 소요시간별 필터 UI
+
+### 3. Custom Hooks
+
+#### `useRouteNavigation` (`src/hooks/useRouteNavigation.ts`)
+```typescript
+interface UseRouteNavigationReturn {
+  /** 현재 진행 중인 코스 */
+  activeRoute: Route | null
+  /** 현재 목표 스팟 인덱스 */
+  currentSpotIndex: number
+  /** 인증 완료한 스팟 ID 목록 */
+  checkedSpotIds: string[]
+  /** 진행률 (0-100) */
+  progress: number
+  /** 다음 스팟까지 거리 (m) */
+  distanceToNext: number | null
+  /** 다음 스팟까지 예상 시간 (분) */
+  estimatedTimeToNext: number | null
+  /** 코스 시작 */
+  startRoute: (route: Route) => void
+  /** 스팟 인증 완료 처리 */
+  checkInSpot: (spotId: string) => void
+  /** 다음 스팟으로 이동 */
+  moveToNextSpot: () => void
+  /** 코스 종료 */
+  endRoute: () => void
+  /** 코스 완주 여부 */
+  isCompleted: boolean
+}
+```
+
+#### `useRouteCache` (`src/hooks/useRouteCache.ts`)
+```typescript
+interface UseRouteCacheReturn {
+  /** 코스 데이터 프리패치 */
+  prefetchRoute: (route: Route) => Promise<void>
+  /** 캐시 상태 확인 */
+  isCached: boolean
+  /** 캐싱 진행률 */
+  cacheProgress: number
+}
+```
+
+### 4. Zustand Store
+
+#### `courseProgressStore` (`src/stores/courseProgressStore.ts`)
+```typescript
+interface CourseProgressState {
+  /** 현재 진행 중인 코스 ID */
+  activeRouteId: string | null
+  /** 현재 진행 중인 코스 데이터 */
+  activeRoute: Route | null
+  /** 현재 목표 스팟 인덱스 (0-based) */
+  currentSpotIndex: number
+  /** 인증 완료한 스팟 ID Set */
+  checkedSpotIds: Set<string>
+  /** 코스 시작 시간 */
+  startedAt: Date | null
+  /** 네비게이션 활성 여부 */
+  isNavigating: boolean
+}
+
+interface CourseProgressActions {
+  /**
+   * 코스 시작
+   * - 기존 Check-in 기록(GET /api/checkins?userId=...)을 조회하여
+   *   코스 내 이미 인증된 스팟을 checkedSpotIds에 자동 포함시킨다.
+   */
+  startRoute: (route: Route) => void
+  /**
+   * 스팟 인증 완료 처리
+   * ⚠️ 주의: 반드시 07번 스펙의 Check-in API(POST /api/checkins) 호출이
+   * 성공한 후에만 실행되어야 한다. 이 액션은 프론트엔드 상태만 업데이트하며,
+   * 실제 DB 기록은 Check-in API가 담당한다.
+   * 
+   * 호출 흐름:
+   * 1. POST /api/checkins → 성공 응답 수신
+   * 2. checkInSpot(spotId) → courseProgressStore 상태 업데이트
+   */
+  checkInSpot: (spotId: string) => void
+  moveToNextSpot: () => void
+  endRoute: () => void
+  resetProgress: () => void
+}
+```
+
+
+## Data Models
+
+### Route (코스)
+
+```typescript
+/** 코스 난이도 */
+type RouteDifficulty = 'easy' | 'moderate' | 'hard'
+
+/** 코스 내 스팟 정보 (순서는 배열 인덱스로 보장) */
+interface RouteSpot {
+  /** 스팟 ID (spots 컬렉션 참조) */
+  spotId: string
+  /** 스팟명 (비정규화, 조회 성능용) */
+  spotName: string
+  /** 좌표 (비정규화, 지도 표시용) */
+  coordinates: { lat: number; lng: number }
+  /** 썸네일 URL (비정규화, 오프라인 캐싱용) */
+  thumbnailUrl: string
+  /** 이전 스팟으로부터의 거리 (m), 첫 스팟은 null */
+  distanceFromPrev: number | null
+  /** 이전 스팟으로부터의 예상 도보 시간 (분), 첫 스팟은 null */
+  walkTimeFromPrev: number | null
+  /** 스팟별 메모 (선택) */
+  note?: string
+  /**
+   * 스팟 유효성 플래그 (비정규화)
+   * - true: 정상 (기본값)
+   * - false: 원본 스팟이 삭제되었거나 09번 스펙의 '소실됨' 상태
+   * 
+   * 코스 상세 조회 API에서 spots 컬렉션과 대조하여 갱신한다.
+   * 클라이언트는 이 값이 false인 스팟을 '소실됨' UI로 표시하고,
+   * 해당 스팟을 건너뛰어 이전→다음 스팟 간 거리를 재계산한다.
+   */
+  isAvailable?: boolean
+}
+
+/** 코스 문서 */
+interface Route {
+  id: string
+  /** 코스명 */
+  name: string
+  /** 코스 설명 */
+  description: string
+  /** 예상 총 소요시간 (분) */
+  estimatedDuration: number
+  /** 난이도 */
+  difficulty: RouteDifficulty
+  /** 스팟 목록 (배열 인덱스 = 순서) */
+  spots: RouteSpot[]
+  /** 총 거리 (m) */
+  totalDistance: number
+  /** 관련 작품명 목록 */
+  relatedContentNames: string[]
+  /** 지역 태그 (예: "도쿄", "가마쿠라") */
+  regionTag?: string
+  /** 공개 여부 */
+  isPublic: boolean
+  /** 공식 추천 코스 여부 (관리자 설정) */
+  isOfficial: boolean
+  /** 북마크 수 (비정규화) */
+  bookmarkCount: number
+  /** 완주 수 (비정규화) */
+  completionCount: number
+  /** 작성자 ID */
+  authorId: string
+  /** 작성자 이름 */
+  authorName: string
+  createdAt: Date
+  updatedAt: Date
+}
+```
+
+### RouteBookmark (코스 저장)
+
+```typescript
+interface RouteBookmark {
+  id: string
+  routeId: string
+  userId: string
+  createdAt: Date
+}
+```
+
+### RouteCompletion (코스 완주 기록)
+
+```typescript
+interface RouteCompletion {
+  id: string
+  routeId: string
+  userId: string
+  /** 완주 시 인증한 스팟 ID 목록 */
+  checkedSpotIds: string[]
+  /** 소요 시간 (분) */
+  duration: number
+  completedAt: Date
+}
+```
+
+### MongoDB 컬렉션 및 인덱스
+
+```typescript
+// db.ts COLLECTIONS에 추가
+ROUTES: 'routes',
+ROUTE_BOOKMARKS: 'route_bookmarks',
+ROUTE_COMPLETIONS: 'route_completions',
+```
+
+**인덱스 설계:**
+
+```javascript
+// routes 컬렉션
+db.routes.createIndex({ isPublic: 1, createdAt: -1 })
+db.routes.createIndex({ isPublic: 1, bookmarkCount: -1 })
+db.routes.createIndex({ isPublic: 1, estimatedDuration: 1 })
+db.routes.createIndex({ relatedContentNames: 1 })
+db.routes.createIndex({ regionTag: 1 })
+db.routes.createIndex({ authorId: 1 })
+db.routes.createIndex({ isOfficial: 1 })
+
+// route_bookmarks 컬렉션
+db.route_bookmarks.createIndex({ userId: 1, routeId: 1 }, { unique: true })
+db.route_bookmarks.createIndex({ routeId: 1 })
+
+// route_completions 컬렉션
+db.route_completions.createIndex({ userId: 1, routeId: 1 })
+db.route_completions.createIndex({ routeId: 1 })
+```
+
+### 스팟 간 거리/시간 계산 로직
+
+기존 `src/lib/geo-utils.ts`의 `calculateDistance` (Haversine)를 활용한다.
+
+```typescript
+// src/lib/route-utils.ts
+
+import { calculateDistance } from '@/lib/geo-utils'
+
+/** 도보 보정 계수 (직선거리 → 실제 도보거리 근사) */
+const WALK_FACTOR = 1.3
+/** 평균 도보 속도 (m/분) */
+const WALK_SPEED_M_PER_MIN = 80 // ≈ 4.8km/h
+
+/** 두 좌표 간 예상 도보 시간 (분) */
+export function estimateWalkTime(
+  lat1: number, lng1: number,
+  lat2: number, lng2: number
+): number {
+  const distance = calculateDistance(lat1, lng1, lat2, lng2)
+  const walkDistance = distance * WALK_FACTOR
+  return Math.ceil(walkDistance / WALK_SPEED_M_PER_MIN)
+}
+
+/** 코스 내 스팟 배열에 거리/시간 정보 채우기 */
+export function calculateRouteDistances(
+  spots: { coordinates: { lat: number; lng: number } }[]
+): { distanceFromPrev: number | null; walkTimeFromPrev: number | null }[] {
+  return spots.map((spot, i) => {
+    if (i === 0) return { distanceFromPrev: null, walkTimeFromPrev: null }
+    const prev = spots[i - 1]
+    const distance = calculateDistance(
+      prev.coordinates.lat, prev.coordinates.lng,
+      spot.coordinates.lat, spot.coordinates.lng
+    )
+    const walkTime = estimateWalkTime(
+      prev.coordinates.lat, prev.coordinates.lng,
+      spot.coordinates.lat, spot.coordinates.lng
+    )
+    return { distanceFromPrev: Math.round(distance), walkTimeFromPrev: walkTime }
+  })
+}
+```
+
+### Service Worker 확장 (오프라인 캐싱)
+
+기존 `public/sw.js`에 코스 전용 캐시를 추가한다.
+
+```javascript
+// sw.js에 추가
+const ROUTE_CACHE = `not-a-trip-route-v${CACHE_VERSION}`
+
+// VALID_CACHES에 ROUTE_CACHE 추가
+
+// 메시지 핸들러 추가
+self.addEventListener('message', (event) => {
+  // 코스 프리패치 요청
+  if (event.data && event.data.type === 'PREFETCH_ROUTE') {
+    event.waitUntil(prefetchRouteData(event.data.payload))
+  }
+})
+
+/**
+ * 코스 데이터 프리패치
+ * - 코스 내 각 스팟의 상세 정보
+ * - 스팟 썸네일 이미지
+ */
+async function prefetchRouteData(payload) {
+  const { routeId, spots } = payload
+  const cache = await caches.open(ROUTE_CACHE)
+  
+  const requests = []
+  
+  // 코스 상세 API 캐싱
+  requests.push(`/api/routes/${routeId}`)
+  
+  // 각 스팟 상세 API + 썸네일 캐싱
+  for (const spot of spots) {
+    requests.push(`/api/spots/${spot.spotId}`)
+    if (spot.thumbnailUrl) {
+      requests.push(spot.thumbnailUrl)
+    }
+  }
+  
+  await Promise.allSettled(
+    requests.map(async (url) => {
+      try {
+        const response = await fetch(url)
+        if (response.ok) {
+          await cache.put(url, response)
+        }
+      } catch { /* 오프라인이면 무시 */ }
+    })
+  )
+}
+```
+
+클라이언트에서 프리패치를 트리거하는 유틸리티:
+
+```typescript
+// src/lib/route-cache.ts
+
+export async function prefetchRouteForOffline(route: Route): Promise<void> {
+  if (!('serviceWorker' in navigator)) return
+  
+  const registration = await navigator.serviceWorker.ready
+  registration.active?.postMessage({
+    type: 'PREFETCH_ROUTE',
+    payload: {
+      routeId: route.id,
+      spots: route.spots.map(s => ({
+        spotId: s.spotId,
+        thumbnailUrl: s.thumbnailUrl,
+      })),
+    },
+  })
+}
+```
+
+
+## Correctness Properties
+
+*속성(Property)은 시스템의 모든 유효한 실행에서 참이어야 하는 특성 또는 동작이다. 속성은 사람이 읽을 수 있는 명세와 기계가 검증할 수 있는 정확성 보장 사이의 다리 역할을 한다.*
+
+### Property 1: 코스 생성 라운드트립
+
+*For any* 유효한 코스 데이터(코스명, 설명, 예상 소요시간, 난이도, 스팟 목록, 공개 여부)를 사용하여 코스를 생성한 후 해당 코스를 조회하면, 모든 필드가 입력한 값과 동일해야 하며, 특히 스팟 목록의 순서가 보존되어야 한다.
+
+**Validates: Requirements 1.2, 1.5**
+
+### Property 2: 도보 시간 계산의 단조성
+
+*For any* 두 쌍의 좌표 (A, B)와 (A, C)에 대해, A-B 간 직선거리가 A-C 간 직선거리보다 크면, A-B 간 예상 도보 시간도 A-C 간 예상 도보 시간보다 크거나 같아야 한다. 또한 동일 좌표 간 거리는 0이고 도보 시간도 0이어야 한다.
+
+**Validates: Requirements 1.4, 3.3**
+
+### Property 3: 코스 목록 정렬 정확성
+
+*For any* 코스 목록과 정렬 기준(인기순, 최신순, 소요시간순)에 대해, 정렬된 결과의 인접한 두 항목은 해당 정렬 기준의 순서를 위반하지 않아야 한다. (인기순: bookmarkCount + completionCount 내림차순, 최신순: createdAt 내림차순, 소요시간순: estimatedDuration 오름차순)
+
+**Validates: Requirements 2.1, 4.2**
+
+### Property 4: 필터링 결과의 조건 충족
+
+*For any* 코스 목록과 필터 조건(작품명, 지역, 소요시간 범위, 공식 추천 여부)에 대해, 필터링된 결과의 모든 항목은 해당 필터 조건을 만족해야 한다. (예: 작품명 필터 시 relatedContentNames에 해당 작품 포함, 공식 추천 필터 시 isOfficial === true)
+
+**Validates: Requirements 2.2, 4.1, 4.3**
+
+### Property 5: 북마크 토글 라운드트립
+
+*For any* 유저와 코스에 대해, 북마크를 추가하면 해당 유저의 북마크 목록에 코스가 포함되고, 다시 해제하면 목록에서 제거되어야 한다. 또한 북마크 추가/해제 시 코스의 bookmarkCount가 각각 1 증가/감소해야 한다.
+
+**Validates: Requirements 2.4**
+
+### Property 6: 네비게이션 시작 시 상태 초기화 (과거 인증 반영)
+
+*For any* 코스에 대해 startRoute를 호출하면, isNavigating이 true가 되고, currentSpotIndex가 0이며, activeRouteId가 해당 코스 ID와 일치해야 한다. 또한 해당 유저의 기존 Check-in 기록(POST /api/checkins로 생성된 기록)을 조회하여, 코스 내 이미 인증된 스팟은 자동으로 checkedSpotIds에 포함되어야 한다.
+
+**Validates: Requirements 3.1**
+
+### Property 7: 진행률 계산 정확성
+
+*For any* N개의 스팟을 가진 코스에서 M개(0 ≤ M ≤ N)의 스팟을 인증했을 때, 진행률은 정확히 (M / N) * 100이어야 하며, 0 이상 100 이하의 범위여야 한다.
+
+**Validates: Requirements 3.4**
+
+### Property 8: 완주 판정 정확성 (과거 인증 포함)
+
+*For any* 코스에 대해, 코스 내 유효한 스팟(`isAvailable !== false`)의 모든 인증이 완료되었을 때만 완주로 판정되어야 한다. 하나라도 유효한 미인증 스팟이 있으면 완주가 아니어야 한다. 과거 Check-in 기록(코스 시작 이전에 인증한 기록)도 유효한 인증으로 인정하며, `isAvailable: false`인 소실/삭제 스팟은 완주 판정 대상에서 제외한다.
+
+**Validates: Requirements 3.5**
+
+### Property 9: 오프라인 프리패치 URL 완전성
+
+*For any* 코스에 대해, 프리패치 대상 URL 목록은 코스 상세 API URL, 코스 내 모든 스팟의 상세 API URL, 그리고 썸네일 URL이 있는 모든 스팟의 썸네일 URL을 포함해야 한다.
+
+**Validates: Requirements 3.6**
+
+## Error Handling
+
+### API 에러 처리
+
+| 상황 | HTTP 상태 | 응답 |
+|------|-----------|------|
+| 코스 미발견 | 404 | `{ error: "코스를 찾을 수 없습니다" }` |
+| 미인증 유저의 코스 생성 | 401 | `{ error: "로그인이 필요합니다" }` |
+| 권한 없는 코스 수정/삭제 | 403 | `{ error: "권한이 없습니다" }` |
+| 필수 필드 누락 | 400 | `{ error: "필수 항목을 입력해주세요", fields: [...] }` |
+| 스팟 최소 2개 미만 | 400 | `{ error: "코스에는 최소 2개의 스팟이 필요합니다" }` |
+| 비공개 코스 타인 접근 | 403 | `{ error: "비공개 코스입니다" }` |
+| 존재하지 않는 스팟 ID 포함 | 400 | `{ error: "유효하지 않은 스팟이 포함되어 있습니다" }` |
+
+### 클라이언트 에러 처리
+
+- **코스 내 스팟 소실/삭제**: 코스 상세 조회 시 spots 컬렉션과 대조하여 삭제되었거나 09번 스펙의 '소실됨/접근 불가' 상태인 스팟은 `isAvailable: false`로 마킹한다. RouteMap과 NavigationPanel은 해당 스팟을 '소실됨' 아이콘(회색 마커 + 취소선)으로 표시하고, 네비게이션 시 해당 스팟을 건너뛰어 이전 유효 스팟에서 다음 유효 스팟으로의 거리/시간을 재계산하여 안내한다. 완주 판정 시에도 `isAvailable: false`인 스팟은 인증 대상에서 제외한다.
+- **위치 권한 거부**: 따라가기 모드 시작 시 위치 권한이 거부되면, 권한 요청 안내 모달 표시. 기존 `useGeolocation` 훅의 에러 핸들링 활용.
+- **오프라인 상태**: 코스 생성/수정은 온라인에서만 가능. 조회는 캐시된 데이터로 제공. `networkStore`의 `isOnline` 상태 활용.
+- **GPS 신호 불안정**: 따라가기 모드에서 GPS 정확도가 낮을 때(accuracy > 100m) 경고 표시.
+- **Service Worker 미지원**: 프리패치 실패 시 무시하고 온라인 모드로 동작.
+
+## Testing Strategy
+
+### 속성 기반 테스트 (Property-Based Testing)
+
+**라이브러리**: `fast-check` (TypeScript/JavaScript용 PBT 라이브러리)
+
+각 속성 테스트는 최소 100회 반복 실행하며, 설계 문서의 속성 번호를 참조하는 태그를 포함한다.
+
+**태그 형식**: `Feature: 10-pilgrimage-route, Property {number}: {property_text}`
+
+| 속성 | 테스트 대상 함수/모듈 | 생성기 |
+|------|----------------------|--------|
+| Property 1 | 코스 CRUD API | 임의의 코스명, 설명, 스팟 배열 생성 |
+| Property 2 | `estimateWalkTime`, `calculateDistance` | 임의의 좌표 쌍 생성 |
+| Property 3 | 코스 목록 정렬 로직 | 임의의 코스 배열 + 정렬 기준 |
+| Property 4 | 코스 필터링 로직 | 임의의 코스 배열 + 필터 조건 |
+| Property 5 | 북마크 API | 임의의 유저 ID + 코스 ID |
+| Property 6 | `courseProgressStore.startRoute` | 임의의 Route 객체 |
+| Property 7 | 진행률 계산 함수 | 임의의 N(스팟 수), M(인증 수) |
+| Property 8 | 완주 판정 로직 | 임의의 코스 + 인증 스팟 부분집합 |
+| Property 9 | `prefetchRouteForOffline` URL 생성 | 임의의 Route 객체 |
+
+### 단위 테스트 (Unit Testing)
+
+**라이브러리**: `vitest`
+
+단위 테스트는 구체적인 예제, 엣지 케이스, 에러 조건에 집중한다.
+
+- **코스 생성 검증**: 필수 필드 누락 시 에러, 스팟 1개 이하 시 에러
+- **거리 계산**: 동일 좌표 → 0m, 알려진 좌표 쌍의 거리 검증
+- **정렬**: 빈 목록, 단일 항목 목록, 동일 값 항목 정렬
+- **필터링**: 빈 필터 → 전체 반환, 매칭 없는 필터 → 빈 배열
+- **북마크**: 중복 북마크 방지, 존재하지 않는 코스 북마크 시 에러
+- **진행률**: 스팟 0개 코스 엣지 케이스, 전체 인증 시 100%
+- **완주 판정**: 빈 코스, 중복 인증 처리
+- **프리패치**: 썸네일 없는 스팟 처리, 빈 스팟 목록
+

--- a/.kiro/specs/10-pilgrimage-route/requirements.md
+++ b/.kiro/specs/10-pilgrimage-route/requirements.md
@@ -21,7 +21,7 @@
 1. WHEN 유저가 "코스 만들기" 버튼을 클릭할 때 THEN THE System SHALL 코스 생성 페이지를 표시한다
 2. WHEN 유저가 코스를 생성할 때 THEN THE System SHALL 다음 정보를 입력받는다: 코스명, 설명, 예상 소요시간, 난이도, 스팟 목록(순서)
 3. WHEN 스팟을 추가할 때 THEN THE System SHALL 지도에서 선택하거나 검색하여 추가할 수 있도록 한다
-4. THE System SHALL 스팟 간 이동 수단(도보/전철/버스)과 예상 이동시간을 표시한다
+4. THE System SHALL 스팟 간의 직선거리(Haversine)를 기반으로 한 대략적인 도보 이동 시간(예: 반경 1km 내)을 우선 제공하고, 유저가 필요 시 '경로 탐색' 버튼을 눌러 외부 지도 앱(구글맵/야후재팬맵)으로 연결하여 정확한 대중교통 시간을 확인하도록 유도한다
 5. THE System SHALL 코스를 공개/비공개로 설정할 수 있도록 한다
 
 ### Requirement 2: 코스 조회 및 탐색
@@ -45,6 +45,8 @@
 2. WHEN 유저가 스팟에 도착하면 THEN THE System SHALL 해당 스팟 정보와 인증 버튼을 표시한다
 3. THE System SHALL 다음 스팟까지의 거리와 예상 시간을 실시간으로 표시한다
 4. THE System SHALL 코스 진행률(완료한 스팟 수/전체 스팟 수)을 표시한다
+5. WHEN 유저가 코스 내의 모든 스팟 인증(Check-in)을 완료하면 THEN THE System SHALL 해당 코스의 '완주 기념 뱃지' 또는 특별한 시각적 이펙트를 제공하고 프로필에 기록한다
+6. WHEN 유저가 특정 코스를 '저장(북마크)'하거나 '시작'할 때 THEN THE System SHALL 해당 코스에 포함된 모든 스팟의 기본 정보(위치, 캡처 이미지 등)를 기기에 오프라인 캐싱(Service Worker)하여 네트워크 연결 없이도 조회할 수 있도록 한다
 
 ### Requirement 4: 추천 코스 (큐레이션)
 

--- a/.kiro/specs/10-pilgrimage-route/tasks.md
+++ b/.kiro/specs/10-pilgrimage-route/tasks.md
@@ -1,0 +1,239 @@
+# Implementation Plan: 성지순례 코스/루트 시스템 (Pilgrimage Route)
+
+## Overview
+
+유저가 여러 스팟을 순서대로 묶어 코스를 생성하고, 탐색·따라가기할 수 있는 시스템을 구현한다. 데이터 모델 → API → UI 컴포넌트 → 네비게이션 → 오프라인 캐싱 순으로 점진적으로 구축한다.
+
+## Tasks
+
+- [x] 1. 데이터 모델, 유틸리티 및 DB 설정
+  - [x] 1.1 Route 관련 타입 정의
+    - `src/types/route.ts`에 `Route`, `RouteSpot`, `RouteDifficulty`, `RouteBookmark`, `RouteCompletion` 인터페이스 정의
+    - _Requirements: 1.2_
+
+  - [x] 1.2 DB 컬렉션 및 인덱스 설정
+    - `src/lib/db.ts`의 COLLECTIONS에 `routes`, `route_bookmarks`, `route_completions` 추가
+    - 인덱스 생성 함수 작성 (routes: isPublic+createdAt, isPublic+bookmarkCount, relatedContentNames, regionTag, authorId, isOfficial / route_bookmarks: userId+routeId unique, routeId / route_completions: userId+routeId, routeId)
+    - _Requirements: 1.2, 2.1, 2.2_
+
+  - [x] 1.3 코스 거리/시간 계산 유틸리티 구현
+    - `src/lib/route-utils.ts`에 `estimateWalkTime`, `calculateRouteDistances` 함수 구현
+    - 기존 `src/lib/geo-utils.ts`의 `calculateDistance` (Haversine) 활용
+    - 도보 보정 계수(1.3)와 평균 도보 속도(80m/분) 적용
+    - _Requirements: 1.4_
+
+  - [ ]* 1.4 데이터 모델 및 유틸리티 테스트
+    - **Property 2: 도보 시간 계산의 단조성** — 거리가 크면 도보 시간도 크거나 같아야 하며, 동일 좌표 간 거리/시간은 0
+    - **Validates: Requirements 1.4, 3.3**
+    - 단위 테스트: 동일 좌표 → 0m, 알려진 좌표 쌍 거리 검증, `calculateRouteDistances` 첫 스팟 null 검증
+    - _Requirements: 1.4_
+
+- [x] 2. 코스 CRUD API 구현
+  - [x] 2.1 코스 생성 API (`POST /api/routes`)
+    - `src/app/api/routes/route.ts`에 코스 생성 엔드포인트 구현
+    - 인증 확인, 필수 필드 검증 (코스명, 설명, 예상 소요시간, 난이도, 스팟 목록)
+    - 스팟 최소 2개 검증, 스팟 ID 유효성 검증 (spots 컬렉션 대조)
+    - `calculateRouteDistances`로 스팟 간 거리/시간 자동 계산
+    - 공개/비공개 설정 처리
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [x] 2.2 코스 목록 조회 API (`GET /api/routes`)
+    - 동일 파일에 목록 조회 엔드포인트 구현
+    - 정렬: 인기순(bookmarkCount+completionCount 내림차순), 최신순(createdAt 내림차순), 소요시간순(estimatedDuration 오름차순)
+    - 필터: 작품별(relatedContentNames), 지역별(regionTag), 소요시간별(estimatedDuration 범위)
+    - 페이지네이션 (cursor 기반 또는 offset)
+    - _Requirements: 2.1, 2.2_
+
+  - [x] 2.3 코스 상세/수정/삭제 API (`/api/routes/[id]`)
+    - `src/app/api/routes/[id]/route.ts`에 GET, PUT, DELETE 구현
+    - GET: 코스 상세 조회 시 spots 컬렉션과 대조하여 `isAvailable` 갱신
+    - PUT: 작성자 권한 확인, 스팟 순서 변경 시 거리/시간 재계산
+    - DELETE: 작성자 권한 확인, 관련 북마크/완주 기록 정리
+    - 비공개 코스 타인 접근 시 403
+    - _Requirements: 1.2, 1.3, 1.4, 2.3_
+
+  - [ ]* 2.4 코스 CRUD API 테스트
+    - **Property 1: 코스 생성 라운드트립** — 생성 후 조회 시 모든 필드 동일, 스팟 순서 보존
+    - **Validates: Requirements 1.2, 1.5**
+    - **Property 3: 코스 목록 정렬 정확성** — 인접 항목이 정렬 기준 위반하지 않음
+    - **Validates: Requirements 2.1, 4.2**
+    - **Property 4: 필터링 결과의 조건 충족** — 필터링 결과 모든 항목이 조건 만족
+    - **Validates: Requirements 2.2, 4.1, 4.3**
+    - 단위 테스트: 필수 필드 누락 에러, 스팟 1개 이하 에러, 빈 목록/단일 항목 정렬, 빈 필터 전체 반환
+    - _Requirements: 1.2, 1.5, 2.1, 2.2_
+
+- [x] 3. 북마크 및 완주 API 구현
+  - [x] 3.1 코스 북마크 API (`POST /api/routes/[id]/bookmark`)
+    - `src/app/api/routes/[id]/bookmark/route.ts`에 토글 방식 북마크 구현
+    - 북마크 추가/해제 시 routes 컬렉션의 `bookmarkCount` 증감
+    - 중복 북마크 방지 (unique 인덱스 활용)
+    - _Requirements: 2.4_
+
+  - [x] 3.2 코스 완주 기록 API (`POST /api/routes/[id]/complete`)
+    - `src/app/api/routes/[id]/complete/route.ts`에 완주 기록 엔드포인트 구현
+    - 완주 시 인증한 스팟 ID 목록, 소요 시간 기록
+    - routes 컬렉션의 `completionCount` 증가
+    - _Requirements: 3.5_
+
+  - [x] 3.3 추천 코스 조회 API (`GET /api/routes/recommended`)
+    - `src/app/api/routes/recommended/route.ts`에 추천 코스 엔드포인트 구현
+    - 공식 추천 코스(isOfficial) 별도 표시
+    - 인기 코스(bookmarkCount + completionCount 기준) 자동 추천
+    - 작품명 파라미터로 해당 작품 관련 코스 필터링
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ]* 3.4 북마크 및 완주 API 테스트
+    - **Property 5: 북마크 토글 라운드트립** — 추가 시 목록 포함, 해제 시 제거, bookmarkCount 정확히 증감
+    - **Validates: Requirements 2.4**
+    - 단위 테스트: 중복 북마크 방지, 존재하지 않는 코스 북마크 에러, 빈 코스 완주 엣지 케이스
+    - _Requirements: 2.4, 3.5_
+
+- [ ] 4. Checkpoint - 백엔드 검증
+  - 모든 API 테스트 통과 확인, 유저에게 질문이 있으면 문의하세요.
+
+- [ ] 5. Zustand 스토어 및 네비게이션 훅 구현
+  - [ ] 5.1 courseProgressStore 구현
+    - `src/stores/courseProgressStore.ts`에 코스 진행 상태 관리 스토어 구현
+    - 상태: activeRouteId, activeRoute, currentSpotIndex, checkedSpotIds(Set), startedAt, isNavigating
+    - 액션: startRoute (기존 Check-in 기록 조회하여 자동 반영), checkInSpot, moveToNextSpot, endRoute, resetProgress
+    - startRoute 시 `GET /api/checkins?userId=...` 호출하여 이미 인증된 스팟 자동 포함
+    - _Requirements: 3.1, 3.2, 3.4_
+
+  - [ ] 5.2 useRouteNavigation 훅 구현
+    - `src/hooks/useRouteNavigation.ts`에 네비게이션 로직 훅 구현
+    - courseProgressStore + useGeolocation 조합
+    - 현재 위치 기반 다음 스팟까지 거리/시간 실시간 계산
+    - 진행률 계산: (checkedSpotIds.size / 유효 스팟 수) * 100
+    - 완주 판정: 유효 스팟(isAvailable !== false) 전체 인증 시 완주
+    - 완주 시 `POST /api/routes/[id]/complete` 호출
+    - _Requirements: 3.1, 3.3, 3.4, 3.5_
+
+  - [ ]* 5.3 스토어 및 네비게이션 훅 테스트
+    - **Property 6: 네비게이션 시작 시 상태 초기화** — startRoute 후 isNavigating=true, currentSpotIndex=0, activeRouteId 일치, 기존 인증 스팟 자동 포함
+    - **Validates: Requirements 3.1**
+    - **Property 7: 진행률 계산 정확성** — N개 스팟 중 M개 인증 시 진행률 = (M/N)*100, 0~100 범위
+    - **Validates: Requirements 3.4**
+    - **Property 8: 완주 판정 정확성** — 유효 스팟 전체 인증 시만 완주, isAvailable:false 스팟 제외
+    - **Validates: Requirements 3.5**
+    - 단위 테스트: 스팟 0개 엣지 케이스, 중복 인증 처리, endRoute 후 상태 초기화
+    - _Requirements: 3.1, 3.4, 3.5_
+
+- [ ] 6. 코스 목록 및 상세 페이지 구현
+  - [ ] 6.1 RouteCard 컴포넌트 구현
+    - `src/components/route/RouteCard.tsx`에 코스 카드 컴포넌트 구현
+    - 코스명, 스팟 수, 예상 시간, 난이도, 북마크 수, 공식 추천 뱃지 표시
+    - _Requirements: 2.1_
+
+  - [ ] 6.2 RouteFilterBar 컴포넌트 구현
+    - `src/components/route/RouteFilterBar.tsx`에 필터 UI 구현
+    - 작품별, 지역별, 소요시간별 필터 + 정렬 옵션 (인기순/최신순/소요시간순)
+    - _Requirements: 2.1, 2.2_
+
+  - [ ] 6.3 코스 목록 페이지 구현
+    - `src/app/routes/page.tsx`에 코스 목록 페이지 구현
+    - RouteCard + RouteFilterBar 조합
+    - 무한 스크롤 페이지네이션
+    - _Requirements: 2.1, 2.2_
+
+  - [ ] 6.4 RouteMap 컴포넌트 구현
+    - `src/components/route/RouteMap.tsx`에 Leaflet 기반 코스 지도 구현
+    - 스팟 마커 + 순서 번호 표시, 스팟 간 Polyline 연결
+    - isAvailable:false 스팟은 회색 마커 + 취소선으로 표시
+    - ⚠️ 주의: 코스 동선의 순서를 명확히 보여주기 위해 RouteMap에서는 마커 클러스터링(Marker Clustering) 플러그인을 반드시 비활성화해야 함 (마커가 합쳐지면 순서 파악 불가)
+    - _Requirements: 2.3_
+
+  - [ ] 6.5 코스 상세 페이지 구현
+    - `src/app/routes/[id]/page.tsx`에 코스 상세 페이지 구현
+    - RouteMap + 스팟 순서 목록 + 스팟 간 이동 거리/시간 표시
+    - "코스 시작" / "코스 저장" 버튼
+    - 외부 지도 앱(구글맵/야후재팬맵) 연결 버튼
+    - 코스 제작자 정보 표시
+    - _Requirements: 1.4, 2.3, 2.4, 3.1_
+
+- [ ] 7. 코스 생성/수정 페이지 구현
+  - [ ] 7.1 SpotOrderList 컴포넌트 구현
+    - `src/components/route/SpotOrderList.tsx`에 스팟 순서 관리 컴포넌트 구현
+    - 드래그 앤 드롭으로 스팟 순서 변경
+    - 스팟 간 거리/시간 표시, 스팟별 메모 입력
+    - _Requirements: 1.2, 1.3_
+
+  - [ ] 7.2 코스 생성 페이지 구현
+    - `src/app/routes/create/page.tsx`에 코스 생성 페이지 구현
+    - 기본 정보 입력 (코스명, 설명, 예상 소요시간, 난이도)
+    - 스팟 검색/선택 UI (지도에서 선택 또는 검색)
+    - SpotOrderList로 순서 관리
+    - 공개/비공개 설정
+    - 미리보기 기능
+    - _Requirements: 1.1, 1.2, 1.3, 1.5_
+
+  - [ ] 7.3 코스 수정 페이지 구현
+    - `src/app/routes/[id]/edit/page.tsx`에 코스 수정 페이지 구현
+    - 생성 페이지와 동일한 폼을 기존 데이터로 프리필
+    - 작성자만 접근 가능
+    - _Requirements: 1.2_
+
+- [ ] 8. Checkpoint - 기본 UI 검증
+  - 코스 목록/상세/생성/수정 페이지 동작 확인, 유저에게 질문이 있으면 문의하세요.
+
+- [ ] 9. 따라가기 모드 (네비게이션) 구현
+  - [ ] 9.1 NavigationPanel 컴포넌트 구현
+    - `src/components/route/NavigationPanel.tsx`에 따라가기 모드 하단 패널 구현
+    - 현재 목표 스팟 정보, 다음 스팟까지 거리/시간
+    - 진행률 바, 인증(Check-in) 버튼, 코스 종료 버튼
+    - isAvailable:false 스팟 건너뛰기 처리
+    - ⚠️ 오프라인 대응: 08번 스펙의 useNetworkStatus 훅을 활용하여 오프라인(isOnline === false) 상태일 경우 '외부 지도 앱 연결(경로 탐색)' 버튼을 disabled 처리하고 "오프라인 상태에서는 외부 앱 연결이 불가합니다" 안내 툴팁 표시
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [ ] 9.2 코스 상세 페이지에 따라가기 모드 통합
+    - 코스 상세 페이지에서 "코스 시작" 클릭 시 NavigationPanel 활성화
+    - RouteMap에 현재 위치 마커 표시
+    - useRouteNavigation 훅 연결
+    - GPS 정확도 낮을 때(accuracy > 100m) 경고 표시
+    - _Requirements: 3.1, 3.3_
+
+  - [ ] 9.3 완주 처리 및 뱃지/이펙트 구현
+    - 모든 유효 스팟 인증 완료 시 완주 기념 시각적 이펙트 표시
+    - `POST /api/routes/[id]/complete` 호출하여 완주 기록 저장
+    - 프로필에 완주 기록 표시
+    - _Requirements: 3.5_
+
+- [ ] 10. 오프라인 캐싱 (Service Worker 확장) 구현
+  - [ ] 10.1 Service Worker 코스 캐시 확장
+    - `public/sw.js`에 `ROUTE_CACHE` 추가
+    - `PREFETCH_ROUTE` 메시지 핸들러 구현
+    - 코스 상세 API, 스팟 상세 API, 썸네일 URL 프리패치
+    - _Requirements: 3.6_
+
+  - [ ] 10.2 useRouteCache 훅 및 클라이언트 프리패치 유틸리티 구현
+    - `src/lib/route-cache.ts`에 `prefetchRouteForOffline` 함수 구현
+    - `src/hooks/useRouteCache.ts`에 캐시 상태 관리 훅 구현
+    - 코스 시작/저장 시 자동 프리패치 트리거
+    - Service Worker 미지원 시 graceful fallback
+    - _Requirements: 3.6_
+
+  - [ ]* 10.3 오프라인 캐싱 테스트
+    - **Property 9: 오프라인 프리패치 URL 완전성** — 코스 상세 API URL + 모든 스팟 상세 API URL + 썸네일 URL 포함 검증
+    - **Validates: Requirements 3.6**
+    - 단위 테스트: 썸네일 없는 스팟 처리, 빈 스팟 목록 처리
+    - _Requirements: 3.6_
+
+- [ ] 11. 추천 코스 UI 및 통합
+  - [ ] 11.1 코스 목록 페이지에 추천 코스 섹션 추가
+    - 공식 추천 코스 별도 섹션 표시
+    - 인기 코스 자동 추천 섹션
+    - _Requirements: 4.1, 4.2_
+
+  - [ ] 11.2 작품 관련 코스 연동
+    - 스팟 상세 페이지 또는 작품 페이지에서 해당 작품 관련 추천 코스 표시
+    - `GET /api/routes/recommended?contentName=...` 활용
+    - _Requirements: 4.3_
+
+- [ ] 12. Final Checkpoint - 전체 기능 검증
+  - 모든 테스트 통과 확인, 유저에게 질문이 있으면 문의하세요.
+
+## Notes
+
+- `*` 표시된 태스크는 선택사항이며 빠른 MVP를 위해 건너뛸 수 있습니다
+- 각 태스크는 특정 Requirements를 참조하여 추적 가능합니다
+- Property-Based Test는 `fast-check` 라이브러리, 단위 테스트는 `vitest`를 사용합니다
+- 기존 인프라 활용: `geo-utils.ts` (Haversine), `useGeolocation` 훅, `public/sw.js` (PWA), Check-in API (`/api/checkins`)

--- a/src/app/api/routes/[id]/bookmark/route.ts
+++ b/src/app/api/routes/[id]/bookmark/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { Route, RouteBookmark } from '@/types/route'
+
+/**
+ * POST /api/routes/[id]/bookmark - 코스 북마크 토글
+ * Requirements: 2.4
+ * - 북마크 추가/해제 토글 방식
+ * - bookmarkCount 증감
+ * - unique 인덱스로 중복 방지
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const routesCollection = await getCollection<Route>('routes')
+    const route = await routesCollection.findOne({ id })
+
+    if (!route) {
+      return NextResponse.json(
+        { error: '코스를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    const bookmarksCollection =
+      await getCollection<RouteBookmark>('route_bookmarks')
+    const userId = session.user.id
+
+    // 기존 북마크 확인
+    const existing = await bookmarksCollection.findOne({
+      userId,
+      routeId: id,
+    })
+
+    if (existing) {
+      // 북마크 해제
+      await bookmarksCollection.deleteOne({ userId, routeId: id })
+      await routesCollection.updateOne(
+        { id },
+        { $inc: { bookmarkCount: -1 }, $set: { updatedAt: new Date() } }
+      )
+
+      return NextResponse.json({
+        bookmarked: false,
+        message: '북마크가 해제되었습니다',
+      })
+    } else {
+      // 북마크 추가
+      const bookmark: RouteBookmark = {
+        id: `RB-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        routeId: id,
+        userId,
+        createdAt: new Date(),
+      }
+
+      await bookmarksCollection.insertOne(bookmark)
+      await routesCollection.updateOne(
+        { id },
+        { $inc: { bookmarkCount: 1 }, $set: { updatedAt: new Date() } }
+      )
+
+      return NextResponse.json({
+        bookmarked: true,
+        message: '북마크에 추가되었습니다',
+      })
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error toggling bookmark:', error)
+    return NextResponse.json(
+      { error: '북마크 처리에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/routes/[id]/complete/route.ts
+++ b/src/app/api/routes/[id]/complete/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { Route, RouteCompletion } from '@/types/route'
+
+/**
+ * POST /api/routes/[id]/complete - 코스 완주 기록
+ * Requirements: 3.5
+ * - 완주 시 인증한 스팟 ID 목록, 소요 시간 기록
+ * - routes 컬렉션의 completionCount 증가
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const body = await request.json()
+
+    // 필수 필드 검증
+    if (
+      !Array.isArray(body.checkedSpotIds) ||
+      body.checkedSpotIds.length === 0
+    ) {
+      return NextResponse.json(
+        { error: '인증한 스팟 목록이 필요합니다' },
+        { status: 400 }
+      )
+    }
+
+    if (!body.duration || body.duration <= 0) {
+      return NextResponse.json(
+        { error: '소요 시간이 필요합니다' },
+        { status: 400 }
+      )
+    }
+
+    const routesCollection = await getCollection<Route>('routes')
+    const route = await routesCollection.findOne({ id })
+
+    if (!route) {
+      return NextResponse.json(
+        { error: '코스를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 완주 기록 생성
+    const completionsCollection =
+      await getCollection<RouteCompletion>('route_completions')
+
+    const completion: RouteCompletion = {
+      id: `RC-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      routeId: id,
+      userId: session.user.id,
+      checkedSpotIds: body.checkedSpotIds,
+      duration: body.duration,
+      completedAt: new Date(),
+    }
+
+    await completionsCollection.insertOne(completion)
+
+    // completionCount 증가
+    await routesCollection.updateOne(
+      { id },
+      { $inc: { completionCount: 1 }, $set: { updatedAt: new Date() } }
+    )
+
+    return NextResponse.json(
+      {
+        id: completion.id,
+        message: '코스 완주가 기록되었습니다',
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error recording completion:', error)
+    return NextResponse.json(
+      { error: '완주 기록에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/routes/recommended/route.ts
+++ b/src/app/api/routes/recommended/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection } from '@/lib/db'
+import { Route } from '@/types/route'
+
+/**
+ * GET /api/routes/recommended - 추천 코스 조회
+ * Requirements: 4.1, 4.2, 4.3
+ * Query params:
+ *   - contentName: 작품명 필터 (해당 작품 관련 코스)
+ *   - limit: 항목 수 (기본: 10)
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url)
+    const contentName = searchParams.get('contentName')
+    const limit = Math.min(
+      50,
+      Math.max(1, parseInt(searchParams.get('limit') || '10', 10))
+    )
+
+    const collection = await getCollection<Route>('routes')
+
+    // 공통 필터: 공개 코스만
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseQuery: Record<string, any> = { isPublic: true }
+
+    // 작품명 필터
+    if (contentName) {
+      baseQuery.relatedContentNames = contentName
+    }
+
+    // 1. 공식 추천 코스 (isOfficial: true)
+    const officialQuery = { ...baseQuery, isOfficial: true }
+    const officialRoutes = await collection
+      .find(officialQuery)
+      .sort({ bookmarkCount: -1, completionCount: -1 })
+      .limit(limit)
+      .toArray()
+
+    // 2. 인기 코스 (bookmarkCount + completionCount 기준, 공식 코스 제외)
+    const popularRoutes = await collection
+      .aggregate<Route>([
+        { $match: { ...baseQuery, isOfficial: { $ne: true } } },
+        {
+          $addFields: {
+            popularityScore: {
+              $add: ['$bookmarkCount', '$completionCount'],
+            },
+          },
+        },
+        { $sort: { popularityScore: -1, createdAt: -1 } },
+        { $limit: limit },
+        { $project: { popularityScore: 0 } },
+      ])
+      .toArray()
+
+    return NextResponse.json({
+      official: officialRoutes,
+      popular: popularRoutes,
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching recommended routes:', error)
+    return NextResponse.json(
+      { error: '추천 코스 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #254

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 코스 북마크 토글, 완주 기록, 추천 코스 조회 API 3개 엔드포인트 구현

---

## 📋 변경 사항

- [x] `POST /api/routes/[id]/bookmark` - 토글 방식 북마크 추가/해제, bookmarkCount 증감
- [x] `POST /api/routes/[id]/complete` - 완주 기록 저장, completionCount 증가
- [x] `GET /api/routes/recommended` - 공식 추천 코스 + 인기 코스 조회, 작품명 필터 지원

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 2.4, 3.5, 4.1, 4.2, 4.3 대응
- Task 3.1, 3.2, 3.3 완료
- 총 3개 커밋, 248줄 추가
