### PR TITLE
[Feat] Task 7 - 코스 생성/수정 페이지 구현

### DIFF
--- a/src/app/routes/[id]/edit/page.tsx
+++ b/src/app/routes/[id]/edit/page.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useAuth } from '@/hooks/useAuth'
+import { RouteFormContent } from '@/components/route/RouteFormContent'
+import { SkeletonBlock } from '@/components/common/SkeletonUI'
+import type { Route } from '@/types/route'
+
+/**
+ * 코스 수정 페이지
+ * - 기존 데이터로 폼 프리필
+ * - 작성자만 접근 가능
+ * Requirements: 1.2
+ */
+export default function RouteEditPage() {
+  const params = useParams()
+  const router = useRouter()
+  const routeId = params.id as string
+  const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth()
+
+  const [route, setRoute] = useState<Route | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchRoute() {
+      try {
+        const res = await fetch(`/api/routes/${routeId}`)
+        if (!res.ok) {
+          const data = await res.json()
+          setError(data.error || '코스를 불러올 수 없습니다')
+          return
+        }
+        const data: Route = await res.json()
+        setRoute(data)
+      } catch {
+        setError('코스를 불러올 수 없습니다')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchRoute()
+  }, [routeId])
+
+  // 작성자 권한 확인
+  useEffect(() => {
+    if (isAuthLoading || isLoading) return
+    if (!isAuthenticated) {
+      router.push('/auth/signin')
+      return
+    }
+    if (route && user && route.authorId !== user.id) {
+      setError('권한이 없습니다')
+    }
+  }, [isAuthLoading, isLoading, isAuthenticated, route, user, router])
+
+  const isAuthor = route && user && route.authorId === user.id
+
+  return (
+    <main className="min-h-screen bg-navy-50 pt-14">
+      <div className="mx-auto max-w-3xl px-4 py-6">
+        {/* 뒤로가기 */}
+        <div className="mb-4">
+          <Link
+            href={`/routes/${routeId}`}
+            className="text-sm text-navy-500 transition-colors hover:text-navy-700"
+          >
+            ← 코스 상세로
+          </Link>
+        </div>
+
+        {isLoading || isAuthLoading ? (
+          <div className="space-y-6">
+            <SkeletonBlock className="h-8 w-48" />
+            <SkeletonBlock className="h-64 w-full rounded-lg" />
+            <SkeletonBlock className="h-48 w-full rounded-lg" />
+          </div>
+        ) : error ? (
+          <div className="py-16 text-center">
+            <p className="text-lg text-red-500">{error}</p>
+            <button
+              onClick={() => router.push('/routes')}
+              className="mt-4 rounded-lg bg-navy-600 px-4 py-2 text-sm text-white hover:bg-navy-700"
+            >
+              코스 목록으로 돌아가기
+            </button>
+          </div>
+        ) : route && isAuthor ? (
+          <>
+            <h1 className="mb-6 text-2xl font-bold text-navy-900">
+              ✏️ 코스 수정
+            </h1>
+            <RouteFormContent initialRoute={route} isEditMode />
+          </>
+        ) : null}
+      </div>
+    </main>
+  )
+}

--- a/src/app/routes/create/page.tsx
+++ b/src/app/routes/create/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Link from 'next/link'
+import { RouteFormContent } from '@/components/route/RouteFormContent'
+
+/**
+ * 코스 생성 페이지
+ * Requirements: 1.1, 1.2, 1.3, 1.5
+ */
+export default function RouteCreatePage() {
+  return (
+    <main className="min-h-screen bg-navy-50 pt-14">
+      <div className="mx-auto max-w-3xl px-4 py-6">
+        {/* 뒤로가기 */}
+        <div className="mb-4">
+          <Link
+            href="/routes"
+            className="text-sm text-navy-500 transition-colors hover:text-navy-700"
+          >
+            ← 코스 목록으로
+          </Link>
+        </div>
+
+        <h1 className="mb-6 text-2xl font-bold text-navy-900">
+          🗺️ 새 코스 만들기
+        </h1>
+
+        <RouteFormContent />
+      </div>
+    </main>
+  )
+}

--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -115,14 +115,17 @@ export function RouteFormContent({
     }
     setIsSearching(true)
     try {
-      const res = await fetch(
-        `/api/spots?search=${encodeURIComponent(query)}`
-      )
+      const res = await fetch(`/api/spots?search=${encodeURIComponent(query)}`)
       if (!res.ok) throw new Error()
       const data = await res.json()
       setSearchResults(
         data.spots.map(
-          (s: { id: string; name: string; thumbnailUrl: string; coordinates: number[] }) => ({
+          (s: {
+            id: string
+            name: string
+            thumbnailUrl: string
+            coordinates: number[]
+          }) => ({
             id: s.id,
             name: s.name,
             thumbnailUrl: s.thumbnailUrl,
@@ -205,8 +208,7 @@ export function RouteFormContent({
     if (!description.trim()) errs.push('설명은 필수입니다')
     if (!estimatedDuration || parseInt(estimatedDuration, 10) <= 0)
       errs.push('예상 소요시간은 필수입니다')
-    if (spots.length < 2)
-      errs.push('코스에는 최소 2개의 스팟이 필요합니다')
+    if (spots.length < 2) errs.push('코스에는 최소 2개의 스팟이 필요합니다')
     return errs
   }, [name, description, estimatedDuration, spots])
 
@@ -255,9 +257,18 @@ export function RouteFormContent({
       setIsSubmitting(false)
     }
   }, [
-    validate, name, description, estimatedDuration, difficulty,
-    spots, relatedContentNames, regionTag, isPublic,
-    isEditMode, initialRoute, router,
+    validate,
+    name,
+    description,
+    estimatedDuration,
+    difficulty,
+    spots,
+    relatedContentNames,
+    regionTag,
+    isPublic,
+    isEditMode,
+    initialRoute,
+    router,
   ])
 
   // 미리보기용 RouteSpot 변환
@@ -352,7 +363,9 @@ export function RouteFormContent({
 
           {/* 공개/비공개 */}
           <div className="flex items-center gap-3">
-            <label className="text-sm font-medium text-navy-700">공개 설정</label>
+            <label className="text-sm font-medium text-navy-700">
+              공개 설정
+            </label>
             <button
               type="button"
               onClick={() => setIsPublic(!isPublic)}
@@ -473,9 +486,7 @@ export function RouteFormContent({
                 </div>
               ) : (
                 searchResults.map((result) => {
-                  const alreadyAdded = spots.some(
-                    (s) => s.spotId === result.id
-                  )
+                  const alreadyAdded = spots.some((s) => s.spotId === result.id)
                   return (
                     <button
                       key={result.id}
@@ -551,11 +562,7 @@ export function RouteFormContent({
           disabled={isSubmitting}
           className="flex-1 rounded-lg bg-navy-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-navy-700 disabled:bg-navy-300"
         >
-          {isSubmitting
-            ? '저장 중...'
-            : isEditMode
-              ? '코스 수정'
-              : '코스 생성'}
+          {isSubmitting ? '저장 중...' : isEditMode ? '코스 수정' : '코스 생성'}
         </button>
       </div>
     </div>

--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -1,0 +1,571 @@
+'use client'
+
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import dynamic from 'next/dynamic'
+import { useAuth } from '@/hooks/useAuth'
+import {
+  SpotOrderList,
+  type SpotOrderItem,
+} from '@/components/route/SpotOrderList'
+import { calculateRouteDistances } from '@/lib/route-utils'
+import type { Route, RouteDifficulty } from '@/types/route'
+
+const RouteMap = dynamic(() => import('@/components/route/RouteMap'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[300px] items-center justify-center rounded-lg bg-navy-100">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-navy-300 border-t-navy-600" />
+    </div>
+  ),
+})
+
+interface RouteFormContentProps {
+  /** 수정 모드 시 기존 코스 데이터 */
+  initialRoute?: Route
+  /** 수정 모드 여부 */
+  isEditMode?: boolean
+}
+
+const DIFFICULTY_OPTIONS: { value: RouteDifficulty; label: string }[] = [
+  { value: 'easy', label: '🟢 쉬움' },
+  { value: 'moderate', label: '🟡 보통' },
+  { value: 'hard', label: '🔴 어려움' },
+]
+
+/** SpotOrderItem 배열에 거리/시간 재계산 적용 */
+function recalcDistances(spots: SpotOrderItem[]): SpotOrderItem[] {
+  if (spots.length === 0) return spots
+  const distances = calculateRouteDistances(spots)
+  return spots.map((spot, i) => ({
+    ...spot,
+    distanceFromPrev: distances[i].distanceFromPrev,
+    walkTimeFromPrev: distances[i].walkTimeFromPrev,
+  }))
+}
+
+/**
+ * RouteFormContent - 코스 생성/수정 공통 폼
+ * Requirements: 1.1, 1.2, 1.3, 1.5
+ */
+export function RouteFormContent({
+  initialRoute,
+  isEditMode = false,
+}: RouteFormContentProps) {
+  const router = useRouter()
+  const { isAuthenticated } = useAuth()
+
+  // 폼 상태
+  const [name, setName] = useState(initialRoute?.name || '')
+  const [description, setDescription] = useState(
+    initialRoute?.description || ''
+  )
+  const [estimatedDuration, setEstimatedDuration] = useState(
+    initialRoute?.estimatedDuration?.toString() || ''
+  )
+  const [difficulty, setDifficulty] = useState<RouteDifficulty>(
+    initialRoute?.difficulty || 'moderate'
+  )
+  const [isPublic, setIsPublic] = useState(initialRoute?.isPublic !== false)
+  const [relatedContentNames, setRelatedContentNames] = useState<string[]>(
+    initialRoute?.relatedContentNames || []
+  )
+  const [regionTag, setRegionTag] = useState(initialRoute?.regionTag || '')
+  const [contentInput, setContentInput] = useState('')
+
+  // 스팟 목록
+  const [spots, setSpots] = useState<SpotOrderItem[]>(() => {
+    if (initialRoute?.spots) {
+      return initialRoute.spots.map((s) => ({
+        spotId: s.spotId,
+        spotName: s.spotName,
+        coordinates: s.coordinates,
+        thumbnailUrl: s.thumbnailUrl,
+        note: s.note,
+        distanceFromPrev: s.distanceFromPrev,
+        walkTimeFromPrev: s.walkTimeFromPrev,
+      }))
+    }
+    return []
+  })
+
+  // 스팟 검색
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<SpotSearchResult[]>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const debounceRef = useRef<NodeJS.Timeout | null>(null)
+
+  // 제출 상태
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errors, setErrors] = useState<string[]>([])
+  const [showPreview, setShowPreview] = useState(false)
+
+  // 미인증 시 리다이렉트
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push('/auth/signin')
+    }
+  }, [isAuthenticated, router])
+
+  /** 스팟 검색 */
+  const searchSpots = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setSearchResults([])
+      return
+    }
+    setIsSearching(true)
+    try {
+      const res = await fetch(
+        `/api/spots?search=${encodeURIComponent(query)}`
+      )
+      if (!res.ok) throw new Error()
+      const data = await res.json()
+      setSearchResults(
+        data.spots.map(
+          (s: { id: string; name: string; thumbnailUrl: string; coordinates: number[] }) => ({
+            id: s.id,
+            name: s.name,
+            thumbnailUrl: s.thumbnailUrl,
+            coordinates: s.coordinates,
+          })
+        )
+      )
+    } catch {
+      setSearchResults([])
+    } finally {
+      setIsSearching(false)
+    }
+  }, [])
+
+  /** 디바운스 검색 */
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setSearchQuery(value)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      debounceRef.current = setTimeout(() => searchSpots(value), 300)
+    },
+    [searchSpots]
+  )
+
+  /** 스팟 추가 */
+  const handleAddSpot = useCallback(
+    async (spotId: string) => {
+      // 중복 체크
+      if (spots.some((s) => s.spotId === spotId)) return
+
+      try {
+        const res = await fetch(`/api/spots/${spotId}`)
+        if (!res.ok) return
+        const spot = await res.json()
+
+        const newSpot: SpotOrderItem = {
+          spotId: spot.id,
+          spotName: spot.name,
+          coordinates: spot.coordinates,
+          thumbnailUrl: spot.photos?.[0] || '',
+          note: undefined,
+          distanceFromPrev: null,
+          walkTimeFromPrev: null,
+        }
+
+        const newSpots = recalcDistances([...spots, newSpot])
+        setSpots(newSpots)
+        setSearchQuery('')
+        setSearchResults([])
+      } catch {
+        // 에러 무시
+      }
+    },
+    [spots]
+  )
+
+  /** 스팟 순서 변경 시 거리 재계산 */
+  const handleSpotsChange = useCallback((newSpots: SpotOrderItem[]) => {
+    setSpots(recalcDistances(newSpots))
+  }, [])
+
+  /** 작품명 추가 */
+  const handleAddContent = useCallback(() => {
+    const trimmed = contentInput.trim()
+    if (!trimmed || relatedContentNames.includes(trimmed)) return
+    setRelatedContentNames((prev) => [...prev, trimmed])
+    setContentInput('')
+  }, [contentInput, relatedContentNames])
+
+  /** 작품명 삭제 */
+  const handleRemoveContent = useCallback((index: number) => {
+    setRelatedContentNames((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
+  /** 폼 유효성 검사 */
+  const validate = useCallback((): string[] => {
+    const errs: string[] = []
+    if (!name.trim()) errs.push('코스명은 필수입니다')
+    if (!description.trim()) errs.push('설명은 필수입니다')
+    if (!estimatedDuration || parseInt(estimatedDuration, 10) <= 0)
+      errs.push('예상 소요시간은 필수입니다')
+    if (spots.length < 2)
+      errs.push('코스에는 최소 2개의 스팟이 필요합니다')
+    return errs
+  }, [name, description, estimatedDuration, spots])
+
+  /** 제출 */
+  const handleSubmit = useCallback(async () => {
+    const validationErrors = validate()
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors)
+      return
+    }
+    setErrors([])
+    setIsSubmitting(true)
+
+    const body = {
+      name: name.trim(),
+      description: description.trim(),
+      estimatedDuration: parseInt(estimatedDuration, 10),
+      difficulty,
+      spots: spots.map((s) => ({ spotId: s.spotId, note: s.note })),
+      relatedContentNames,
+      regionTag: regionTag.trim() || undefined,
+      isPublic,
+    }
+
+    try {
+      const url = isEditMode ? `/api/routes/${initialRoute!.id}` : '/api/routes'
+      const method = isEditMode ? 'PUT' : 'POST'
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        setErrors([data.error || '저장에 실패했습니다'])
+        return
+      }
+
+      const data = await res.json()
+      router.push(`/routes/${isEditMode ? initialRoute!.id : data.id}`)
+    } catch {
+      setErrors(['네트워크 오류가 발생했습니다'])
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [
+    validate, name, description, estimatedDuration, difficulty,
+    spots, relatedContentNames, regionTag, isPublic,
+    isEditMode, initialRoute, router,
+  ])
+
+  // 미리보기용 RouteSpot 변환
+  const previewSpots = spots.map((s) => ({
+    ...s,
+    isAvailable: true,
+  }))
+
+  return (
+    <div className="space-y-6">
+      {/* 에러 표시 */}
+      {errors.length > 0 && (
+        <div className="rounded-lg bg-red-50 p-4">
+          {errors.map((err, i) => (
+            <p key={i} className="text-sm text-red-600">
+              {err}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* 기본 정보 */}
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-navy-900">기본 정보</h2>
+        <div className="space-y-4">
+          {/* 코스명 */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              코스명 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 도쿄 반일 봇치 더 록 코스"
+              className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+              maxLength={100}
+            />
+          </div>
+
+          {/* 설명 */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              설명 <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="코스에 대한 설명을 작성해주세요"
+              rows={3}
+              className="w-full resize-none rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+            />
+          </div>
+
+          {/* 예상 소요시간 + 난이도 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-navy-700">
+                예상 소요시간 (분) <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                value={estimatedDuration}
+                onChange={(e) => setEstimatedDuration(e.target.value)}
+                placeholder="120"
+                min={1}
+                className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-navy-700">
+                난이도 <span className="text-red-500">*</span>
+              </label>
+              <div className="flex gap-2">
+                {DIFFICULTY_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setDifficulty(opt.value)}
+                    className={`flex-1 rounded-lg border px-2 py-2 text-sm transition-colors ${
+                      difficulty === opt.value
+                        ? 'border-navy-500 bg-navy-50 font-medium text-navy-700'
+                        : 'border-navy-200 text-navy-500 hover:border-navy-300'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* 공개/비공개 */}
+          <div className="flex items-center gap-3">
+            <label className="text-sm font-medium text-navy-700">공개 설정</label>
+            <button
+              type="button"
+              onClick={() => setIsPublic(!isPublic)}
+              className={`relative h-6 w-11 rounded-full transition-colors ${
+                isPublic ? 'bg-navy-600' : 'bg-navy-200'
+              }`}
+              role="switch"
+              aria-checked={isPublic}
+            >
+              <span
+                className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                  isPublic ? 'left-[22px]' : 'left-0.5'
+                }`}
+              />
+            </button>
+            <span className="text-sm text-navy-500">
+              {isPublic ? '공개' : '비공개'}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* 관련 작품 + 지역 태그 */}
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-navy-900">태그 정보</h2>
+        <div className="space-y-4">
+          {/* 관련 작품 */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              관련 작품
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={contentInput}
+                onChange={(e) => setContentInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleAddContent()
+                  }
+                }}
+                placeholder="작품명 입력 후 추가"
+                className="flex-1 rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleAddContent}
+                disabled={!contentInput.trim()}
+                className="rounded-lg bg-navy-100 px-3 text-sm text-navy-600 hover:bg-navy-200 disabled:opacity-40"
+              >
+                추가
+              </button>
+            </div>
+            {relatedContentNames.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {relatedContentNames.map((c, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center gap-1 rounded-full bg-navy-100 px-2.5 py-0.5 text-xs text-navy-600"
+                  >
+                    {c}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveContent(i)}
+                      className="text-navy-400 hover:text-red-500"
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 지역 태그 */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              지역 태그
+            </label>
+            <input
+              type="text"
+              value={regionTag}
+              onChange={(e) => setRegionTag(e.target.value)}
+              placeholder="예: 도쿄, 가마쿠라"
+              className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 스팟 관리 */}
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-navy-900">
+          스팟 목록 <span className="text-red-500">*</span>
+          <span className="ml-2 text-sm font-normal text-navy-400">
+            ({spots.length}개)
+          </span>
+        </h2>
+
+        {/* 스팟 검색 */}
+        <div className="relative mb-4">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={handleSearchChange}
+            placeholder="스팟 이름 또는 작품명으로 검색하여 추가"
+            className="w-full rounded-lg border border-navy-200 px-3 py-2 pl-9 text-sm focus:border-navy-500 focus:outline-none"
+          />
+          <span className="absolute left-3 top-2.5 text-navy-300">🔍</span>
+
+          {/* 검색 결과 드롭다운 */}
+          {(searchResults.length > 0 || isSearching) && searchQuery && (
+            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-navy-200 bg-white shadow-lg">
+              {isSearching ? (
+                <div className="flex items-center justify-center py-4">
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-navy-400 border-t-transparent" />
+                </div>
+              ) : (
+                searchResults.map((result) => {
+                  const alreadyAdded = spots.some(
+                    (s) => s.spotId === result.id
+                  )
+                  return (
+                    <button
+                      key={result.id}
+                      type="button"
+                      onClick={() => handleAddSpot(result.id)}
+                      disabled={alreadyAdded}
+                      className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-navy-50 disabled:opacity-40"
+                    >
+                      <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded bg-navy-100">
+                        {result.thumbnailUrl ? (
+                          <img
+                            src={result.thumbnailUrl}
+                            alt={result.name}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-full items-center justify-center text-xs text-navy-300">
+                            📍
+                          </div>
+                        )}
+                      </div>
+                      <span className="truncate text-sm text-navy-800">
+                        {result.name}
+                      </span>
+                      {alreadyAdded && (
+                        <span className="ml-auto text-xs text-navy-400">
+                          추가됨
+                        </span>
+                      )}
+                    </button>
+                  )
+                })
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* 스팟 순서 목록 */}
+        <SpotOrderList spots={spots} onSpotsChange={handleSpotsChange} />
+      </section>
+
+      {/* 미리보기 */}
+      {showPreview && spots.length >= 2 && (
+        <section className="rounded-lg bg-white p-6 shadow-sm">
+          <h2 className="mb-3 text-lg font-semibold text-navy-900">
+            코스 미리보기
+          </h2>
+          <RouteMap spots={previewSpots} />
+        </section>
+      )}
+
+      {/* 하단 액션 */}
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="rounded-lg border border-navy-200 bg-white px-6 py-3 text-sm text-navy-600 transition-colors hover:bg-navy-50"
+        >
+          취소
+        </button>
+        {spots.length >= 2 && (
+          <button
+            type="button"
+            onClick={() => setShowPreview(!showPreview)}
+            className="rounded-lg border border-navy-200 bg-white px-6 py-3 text-sm text-navy-600 transition-colors hover:bg-navy-50"
+          >
+            {showPreview ? '미리보기 닫기' : '🗺️ 미리보기'}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+          className="flex-1 rounded-lg bg-navy-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-navy-700 disabled:bg-navy-300"
+        >
+          {isSubmitting
+            ? '저장 중...'
+            : isEditMode
+              ? '코스 수정'
+              : '코스 생성'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/** 스팟 검색 결과 타입 */
+interface SpotSearchResult {
+  id: string
+  name: string
+  thumbnailUrl: string
+  coordinates: number[]
+}

--- a/src/components/route/SpotOrderList.tsx
+++ b/src/components/route/SpotOrderList.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useState, useCallback, useRef } from 'react'
+import type { RouteSpot } from '@/types/route'
+
+/** 스팟 순서 관리용 아이템 (생성/수정 폼에서 사용) */
+export interface SpotOrderItem {
+  spotId: string
+  spotName: string
+  coordinates: { lat: number; lng: number }
+  thumbnailUrl: string
+  note?: string
+  /** 클라이언트에서 계산된 거리/시간 (읽기 전용 표시용) */
+  distanceFromPrev: number | null
+  walkTimeFromPrev: number | null
+}
+
+interface SpotOrderListProps {
+  spots: SpotOrderItem[]
+  onSpotsChange: (spots: SpotOrderItem[]) => void
+}
+
+/** 거리 포맷 */
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters}m`
+  return `${(meters / 1000).toFixed(1)}km`
+}
+
+/**
+ * SpotOrderList - 스팟 순서 관리 컴포넌트
+ * 드래그 앤 드롭으로 순서 변경, 거리/시간 표시, 메모 입력
+ * Requirements: 1.2, 1.3
+ */
+export function SpotOrderList({ spots, onSpotsChange }: SpotOrderListProps) {
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+  const [editingNoteIndex, setEditingNoteIndex] = useState<number | null>(null)
+  const noteInputRef = useRef<HTMLTextAreaElement>(null)
+
+  /** 드래그 시작 */
+  const handleDragStart = useCallback((index: number) => {
+    setDraggedIndex(index)
+  }, [])
+
+  /** 드래그 오버 */
+  const handleDragOver = useCallback(
+    (e: React.DragEvent, index: number) => {
+      e.preventDefault()
+      if (draggedIndex === null || draggedIndex === index) return
+      setDragOverIndex(index)
+    },
+    [draggedIndex]
+  )
+
+  /** 드롭 - 순서 변경 */
+  const handleDrop = useCallback(
+    (e: React.DragEvent, dropIndex: number) => {
+      e.preventDefault()
+      if (draggedIndex === null || draggedIndex === dropIndex) return
+
+      const newSpots = [...spots]
+      const [dragged] = newSpots.splice(draggedIndex, 1)
+      newSpots.splice(dropIndex, 0, dragged)
+      onSpotsChange(newSpots)
+      setDraggedIndex(null)
+      setDragOverIndex(null)
+    },
+    [draggedIndex, spots, onSpotsChange]
+  )
+
+  /** 드래그 종료 */
+  const handleDragEnd = useCallback(() => {
+    setDraggedIndex(null)
+    setDragOverIndex(null)
+  }, [])
+
+  /** 스팟 삭제 */
+  const handleRemove = useCallback(
+    (index: number) => {
+      onSpotsChange(spots.filter((_, i) => i !== index))
+    },
+    [spots, onSpotsChange]
+  )
+
+  /** 메모 업데이트 */
+  const handleNoteChange = useCallback(
+    (index: number, note: string) => {
+      const newSpots = [...spots]
+      newSpots[index] = { ...newSpots[index], note: note || undefined }
+      onSpotsChange(newSpots)
+    },
+    [spots, onSpotsChange]
+  )
+
+  if (spots.length === 0) {
+    return (
+      <div className="rounded-lg border-2 border-dashed border-navy-200 p-8 text-center">
+        <p className="text-sm text-navy-400">
+          스팟을 검색하여 코스에 추가해주세요
+        </p>
+        <p className="mt-1 text-xs text-navy-300">최소 2개의 스팟이 필요합니다</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-0">
+      {spots.map((spot, idx) => (
+        <div key={`${spot.spotId}-${idx}`}>
+          {/* 이동 거리/시간 표시 (첫 스팟 제외) */}
+          {idx > 0 && spot.distanceFromPrev !== null && (
+            <div className="flex items-center gap-2 py-1.5 pl-8">
+              <div className="h-4 w-px bg-navy-200" />
+              <span className="text-xs text-navy-400">
+                ↓ {formatDistance(spot.distanceFromPrev)}
+                {spot.walkTimeFromPrev !== null &&
+                  ` · 도보 약 ${spot.walkTimeFromPrev}분`}
+              </span>
+            </div>
+          )}
+
+          {/* 스팟 카드 */}
+          <div
+            draggable
+            onDragStart={() => handleDragStart(idx)}
+            onDragOver={(e) => handleDragOver(e, idx)}
+            onDrop={(e) => handleDrop(e, idx)}
+            onDragEnd={handleDragEnd}
+            className={`flex items-center gap-3 rounded-lg border p-3 transition-colors ${
+              draggedIndex === idx
+                ? 'border-navy-400 bg-navy-50 opacity-50'
+                : dragOverIndex === idx
+                  ? 'border-navy-500 bg-navy-50'
+                  : 'border-navy-200 bg-white hover:border-navy-300'
+            } cursor-grab active:cursor-grabbing`}
+          >
+            {/* 드래그 핸들 + 순서 번호 */}
+            <div className="flex flex-shrink-0 flex-col items-center gap-1">
+              <span className="text-xs text-navy-300">⠿</span>
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-navy-600 text-xs font-bold text-white">
+                {idx + 1}
+              </div>
+            </div>
+
+            {/* 썸네일 */}
+            <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg bg-navy-100">
+              {spot.thumbnailUrl ? (
+                <img
+                  src={spot.thumbnailUrl}
+                  alt={spot.spotName}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-lg text-navy-300">
+                  📍
+                </div>
+              )}
+            </div>
+
+            {/* 스팟 정보 */}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-navy-900">
+                {spot.spotName}
+              </p>
+              {spot.note && editingNoteIndex !== idx && (
+                <p className="truncate text-xs text-navy-400">{spot.note}</p>
+              )}
+              {editingNoteIndex === idx && (
+                <textarea
+                  ref={noteInputRef}
+                  defaultValue={spot.note || ''}
+                  placeholder="메모 입력..."
+                  rows={2}
+                  className="mt-1 w-full resize-none rounded border border-navy-200 px-2 py-1 text-xs text-navy-700 focus:border-navy-400 focus:outline-none"
+                  onBlur={(e) => {
+                    handleNoteChange(idx, e.target.value)
+                    setEditingNoteIndex(null)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      handleNoteChange(idx, e.currentTarget.value)
+                      setEditingNoteIndex(null)
+                    }
+                  }}
+                  autoFocus
+                />
+              )}
+            </div>
+
+            {/* 액션 버튼 */}
+            <div className="flex flex-shrink-0 gap-1">
+              <button
+                type="button"
+                onClick={() => setEditingNoteIndex(editingNoteIndex === idx ? null : idx)}
+                className="rounded p-1.5 text-navy-400 transition-colors hover:bg-navy-50 hover:text-navy-600"
+                title="메모"
+              >
+                📝
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRemove(idx)}
+                className="rounded p-1.5 text-navy-400 transition-colors hover:bg-red-50 hover:text-red-500"
+                title="삭제"
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {spots.length < 2 && (
+        <p className="mt-2 text-center text-xs text-amber-600">
+          ⚠️ 코스에는 최소 2개의 스팟이 필요합니다 (현재 {spots.length}개)
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** RouteSpot → SpotOrderItem 변환 유틸리티 */
+export function routeSpotToOrderItem(spot: RouteSpot): SpotOrderItem {
+  return {
+    spotId: spot.spotId,
+    spotName: spot.spotName,
+    coordinates: spot.coordinates,
+    thumbnailUrl: spot.thumbnailUrl,
+    note: spot.note,
+    distanceFromPrev: spot.distanceFromPrev,
+    walkTimeFromPrev: spot.walkTimeFromPrev,
+  }
+}

--- a/src/components/route/SpotOrderList.tsx
+++ b/src/components/route/SpotOrderList.tsx
@@ -98,7 +98,9 @@ export function SpotOrderList({ spots, onSpotsChange }: SpotOrderListProps) {
         <p className="text-sm text-navy-400">
           스팟을 검색하여 코스에 추가해주세요
         </p>
-        <p className="mt-1 text-xs text-navy-300">최소 2개의 스팟이 필요합니다</p>
+        <p className="mt-1 text-xs text-navy-300">
+          최소 2개의 스팟이 필요합니다
+        </p>
       </div>
     )
   }
@@ -192,7 +194,9 @@ export function SpotOrderList({ spots, onSpotsChange }: SpotOrderListProps) {
             <div className="flex flex-shrink-0 gap-1">
               <button
                 type="button"
-                onClick={() => setEditingNoteIndex(editingNoteIndex === idx ? null : idx)}
+                onClick={() =>
+                  setEditingNoteIndex(editingNoteIndex === idx ? null : idx)
+                }
                 className="rounded p-1.5 text-navy-400 transition-colors hover:bg-navy-50 hover:text-navy-600"
                 title="메모"
               >


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #260

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 코스 생성/수정 페이지 및 스팟 순서 관리 컴포넌트 구현

---

## 📋 변경 사항

- [x] SpotOrderList 컴포넌트 (HTML5 Drag API 기반 드래그 앤 드롭 순서 변경, 거리/시간 표시, 메모 입력)
- [x] RouteFormContent 공통 폼 컴포넌트 (기본 정보 입력, 스팟 검색/선택, 태그 관리, 공개/비공개 설정, 미리보기)
- [x] 코스 생성 페이지 (/routes/create)
- [x] 코스 수정 페이지 (/routes/[id]/edit) - 기존 데이터 프리필, 작성자 권한 확인

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 1.1, 1.2, 1.3, 1.5 대응
- RouteFormContent를 생성/수정 페이지에서 공통으로 재사용하는 구조
- 외부 DnD 라이브러리 없이 HTML5 Drag API로 구현
