### PR TITLE
[Feat] Task 6 - 코스 목록 및 상세 페이지 구현

### DIFF
--- a/src/app/routes/[id]/page.tsx
+++ b/src/app/routes/[id]/page.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { RouteDetailContent } from '@/components/route/RouteDetailContent'
+import { SkeletonBlock } from '@/components/common/SkeletonUI'
+import type { Route } from '@/types/route'
+
+/** 코스 상세 페이지 스켈레톤 */
+function RouteDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <SkeletonBlock className="mb-2 h-5 w-24" />
+        <SkeletonBlock className="mb-3 h-8 w-2/3" />
+        <SkeletonBlock className="mb-4 h-4 w-full" />
+        <div className="flex gap-3">
+          <SkeletonBlock className="h-4 w-16" />
+          <SkeletonBlock className="h-4 w-20" />
+          <SkeletonBlock className="h-4 w-16" />
+        </div>
+      </div>
+      <div className="flex gap-3">
+        <SkeletonBlock className="h-12 flex-1" />
+        <SkeletonBlock className="h-12 w-24" />
+      </div>
+      <SkeletonBlock className="h-[400px] rounded-lg" />
+    </div>
+  )
+}
+
+/**
+ * 코스 상세 페이지
+ * Requirements: 1.4, 2.3, 2.4, 3.1
+ */
+export default function RouteDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const routeId = params.id as string
+
+  const [route, setRoute] = useState<Route | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchRoute() {
+      try {
+        const res = await fetch(`/api/routes/${routeId}`)
+        if (!res.ok) {
+          const data = await res.json()
+          setError(data.error || '코스를 불러올 수 없습니다')
+          return
+        }
+        const data = await res.json()
+        setRoute(data)
+      } catch {
+        setError('코스를 불러올 수 없습니다')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchRoute()
+  }, [routeId])
+
+  return (
+    <main className="min-h-screen bg-navy-50 pt-14">
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        {/* 뒤로가기 */}
+        <div className="mb-4">
+          <Link
+            href="/routes"
+            className="text-sm text-navy-500 transition-colors hover:text-navy-700"
+          >
+            ← 코스 목록으로
+          </Link>
+        </div>
+
+        {isLoading ? (
+          <RouteDetailSkeleton />
+        ) : error ? (
+          <div className="py-16 text-center">
+            <p className="text-lg text-red-500">{error}</p>
+            <button
+              onClick={() => router.push('/routes')}
+              className="mt-4 rounded-lg bg-navy-600 px-4 py-2 text-sm text-white hover:bg-navy-700"
+            >
+              코스 목록으로 돌아가기
+            </button>
+          </div>
+        ) : route ? (
+          <RouteDetailContent route={route} />
+        ) : null}
+      </div>
+    </main>
+  )
+}

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { Suspense } from 'react'
+import Link from 'next/link'
+import { RouteListContent } from '@/components/route/RouteListContent'
+import { SkeletonBlock } from '@/components/common/SkeletonUI'
+
+/** 코스 목록 페이지 스켈레톤 */
+function RouteListSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-2">
+        <SkeletonBlock className="h-9 w-48" />
+        <SkeletonBlock className="h-9 w-32" />
+        <SkeletonBlock className="h-9 w-32" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div
+            key={i}
+            className="overflow-hidden rounded-lg border border-navy-200 bg-white"
+          >
+            <SkeletonBlock className="h-40 w-full rounded-none" />
+            <div className="p-4">
+              <SkeletonBlock className="mb-2 h-5 w-3/4" />
+              <SkeletonBlock className="h-4 w-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 코스 목록 페이지
+ * Requirements: 2.1, 2.2
+ */
+export default function RoutesPage() {
+  return (
+    <main className="min-h-screen bg-navy-50 pt-14">
+      <div className="mx-auto max-w-6xl px-4 py-6">
+        {/* 헤더 */}
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-navy-900">🗺️ 순례 코스</h1>
+            <p className="mt-1 text-sm text-navy-500">
+              다른 순례자들이 만든 코스를 탐색하고 따라가보세요
+            </p>
+          </div>
+          <Link
+            href="/routes/create"
+            className="rounded-lg bg-navy-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+          >
+            코스 만들기
+          </Link>
+        </div>
+
+        <Suspense fallback={<RouteListSkeleton />}>
+          <RouteListContent />
+        </Suspense>
+      </div>
+    </main>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,6 +29,12 @@ export function Header() {
             순례 갤러리
           </Link>
           <Link
+            href="/routes"
+            className="text-sm text-slate-300 transition hover:text-white"
+          >
+            순례 코스
+          </Link>
+          <Link
             href="/spots/register"
             className="text-sm text-slate-300 transition hover:text-white"
           >

--- a/src/components/route/RouteCard.tsx
+++ b/src/components/route/RouteCard.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import Link from 'next/link'
+import type { Route, RouteDifficulty } from '@/types/route'
+
+interface RouteCardProps {
+  route: Route
+}
+
+/** 난이도 라벨 및 색상 */
+const DIFFICULTY_CONFIG: Record<
+  RouteDifficulty,
+  { label: string; color: string }
+> = {
+  easy: { label: '쉬움', color: 'bg-green-100 text-green-700' },
+  moderate: { label: '보통', color: 'bg-yellow-100 text-yellow-700' },
+  hard: { label: '어려움', color: 'bg-red-100 text-red-700' },
+}
+
+/** 소요시간 포맷 (분 → 시간+분) */
+function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}분`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m > 0 ? `${h}시간 ${m}분` : `${h}시간`
+}
+
+/** 거리 포맷 (m → km) */
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters}m`
+  return `${(meters / 1000).toFixed(1)}km`
+}
+
+/**
+ * RouteCard - 코스 카드 컴포넌트
+ * 코스 목록에서 각 코스를 카드 형태로 표시
+ * Requirements: 2.1
+ */
+export function RouteCard({ route }: RouteCardProps) {
+  const difficulty = DIFFICULTY_CONFIG[route.difficulty]
+  const availableSpots = route.spots.filter((s) => s.isAvailable !== false)
+
+  return (
+    <Link href={`/routes/${route.id}`} className="block">
+      <article className="overflow-hidden rounded-lg border border-navy-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+        {/* 썸네일 영역 */}
+        <div className="relative h-40 bg-navy-100">
+          {route.spots[0]?.thumbnailUrl ? (
+            <img
+              src={route.spots[0].thumbnailUrl}
+              alt={route.name}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-4xl text-navy-300">
+              🗺️
+            </div>
+          )}
+
+          {/* 공식 추천 뱃지 */}
+          {route.isOfficial && (
+            <span className="absolute left-2 top-2 rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white shadow">
+              ⭐ 공식 추천
+            </span>
+          )}
+
+          {/* 난이도 뱃지 */}
+          <span
+            className={`absolute right-2 top-2 rounded-full px-2 py-0.5 text-xs font-medium ${difficulty.color}`}
+          >
+            {difficulty.label}
+          </span>
+        </div>
+
+        {/* 정보 영역 */}
+        <div className="p-4">
+          <h3 className="mb-1 truncate text-base font-semibold text-navy-900">
+            {route.name}
+          </h3>
+          <p className="mb-3 line-clamp-2 text-sm text-navy-500">
+            {route.description}
+          </p>
+
+          {/* 작품 태그 */}
+          {route.relatedContentNames.length > 0 && (
+            <div className="mb-3 flex flex-wrap gap-1">
+              {route.relatedContentNames.slice(0, 3).map((name) => (
+                <span
+                  key={name}
+                  className="rounded bg-navy-50 px-1.5 py-0.5 text-xs text-navy-600"
+                >
+                  {name}
+                </span>
+              ))}
+              {route.relatedContentNames.length > 3 && (
+                <span className="text-xs text-navy-400">
+                  +{route.relatedContentNames.length - 3}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* 메타 정보 */}
+          <div className="flex items-center gap-3 text-xs text-navy-400">
+            <span title="스팟 수">📍 {availableSpots.length}곳</span>
+            <span title="예상 소요시간">
+              ⏱️ {formatDuration(route.estimatedDuration)}
+            </span>
+            <span title="총 거리">
+              🚶 {formatDistance(route.totalDistance)}
+            </span>
+          </div>
+
+          {/* 하단: 북마크/완주 수 + 작성자 */}
+          <div className="mt-3 flex items-center justify-between border-t border-navy-100 pt-3">
+            <div className="flex items-center gap-3 text-xs text-navy-400">
+              <span>🔖 {route.bookmarkCount}</span>
+              <span>🏆 {route.completionCount}</span>
+            </div>
+            <span className="text-xs text-navy-400">{route.authorName}</span>
+          </div>
+        </div>
+      </article>
+    </Link>
+  )
+}

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import dynamic from 'next/dynamic'
+import { useAuth } from '@/hooks/useAuth'
+import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
+import type { Route, RouteDifficulty } from '@/types/route'
+
+const RouteMap = dynamic(() => import('@/components/route/RouteMap'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[400px] items-center justify-center rounded-lg bg-navy-100">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-navy-300 border-t-navy-600" />
+    </div>
+  ),
+})
+
+interface RouteDetailContentProps {
+  route: Route
+}
+
+const DIFFICULTY_LABEL: Record<RouteDifficulty, string> = {
+  easy: '🟢 쉬움',
+  moderate: '🟡 보통',
+  hard: '🔴 어려움',
+}
+
+function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}분`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m > 0 ? `${h}시간 ${m}분` : `${h}시간`
+}
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters}m`
+  return `${(meters / 1000).toFixed(1)}km`
+}
+
+/** 외부 지도 앱 URL 생성 */
+function getExternalMapUrl(
+  lat: number,
+  lng: number,
+  name: string,
+  app: 'google' | 'yahoo'
+): string {
+  if (app === 'google') {
+    return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&destination_place_id=${encodeURIComponent(name)}`
+  }
+  return `https://map.yahoo.co.jp/route/walk?lat=${lat}&lon=${lng}&name=${encodeURIComponent(name)}`
+}
+
+/**
+ * RouteDetailContent - 코스 상세 콘텐츠
+ * RouteMap + 스팟 순서 목록 + 거리/시간 + 코스 시작/저장 버튼
+ * Requirements: 1.4, 2.3, 2.4, 3.1
+ */
+export function RouteDetailContent({ route }: RouteDetailContentProps) {
+  const router = useRouter()
+  const { user, isAuthenticated } = useAuth()
+  const [isBookmarked, setIsBookmarked] = useState(false)
+  const [bookmarkCount, setBookmarkCount] = useState(route.bookmarkCount)
+  const [isBookmarking, setIsBookmarking] = useState(false)
+  const [showLoginModal, setShowLoginModal] = useState(false)
+
+  const availableSpots = route.spots.filter((s) => s.isAvailable !== false)
+
+  /** 북마크 토글 */
+  const handleBookmark = useCallback(async () => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true)
+      return
+    }
+    if (isBookmarking) return
+    setIsBookmarking(true)
+
+    try {
+      const res = await fetch(`/api/routes/${route.id}/bookmark`, {
+        method: 'POST',
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setIsBookmarked(data.bookmarked)
+        setBookmarkCount((prev) => prev + (data.bookmarked ? 1 : -1))
+      }
+    } catch {
+      // 에러 무시
+    } finally {
+      setIsBookmarking(false)
+    }
+  }, [isAuthenticated, isBookmarking, route.id])
+
+  /** 코스 시작 */
+  const handleStartRoute = useCallback(() => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true)
+      return
+    }
+    // 코스 상세 페이지에서 따라가기 모드 활성화 (Task 9에서 구현)
+    // 현재는 알림만 표시
+    alert('따라가기 모드는 준비 중입니다')
+  }, [isAuthenticated])
+
+  return (
+    <div className="space-y-6">
+      {/* 코스 기본 정보 */}
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              {route.isOfficial && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                  ⭐ 공식 추천
+                </span>
+              )}
+              <span className="text-sm text-navy-400">
+                {DIFFICULTY_LABEL[route.difficulty]}
+              </span>
+            </div>
+            <h1 className="text-2xl font-bold text-navy-900">{route.name}</h1>
+            <p className="mt-2 text-sm text-navy-500">{route.description}</p>
+          </div>
+        </div>
+
+        {/* 메타 정보 */}
+        <div className="mb-4 flex flex-wrap gap-4 text-sm text-navy-500">
+          <span>📍 {availableSpots.length}곳</span>
+          <span>⏱️ {formatDuration(route.estimatedDuration)}</span>
+          <span>🚶 {formatDistance(route.totalDistance)}</span>
+          <span>🔖 {bookmarkCount}</span>
+          <span>🏆 {route.completionCount}</span>
+        </div>
+
+        {/* 작품 태그 */}
+        {route.relatedContentNames.length > 0 && (
+          <div className="mb-4 flex flex-wrap gap-1.5">
+            {route.relatedContentNames.map((name) => (
+              <span
+                key={name}
+                className="rounded-full bg-navy-50 px-2.5 py-0.5 text-xs text-navy-600"
+              >
+                {name}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* 지역 태그 */}
+        {route.regionTag && (
+          <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs text-blue-600">
+            📍 {route.regionTag}
+          </span>
+        )}
+
+        {/* 작성자 정보 */}
+        <div className="mt-4 border-t border-navy-100 pt-4 text-sm text-navy-400">
+          코스 제작: {route.authorName}
+        </div>
+      </div>
+
+      {/* 액션 버튼 */}
+      <div className="flex gap-3">
+        <button
+          onClick={handleStartRoute}
+          className="flex-1 rounded-lg bg-navy-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-navy-700"
+        >
+          🚶 코스 시작
+        </button>
+        <button
+          onClick={handleBookmark}
+          disabled={isBookmarking}
+          className={`rounded-lg border-2 px-6 py-3 text-sm font-semibold transition-colors ${
+            isBookmarked
+              ? 'border-amber-400 bg-amber-50 text-amber-700'
+              : 'border-navy-200 bg-white text-navy-600 hover:bg-navy-50'
+          }`}
+        >
+          {isBookmarked ? '🔖 저장됨' : '🔖 저장'}
+        </button>
+        {user && route.authorId === user.id && (
+          <button
+            onClick={() => router.push(`/routes/${route.id}/edit`)}
+            className="rounded-lg border-2 border-navy-200 bg-white px-4 py-3 text-sm text-navy-600 transition-colors hover:bg-navy-50"
+          >
+            ✏️ 수정
+          </button>
+        )}
+      </div>
+
+      {/* 코스 지도 */}
+      <div className="rounded-lg bg-white p-4 shadow-sm">
+        <h2 className="mb-3 text-lg font-semibold text-navy-900">코스 지도</h2>
+        <RouteMap spots={route.spots} />
+      </div>
+
+      {/* 스팟 순서 목록 */}
+      <div className="rounded-lg bg-white p-4 shadow-sm">
+        <h2 className="mb-3 text-lg font-semibold text-navy-900">
+          코스 순서 ({availableSpots.length}곳)
+        </h2>
+        <ol className="space-y-0">
+          {route.spots.map((spot, idx) => {
+            const isUnavailable = spot.isAvailable === false
+            return (
+              <li key={spot.spotId}>
+                {/* 이동 거리/시간 표시 (첫 스팟 제외) */}
+                {idx > 0 && spot.distanceFromPrev && (
+                  <div className="flex items-center gap-2 py-2 pl-8">
+                    <div className="h-4 w-px bg-navy-200" />
+                    <span className="text-xs text-navy-400">
+                      ↓ {formatDistance(spot.distanceFromPrev)}
+                      {spot.walkTimeFromPrev &&
+                        ` · 도보 약 ${spot.walkTimeFromPrev}분`}
+                    </span>
+                  </div>
+                )}
+
+                {/* 스팟 카드 */}
+                <div
+                  className={`flex items-center gap-3 rounded-lg p-3 ${
+                    isUnavailable ? 'bg-gray-50 opacity-60' : 'hover:bg-navy-50'
+                  }`}
+                >
+                  {/* 순서 번호 */}
+                  <div
+                    className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold text-white ${
+                      isUnavailable ? 'bg-gray-400' : 'bg-navy-600'
+                    }`}
+                  >
+                    {idx + 1}
+                  </div>
+
+                  {/* 썸네일 */}
+                  <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg bg-navy-100">
+                    {spot.thumbnailUrl ? (
+                      <img
+                        src={spot.thumbnailUrl}
+                        alt={spot.spotName}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full items-center justify-center text-lg text-navy-300">
+                        📍
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 스팟 정보 */}
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={`truncate text-sm font-medium ${
+                        isUnavailable
+                          ? 'text-gray-400 line-through'
+                          : 'text-navy-900'
+                      }`}
+                    >
+                      {spot.spotName}
+                    </p>
+                    {isUnavailable && (
+                      <p className="text-xs text-red-400">소실된 스팟</p>
+                    )}
+                    {spot.note && (
+                      <p className="truncate text-xs text-navy-400">
+                        {spot.note}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* 외부 지도 앱 버튼 */}
+                  {!isUnavailable && (
+                    <div className="flex flex-shrink-0 gap-1">
+                      <a
+                        href={getExternalMapUrl(
+                          spot.coordinates.lat,
+                          spot.coordinates.lng,
+                          spot.spotName,
+                          'google'
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded bg-navy-50 px-2 py-1 text-xs text-navy-500 transition-colors hover:bg-navy-100"
+                        title="구글맵에서 경로 탐색"
+                      >
+                        🗺️
+                      </a>
+                      <a
+                        href={getExternalMapUrl(
+                          spot.coordinates.lat,
+                          spot.coordinates.lng,
+                          spot.spotName,
+                          'yahoo'
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded bg-navy-50 px-2 py-1 text-xs text-navy-500 transition-colors hover:bg-navy-100"
+                        title="야후재팬맵에서 경로 탐색"
+                      >
+                        🇯🇵
+                      </a>
+                    </div>
+                  )}
+                </div>
+              </li>
+            )
+          })}
+        </ol>
+      </div>
+
+      {/* 로그인 모달 */}
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        title="로그인이 필요합니다"
+        description="코스 시작 및 저장 기능을 사용하려면 로그인이 필요합니다."
+        onConfirm={() => router.push('/auth/signin')}
+      />
+    </div>
+  )
+}

--- a/src/components/route/RouteFilterBar.tsx
+++ b/src/components/route/RouteFilterBar.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useCallback } from 'react'
+
+/** 정렬 기준 */
+export type RouteSortType = 'popular' | 'newest' | 'duration'
+
+/** 소요시간 필터 프리셋 */
+interface DurationPreset {
+  label: string
+  min?: number
+  max?: number
+}
+
+const DURATION_PRESETS: DurationPreset[] = [
+  { label: '전체' },
+  { label: '1시간 이내', max: 60 },
+  { label: '1~3시간', min: 60, max: 180 },
+  { label: '3~6시간', min: 180, max: 360 },
+  { label: '6시간 이상', min: 360 },
+]
+
+const SORT_OPTIONS: { value: RouteSortType; label: string }[] = [
+  { value: 'popular', label: '인기순' },
+  { value: 'newest', label: '최신순' },
+  { value: 'duration', label: '소요시간순' },
+]
+
+export interface RouteFilters {
+  sort: RouteSortType
+  contentName: string
+  regionTag: string
+  minDuration?: number
+  maxDuration?: number
+}
+
+interface RouteFilterBarProps {
+  filters: RouteFilters
+  onFiltersChange: (filters: RouteFilters) => void
+}
+
+/**
+ * RouteFilterBar - 코스 필터/정렬 UI
+ * 작품별, 지역별, 소요시간별 필터 + 정렬 옵션
+ * Requirements: 2.1, 2.2
+ */
+export function RouteFilterBar({
+  filters,
+  onFiltersChange,
+}: RouteFilterBarProps) {
+  const updateFilter = useCallback(
+    (partial: Partial<RouteFilters>) => {
+      onFiltersChange({ ...filters, ...partial })
+    },
+    [filters, onFiltersChange]
+  )
+
+  const handleDurationPreset = useCallback(
+    (preset: DurationPreset) => {
+      updateFilter({ minDuration: preset.min, maxDuration: preset.max })
+    },
+    [updateFilter]
+  )
+
+  /** 현재 선택된 소요시간 프리셋 인덱스 */
+  const activeDurationIdx = DURATION_PRESETS.findIndex((p) => {
+    if (!filters.minDuration && !filters.maxDuration) return !p.min && !p.max
+    return p.min === filters.minDuration && p.max === filters.maxDuration
+  })
+
+  return (
+    <div className="space-y-3">
+      {/* 정렬 + 텍스트 필터 */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* 정렬 */}
+        <div className="flex rounded-lg border border-navy-200 bg-white">
+          {SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => updateFilter({ sort: opt.value })}
+              className={`px-3 py-1.5 text-sm transition-colors ${
+                filters.sort === opt.value
+                  ? 'bg-navy-600 text-white'
+                  : 'text-navy-600 hover:bg-navy-50'
+              } ${opt.value === 'popular' ? 'rounded-l-lg' : ''} ${opt.value === 'duration' ? 'rounded-r-lg' : ''}`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 작품명 필터 */}
+        <input
+          type="text"
+          placeholder="작품명 검색"
+          value={filters.contentName}
+          onChange={(e) => updateFilter({ contentName: e.target.value })}
+          className="rounded-lg border border-navy-200 bg-white px-3 py-1.5 text-sm text-navy-800 placeholder-navy-300 outline-none focus:border-navy-400"
+        />
+
+        {/* 지역 필터 */}
+        <input
+          type="text"
+          placeholder="지역 검색"
+          value={filters.regionTag}
+          onChange={(e) => updateFilter({ regionTag: e.target.value })}
+          className="rounded-lg border border-navy-200 bg-white px-3 py-1.5 text-sm text-navy-800 placeholder-navy-300 outline-none focus:border-navy-400"
+        />
+      </div>
+
+      {/* 소요시간 프리셋 */}
+      <div className="flex flex-wrap gap-1.5">
+        {DURATION_PRESETS.map((preset, idx) => (
+          <button
+            key={preset.label}
+            onClick={() => handleDurationPreset(preset)}
+            className={`rounded-full px-3 py-1 text-xs transition-colors ${
+              activeDurationIdx === idx
+                ? 'bg-navy-600 text-white'
+                : 'bg-navy-50 text-navy-600 hover:bg-navy-100'
+            }`}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/route/RouteListContent.tsx
+++ b/src/components/route/RouteListContent.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { RouteCard } from '@/components/route/RouteCard'
+import {
+  RouteFilterBar,
+  type RouteFilters,
+} from '@/components/route/RouteFilterBar'
+import { SkeletonBlock } from '@/components/common/SkeletonUI'
+import type { Route } from '@/types/route'
+
+const PAGE_LIMIT = 12
+
+/** 코스 카드 스켈레톤 */
+function RouteCardSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-navy-200 bg-white shadow-sm">
+      <SkeletonBlock className="h-40 w-full rounded-none" />
+      <div className="p-4">
+        <SkeletonBlock className="mb-2 h-5 w-3/4" />
+        <SkeletonBlock className="mb-3 h-4 w-full" />
+        <SkeletonBlock className="mb-3 h-4 w-1/2" />
+        <div className="flex gap-2">
+          <SkeletonBlock className="h-4 w-12" />
+          <SkeletonBlock className="h-4 w-16" />
+          <SkeletonBlock className="h-4 w-14" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface RoutesResponse {
+  routes: Route[]
+  total: number
+  page: number
+  totalPages: number
+}
+
+/**
+ * RouteListContent - 코스 목록 콘텐츠
+ * RouteCard + RouteFilterBar + 무한 스크롤
+ * Requirements: 2.1, 2.2
+ */
+export function RouteListContent() {
+  const [filters, setFilters] = useState<RouteFilters>({
+    sort: 'popular',
+    contentName: '',
+    regionTag: '',
+  })
+  const [routes, setRoutes] = useState<Route[]>([])
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const observerRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<NodeJS.Timeout | undefined>(undefined)
+
+  /** API 호출 */
+  const fetchRoutes = useCallback(
+    async (pageNum: number, append: boolean) => {
+      if (append) setIsLoadingMore(true)
+      else setIsLoading(true)
+
+      try {
+        const params = new URLSearchParams({
+          sort: filters.sort,
+          page: String(pageNum),
+          limit: String(PAGE_LIMIT),
+        })
+        if (filters.contentName) params.set('contentName', filters.contentName)
+        if (filters.regionTag) params.set('regionTag', filters.regionTag)
+        if (filters.minDuration)
+          params.set('minDuration', String(filters.minDuration))
+        if (filters.maxDuration)
+          params.set('maxDuration', String(filters.maxDuration))
+
+        const res = await fetch(`/api/routes?${params}`)
+        if (!res.ok) throw new Error('fetch failed')
+        const data: RoutesResponse = await res.json()
+
+        if (append) {
+          setRoutes((prev) => [...prev, ...data.routes])
+        } else {
+          setRoutes(data.routes)
+        }
+        setTotalPages(data.totalPages)
+      } catch {
+        // 에러 시 빈 상태 유지
+      } finally {
+        setIsLoading(false)
+        setIsLoadingMore(false)
+      }
+    },
+    [filters]
+  )
+
+  /** 필터 변경 시 디바운스 후 리셋 */
+  useEffect(() => {
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setPage(1)
+      fetchRoutes(1, false)
+    }, 300)
+    return () => clearTimeout(debounceRef.current)
+  }, [fetchRoutes])
+
+  /** 무한 스크롤 IntersectionObserver */
+  useEffect(() => {
+    const el = observerRef.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoadingMore && page < totalPages) {
+          const nextPage = page + 1
+          setPage(nextPage)
+          fetchRoutes(nextPage, true)
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [page, totalPages, isLoadingMore, fetchRoutes])
+
+  return (
+    <div className="space-y-6">
+      <RouteFilterBar filters={filters} onFiltersChange={setFilters} />
+
+      {/* 코스 그리드 */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }, (_, i) => (
+            <RouteCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : routes.length === 0 ? (
+        <div className="py-16 text-center">
+          <p className="text-lg text-navy-400">🗺️ 코스가 없습니다</p>
+          <p className="mt-1 text-sm text-navy-300">
+            필터를 변경하거나 새 코스를 만들어보세요
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {routes.map((route) => (
+              <RouteCard key={route.id} route={route} />
+            ))}
+          </div>
+
+          {/* 무한 스크롤 트리거 */}
+          {page < totalPages && (
+            <div ref={observerRef} className="flex justify-center py-4">
+              {isLoadingMore && (
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-navy-200 border-t-navy-600" />
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useEffect, useRef, useMemo } from 'react'
+import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet'
+import { Map as LeafletMap, DivIcon } from 'leaflet'
+import type { RouteSpot } from '@/types/route'
+import '../map/map.css'
+
+interface RouteMapProps {
+  spots: RouteSpot[]
+  /** 현재 위치 (따라가기 모드용, 선택) */
+  currentPosition?: { lat: number; lng: number } | null
+  /** 현재 목표 스팟 인덱스 (따라가기 모드용, 선택) */
+  currentSpotIndex?: number
+  /** 인증 완료 스팟 ID 목록 (따라가기 모드용, 선택) */
+  checkedSpotIds?: string[]
+  className?: string
+}
+
+/** 순서 번호 마커 아이콘 생성 */
+function createNumberIcon(
+  num: number,
+  isAvailable: boolean,
+  isChecked: boolean,
+  isCurrent: boolean
+): DivIcon {
+  let bgColor = '#345084' // navy-600
+  let borderColor = '#4164a5' // navy-500
+  let textDecoration = ''
+
+  if (!isAvailable) {
+    bgColor = '#9ca3af' // gray-400
+    borderColor = '#6b7280' // gray-500
+    textDecoration = 'line-through'
+  } else if (isChecked) {
+    bgColor = '#16a34a' // green-600
+    borderColor = '#22c55e' // green-500
+  } else if (isCurrent) {
+    bgColor = '#dc2626' // red-600
+    borderColor = '#ef4444' // red-500
+  }
+
+  return new DivIcon({
+    className: 'route-number-marker',
+    html: `<div style="
+      width:28px;height:28px;border-radius:50%;
+      background:${bgColor};border:2px solid ${borderColor};
+      color:white;font-size:12px;font-weight:700;
+      display:flex;align-items:center;justify-content:center;
+      box-shadow:0 2px 6px rgba(0,0,0,0.3);
+      text-decoration:${textDecoration};
+    ">${num}</div>`,
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+    popupAnchor: [0, -16],
+  })
+}
+
+/** 현재 위치 마커 아이콘 */
+const currentLocationIcon = new DivIcon({
+  className: 'current-location-marker',
+  html: `<div style="
+    width:16px;height:16px;border-radius:50%;
+    background:#3b82f6;border:3px solid white;
+    box-shadow:0 0 0 2px #3b82f6,0 2px 8px rgba(59,130,246,0.5);
+  "></div>`,
+  iconSize: [16, 16],
+  iconAnchor: [8, 8],
+})
+
+/**
+ * RouteMap - Leaflet 기반 코스 지도
+ * 스팟 마커(순서 번호) + Polyline 연결
+ * isAvailable:false 스팟은 회색 마커 + 취소선
+ * ⚠️ 마커 클러스터링 비활성화 (순서 파악 필수)
+ * Requirements: 2.3
+ */
+export default function RouteMap({
+  spots,
+  currentPosition,
+  currentSpotIndex,
+  checkedSpotIds = [],
+  className = '',
+}: RouteMapProps) {
+  const mapRef = useRef<LeafletMap | null>(null)
+
+  // 유효 스팟 좌표로 지도 bounds 계산
+  const bounds = useMemo(() => {
+    const coords = spots
+      .filter((s) => s.coordinates)
+      .map((s) => [s.coordinates.lat, s.coordinates.lng] as [number, number])
+    if (coords.length === 0) return null
+    return coords
+  }, [spots])
+
+  // Polyline 좌표 (유효 스팟만)
+  const polylinePositions = useMemo(() => {
+    return spots
+      .filter((s) => s.isAvailable !== false)
+      .map((s) => [s.coordinates.lat, s.coordinates.lng] as [number, number])
+  }, [spots])
+
+  // 소실 스팟 연결선 (점선)
+  const unavailableSegments = useMemo(() => {
+    const segments: [number, number][][] = []
+    for (let i = 0; i < spots.length; i++) {
+      if (spots[i].isAvailable === false) {
+        // 이전 유효 스팟 ~ 소실 스팟 ~ 다음 유효 스팟
+        const prev = spots
+          .slice(0, i)
+          .reverse()
+          .find((s) => s.isAvailable !== false)
+        const next = spots.slice(i + 1).find((s) => s.isAvailable !== false)
+        if (prev && next) {
+          segments.push([
+            [prev.coordinates.lat, prev.coordinates.lng],
+            [spots[i].coordinates.lat, spots[i].coordinates.lng],
+            [next.coordinates.lat, next.coordinates.lng],
+          ])
+        }
+      }
+    }
+    return segments
+  }, [spots])
+
+  const checkedSet = useMemo(() => new Set(checkedSpotIds), [checkedSpotIds])
+
+  // 지도 bounds 맞추기
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !bounds || bounds.length === 0) return
+
+    const timer = setTimeout(() => {
+      map.invalidateSize()
+      if (bounds.length === 1) {
+        map.setView(bounds[0], 15)
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const L = (window as any).L
+        if (L) {
+          const latLngBounds = bounds.reduce(
+            (b: InstanceType<typeof L.LatLngBounds>, point: [number, number]) =>
+              b.extend(point),
+            new L.LatLngBounds()
+          )
+          map.fitBounds(latLngBounds, { padding: [30, 30] })
+        }
+      }
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [bounds])
+
+  const defaultCenter: [number, number] =
+    bounds && bounds.length > 0 ? bounds[0] : [35.6762, 139.6503]
+
+  return (
+    <div className={`relative w-full ${className}`} style={{ height: '400px' }}>
+      <MapContainer
+        center={defaultCenter}
+        zoom={13}
+        style={{ height: '100%', width: '100%' }}
+        className="overflow-hidden rounded-lg border-2 border-navy-200"
+        ref={mapRef}
+        zoomControl={true}
+        scrollWheelZoom={true}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+          className="map-tiles"
+          maxZoom={19}
+        />
+
+        {/* 유효 스팟 연결 Polyline */}
+        {polylinePositions.length >= 2 && (
+          <Polyline
+            positions={polylinePositions}
+            pathOptions={{
+              color: '#345084',
+              weight: 3,
+              opacity: 0.8,
+              dashArray: undefined,
+            }}
+          />
+        )}
+
+        {/* 소실 스팟 구간 점선 */}
+        {unavailableSegments.map((segment, idx) => (
+          <Polyline
+            key={`unavail-${idx}`}
+            positions={segment}
+            pathOptions={{
+              color: '#9ca3af',
+              weight: 2,
+              opacity: 0.5,
+              dashArray: '8, 8',
+            }}
+          />
+        ))}
+
+        {/* 스팟 마커 (순서 번호) */}
+        {spots.map((spot, idx) => (
+          <Marker
+            key={spot.spotId}
+            position={[spot.coordinates.lat, spot.coordinates.lng]}
+            icon={createNumberIcon(
+              idx + 1,
+              spot.isAvailable !== false,
+              checkedSet.has(spot.spotId),
+              currentSpotIndex === idx
+            )}
+          >
+            <Popup>
+              <div className="min-w-[160px] p-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-navy-800">
+                    {idx + 1}.
+                  </span>
+                  <span
+                    className={`text-sm font-semibold ${
+                      spot.isAvailable === false
+                        ? 'text-gray-400 line-through'
+                        : 'text-navy-900'
+                    }`}
+                  >
+                    {spot.spotName}
+                  </span>
+                </div>
+                {spot.isAvailable === false && (
+                  <p className="mt-1 text-xs text-red-500">소실된 스팟</p>
+                )}
+                {spot.distanceFromPrev && (
+                  <p className="mt-1 text-xs text-navy-400">
+                    이전 스팟에서 {spot.distanceFromPrev}m
+                    {spot.walkTimeFromPrev &&
+                      ` · 도보 ${spot.walkTimeFromPrev}분`}
+                  </p>
+                )}
+                {spot.note && (
+                  <p className="mt-1 text-xs text-navy-500">{spot.note}</p>
+                )}
+              </div>
+            </Popup>
+          </Marker>
+        ))}
+
+        {/* 현재 위치 마커 (따라가기 모드) */}
+        {currentPosition && (
+          <Marker
+            position={[currentPosition.lat, currentPosition.lng]}
+            icon={currentLocationIcon}
+          />
+        )}
+      </MapContainer>
+
+      {/* 범례 */}
+      <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm">
+        <div className="flex flex-wrap items-center gap-3 text-xs">
+          <div className="flex items-center gap-1">
+            <div className="h-3 w-3 rounded-full bg-[#345084]" />
+            <span>스팟</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="h-3 w-3 rounded-full bg-gray-400" />
+            <span>소실됨</span>
+          </div>
+          {checkedSpotIds.length > 0 && (
+            <div className="flex items-center gap-1">
+              <div className="h-3 w-3 rounded-full bg-green-600" />
+              <span>인증완료</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #258

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 코스 목록/상세 페이지 UI 및 관련 컴포넌트 구현

---

## 📋 변경 사항

- [x] RouteCard 코스 카드 컴포넌트 (난이도/공식추천 뱃지, 메타정보 표시)
- [x] RouteFilterBar 필터/정렬 컴포넌트 (작품별/지역별/소요시간별 필터 + 인기순/최신순/소요시간순 정렬)
- [x] RouteListContent 무한 스크롤 목록 컴포넌트 (IntersectionObserver 기반)
- [x] 코스 목록 페이지 (/routes)
- [x] RouteMap Leaflet 기반 코스 지도 (순서 번호 마커 + Polyline + 소실 스팟 회색 처리, 클러스터링 비활성화)
- [x] RouteDetailContent 코스 상세 콘텐츠 (지도 + 스팟 순서 목록 + 거리/시간 + 북마크 + 외부 지도 앱 연결)
- [x] 코스 상세 페이지 (/routes/[id])
- [x] Header에 순례 코스 네비게이션 링크 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run build` 통과

---

## 📝 추가 정보

- Requirements 1.4, 2.1, 2.2, 2.3, 2.4, 3.1 대응
- 따라가기 모드(Task 9)는 placeholder로 처리, 추후 구현 예정
- RouteMap은 dynamic import로 SSR 비활성화 (Leaflet 특성)
