### PR TITLE
[Feat] 코스 등록 시퀀스 재배치 및 regionTags 복수 선택 개선

### DIFF
--- a/.kiro/specs/10-pilgrimage-route/tasks.md
+++ b/.kiro/specs/10-pilgrimage-route/tasks.md
@@ -91,15 +91,15 @@
 - [ ] 4. Checkpoint - 백엔드 검증
   - 모든 API 테스트 통과 확인, 유저에게 질문이 있으면 문의하세요.
 
-- [ ] 5. Zustand 스토어 및 네비게이션 훅 구현
-  - [ ] 5.1 courseProgressStore 구현
+- [x] 5. Zustand 스토어 및 네비게이션 훅 구현
+  - [x] 5.1 courseProgressStore 구현
     - `src/stores/courseProgressStore.ts`에 코스 진행 상태 관리 스토어 구현
     - 상태: activeRouteId, activeRoute, currentSpotIndex, checkedSpotIds(Set), startedAt, isNavigating
     - 액션: startRoute (기존 Check-in 기록 조회하여 자동 반영), checkInSpot, moveToNextSpot, endRoute, resetProgress
     - startRoute 시 `GET /api/checkins?userId=...` 호출하여 이미 인증된 스팟 자동 포함
     - _Requirements: 3.1, 3.2, 3.4_
 
-  - [ ] 5.2 useRouteNavigation 훅 구현
+  - [x] 5.2 useRouteNavigation 훅 구현
     - `src/hooks/useRouteNavigation.ts`에 네비게이션 로직 훅 구현
     - courseProgressStore + useGeolocation 조합
     - 현재 위치 기반 다음 스팟까지 거리/시간 실시간 계산
@@ -118,31 +118,31 @@
     - 단위 테스트: 스팟 0개 엣지 케이스, 중복 인증 처리, endRoute 후 상태 초기화
     - _Requirements: 3.1, 3.4, 3.5_
 
-- [ ] 6. 코스 목록 및 상세 페이지 구현
-  - [ ] 6.1 RouteCard 컴포넌트 구현
+- [x] 6. 코스 목록 및 상세 페이지 구현
+  - [x] 6.1 RouteCard 컴포넌트 구현
     - `src/components/route/RouteCard.tsx`에 코스 카드 컴포넌트 구현
     - 코스명, 스팟 수, 예상 시간, 난이도, 북마크 수, 공식 추천 뱃지 표시
     - _Requirements: 2.1_
 
-  - [ ] 6.2 RouteFilterBar 컴포넌트 구현
+  - [x] 6.2 RouteFilterBar 컴포넌트 구현
     - `src/components/route/RouteFilterBar.tsx`에 필터 UI 구현
     - 작품별, 지역별, 소요시간별 필터 + 정렬 옵션 (인기순/최신순/소요시간순)
     - _Requirements: 2.1, 2.2_
 
-  - [ ] 6.3 코스 목록 페이지 구현
+  - [x] 6.3 코스 목록 페이지 구현
     - `src/app/routes/page.tsx`에 코스 목록 페이지 구현
     - RouteCard + RouteFilterBar 조합
     - 무한 스크롤 페이지네이션
     - _Requirements: 2.1, 2.2_
 
-  - [ ] 6.4 RouteMap 컴포넌트 구현
+  - [x] 6.4 RouteMap 컴포넌트 구현
     - `src/components/route/RouteMap.tsx`에 Leaflet 기반 코스 지도 구현
     - 스팟 마커 + 순서 번호 표시, 스팟 간 Polyline 연결
     - isAvailable:false 스팟은 회색 마커 + 취소선으로 표시
     - ⚠️ 주의: 코스 동선의 순서를 명확히 보여주기 위해 RouteMap에서는 마커 클러스터링(Marker Clustering) 플러그인을 반드시 비활성화해야 함 (마커가 합쳐지면 순서 파악 불가)
     - _Requirements: 2.3_
 
-  - [ ] 6.5 코스 상세 페이지 구현
+  - [x] 6.5 코스 상세 페이지 구현
     - `src/app/routes/[id]/page.tsx`에 코스 상세 페이지 구현
     - RouteMap + 스팟 순서 목록 + 스팟 간 이동 거리/시간 표시
     - "코스 시작" / "코스 저장" 버튼
@@ -150,14 +150,14 @@
     - 코스 제작자 정보 표시
     - _Requirements: 1.4, 2.3, 2.4, 3.1_
 
-- [ ] 7. 코스 생성/수정 페이지 구현
-  - [ ] 7.1 SpotOrderList 컴포넌트 구현
+- [x] 7. 코스 생성/수정 페이지 구현
+  - [x] 7.1 SpotOrderList 컴포넌트 구현
     - `src/components/route/SpotOrderList.tsx`에 스팟 순서 관리 컴포넌트 구현
     - 드래그 앤 드롭으로 스팟 순서 변경
     - 스팟 간 거리/시간 표시, 스팟별 메모 입력
     - _Requirements: 1.2, 1.3_
 
-  - [ ] 7.2 코스 생성 페이지 구현
+  - [x] 7.2 코스 생성 페이지 구현
     - `src/app/routes/create/page.tsx`에 코스 생성 페이지 구현
     - 기본 정보 입력 (코스명, 설명, 예상 소요시간, 난이도)
     - 스팟 검색/선택 UI (지도에서 선택 또는 검색)
@@ -166,13 +166,13 @@
     - 미리보기 기능
     - _Requirements: 1.1, 1.2, 1.3, 1.5_
 
-  - [ ] 7.3 코스 수정 페이지 구현
+  - [x] 7.3 코스 수정 페이지 구현
     - `src/app/routes/[id]/edit/page.tsx`에 코스 수정 페이지 구현
     - 생성 페이지와 동일한 폼을 기존 데이터로 프리필
     - 작성자만 접근 가능
     - _Requirements: 1.2_
 
-- [ ] 8. Checkpoint - 기본 UI 검증
+- [x] 8. Checkpoint - 기본 UI 검증
   - 코스 목록/상세/생성/수정 페이지 동작 확인, 유저에게 질문이 있으면 문의하세요.
 
 - [ ] 9. 따라가기 모드 (네비게이션) 구현

--- a/public/icons/start-point/building.svg
+++ b/public/icons/start-point/building.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="2" width="16" height="20" rx="1"/><path d="M9 22V12h6v10"/><path d="M8 6h.01"/><path d="M16 6h.01"/><path d="M8 10h.01"/><path d="M16 10h.01"/></svg>

--- a/public/icons/start-point/bus.svg
+++ b/public/icons/start-point/bus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6v6"/><path d="M16 6v6"/><rect x="4" y="3" width="16" height="16" rx="3"/><path d="M4 12h16"/><circle cx="8" cy="21" r="1"/><circle cx="16" cy="21" r="1"/><path d="M7 19h10"/></svg>

--- a/public/icons/start-point/default.svg
+++ b/public/icons/start-point/default.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>

--- a/public/icons/start-point/station.svg
+++ b/public/icons/start-point/station.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="3" width="16" height="14" rx="2"/><path d="M4 11h16"/><path d="M12 3v8"/><circle cx="8" cy="19" r="2"/><circle cx="16" cy="19" r="2"/><path d="M6 17l-2 4"/><path d="M18 17l2 4"/></svg>

--- a/public/icons/start-point/stop.svg
+++ b/public/icons/start-point/stop.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 10h18"/><path d="M8 5v5"/><path d="M16 5v5"/><circle cx="8" cy="16" r="1"/><circle cx="16" cy="16" r="1"/></svg>

--- a/src/app/api/routes/[id]/route.ts
+++ b/src/app/api/routes/[id]/route.ts
@@ -152,8 +152,10 @@ export async function PUT(
     if (body.difficulty) updateFields.difficulty = body.difficulty
     if (body.relatedContentNames !== undefined)
       updateFields.relatedContentNames = body.relatedContentNames
-    if (body.regionTag !== undefined) updateFields.regionTag = body.regionTag
+    if (body.regionTags !== undefined) updateFields.regionTags = body.regionTags
     if (body.isPublic !== undefined) updateFields.isPublic = body.isPublic
+    if (body.startPoint !== undefined)
+      updateFields.startPoint = body.startPoint || undefined
 
     // 스팟 목록 변경 시 거리/시간 재계산
     if (body.spots) {

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -130,10 +130,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       description: body.description.trim(),
       estimatedDuration: body.estimatedDuration,
       difficulty: body.difficulty,
+      startPoint: body.startPoint || undefined,
       spots: routeSpots,
       totalDistance,
       relatedContentNames: body.relatedContentNames || [],
-      regionTag: body.regionTag || undefined,
+      regionTags:
+        Array.isArray(body.regionTags) && body.regionTags.length > 0
+          ? body.regionTags
+          : undefined,
       isPublic: body.isPublic !== false,
       isOfficial: false,
       bookmarkCount: 0,
@@ -219,7 +223,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // 지역별 필터
     if (regionTag) {
-      query.regionTag = regionTag
+      query.regionTags = { $in: [regionTag] }
     }
 
     // 소요시간별 필터

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -222,7 +222,7 @@ export default function Home() {
             <ContentSearchFilter onExpandChange={setIsSearchExpanded} />
             {/* 카테고리 필터 - 검색창이 열리면 숨김 */}
             {!isSearchExpanded && (
-              <div className="rounded-full bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
+              <div className="rounded-2xl bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
                 <CategoryFilter />
               </div>
             )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
 import { useAuth } from '@/hooks/useAuth'
 
 export function Header() {
   const { user, isAuthenticated, isLoading, logout } = useAuth()
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   return (
     <header className="fixed left-0 right-0 top-0 z-50 border-b border-slate-700 bg-slate-900/95 pt-safe-top backdrop-blur-sm">
@@ -14,7 +16,7 @@ export function Header() {
           <span className="text-xl font-bold text-white">✈️ Not a Trip</span>
         </Link>
 
-        {/* 네비게이션 */}
+        {/* 데스크톱 네비게이션 */}
         <nav className="hidden items-center gap-6 md:flex">
           <Link
             href="/"
@@ -48,7 +50,7 @@ export function Header() {
           </Link>
         </nav>
 
-        {/* 인증 영역 */}
+        {/* 인증 영역 + 모바일 메뉴 버튼 */}
         <div className="flex items-center gap-3">
           {isLoading ? (
             <div className="h-8 w-20 animate-pulse rounded bg-slate-700" />
@@ -72,8 +74,88 @@ export function Header() {
               로그인
             </Link>
           )}
+
+          {/* 모바일 햄버거 버튼 */}
+          <button
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-300 transition hover:bg-slate-700 hover:text-white md:hidden"
+            aria-label="메뉴 열기"
+          >
+            {isMobileMenuOpen ? (
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
+
+      {/* 모바일 드롭다운 메뉴 */}
+      {isMobileMenuOpen && (
+        <nav className="border-t border-slate-700 bg-slate-900/95 backdrop-blur-sm md:hidden">
+          <div className="space-y-1 px-4 py-3">
+            <Link
+              href="/"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+            >
+              홈
+            </Link>
+            <Link
+              href="/gallery"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+            >
+              순례 갤러리
+            </Link>
+            <Link
+              href="/routes"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+            >
+              순례 코스
+            </Link>
+            <Link
+              href="/spots/register"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+            >
+              스팟 등록
+            </Link>
+            <Link
+              href="/test/status-report"
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="block rounded-lg px-3 py-2 text-sm text-yellow-400 transition hover:bg-slate-800 hover:text-yellow-300"
+            >
+              🧪 테스트
+            </Link>
+          </div>
+        </nav>
+      )}
     </header>
   )
 }

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -6,6 +6,13 @@ import dynamic from 'next/dynamic'
 import { useAuth } from '@/hooks/useAuth'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import type { Route, RouteDifficulty } from '@/types/route'
+import {
+  getTravelMode,
+  getTravelModeLabel,
+  getTravelModeIcon,
+  getGoogleMapsDirectionsUrl,
+  calculateStartToFirstSpot,
+} from '@/lib/route-utils'
 
 const RouteMap = dynamic(() => import('@/components/route/RouteMap'), {
   ssr: false,
@@ -36,19 +43,6 @@ function formatDuration(minutes: number): string {
 function formatDistance(meters: number): string {
   if (meters < 1000) return `${meters}m`
   return `${(meters / 1000).toFixed(1)}km`
-}
-
-/** 외부 지도 앱 URL 생성 */
-function getExternalMapUrl(
-  lat: number,
-  lng: number,
-  name: string,
-  app: 'google' | 'yahoo'
-): string {
-  if (app === 'google') {
-    return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&destination_place_id=${encodeURIComponent(name)}`
-  }
-  return `https://map.yahoo.co.jp/route/walk?lat=${lat}&lon=${lng}&name=${encodeURIComponent(name)}`
 }
 
 /**
@@ -147,10 +141,17 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         )}
 
         {/* 지역 태그 */}
-        {route.regionTag && (
-          <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs text-blue-600">
-            📍 {route.regionTag}
-          </span>
+        {route.regionTags && route.regionTags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {route.regionTags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs text-blue-600"
+              >
+                📍 {tag}
+              </span>
+            ))}
+          </div>
         )}
 
         {/* 작성자 정보 */}
@@ -191,7 +192,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       {/* 코스 지도 */}
       <div className="rounded-lg bg-white p-4 shadow-sm">
         <h2 className="mb-3 text-lg font-semibold text-navy-900">코스 지도</h2>
-        <RouteMap spots={route.spots} />
+        <RouteMap spots={route.spots} startPoint={route.startPoint} />
       </div>
 
       {/* 스팟 순서 목록 */}
@@ -200,6 +201,65 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
           코스 순서 ({availableSpots.length}곳)
         </h2>
         <ol className="space-y-0">
+          {/* 시작 지점 표시 */}
+          {route.startPoint &&
+            route.spots.length > 0 &&
+            (() => {
+              const info = calculateStartToFirstSpot(
+                route.startPoint,
+                route.spots[0]
+              )
+              const mode = info ? getTravelMode(info.distance) : null
+              return (
+                <li>
+                  <div className="flex items-center gap-3 rounded-lg bg-blue-50 p-3">
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-sm text-white">
+                      🏠
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-navy-900">
+                        {route.startPoint.name}
+                      </p>
+                      <p className="truncate text-xs text-navy-400">
+                        {route.startPoint.address}
+                      </p>
+                    </div>
+                  </div>
+                  {info && mode && (
+                    <div className="flex items-center gap-2 py-2 pl-8">
+                      <div className="h-4 w-px bg-navy-200" />
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-xs text-navy-400">
+                          ↓ {formatDistance(info.distance)}
+                          {' · '}
+                          {getTravelModeIcon(mode)}{' '}
+                          {mode === 'walking' && info.walkTime !== null
+                            ? `도보 약 ${info.walkTime}분`
+                            : getTravelModeLabel(mode)}
+                        </span>
+                        {mode !== 'walking' && (
+                          <a
+                            href={getGoogleMapsDirectionsUrl(
+                              route.startPoint.coordinates.lat,
+                              route.startPoint.coordinates.lng,
+                              route.spots[0].coordinates.lat,
+                              route.spots[0].coordinates.lng,
+                              mode
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-600 transition-colors hover:bg-blue-100"
+                          >
+                            🗺️ 구글맵 길찾기
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </li>
+              )
+            })()}
+
           {route.spots.map((spot, idx) => {
             const isUnavailable = spot.isAvailable === false
             return (
@@ -208,11 +268,38 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
                 {idx > 0 && spot.distanceFromPrev && (
                   <div className="flex items-center gap-2 py-2 pl-8">
                     <div className="h-4 w-px bg-navy-200" />
-                    <span className="text-xs text-navy-400">
-                      ↓ {formatDistance(spot.distanceFromPrev)}
-                      {spot.walkTimeFromPrev &&
-                        ` · 도보 약 ${spot.walkTimeFromPrev}분`}
-                    </span>
+                    {(() => {
+                      const mode = getTravelMode(spot.distanceFromPrev)
+                      const prev = route.spots[idx - 1]
+                      return (
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-xs text-navy-400">
+                            ↓ {formatDistance(spot.distanceFromPrev)}
+                            {' · '}
+                            {getTravelModeIcon(mode)}{' '}
+                            {mode === 'walking' && spot.walkTimeFromPrev
+                              ? `도보 약 ${spot.walkTimeFromPrev}분`
+                              : getTravelModeLabel(mode)}
+                          </span>
+                          {mode !== 'walking' && prev.isAvailable !== false && (
+                            <a
+                              href={getGoogleMapsDirectionsUrl(
+                                prev.coordinates.lat,
+                                prev.coordinates.lng,
+                                spot.coordinates.lat,
+                                spot.coordinates.lng,
+                                mode
+                              )}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-600 transition-colors hover:bg-blue-100"
+                            >
+                              🗺️ 구글맵 길찾기
+                            </a>
+                          )}
+                        </div>
+                      )
+                    })()}
                   </div>
                 )}
 
@@ -267,39 +354,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
                     )}
                   </div>
 
-                  {/* 외부 지도 앱 버튼 */}
-                  {!isUnavailable && (
-                    <div className="flex flex-shrink-0 gap-1">
-                      <a
-                        href={getExternalMapUrl(
-                          spot.coordinates.lat,
-                          spot.coordinates.lng,
-                          spot.spotName,
-                          'google'
-                        )}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="rounded bg-navy-50 px-2 py-1 text-xs text-navy-500 transition-colors hover:bg-navy-100"
-                        title="구글맵에서 경로 탐색"
-                      >
-                        🗺️
-                      </a>
-                      <a
-                        href={getExternalMapUrl(
-                          spot.coordinates.lat,
-                          spot.coordinates.lng,
-                          spot.spotName,
-                          'yahoo'
-                        )}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="rounded bg-navy-50 px-2 py-1 text-xs text-navy-500 transition-colors hover:bg-navy-100"
-                        title="야후재팬맵에서 경로 탐색"
-                      >
-                        🇯🇵
-                      </a>
-                    </div>
-                  )}
+                  {/* 외부 지도 앱 버튼 - 제거됨 (코스 상세에서 불필요) */}
                 </div>
               </li>
             )

--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -33,6 +33,53 @@ const DIFFICULTY_OPTIONS: { value: RouteDifficulty; label: string }[] = [
   { value: 'hard', label: '🔴 어려움' },
 ]
 
+/** 사전 정의된 지역 태그 목록 */
+const REGION_TAG_OPTIONS = [
+  '도쿄',
+  '가마쿠라/에노시마',
+  '교토',
+  '오사카',
+  '나고야',
+  '삿포로',
+  '후쿠오카',
+  '오키나와',
+  '기타',
+]
+
+/** 주소 키워드 → 지역 태그 매핑 (일본어/한국어 주소 대응) */
+const REGION_ADDRESS_MAP: { keywords: string[]; tag: string }[] = [
+  { keywords: ['東京', '도쿄', 'Tokyo'], tag: '도쿄' },
+  {
+    keywords: [
+      '鎌倉',
+      '가마쿠라',
+      '江ノ島',
+      '에노시마',
+      '藤沢',
+      'Kamakura',
+      'Enoshima',
+    ],
+    tag: '가마쿠라/에노시마',
+  },
+  { keywords: ['京都', '교토', 'Kyoto'], tag: '교토' },
+  { keywords: ['大阪', '오사카', 'Osaka'], tag: '오사카' },
+  { keywords: ['名古屋', '나고야', '愛知', 'Nagoya'], tag: '나고야' },
+  {
+    keywords: ['札幌', '삿포로', '北海道', 'Sapporo', 'Hokkaido'],
+    tag: '삿포로',
+  },
+  { keywords: ['福岡', '후쿠오카', 'Fukuoka'], tag: '후쿠오카' },
+  { keywords: ['沖縄', '오키나와', 'Okinawa'], tag: '오키나와' },
+]
+
+/** 주소 문자열에서 지역 태그 추출 */
+function extractRegionFromAddress(address: string): string | null {
+  for (const { keywords, tag } of REGION_ADDRESS_MAP) {
+    if (keywords.some((kw) => address.includes(kw))) return tag
+  }
+  return null
+}
+
 /** SpotOrderItem 배열에 거리/시간 재계산 적용 */
 function recalcDistances(spots: SpotOrderItem[]): SpotOrderItem[] {
   if (spots.length === 0) return spots
@@ -70,8 +117,29 @@ export function RouteFormContent({
   const [relatedContentNames, setRelatedContentNames] = useState<string[]>(
     initialRoute?.relatedContentNames || []
   )
-  const [regionTag, setRegionTag] = useState(initialRoute?.regionTag || '')
+  const [regionTags, setRegionTags] = useState<string[]>(
+    initialRoute?.regionTags || []
+  )
   const [contentInput, setContentInput] = useState('')
+  const [contentSuggestions, setContentSuggestions] = useState<string[]>([])
+  const [hasContentSearched, setHasContentSearched] = useState(false)
+  const contentDebounceRef = useRef<NodeJS.Timeout | null>(null)
+
+  // 시작 지점
+  const [startPointName, setStartPointName] = useState(
+    initialRoute?.startPoint?.name || ''
+  )
+  const [startPointAddress, setStartPointAddress] = useState(
+    initialRoute?.startPoint?.address || ''
+  )
+  const [startPointCoords, setStartPointCoords] = useState<{
+    lat: number
+    lng: number
+  } | null>(initialRoute?.startPoint?.coordinates || null)
+  const [isGeocoding, setIsGeocoding] = useState(false)
+  const [geocodeError, setGeocodeError] = useState('')
+  const [geocodeResults, setGeocodeResults] = useState<GeocodeSuggestion[]>([])
+  const [hasGeoSearched, setHasGeoSearched] = useState(false)
 
   // 스팟 목록
   const [spots, setSpots] = useState<SpotOrderItem[]>(() => {
@@ -92,7 +160,7 @@ export function RouteFormContent({
   // 스팟 검색
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState<SpotSearchResult[]>([])
-  const [isSearching, setIsSearching] = useState(false)
+  const [hasSearched, setHasSearched] = useState(false)
   const debounceRef = useRef<NodeJS.Timeout | null>(null)
 
   // 제출 상태
@@ -111,9 +179,9 @@ export function RouteFormContent({
   const searchSpots = useCallback(async (query: string) => {
     if (!query.trim()) {
       setSearchResults([])
+      setHasSearched(false)
       return
     }
-    setIsSearching(true)
     try {
       const res = await fetch(`/api/spots?search=${encodeURIComponent(query)}`)
       if (!res.ok) throw new Error()
@@ -136,7 +204,7 @@ export function RouteFormContent({
     } catch {
       setSearchResults([])
     } finally {
-      setIsSearching(false)
+      setHasSearched(true)
     }
   }, [])
 
@@ -165,7 +233,9 @@ export function RouteFormContent({
         const newSpot: SpotOrderItem = {
           spotId: spot.id,
           spotName: spot.name,
-          coordinates: spot.coordinates,
+          coordinates: Array.isArray(spot.coordinates)
+            ? { lat: spot.coordinates[0], lng: spot.coordinates[1] }
+            : spot.coordinates,
           thumbnailUrl: spot.photos?.[0] || '',
           note: undefined,
           distanceFromPrev: null,
@@ -176,11 +246,37 @@ export function RouteFormContent({
         setSpots(newSpots)
         setSearchQuery('')
         setSearchResults([])
+        setHasSearched(false)
+
+        // 스팟의 relatedContent에서 작품명 자동 추출
+        if (spot.relatedContent && Array.isArray(spot.relatedContent)) {
+          const newNames = spot.relatedContent
+            .map((rc: { name: string }) => rc.name)
+            .filter(
+              (name: string) => name && !relatedContentNames.includes(name)
+            )
+          if (newNames.length > 0) {
+            setRelatedContentNames((prev) => [
+              ...new Set([...prev, ...newNames]),
+            ])
+          }
+        }
+
+        // 스팟 주소에서 지역 태그 자동 추출
+        const address = spot.address || ''
+        if (address) {
+          const extracted = extractRegionFromAddress(address)
+          if (extracted) {
+            setRegionTags((prev) =>
+              prev.includes(extracted) ? prev : [...prev, extracted]
+            )
+          }
+        }
       } catch {
         // 에러 무시
       }
     },
-    [spots]
+    [spots, relatedContentNames]
   )
 
   /** 스팟 순서 변경 시 거리 재계산 */
@@ -188,13 +284,110 @@ export function RouteFormContent({
     setSpots(recalcDistances(newSpots))
   }, [])
 
-  /** 작품명 추가 */
-  const handleAddContent = useCallback(() => {
-    const trimmed = contentInput.trim()
-    if (!trimmed || relatedContentNames.includes(trimmed)) return
-    setRelatedContentNames((prev) => [...prev, trimmed])
-    setContentInput('')
-  }, [contentInput, relatedContentNames])
+  /** 작품명 자동완성 검색 */
+  const searchContent = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setContentSuggestions([])
+      setHasContentSearched(false)
+      return
+    }
+    try {
+      const res = await fetch(
+        `/api/content-names?type=content&search=${encodeURIComponent(query)}`
+      )
+      if (!res.ok) throw new Error()
+      const data = await res.json()
+      setContentSuggestions(
+        data.items.map((item: { name: string }) => item.name)
+      )
+    } catch {
+      setContentSuggestions([])
+    } finally {
+      setHasContentSearched(true)
+    }
+  }, [])
+
+  /** 작품명 입력 디바운스 핸들러 */
+  const handleContentInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setContentInput(value)
+      if (contentDebounceRef.current) clearTimeout(contentDebounceRef.current)
+      contentDebounceRef.current = setTimeout(() => searchContent(value), 300)
+    },
+    [searchContent]
+  )
+
+  /** Nominatim 주소 검색 (복수 결과) */
+  const handleGeocode = useCallback(async () => {
+    if (!startPointAddress.trim()) return
+    setIsGeocoding(true)
+    setGeocodeError('')
+    setGeocodeResults([])
+    setHasGeoSearched(false)
+    try {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(startPointAddress)}&limit=5&addressdetails=1`,
+        { headers: { 'Accept-Language': 'ja,ko,en' } }
+      )
+      const data = await res.json()
+      if (data.length > 0) {
+        setGeocodeResults(
+          data.map(
+            (item: {
+              lat: string
+              lon: string
+              display_name: string
+              type: string
+              class: string
+            }) => ({
+              lat: parseFloat(item.lat),
+              lng: parseFloat(item.lon),
+              displayName: item.display_name,
+              type: item.type,
+              placeClass: item.class,
+            })
+          )
+        )
+      } else {
+        setGeocodeError('검색 결과가 없습니다')
+      }
+    } catch {
+      setGeocodeError('주소 검색에 실패했습니다')
+    } finally {
+      setIsGeocoding(false)
+      setHasGeoSearched(true)
+    }
+  }, [startPointAddress])
+
+  /** 검색 결과에서 장소 선택 */
+  const handleSelectGeoResult = useCallback(
+    (result: GeocodeSuggestion) => {
+      setStartPointCoords({ lat: result.lat, lng: result.lng })
+      setStartPointAddress(result.displayName)
+      if (!startPointName.trim()) {
+        // 장소명이 비어있으면 display_name의 첫 부분을 자동 채움
+        const shortName = result.displayName.split(',')[0].trim()
+        setStartPointName(shortName)
+      }
+      setGeocodeResults([])
+      setHasGeoSearched(false)
+    },
+    [startPointName]
+  )
+
+  /** 자동완성에서 작품명 선택 */
+  const handleSelectContent = useCallback(
+    (name: string) => {
+      if (!relatedContentNames.includes(name)) {
+        setRelatedContentNames((prev) => [...prev, name])
+      }
+      setContentInput('')
+      setContentSuggestions([])
+      setHasContentSearched(false)
+    },
+    [relatedContentNames]
+  )
 
   /** 작품명 삭제 */
   const handleRemoveContent = useCallback((index: number) => {
@@ -222,14 +415,24 @@ export function RouteFormContent({
     setErrors([])
     setIsSubmitting(true)
 
+    const startPoint =
+      startPointName.trim() && startPointAddress.trim() && startPointCoords
+        ? {
+            name: startPointName.trim(),
+            address: startPointAddress.trim(),
+            coordinates: startPointCoords,
+          }
+        : undefined
+
     const body = {
       name: name.trim(),
       description: description.trim(),
       estimatedDuration: parseInt(estimatedDuration, 10),
       difficulty,
+      startPoint,
       spots: spots.map((s) => ({ spotId: s.spotId, note: s.note })),
       relatedContentNames,
-      regionTag: regionTag.trim() || undefined,
+      regionTags: regionTags.length > 0 ? regionTags : undefined,
       isPublic,
     }
 
@@ -264,7 +467,7 @@ export function RouteFormContent({
     difficulty,
     spots,
     relatedContentNames,
-    regionTag,
+    regionTags,
     isPublic,
     isEditMode,
     initialRoute,
@@ -290,7 +493,7 @@ export function RouteFormContent({
         </div>
       )}
 
-      {/* 기본 정보 */}
+      {/* Step 1: 기본 정보 (코스명 + 설명만) */}
       <section className="rounded-lg bg-white p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold text-navy-900">기본 정보</h2>
         <div className="space-y-4">
@@ -322,142 +525,10 @@ export function RouteFormContent({
               className="w-full resize-none rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
             />
           </div>
-
-          {/* 예상 소요시간 + 난이도 */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="mb-1 block text-sm font-medium text-navy-700">
-                예상 소요시간 (분) <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="number"
-                value={estimatedDuration}
-                onChange={(e) => setEstimatedDuration(e.target.value)}
-                placeholder="120"
-                min={1}
-                className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-navy-700">
-                난이도 <span className="text-red-500">*</span>
-              </label>
-              <div className="flex gap-2">
-                {DIFFICULTY_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => setDifficulty(opt.value)}
-                    className={`flex-1 rounded-lg border px-2 py-2 text-sm transition-colors ${
-                      difficulty === opt.value
-                        ? 'border-navy-500 bg-navy-50 font-medium text-navy-700'
-                        : 'border-navy-200 text-navy-500 hover:border-navy-300'
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {/* 공개/비공개 */}
-          <div className="flex items-center gap-3">
-            <label className="text-sm font-medium text-navy-700">
-              공개 설정
-            </label>
-            <button
-              type="button"
-              onClick={() => setIsPublic(!isPublic)}
-              className={`relative h-6 w-11 rounded-full transition-colors ${
-                isPublic ? 'bg-navy-600' : 'bg-navy-200'
-              }`}
-              role="switch"
-              aria-checked={isPublic}
-            >
-              <span
-                className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
-                  isPublic ? 'left-[22px]' : 'left-0.5'
-                }`}
-              />
-            </button>
-            <span className="text-sm text-navy-500">
-              {isPublic ? '공개' : '비공개'}
-            </span>
-          </div>
         </div>
       </section>
 
-      {/* 관련 작품 + 지역 태그 */}
-      <section className="rounded-lg bg-white p-6 shadow-sm">
-        <h2 className="mb-4 text-lg font-semibold text-navy-900">태그 정보</h2>
-        <div className="space-y-4">
-          {/* 관련 작품 */}
-          <div>
-            <label className="mb-1 block text-sm font-medium text-navy-700">
-              관련 작품
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={contentInput}
-                onChange={(e) => setContentInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault()
-                    handleAddContent()
-                  }
-                }}
-                placeholder="작품명 입력 후 추가"
-                className="flex-1 rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={handleAddContent}
-                disabled={!contentInput.trim()}
-                className="rounded-lg bg-navy-100 px-3 text-sm text-navy-600 hover:bg-navy-200 disabled:opacity-40"
-              >
-                추가
-              </button>
-            </div>
-            {relatedContentNames.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                {relatedContentNames.map((c, i) => (
-                  <span
-                    key={i}
-                    className="inline-flex items-center gap-1 rounded-full bg-navy-100 px-2.5 py-0.5 text-xs text-navy-600"
-                  >
-                    {c}
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveContent(i)}
-                      className="text-navy-400 hover:text-red-500"
-                    >
-                      ×
-                    </button>
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* 지역 태그 */}
-          <div>
-            <label className="mb-1 block text-sm font-medium text-navy-700">
-              지역 태그
-            </label>
-            <input
-              type="text"
-              value={regionTag}
-              onChange={(e) => setRegionTag(e.target.value)}
-              placeholder="예: 도쿄, 가마쿠라"
-              className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* 스팟 관리 */}
+      {/* Step 2: 스팟 관리 (핵심) */}
       <section className="rounded-lg bg-white p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold text-navy-900">
           스팟 목록 <span className="text-red-500">*</span>
@@ -478,11 +549,11 @@ export function RouteFormContent({
           <span className="absolute left-3 top-2.5 text-navy-300">🔍</span>
 
           {/* 검색 결과 드롭다운 */}
-          {(searchResults.length > 0 || isSearching) && searchQuery && (
+          {searchQuery && hasSearched && (
             <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-navy-200 bg-white shadow-lg">
-              {isSearching ? (
-                <div className="flex items-center justify-center py-4">
-                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-navy-400 border-t-transparent" />
+              {searchResults.length === 0 ? (
+                <div className="px-4 py-4 text-center text-sm text-navy-400">
+                  &ldquo;{searchQuery}&rdquo;에 대한 검색 결과가 없습니다
                 </div>
               ) : (
                 searchResults.map((result) => {
@@ -525,7 +596,325 @@ export function RouteFormContent({
         </div>
 
         {/* 스팟 순서 목록 */}
-        <SpotOrderList spots={spots} onSpotsChange={handleSpotsChange} />
+        <SpotOrderList
+          spots={spots}
+          onSpotsChange={handleSpotsChange}
+          startPoint={
+            startPointName && startPointCoords
+              ? {
+                  name: startPointName,
+                  address: startPointAddress,
+                  coordinates: startPointCoords,
+                }
+              : undefined
+          }
+        />
+      </section>
+
+      {/* Step 3: 시작 지점 (선택) */}
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="mb-1 text-lg font-semibold text-navy-900">
+          시작 지점
+          <span className="ml-2 text-sm font-normal text-navy-400">(선택)</span>
+        </h2>
+        <p className="mb-4 text-xs text-navy-400">
+          숙소, 역 등 출발 지점을 등록하면 첫 스팟까지의 거리/이동 정보가
+          표시됩니다.
+        </p>
+        <div className="space-y-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              출발지 별명
+            </label>
+            <input
+              type="text"
+              value={startPointName}
+              onChange={(e) => setStartPointName(e.target.value)}
+              placeholder="예: 우리 숙소, 신주쿠역 앞, 출발점"
+              className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+              maxLength={100}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              주소
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={startPointAddress}
+                onChange={(e) => {
+                  setStartPointAddress(e.target.value)
+                  setGeocodeError('')
+                  setGeocodeResults([])
+                  setHasGeoSearched(false)
+                  setStartPointCoords(null)
+                }}
+                placeholder="예: 東京都新宿区新宿3丁目"
+                className="flex-1 rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleGeocode()
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleGeocode}
+                disabled={isGeocoding || !startPointAddress.trim()}
+                className="flex-shrink-0 rounded-lg bg-navy-600 px-4 py-2 text-sm text-white transition-colors hover:bg-navy-700 disabled:bg-navy-300"
+              >
+                {isGeocoding ? '검색 중...' : '🔍 주소 검색'}
+              </button>
+            </div>
+            {geocodeError && (
+              <p className="mt-1 text-xs text-red-500">{geocodeError}</p>
+            )}
+            {!startPointCoords && (
+              <p className="mt-1.5 text-xs text-blue-500">
+                💡 검색이 잘 안 되나요? &apos;역&apos;, &apos;호텔&apos;을 빼고
+                핵심 키워드(예: 신주쿠)만 검색해 보세요.
+              </p>
+            )}
+            {hasGeoSearched &&
+              geocodeResults.length > 0 &&
+              !startPointCoords && (
+                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-navy-200 bg-white shadow-lg">
+                  {geocodeResults.map((result, idx) => (
+                    <button
+                      key={idx}
+                      type="button"
+                      onClick={() => handleSelectGeoResult(result)}
+                      className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-navy-50"
+                    >
+                      <img
+                        src={getPlaceIconPath(result.type, result.placeClass)}
+                        alt={result.type}
+                        className="h-5 w-5 flex-shrink-0"
+                      />
+                      <span className="truncate text-sm text-navy-800">
+                        {result.displayName}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+          </div>
+          {startPointCoords && (
+            <div className="flex items-center gap-2 rounded-lg bg-green-50 px-3 py-2">
+              <span className="text-sm text-green-700">
+                ✅ 좌표 확인: {startPointCoords.lat.toFixed(5)},{' '}
+                {startPointCoords.lng.toFixed(5)}
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  setStartPointName('')
+                  setStartPointAddress('')
+                  setStartPointCoords(null)
+                  setGeocodeError('')
+                }}
+                className="ml-auto text-xs text-red-400 hover:text-red-600"
+              >
+                초기화
+              </button>
+            </div>
+          )}
+          {startPointCoords && (
+            <div className="overflow-hidden rounded-lg border border-navy-200">
+              <iframe
+                title="선택된 출발지 위치"
+                width="100%"
+                height="200"
+                style={{ border: 0, pointerEvents: 'none' }}
+                loading="lazy"
+                src={`https://www.openstreetmap.org/export/embed.html?bbox=${startPointCoords.lng - 0.005},${startPointCoords.lat - 0.003},${startPointCoords.lng + 0.005},${startPointCoords.lat + 0.003}&layer=mapnik&marker=${startPointCoords.lat},${startPointCoords.lng}`}
+              />
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Step 4: 코스 디테일 (태그 + 소요시간 + 난이도 + 공개설정) */}
+      <section className="rounded-lg bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-navy-900">
+          코스 디테일
+        </h2>
+        <div className="space-y-4">
+          {/* 관련 작품 (자동완성) */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              관련 작품
+            </label>
+            <p className="mb-2 text-xs text-navy-400">
+              스팟 추가 시 작품명이 자동 추출됩니다. 검색하여 추가할 수도
+              있습니다.
+            </p>
+            <div className="relative">
+              <input
+                type="text"
+                value={contentInput}
+                onChange={handleContentInputChange}
+                placeholder="작품명 검색"
+                className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+              />
+              {contentInput &&
+                hasContentSearched &&
+                contentSuggestions.length > 0 && (
+                  <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-navy-200 bg-white shadow-lg">
+                    {contentSuggestions.map((suggestion) => {
+                      const alreadyAdded =
+                        relatedContentNames.includes(suggestion)
+                      return (
+                        <button
+                          key={suggestion}
+                          type="button"
+                          onClick={() => handleSelectContent(suggestion)}
+                          disabled={alreadyAdded}
+                          className="flex w-full items-center px-4 py-2 text-left text-sm text-navy-800 transition-colors hover:bg-navy-50 disabled:opacity-40"
+                        >
+                          <span className="truncate">{suggestion}</span>
+                          {alreadyAdded && (
+                            <span className="ml-auto text-xs text-navy-400">
+                              추가됨
+                            </span>
+                          )}
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+            </div>
+            {relatedContentNames.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {relatedContentNames.map((c, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center gap-1 rounded-full bg-navy-100 px-2.5 py-0.5 text-xs text-navy-600"
+                  >
+                    {c}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveContent(i)}
+                      className="text-navy-400 hover:text-red-500"
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 지역 태그 (복수 선택 토글) */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              지역 태그
+            </label>
+            <p className="mb-2 text-xs text-navy-400">
+              스팟 추가 시 주소에서 자동 추출됩니다. 직접 선택할 수도 있습니다.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {REGION_TAG_OPTIONS.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => {
+                    setRegionTags((prev) =>
+                      prev.includes(tag)
+                        ? prev.filter((t) => t !== tag)
+                        : [...prev, tag]
+                    )
+                  }}
+                  className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
+                    regionTags.includes(tag)
+                      ? 'border-navy-500 bg-navy-600 text-white'
+                      : 'border-navy-200 bg-white text-navy-600 hover:border-navy-300 hover:bg-navy-50'
+                  }`}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 예상 소요시간 + 이동시간 힌트 */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              예상 소요시간 (분) <span className="text-red-500">*</span>
+            </label>
+            {spots.length >= 2 &&
+              (() => {
+                const totalWalkTime = spots.reduce(
+                  (sum, s) => sum + (s.walkTimeFromPrev || 0),
+                  0
+                )
+                return totalWalkTime > 0 ? (
+                  <p className="mb-1.5 text-xs text-blue-500">
+                    💡 스팟 간 이동시간 합계: 약 {totalWalkTime}분 (도보 기준).
+                    관람 시간을 더해 입력해 주세요.
+                  </p>
+                ) : null
+              })()}
+            <input
+              type="number"
+              value={estimatedDuration}
+              onChange={(e) => setEstimatedDuration(e.target.value)}
+              placeholder="120"
+              min={1}
+              className="w-full rounded-lg border border-navy-200 px-3 py-2 text-sm focus:border-navy-500 focus:outline-none"
+            />
+          </div>
+
+          {/* 난이도 */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-navy-700">
+              난이도 <span className="text-red-500">*</span>
+            </label>
+            <div className="flex gap-2">
+              {DIFFICULTY_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setDifficulty(opt.value)}
+                  className={`flex-1 rounded-lg border px-2 py-2 text-sm transition-colors ${
+                    difficulty === opt.value
+                      ? 'border-navy-500 bg-navy-50 font-medium text-navy-700'
+                      : 'border-navy-200 text-navy-500 hover:border-navy-300'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 공개/비공개 */}
+          <div className="flex items-center gap-3">
+            <label className="text-sm font-medium text-navy-700">
+              공개 설정
+            </label>
+            <button
+              type="button"
+              onClick={() => setIsPublic(!isPublic)}
+              className={`relative h-6 w-11 rounded-full transition-colors ${
+                isPublic ? 'bg-navy-600' : 'bg-navy-200'
+              }`}
+              role="switch"
+              aria-checked={isPublic}
+            >
+              <span
+                className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                  isPublic ? 'left-[22px]' : 'left-0.5'
+                }`}
+              />
+            </button>
+            <span className="text-sm text-navy-500">
+              {isPublic ? '공개' : '비공개'}
+            </span>
+          </div>
+        </div>
       </section>
 
       {/* 미리보기 */}
@@ -534,7 +923,18 @@ export function RouteFormContent({
           <h2 className="mb-3 text-lg font-semibold text-navy-900">
             코스 미리보기
           </h2>
-          <RouteMap spots={previewSpots} />
+          <RouteMap
+            spots={previewSpots}
+            startPoint={
+              startPointName && startPointCoords
+                ? {
+                    name: startPointName,
+                    address: startPointAddress,
+                    coordinates: startPointCoords,
+                  }
+                : undefined
+            }
+          />
         </section>
       )}
 
@@ -575,4 +975,29 @@ interface SpotSearchResult {
   name: string
   thumbnailUrl: string
   coordinates: number[]
+}
+
+/** Nominatim 검색 결과 타입 */
+interface GeocodeSuggestion {
+  lat: number
+  lng: number
+  displayName: string
+  type: string // e.g., "station", "stop", "administrative"
+  placeClass: string // e.g., "railway", "highway", "place"
+}
+
+/** Nominatim type/class → 아이콘 경로 매핑 */
+function getPlaceIconPath(type: string, placeClass: string): string {
+  if (placeClass === 'railway' && type === 'station')
+    return '/icons/start-point/station.svg'
+  if (placeClass === 'railway' && (type === 'stop' || type === 'halt'))
+    return '/icons/start-point/stop.svg'
+  if (
+    placeClass === 'highway' &&
+    (type === 'bus_stop' || type === 'bus_station')
+  )
+    return '/icons/start-point/bus.svg'
+  if (placeClass === 'tourism' || placeClass === 'amenity')
+    return '/icons/start-point/building.svg'
+  return '/icons/start-point/default.svg'
 }

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -3,11 +3,15 @@
 import { useEffect, useRef, useMemo } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet'
 import { Map as LeafletMap, DivIcon } from 'leaflet'
-import type { RouteSpot } from '@/types/route'
+import type { RouteSpot, RouteStartPoint } from '@/types/route'
+import { getTravelMode } from '@/lib/route-utils'
+import { calculateDistance } from '@/lib/geo-utils'
 import '../map/map.css'
 
 interface RouteMapProps {
   spots: RouteSpot[]
+  /** 시작 지점 (선택) */
+  startPoint?: RouteStartPoint
   /** 현재 위치 (따라가기 모드용, 선택) */
   currentPosition?: { lat: number; lng: number } | null
   /** 현재 목표 스팟 인덱스 (따라가기 모드용, 선택) */
@@ -56,6 +60,21 @@ function createNumberIcon(
   })
 }
 
+/** 시작 지점 마커 아이콘 */
+const startPointIcon = new DivIcon({
+  className: 'start-point-marker',
+  html: `<div style="
+    width:28px;height:28px;border-radius:50%;
+    background:#2563eb;border:2px solid #1d4ed8;
+    color:white;font-size:14px;
+    display:flex;align-items:center;justify-content:center;
+    box-shadow:0 2px 6px rgba(0,0,0,0.3);
+  ">🏠</div>`,
+  iconSize: [28, 28],
+  iconAnchor: [14, 14],
+  popupAnchor: [0, -16],
+})
+
 /** 현재 위치 마커 아이콘 */
 const currentLocationIcon = new DivIcon({
   className: 'current-location-marker',
@@ -77,6 +96,7 @@ const currentLocationIcon = new DivIcon({
  */
 export default function RouteMap({
   spots,
+  startPoint,
   currentPosition,
   currentSpotIndex,
   checkedSpotIds = [],
@@ -84,20 +104,44 @@ export default function RouteMap({
 }: RouteMapProps) {
   const mapRef = useRef<LeafletMap | null>(null)
 
-  // 유효 스팟 좌표로 지도 bounds 계산
+  // 유효 스팟 좌표로 지도 bounds 계산 (시작 지점 포함)
   const bounds = useMemo(() => {
     const coords = spots
       .filter((s) => s.coordinates)
       .map((s) => [s.coordinates.lat, s.coordinates.lng] as [number, number])
+    if (startPoint?.coordinates) {
+      coords.unshift([startPoint.coordinates.lat, startPoint.coordinates.lng])
+    }
     if (coords.length === 0) return null
     return coords
-  }, [spots])
+  }, [spots, startPoint])
 
-  // Polyline 좌표 (유효 스팟만)
-  const polylinePositions = useMemo(() => {
-    return spots
-      .filter((s) => s.isAvailable !== false)
-      .map((s) => [s.coordinates.lat, s.coordinates.lng] as [number, number])
+  // 구간별 Polyline 세그먼트 (거리 기반 스타일 분기)
+  const routeSegments = useMemo(() => {
+    const availableSpots = spots.filter((s) => s.isAvailable !== false)
+    const segments: {
+      positions: [number, number][]
+      isDashed: boolean
+    }[] = []
+    for (let i = 1; i < availableSpots.length; i++) {
+      const prev = availableSpots[i - 1]
+      const curr = availableSpots[i]
+      const distance = calculateDistance(
+        prev.coordinates.lat,
+        prev.coordinates.lng,
+        curr.coordinates.lat,
+        curr.coordinates.lng
+      )
+      const mode = getTravelMode(distance)
+      segments.push({
+        positions: [
+          [prev.coordinates.lat, prev.coordinates.lng],
+          [curr.coordinates.lat, curr.coordinates.lng],
+        ],
+        isDashed: mode !== 'walking',
+      })
+    }
+    return segments
   }, [spots])
 
   // 소실 스팟 연결선 (점선)
@@ -172,18 +216,19 @@ export default function RouteMap({
           maxZoom={19}
         />
 
-        {/* 유효 스팟 연결 Polyline */}
-        {polylinePositions.length >= 2 && (
+        {/* 구간별 Polyline (도보=실선, 대중교통/장거리=점선) */}
+        {routeSegments.map((segment, idx) => (
           <Polyline
-            positions={polylinePositions}
+            key={`segment-${idx}`}
+            positions={segment.positions}
             pathOptions={{
-              color: '#345084',
-              weight: 3,
-              opacity: 0.8,
-              dashArray: undefined,
+              color: segment.isDashed ? '#6b7280' : '#345084',
+              weight: segment.isDashed ? 2 : 3,
+              opacity: segment.isDashed ? 0.6 : 0.8,
+              dashArray: segment.isDashed ? '8, 8' : undefined,
             }}
           />
-        )}
+        ))}
 
         {/* 소실 스팟 구간 점선 */}
         {unavailableSegments.map((segment, idx) => (
@@ -198,6 +243,57 @@ export default function RouteMap({
             }}
           />
         ))}
+
+        {/* 시작 지점 → 첫 스팟 연결선 */}
+        {startPoint &&
+          spots.length > 0 &&
+          (() => {
+            const firstAvailable = spots.find((s) => s.isAvailable !== false)
+            if (!firstAvailable) return null
+            const distance = calculateDistance(
+              startPoint.coordinates.lat,
+              startPoint.coordinates.lng,
+              firstAvailable.coordinates.lat,
+              firstAvailable.coordinates.lng
+            )
+            const mode = getTravelMode(distance)
+            return (
+              <Polyline
+                positions={[
+                  [startPoint.coordinates.lat, startPoint.coordinates.lng],
+                  [
+                    firstAvailable.coordinates.lat,
+                    firstAvailable.coordinates.lng,
+                  ],
+                ]}
+                pathOptions={{
+                  color: mode === 'walking' ? '#2563eb' : '#6b7280',
+                  weight: 2,
+                  opacity: 0.6,
+                  dashArray: '6, 6',
+                }}
+              />
+            )
+          })()}
+
+        {/* 시작 지점 마커 */}
+        {startPoint && (
+          <Marker
+            position={[startPoint.coordinates.lat, startPoint.coordinates.lng]}
+            icon={startPointIcon}
+          >
+            <Popup>
+              <div className="min-w-[140px] p-1">
+                <p className="text-sm font-semibold text-navy-900">
+                  🏠 {startPoint.name}
+                </p>
+                <p className="mt-0.5 text-xs text-navy-400">
+                  {startPoint.address}
+                </p>
+              </div>
+            </Popup>
+          </Marker>
+        )}
 
         {/* 스팟 마커 (순서 번호) */}
         {spots.map((spot, idx) => (
@@ -257,6 +353,12 @@ export default function RouteMap({
       {/* 범례 */}
       <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm">
         <div className="flex flex-wrap items-center gap-3 text-xs">
+          {startPoint && (
+            <div className="flex items-center gap-1">
+              <div className="h-3 w-3 rounded-full bg-[#2563eb]" />
+              <span>시작</span>
+            </div>
+          )}
           <div className="flex items-center gap-1">
             <div className="h-3 w-3 rounded-full bg-[#345084]" />
             <span>스팟</span>

--- a/src/components/route/SpotOrderList.tsx
+++ b/src/components/route/SpotOrderList.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { useState, useCallback, useRef } from 'react'
-import type { RouteSpot } from '@/types/route'
+import type { RouteSpot, RouteStartPoint } from '@/types/route'
+import {
+  getTravelMode,
+  getTravelModeLabel,
+  getTravelModeIcon,
+  getGoogleMapsDirectionsUrl,
+  calculateStartToFirstSpot,
+} from '@/lib/route-utils'
 
 /** 스팟 순서 관리용 아이템 (생성/수정 폼에서 사용) */
 export interface SpotOrderItem {
@@ -18,6 +25,8 @@ export interface SpotOrderItem {
 interface SpotOrderListProps {
   spots: SpotOrderItem[]
   onSpotsChange: (spots: SpotOrderItem[]) => void
+  /** 시작 지점 (선택) */
+  startPoint?: RouteStartPoint
 }
 
 /** 거리 포맷 */
@@ -31,7 +40,11 @@ function formatDistance(meters: number): string {
  * 드래그 앤 드롭으로 순서 변경, 거리/시간 표시, 메모 입력
  * Requirements: 1.2, 1.3
  */
-export function SpotOrderList({ spots, onSpotsChange }: SpotOrderListProps) {
+export function SpotOrderList({
+  spots,
+  onSpotsChange,
+  startPoint,
+}: SpotOrderListProps) {
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const [editingNoteIndex, setEditingNoteIndex] = useState<number | null>(null)
@@ -107,17 +120,92 @@ export function SpotOrderList({ spots, onSpotsChange }: SpotOrderListProps) {
 
   return (
     <div className="space-y-0">
+      {/* 시작 지점 → 첫 스팟 이동 정보 */}
+      {startPoint &&
+        spots.length > 0 &&
+        (() => {
+          const info = calculateStartToFirstSpot(startPoint, spots[0])
+          if (!info) return null
+          const mode = getTravelMode(info.distance)
+          return (
+            <div className="mb-1">
+              <div className="flex items-center gap-2 rounded-lg bg-blue-50 px-3 py-2">
+                <span className="text-sm">🏠</span>
+                <span className="text-xs font-medium text-navy-700">
+                  {startPoint.name}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 py-1.5 pl-8">
+                <div className="h-4 w-px bg-navy-200" />
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-navy-400">
+                    ↓ {formatDistance(info.distance)}
+                    {' · '}
+                    {getTravelModeIcon(mode)}{' '}
+                    {mode === 'walking' && info.walkTime !== null
+                      ? `도보 약 ${info.walkTime}분`
+                      : getTravelModeLabel(mode)}
+                  </span>
+                  {mode !== 'walking' && (
+                    <a
+                      href={getGoogleMapsDirectionsUrl(
+                        startPoint.coordinates.lat,
+                        startPoint.coordinates.lng,
+                        spots[0].coordinates.lat,
+                        spots[0].coordinates.lng,
+                        mode
+                      )}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-600 transition-colors hover:bg-blue-100"
+                    >
+                      길찾기 →
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })()}
+
       {spots.map((spot, idx) => (
         <div key={`${spot.spotId}-${idx}`}>
           {/* 이동 거리/시간 표시 (첫 스팟 제외) */}
           {idx > 0 && spot.distanceFromPrev !== null && (
             <div className="flex items-center gap-2 py-1.5 pl-8">
               <div className="h-4 w-px bg-navy-200" />
-              <span className="text-xs text-navy-400">
-                ↓ {formatDistance(spot.distanceFromPrev)}
-                {spot.walkTimeFromPrev !== null &&
-                  ` · 도보 약 ${spot.walkTimeFromPrev}분`}
-              </span>
+              {(() => {
+                const mode = getTravelMode(spot.distanceFromPrev)
+                const prev = spots[idx - 1]
+                return (
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-navy-400">
+                      ↓ {formatDistance(spot.distanceFromPrev)}
+                      {' · '}
+                      {getTravelModeIcon(mode)}{' '}
+                      {mode === 'walking' && spot.walkTimeFromPrev !== null
+                        ? `도보 약 ${spot.walkTimeFromPrev}분`
+                        : getTravelModeLabel(mode)}
+                    </span>
+                    {mode !== 'walking' && (
+                      <a
+                        href={getGoogleMapsDirectionsUrl(
+                          prev.coordinates.lat,
+                          prev.coordinates.lng,
+                          spot.coordinates.lat,
+                          spot.coordinates.lng,
+                          mode
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-600 transition-colors hover:bg-blue-100"
+                      >
+                        길찾기 →
+                      </a>
+                    )}
+                  </div>
+                )
+              })()}
             </div>
           )}
 

--- a/src/lib/route-utils.ts
+++ b/src/lib/route-utils.ts
@@ -10,6 +10,56 @@ const WALK_FACTOR = 1.3
 /** 평균 도보 속도 (m/분) ≈ 4.8km/h */
 const WALK_SPEED_M_PER_MIN = 80
 
+/** 이동수단 타입 */
+export type TravelMode = 'walking' | 'transit' | 'long_distance'
+
+/** 거리 기반 이동수단 임계값 (미터) */
+const WALK_THRESHOLD = 3000 // 3km 이내: 도보
+const TRANSIT_THRESHOLD = 50000 // 50km 이내: 대중교통
+
+/** 거리 기반 이동수단 판별 */
+export function getTravelMode(distanceMeters: number): TravelMode {
+  if (distanceMeters <= WALK_THRESHOLD) return 'walking'
+  if (distanceMeters <= TRANSIT_THRESHOLD) return 'transit'
+  return 'long_distance'
+}
+
+/** 이동수단별 라벨 */
+export function getTravelModeLabel(mode: TravelMode): string {
+  switch (mode) {
+    case 'walking':
+      return '도보'
+    case 'transit':
+      return '대중교통 권장'
+    case 'long_distance':
+      return '신칸센/항공 이동'
+  }
+}
+
+/** 이동수단별 아이콘 */
+export function getTravelModeIcon(mode: TravelMode): string {
+  switch (mode) {
+    case 'walking':
+      return '🚶'
+    case 'transit':
+      return '🚃'
+    case 'long_distance':
+      return '🚄'
+  }
+}
+
+/** 구글맵 두 지점 간 길찾기 URL 생성 */
+export function getGoogleMapsDirectionsUrl(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  mode: TravelMode
+): string {
+  const travelmode = mode === 'walking' ? 'walking' : 'transit'
+  return `https://www.google.com/maps/dir/?api=1&origin=${fromLat},${fromLng}&destination=${toLat},${toLng}&travelmode=${travelmode}`
+}
+
 /** 두 좌표 간 예상 도보 시간 (분) */
 export function estimateWalkTime(
   lat1: number,
@@ -20,6 +70,35 @@ export function estimateWalkTime(
   const distance = calculateDistance(lat1, lng1, lat2, lng2)
   const walkDistance = distance * WALK_FACTOR
   return Math.ceil(walkDistance / WALK_SPEED_M_PER_MIN)
+}
+
+/** 시작 지점 → 첫 스팟 거리/시간 계산 */
+export function calculateStartToFirstSpot(
+  startPoint: { coordinates: { lat: number; lng: number } },
+  firstSpot: { coordinates: { lat: number; lng: number } }
+): { distance: number; walkTime: number | null } | null {
+  if (!startPoint?.coordinates || !firstSpot?.coordinates) return null
+  const distance = Math.round(
+    calculateDistance(
+      startPoint.coordinates.lat,
+      startPoint.coordinates.lng,
+      firstSpot.coordinates.lat,
+      firstSpot.coordinates.lng
+    )
+  )
+  const mode = getTravelMode(distance)
+  return {
+    distance,
+    walkTime:
+      mode === 'walking'
+        ? estimateWalkTime(
+            startPoint.coordinates.lat,
+            startPoint.coordinates.lng,
+            firstSpot.coordinates.lat,
+            firstSpot.coordinates.lng
+          )
+        : null,
+  }
 }
 
 /** 코스 내 스팟 배열에 거리/시간 정보 채우기 */
@@ -35,15 +114,19 @@ export function calculateRouteDistances(
       spot.coordinates.lat,
       spot.coordinates.lng
     )
-    const walkTime = estimateWalkTime(
-      prev.coordinates.lat,
-      prev.coordinates.lng,
-      spot.coordinates.lat,
-      spot.coordinates.lng
-    )
+    const mode = getTravelMode(distance)
     return {
       distanceFromPrev: Math.round(distance),
-      walkTimeFromPrev: walkTime,
+      // 도보 시간은 도보 권장 거리일 때만 계산
+      walkTimeFromPrev:
+        mode === 'walking'
+          ? estimateWalkTime(
+              prev.coordinates.lat,
+              prev.coordinates.lng,
+              spot.coordinates.lat,
+              spot.coordinates.lng
+            )
+          : null,
     }
   })
 }

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -34,6 +34,16 @@ export interface RouteSpot {
   isAvailable?: boolean
 }
 
+/** 시작 지점 (숙소, 역 등) */
+export interface RouteStartPoint {
+  /** 장소명 (예: "신주쿠역", "호텔 그레이서리 신주쿠") */
+  name: string
+  /** 주소 텍스트 */
+  address: string
+  /** 좌표 (Geocoding 결과) */
+  coordinates: { lat: number; lng: number }
+}
+
 /** 코스 문서 */
 export interface Route {
   id: string
@@ -45,14 +55,16 @@ export interface Route {
   estimatedDuration: number
   /** 난이도 */
   difficulty: RouteDifficulty
+  /** 시작 지점 (선택) */
+  startPoint?: RouteStartPoint
   /** 스팟 목록 (배열 인덱스 = 순서) */
   spots: RouteSpot[]
   /** 총 거리 (m) */
   totalDistance: number
   /** 관련 작품명 목록 */
   relatedContentNames: string[]
-  /** 지역 태그 (예: "도쿄", "가마쿠라") */
-  regionTag?: string
+  /** 지역 태그 목록 (예: ["도쿄", "가마쿠라"]) */
+  regionTags?: string[]
   /** 공개 여부 */
   isPublic: boolean
   /** 공식 추천 코스 여부 (관리자 설정) */


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #262

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

코스 등록 폼의 입력 시퀀스를 재배치하고, regionTag를 regionTags 배열로 변경하여 복수 지역 태그 선택을 지원합니다.

---

## 📋 변경 사항

- [x] `regionTag: string` → `regionTags: string[]` 타입 변경 및 API 적용
- [x] 코스 등록 폼 시퀀스 재배치 (기본정보 → 스팟 → 시작지점 → 코스디테일)
- [x] 지역 태그 복수 선택 토글 + 스팟 주소 기반 자동 추출
- [x] 소요시간 입력 영역에 스팟 간 이동시간 합산 힌트 표시
- [x] 코스 상세 페이지 regionTags 복수 태그 칩 표시
- [x] 시작지점(startPoint) 데이터 모델 추가 및 상세/지도 표시
- [x] Nominatim 주소 검색 복수 결과 드롭다운 + 장소 유형 아이콘
- [x] Header 모바일 햄버거 메뉴 추가
- [x] 필터 배경 rounded-full → rounded-2xl 변경

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<img width="890" height="553" alt="image" src="https://github.com/user-attachments/assets/27fb8ede-382f-442e-87ad-5c8b40f7e1d6" />
<img width="896" height="495" alt="image" src="https://github.com/user-attachments/assets/dabaf5f2-9489-4207-861e-e4655c215a3f" />

---

## 📝 추가 정보 (선택)

- 커밋 10개로 기능별 분할
- route-utils에 `REGION_ADDRESS_MAP`, `extractRegionFromAddress()` 추가하여 스팟 주소에서 지역 태그 자동 추출
- 기존 DB의 `regionTag` 필드를 사용하는 코스는 API GET에서 `$in` 쿼리로 호환 유지
