### PR TITLE
[Feat] Task 1 - 덕후 편의시설 데이터 모델 및 타입 정의

### DIFF
--- a/.kiro/specs/11-otaku-facilities/.config.kiro
+++ b/.kiro/specs/11-otaku-facilities/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4b709d6b-1764-4779-9586-81b3a0cb47dc", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/11-otaku-facilities/design.md
+++ b/.kiro/specs/11-otaku-facilities/design.md
@@ -1,0 +1,522 @@
+# Design Document: 덕후 친화적 편의시설 (Otaku-Friendly Facilities)
+
+## Overview
+
+기존 편의시설 시스템(5개 Legacy_Category)을 확장하여 덕후 특화 5개 카테고리(Otaku_Category)를 추가하고, 유저 제보/마이크로 투표 기반 데이터 검증 시스템을 구축합니다. 기존 `NearbyFacility` 인터페이스와 `/api/spots/[id]/facilities` API를 하위 호환성을 유지하며 확장합니다.
+
+## Architecture
+
+### 데이터 출처(Source) 이원화 전략
+
+편의시설 데이터는 두 가지 출처로 관리합니다:
+
+1. **유저 직접 제보 (Pin-based)**: 코인 로커, 개방 화장실 등 외부 지도 서비스에 없는 시설 → 유저가 지도에 핀을 꽂아 위치와 상세 정보를 직접 입력
+2. **외부 장소 태깅 (Overlay)**: 식당, 카페 등 이미 구글맵에 존재하는 장소 → `googlePlaceId`로 매핑하고 덕후 특화 속성(혼밥 가능, 콘센트 유무 등)만 덧붙이는 방식
+
+이 이원화를 통해 데이터 정합성을 유지하고 유저 입력 부담을 최소화합니다.
+
+### 시스템 구성도
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Client (Next.js)                   │
+│                                                      │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────┐ │
+│  │ NearbyFacili │  │ FacilityRepo │  │ MicroVote  │ │
+│  │ ties.tsx     │  │ rtForm.tsx   │  │ Button.tsx │ │
+│  │ (확장)       │  │ (신규)       │  │ (신규)     │ │
+│  └──────┬───────┘  └──────┬───────┘  └─────┬──────┘ │
+│         │                 │                │         │
+│  ┌──────┴─────────────────┴────────────────┴───────┐ │
+│  │              useFacilities Hook (확장)            │ │
+│  └──────────────────────┬──────────────────────────┘ │
+└─────────────────────────┼────────────────────────────┘
+                          │
+┌─────────────────────────┼────────────────────────────┐
+│                   API Routes                          │
+│                                                       │
+│  GET /api/spots/[id]/facilities  (확장: type, status) │
+│  POST /api/facilities/report     (신규: 제보)         │
+│  POST /api/facilities/[id]/vote  (신규: 투표)         │
+└─────────────────────────┼────────────────────────────┘
+                          │
+┌─────────────────────────┼────────────────────────────┐
+│              MongoDB (facilities collection)           │
+│                                                       │
+│  기존 필드 + otakuDetails + verification + status     │
+└───────────────────────────────────────────────────────┘
+```
+
+## Data Model
+
+### 확장된 FacilityType (Req 1, 6.1)
+
+```typescript
+// src/types/spot.ts - 기존 타입 확장
+export type LegacyFacilityType =
+  | 'restaurant'
+  | 'convenience_store'
+  | 'cafe'
+  | 'station'
+  | 'other'
+
+export type OtakuFacilityType =
+  | 'coin_locker'
+  | 'solo_dining'
+  | 'charging_cafe'
+  | 'public_restroom'
+  | 'goods_shop'
+
+export type FacilityType = LegacyFacilityType | OtakuFacilityType
+
+export type FacilityStatus = 'active' | 'needs_verification' | 'hidden'
+
+export type GoodsShopSubtype = 'subculture_shop' | 'general_store'
+export type LockerSize = 'small' | 'medium' | 'large'
+```
+
+### 카테고리별 상세 정보 인터페이스 (Req 6.2~6.6)
+
+```typescript
+// src/types/facility.ts (신규 파일)
+
+export interface CoinLockerDetails {
+  sizes: LockerSize[]
+  prices: Record<LockerSize, number | null>  // 엔화 기준, null = 미등록
+  operatingHours: string | null              // "05:00-24:00" 형식
+  hasLargeLocker: boolean | null
+}
+
+export interface SoloDiningDetails {
+  hasCounterSeat: boolean | null
+  hasSoloMenu: boolean | null
+  isQuickMeal: boolean | null
+  isLateNight: boolean | null
+}
+
+export interface ChargingCafeDetails {
+  hasCharging: boolean | null
+  hasWifi: boolean | null
+}
+
+export interface PublicRestroomDetails {
+  isAccessible: boolean | null
+  is24Hours: boolean | null
+}
+
+export interface GoodsShopDetails {
+  subtype: GoodsShopSubtype
+  operatingHours: string | null
+}
+
+export type OtakuFacilityDetails =
+  | { type: 'coin_locker'; details: CoinLockerDetails }
+  | { type: 'solo_dining'; details: SoloDiningDetails }
+  | { type: 'charging_cafe'; details: ChargingCafeDetails }
+  | { type: 'public_restroom'; details: PublicRestroomDetails }
+  | { type: 'goods_shop'; details: GoodsShopDetails }
+```
+
+### 확장된 NearbyFacility 인터페이스 (Req 6.7~6.10)
+
+```typescript
+// src/types/spot.ts - 기존 인터페이스 확장
+export interface NearbyFacility {
+  id: string
+  name: string
+  type: FacilityType
+  distance: number
+  address: string
+  coordinates: [number, number]
+  // 신규 필드
+  status: FacilityStatus
+  verificationScore: number        // 0~100, 기본값 50
+  upvotes: number
+  downvotes: number
+  googlePlaceId?: string           // 외부 지도 매핑 (선택)
+  otakuDetails?: OtakuFacilityDetails  // Otaku_Category 전용 상세 정보
+  reportedBy?: string              // 제보자 userId
+  createdAt?: string
+  updatedAt?: string
+}
+```
+
+### MongoDB Document 스키마
+
+```typescript
+// facilities collection document
+interface FacilityDocument {
+  _id: ObjectId
+  name: string
+  type: FacilityType
+  address: string
+  coordinates: { lat: number; lng: number }
+  status: FacilityStatus              // 기본값: 'active'
+  verificationScore: number           // 기본값: 50
+  upvotes: number                     // 기본값: 0
+  downvotes: number                   // 기본값: 0
+  googlePlaceId?: string
+  otakuDetails?: {
+    coin_locker?: CoinLockerDetails
+    solo_dining?: SoloDiningDetails
+    charging_cafe?: ChargingCafeDetails
+    public_restroom?: PublicRestroomDetails
+    goods_shop?: GoodsShopDetails
+  }
+  reportedBy?: string
+  createdAt: Date
+  updatedAt: Date
+}
+```
+
+### 투표 기록 컬렉션 (Req 7.8 중복 투표 방지)
+
+MVP 단계에서는 개별 속성(콘센트 유무, 혼밥 가능 여부 등)마다 투표하는 대신, **시설 단위(Facility-level) 단일 투표**로 통일합니다. "이 편의시설 정보가 정확한가요? 👍/👎" 형태로 시설 전체에 대해 1인 1투표만 허용합니다. 이를 통해 DB 연산 복잡도를 낮추고, upvotes/downvotes가 시설 전체 레벨에서 일관되게 관리됩니다.
+
+```typescript
+// facility_votes collection document
+interface FacilityVoteDocument {
+  _id: ObjectId
+  facilityId: string
+  userId: string
+  value: boolean          // true = 정확해요(👍), false = 아니에요(👎)
+  createdAt: Date
+  updatedAt: Date
+}
+
+// 복합 유니크 인덱스: { facilityId, userId } → 시설당 1인 1투표 보장
+```
+
+## API Design
+
+### 1. GET /api/spots/[id]/facilities (확장) — Req 7.1, 7.2, 7.5
+
+기존 API를 확장하여 `type` 쿼리 파라미터와 `status` 필터링을 추가합니다.
+
+```
+GET /api/spots/[id]/facilities?type=coin_locker&radius=2&limit=50
+```
+
+**변경 사항:**
+- `type` 파라미터 추가: 특정 카테고리만 필터링
+- `status` 필터 자동 적용: `hidden` 상태 제외
+- 응답에 `otakuDetails`, `status`, `verificationScore` 포함
+
+**응답 예시:**
+```json
+[
+  {
+    "id": "abc123",
+    "name": "아키하바라역 코인 로커",
+    "type": "coin_locker",
+    "distance": 150,
+    "address": "東京都千代田区...",
+    "coordinates": [35.6984, 139.7731],
+    "status": "active",
+    "verificationScore": 85,
+    "upvotes": 12,
+    "downvotes": 2,
+    "otakuDetails": {
+      "type": "coin_locker",
+      "details": {
+        "sizes": ["small", "medium", "large"],
+        "prices": { "small": 300, "medium": 500, "large": 700 },
+        "operatingHours": "05:00-24:00",
+        "hasLargeLocker": true
+      }
+    }
+  }
+]
+```
+
+### 2. POST /api/facilities/report (신규) — Req 7.3, 7.4
+
+```
+POST /api/facilities/report
+Content-Type: application/json
+```
+
+**요청 Body:**
+```json
+{
+  "name": "이케부쿠로 코인 로커",
+  "type": "coin_locker",
+  "coordinates": { "lat": 35.7295, "lng": 139.7109 },
+  "address": "東京都豊島区...",
+  "googlePlaceId": "ChIJ...",
+  "otakuDetails": {
+    "sizes": ["small", "large"],
+    "prices": { "small": 300, "large": 700 },
+    "operatingHours": "05:00-24:00",
+    "hasLargeLocker": true
+  }
+}
+```
+
+**필수 필드:** `name`, `type`, `coordinates`
+**응답:** 201 Created + 생성된 facility 객체
+**에러:** 400 Bad Request + 누락 필드 목록
+
+### 3. POST /api/facilities/[id]/vote (신규) — Req 7.6, 7.7, 7.8
+
+시설 단위(Facility-level) 단일 투표. "이 편의시설 정보가 정확한가요?"에 대한 👍/👎 투표입니다.
+
+```
+POST /api/facilities/[id]/vote
+Content-Type: application/json
+```
+
+**요청 Body:**
+```json
+{
+  "value": true
+}
+```
+
+- `value`: `true` = 정확해요(👍), `false` = 아니에요(👎)
+
+**처리 로직:**
+1. `facility_votes` 컬렉션에서 `{ facilityId, userId }` 조회
+2. 기존 투표 존재 → 값 업데이트 (중복 누적 방지, 토글 가능)
+3. 신규 투표 → 새 문서 삽입
+4. `facilities` 컬렉션의 `upvotes`/`downvotes` 재계산
+5. `verificationScore` 재계산: `Math.round((upvotes / (upvotes + downvotes)) * 100)` (투표 0건이면 50)
+6. `verificationScore` 임계치 확인 → 필요 시 `status` 변경
+
+**응답:**
+```json
+{
+  "verificationScore": 78,
+  "upvotes": 14,
+  "downvotes": 4
+}
+```
+
+## Verification Score & Status 관리 (Req 5.11, 6.8, 6.9)
+
+### 점수 계산
+
+```
+verificationScore = upvotes + downvotes > 0
+  ? Math.round((upvotes / (upvotes + downvotes)) * 100)
+  : 50  // 투표 없으면 기본 50
+```
+
+### 상태 전이 규칙
+
+```
+active → needs_verification:
+  downvotes - upvotes >= 5 (downvotes가 5개 이상 더 많을 때)
+
+needs_verification → hidden:
+  verificationScore < 20 (신뢰도 20% 미만)
+
+hidden/needs_verification → active:
+  관리자 수동 복원 (향후 admin API로 확장)
+```
+
+## UI Components
+
+### 1. FACILITY_CONFIG 확장 (Req 1.2)
+
+```typescript
+// src/components/spot/NearbyFacilities.tsx 내 FACILITY_CONFIG 확장
+const FACILITY_CONFIG: Record<FacilityType, { label: string; icon: string; color: string }> = {
+  // Legacy
+  restaurant:        { label: '음식점',      icon: '🍽️', color: 'bg-orange-100 ...' },
+  convenience_store: { label: '편의점',      icon: '🏪', color: 'bg-blue-100 ...' },
+  cafe:              { label: '카페',        icon: '☕', color: 'bg-amber-100 ...' },
+  station:           { label: '역/정류장',   icon: '🚉', color: 'bg-green-100 ...' },
+  other:             { label: '기타',        icon: '📍', color: 'bg-gray-100 ...' },
+  // Otaku (신규)
+  coin_locker:       { label: '코인 로커',   icon: '🔐', color: 'bg-purple-100 ...' },
+  solo_dining:       { label: '혼밥 식당',   icon: '🍜', color: 'bg-rose-100 ...' },
+  charging_cafe:     { label: '충전/와이파이', icon: '🔌', color: 'bg-cyan-100 ...' },
+  public_restroom:   { label: '화장실',      icon: '🚻', color: 'bg-teal-100 ...' },
+  goods_shop:        { label: '굿즈/잡화',   icon: '🛍️', color: 'bg-pink-100 ...' },
+}
+```
+
+### 2. FacilityCard 확장 (Req 2, 3, 4)
+
+기존 `FacilityCard` 컴포넌트에 카테고리별 상세 정보 렌더링을 추가합니다.
+
+```
+┌─────────────────────────────────────────┐
+│ 🔐 아키하바라역 코인 로커    150m       │
+│ 東京都千代田区...                        │
+│ ┌─────────────────────────────────────┐ │
+│ │ 소형 ¥300 │ 중형 ¥500 │ 대형 ¥700 │ │
+│ │ 🧳 대형 로커 있음  ⏰ 05:00-24:00  │ │
+│ └─────────────────────────────────────┘ │
+│ ✅ 신뢰도 85%  👍12 👎2               │
+│ [콘센트 있나요? 예/아니오]              │
+└─────────────────────────────────────────┘
+```
+
+카테고리별 상세 렌더링:
+- `coin_locker`: 크기별 가격 테이블, 대형 로커 유무 배지, 이용 시간
+- `solo_dining`: "1인 OK" 태그, 카운터석/1인 메뉴 유무, 빠른 식사/심야 배지
+- `charging_cafe`: 충전/와이파이 유무 아이콘
+- `public_restroom`: 접근성/24시간 유무 아이콘
+- `goods_shop`: 매장 유형 배지(서브컬처/잡화), 영업시간
+
+### 3. FacilityFilter 컴포넌트 (Req 1.4, 1.5)
+
+카테고리 필터 칩 UI를 NearbyFacilities 상단에 추가합니다.
+
+```
+┌─────────────────────────────────────────────────┐
+│ [전체] [🍽️음식점] [🏪편의점] ... [🔐로커]      │
+│ [🍜혼밥] [🔌충전] [🚻화장실] [🛍️굿즈]         │
+└─────────────────────────────────────────────────┘
+```
+
+- 칩 클릭 → 해당 카테고리만 필터링
+- 다시 클릭 → 필터 해제 (전체 표시)
+- 복수 선택 가능
+
+### 4. FacilityReportForm 컴포넌트 (Req 5.1~5.9)
+
+모달 형태의 제보 폼. 데이터 출처 이원화 전략에 따라 **투트랙 입력 UI**를 제공하며, 카테고리 선택에 따라 동적 필드가 표시됩니다.
+
+**Step 1: 장소 입력 방식 선택 (투트랙)**
+
+```
+┌─────────────────────────────────────────┐
+│ 편의시설 제보                    [X]    │
+│                                         │
+│ 장소를 어떻게 등록하시겠어요?           │
+│                                         │
+│ ┌─────────────────────────────────────┐ │
+│ │ [🔍 구글맵 장소 검색]              │ │
+│ │  식당, 카페 등 이미 있는 장소에     │ │
+│ │  덕후 정보만 추가                   │ │
+│ └─────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────┐ │
+│ │ [📍 지도에 직접 핀 꽂기]           │ │
+│ │  코인 로커, 화장실 등 지도에        │ │
+│ │  없는 장소를 새로 등록              │ │
+│ └─────────────────────────────────────┘ │
+└─────────────────────────────────────────┘
+```
+
+- **구글맵 검색 탭**: 구글 Places Autocomplete로 장소 검색 → 선택 시 `googlePlaceId`, 이름, 주소, 좌표 자동 입력 → 유저는 카테고리와 덕후 특화 속성만 추가 입력
+- **직접 핀 탭**: 지도에서 위치를 직접 클릭하여 핀 설정 → 이름, 주소, 카테고리, 상세 정보 모두 직접 입력
+
+**Step 2: 카테고리 및 상세 정보 입력**
+
+```
+┌─────────────────────────────────────────┐
+│ 편의시설 제보                    [X]    │
+│                                         │
+│ 📍 선택된 장소: 아키하바라역 앞         │
+│    東京都千代田区... (자동 입력)         │
+│                                         │
+│ 카테고리*: [▼ 코인 로커    ]            │
+│                                         │
+│ ── 코인 로커 상세 정보 ──               │
+│ 크기: [☑소형] [☑중형] [☑대형]          │
+│ 가격: 소형[300] 중형[500] 대형[700]     │
+│ 이용시간: [05:00-24:00]                 │
+│ 대형 로커: [☑ 있음]                     │
+│                                         │
+│           [제보하기]                     │
+└─────────────────────────────────────────┘
+```
+
+### 5. MicroVoteButton 컴포넌트 (Req 5.10)
+
+FacilityCard 하단에 표시되는 시설 단위 단일 투표 UI. 개별 속성이 아닌 시설 전체 정보의 정확성을 검증합니다.
+
+```
+┌──────────────────────────────────────────────┐
+│ 이 정보가 정확한가요?  [👍 정확해요] [👎 아니에요] │
+└──────────────────────────────────────────────┘
+```
+
+- 시설당 1인 1투표 (재투표 시 기존 값 토글/업데이트)
+- 이미 투표한 경우 선택 상태 하이라이트 표시
+- 투표 후 verificationScore 실시간 업데이트
+- 로그인하지 않은 유저에게는 로그인 유도 메시지 표시
+
+## File Structure (신규/변경 파일)
+
+```
+src/
+├── types/
+│   ├── spot.ts                          # FacilityType, NearbyFacility 확장
+│   └── facility.ts                      # 카테고리별 상세 인터페이스 (신규)
+├── lib/
+│   └── facility-utils.ts                # groupFacilitiesByType 확장
+├── app/api/
+│   ├── spots/[id]/facilities/route.ts   # GET 확장 (type, status 필터)
+│   └── facilities/
+│       ├── report/route.ts              # POST 제보 API (신규)
+│       └── [id]/vote/route.ts           # POST 투표 API (신규)
+├── components/spot/
+│   ├── NearbyFacilities.tsx             # FACILITY_CONFIG 확장, 필터 추가
+│   ├── FacilityCard.tsx                 # 카테고리별 상세 렌더링 확장
+│   ├── FacilityFilter.tsx               # 카테고리 필터 칩 (신규)
+│   ├── FacilityReportForm.tsx           # 제보 폼 모달 (신규)
+│   └── MicroVoteButton.tsx              # 마이크로 투표 버튼 (신규)
+└── hooks/
+    └── useSpotDetail.ts                 # useNearbyFacilities 확장
+```
+
+## Correctness Properties
+
+### Property 1: 카테고리 분류 무결성
+
+모든 편의시설은 정확히 하나의 FacilityType에 속해야 하며, groupFacilitiesByType 함수는 입력된 모든 시설을 누락 없이 분류해야 한다.
+
+```
+∀ facilities: NearbyFacility[] →
+  sum(grouped[type].length for type in FacilityType) === facilities.length
+```
+
+### Property 2: 하위 호환성
+
+Legacy_Category 편의시설은 otakuDetails 필드 없이도 정상 렌더링되어야 한다.
+
+```
+∀ facility where facility.type ∈ LegacyFacilityType →
+  render(facility) succeeds regardless of otakuDetails presence
+```
+
+### Property 3: 투표 중복 방지 불변식
+
+동일 유저가 동일 시설에 대해 투표하면, facility_votes 컬렉션에는 항상 최대 1개의 문서만 존재해야 한다.
+
+```
+∀ (facilityId, userId) →
+  count(facility_votes where facilityId AND userId) <= 1
+```
+
+### Property 4: Verification Score 범위 불변식
+
+verificationScore는 항상 0~100 범위이며, upvotes + downvotes가 0이면 50이어야 한다.
+
+```
+∀ facility →
+  0 <= facility.verificationScore <= 100
+  AND (facility.upvotes + facility.downvotes === 0 → facility.verificationScore === 50)
+```
+
+### Property 5: Status 필터링 일관성
+
+API 응답에 status가 'hidden'인 편의시설이 포함되어서는 안 된다.
+
+```
+∀ response from GET /api/spots/[id]/facilities →
+  response.every(f => f.status !== 'hidden')
+```
+
+### Property 6: 제보 필수 필드 검증
+
+name, type, coordinates 중 하나라도 누락되면 400 에러를 반환해야 한다.
+
+```
+∀ request to POST /api/facilities/report →
+  missing(name OR type OR coordinates) → response.status === 400
+```

--- a/.kiro/specs/11-otaku-facilities/requirements.md
+++ b/.kiro/specs/11-otaku-facilities/requirements.md
@@ -2,64 +2,118 @@
 
 ## Introduction
 
-일반적인 편의시설 정보가 아닌, 성지순례 유저(오타쿠)의 페인포인트를 정확히 해결하는 타겟화된 편의시설 정보를 제공합니다. 코인 로커, 혼밥 가능 식당, 굿즈샵 등 덕후들에게 실질적으로 필요한 정보에 집중합니다.
+일반적인 편의시설 정보(식당, 편의점, 카페, 역)를 넘어, 성지순례 유저(오타쿠)의 실질적 페인포인트를 해결하는 특화 편의시설 정보를 제공합니다. 기존 편의시설 시스템(`FacilityType`: restaurant, convenience_store, cafe, station, other)을 확장하여 코인 로커, 혼밥 친화 식당, 충전/와이파이 카페, 개방 화장실, 굿즈/잡화점 등 덕후 특화 카테고리를 추가합니다.
 
 ## Glossary
 
-- **Coin Locker (코인 로커)**: 짐을 보관할 수 있는 유료 보관함
-- **Solo-Friendly (혼밥 친화)**: 혼자 식사하기 편한 식당
-- **Goods Shop (굿즈샵)**: 애니메이션 관련 상품을 판매하는 매장 (애니메이트, 만다라케 등)
+- **Facility_System**: 스팟 주변 편의시설 정보를 관리하고 표시하는 시스템
+- **Otaku_Category**: 덕후 특화 편의시설 카테고리 (coin_locker, solo_dining, charging_cafe, public_restroom, goods_shop)
+- **Legacy_Category**: 기존 편의시설 카테고리 (restaurant, convenience_store, cafe, station, other)
+- **Coin_Locker (코인 로커)**: 역이나 상업시설에 설치된 유료 짐 보관함
+- **Solo_Dining (혼밥 친화 식당)**: 1인 식사에 적합한 구조(카운터석, 1인 메뉴 등)를 갖춘 식당
+- **Charging_Cafe (충전/와이파이 카페)**: 콘센트(충전)와 무료 와이파이를 제공하는 카페 또는 공간
+- **Public_Restroom (개방 화장실)**: 누구나 이용 가능한 공중 화장실 또는 상업시설 내 개방 화장실
+- **Goods_Shop (굿즈/잡화점)**: 서브컬처 매장(애니메이트, 만다라케 등) 및 대형 잡화점(돈키호테 등)
+- **Spot_Detail_Page**: 개별 스팟의 상세 정보를 표시하는 페이지
+- **Facility_Filter**: 편의시설 카테고리를 선택하여 표시를 제어하는 UI 컴포넌트
+- **Facility_Card**: 개별 편의시설의 정보를 표시하는 UI 컴포넌트
+- **Facility_Report_Form**: 유저가 새로운 편의시설 정보를 제보하는 입력 폼
+- **Micro_Vote**: 편의시설 상세 정보의 정확성을 유저 투표로 검증하는 간단한 예/아니오 UI
+- **Verification_Score**: Micro_Vote 결과를 기반으로 산출되는 편의시설 정보의 신뢰도 점수 (upvotes, downvotes로 계산)
+- **Facility_Status**: 편의시설의 현재 상태 (active: 정상 표시, needs_verification: 확인 필요, hidden: 숨김)
 
 ## Requirements
 
-### Requirement 1: 덕후 특화 편의시설 카테고리
+### Requirement 1: 덕후 특화 편의시설 카테고리 확장
 
-**User Story:** As a 성지순례 유저, I want 나에게 필요한 편의시설만 빠르게 찾을 수 있기를, so that 순례 중 불편함을 최소화할 수 있습니다.
-
-#### Acceptance Criteria
-
-1. THE System SHALL 다음 덕후 특화 카테고리를 제공한다: 코인 로커, 혼밥 식당, 굿즈샵, 포토스팟, 휴식 공간
-2. WHEN 스팟 상세 페이지를 조회할 때 THEN THE System SHALL 해당 스팟 주변의 덕후 특화 편의시설을 우선 표시한다
-3. WHEN 유저가 편의시설 필터를 선택할 때 THEN THE System SHALL 지도에 해당 카테고리만 표시한다
-
-### Requirement 2: 코인 로커 정보
-
-**User Story:** As a 유저, I want 근처 코인 로커 위치와 크기/가격 정보를 알 수 있기를, so that 무거운 짐(굿즈, 카메라 등)을 보관할 수 있습니다.
+**User Story:** As a 성지순례 유저, I want 덕후에게 필요한 편의시설 카테고리로 분류된 정보를 볼 수 있기를, so that 순례 중 필요한 시설을 빠르게 찾을 수 있습니다.
 
 #### Acceptance Criteria
 
-1. THE System SHALL 코인 로커의 위치, 크기별 가격, 이용 가능 시간을 표시한다
-2. THE System SHALL 대형 로커(캐리어 보관 가능) 여부를 표시한다
-3. WHEN 역 근처 스팟을 조회할 때 THEN THE System SHALL 해당 역의 코인 로커 정보를 자동으로 표시한다
+1. THE Facility_System SHALL 기존 Legacy_Category(restaurant, convenience_store, cafe, station, other)에 추가로 Otaku_Category(coin_locker, solo_dining, charging_cafe, public_restroom, goods_shop) 5개 카테고리를 지원한다
+2. THE Facility_System SHALL 각 Otaku_Category에 대해 고유한 아이콘과 라벨을 표시한다
+3. WHEN 유저가 Spot_Detail_Page를 조회할 때, THE Facility_System SHALL 해당 스팟 반경 내의 편의시설을 Legacy_Category와 Otaku_Category 모두 포함하여 목록으로 표시한다
+4. WHEN 유저가 Facility_Filter에서 특정 카테고리를 선택할 때, THE Facility_System SHALL 선택된 카테고리에 해당하는 편의시설만 목록에 표시한다
+5. WHEN 유저가 Facility_Filter에서 카테고리 선택을 해제할 때, THE Facility_System SHALL 모든 카테고리의 편의시설을 다시 표시한다
+
+### Requirement 2: 코인 로커 상세 정보
+
+**User Story:** As a 짐이 많은 순례 유저, I want 근처 코인 로커의 위치와 크기/가격 정보를 확인할 수 있기를, so that 무거운 짐(굿즈, 캐리어 등)을 보관하고 가볍게 순례할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. THE Facility_Card SHALL coin_locker 타입 편의시설에 대해 위치, 크기 정보(소형/중형/대형), 가격 정보를 표시한다
+2. THE Facility_Card SHALL coin_locker 타입 편의시설에 대해 이용 가능 시간을 표시한다
+3. THE Facility_Card SHALL coin_locker 타입 편의시설에 대해 대형 로커(캐리어 보관 가능) 유무를 명시한다
+4. IF coin_locker 편의시설의 크기 또는 가격 정보가 등록되지 않은 경우, THEN THE Facility_Card SHALL "정보 미등록" 텍스트를 해당 필드에 표시한다
 
 ### Requirement 3: 혼밥 친화 식당 정보
 
-**User Story:** As a 혼자 순례하는 유저, I want 혼밥하기 편한 식당을 찾을 수 있기를, so that 눈치 보지 않고 식사할 수 있습니다.
+**User Story:** As a 혼자 순례하는 유저, I want 혼밥하기 편한 식당을 구분하여 찾을 수 있기를, so that 눈치 보지 않고 편하게 식사할 수 있습니다.
 
 #### Acceptance Criteria
 
-1. THE System SHALL 혼밥 친화 식당에 "1인 OK" 태그를 표시한다
-2. THE System SHALL 카운터석 유무, 1인 메뉴 유무 정보를 제공한다
-3. THE System SHALL 유저 리뷰에서 "혼밥 후기"를 별도로 표시한다
+1. THE Facility_Card SHALL solo_dining 타입 편의시설에 대해 "1인 OK" 태그를 표시한다
+2. THE Facility_Card SHALL solo_dining 타입 편의시설에 대해 카운터석 유무와 1인 메뉴 유무 정보를 표시한다
+3. IF solo_dining 편의시설의 카운터석 또는 1인 메뉴 정보가 등록되지 않은 경우, THEN THE Facility_Card SHALL "정보 미등록" 텍스트를 해당 필드에 표시한다
+4. THE Facility_Card SHALL solo_dining 타입 편의시설에 대해 빠른 식사 가능 여부(패스트푸드/규동 체인점 등)와 심야 영업 여부를 필터링할 수 있는 정보를 표시한다
 
-### Requirement 4: 굿즈샵 연계 정보
+### Requirement 4: 덕후 쇼핑 및 잡화점 정보
 
-**User Story:** As a 유저, I want 성지 근처의 굿즈샵을 찾을 수 있기를, so that 순례 중 관련 굿즈를 구매할 수 있습니다.
-
-#### Acceptance Criteria
-
-1. THE System SHALL 애니메이트, 만다라케, 중고 피규어샵 등의 위치를 표시한다
-2. WHEN 특정 작품 성지를 조회할 때 THEN THE System SHALL 해당 작품 굿즈를 판매하는 근처 매장을 추천한다
-3. THE System SHALL 매장별 취급 장르/작품 정보를 제공한다
-
-### Requirement 5: 편의시설 유저 제보
-
-**User Story:** As a 유저, I want 내가 발견한 유용한 편의시설을 제보할 수 있기를, so that 다른 유저들에게 도움이 될 수 있습니다.
+**User Story:** As a 유저, I want 성지 근처의 서브컬처 매장과 잡화점 위치를 확인할 수 있기를, so that 순례 중 필요한 물품이나 기념품을 구매할 수 있습니다.
 
 #### Acceptance Criteria
 
-1. WHEN 유저가 "편의시설 제보" 버튼을 클릭할 때 THEN THE System SHALL 제보 폼을 표시한다
-2. THE System SHALL 제보된 편의시설을 검토 후 지도에 추가한다
-3. THE System SHALL 편의시설 정보의 정확성을 유저 투표로 검증한다
+1. THE Facility_Card SHALL goods_shop 타입 편의시설에 대해 주요 서브컬처 매장(애니메이트, 만다라케 등)의 매장명과 위치를 표시한다
+2. THE Facility_Card SHALL goods_shop 타입 편의시설에 대해 여행 중 필요한 물품이나 가벼운 기념품을 살 수 있는 대형 잡화점(예: 돈키호테)의 위치를 표시한다
+3. THE Facility_Card SHALL goods_shop 타입 편의시설에 대해 영업시간 정보를 표시한다
 
-</content>
+### Requirement 5: 편의시설 제보 기능
+
+**User Story:** As a 유저, I want 내가 발견한 덕후 특화 편의시설을 제보할 수 있기를, so that 다른 순례 유저들에게 도움이 될 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 유저가 Spot_Detail_Page에서 "편의시설 제보" 버튼을 클릭할 때, THE Facility_System SHALL Facility_Report_Form을 표시한다
+2. THE Facility_Report_Form SHALL 편의시설 이름, 카테고리(Legacy_Category 또는 Otaku_Category 중 택 1), 위치(지도 핀 또는 주소 입력), 상세 정보 입력 필드를 제공한다
+3. WHEN 유저가 Facility_Report_Form에서 coin_locker 카테고리를 선택할 때, THE Facility_Report_Form SHALL 크기, 가격, 이용 시간 입력 필드를 추가로 표시한다
+4. WHEN 유저가 Facility_Report_Form에서 solo_dining 카테고리를 선택할 때, THE Facility_Report_Form SHALL 카운터석 유무, 1인 메뉴 유무, 빠른 식사 가능 여부, 심야 영업 여부 입력 필드를 추가로 표시한다
+5. WHEN 유저가 Facility_Report_Form에서 goods_shop 카테고리를 선택할 때, THE Facility_Report_Form SHALL 매장 유형(서브컬처 매장/대형 잡화점), 영업시간 입력 필드를 추가로 표시한다
+6. WHEN 유저가 Facility_Report_Form에서 charging_cafe 카테고리를 선택할 때, THE Facility_Report_Form SHALL 충전 콘센트 유무, 무료 와이파이 유무 입력 필드를 추가로 표시한다
+7. WHEN 유저가 Facility_Report_Form에서 public_restroom 카테고리를 선택할 때, THE Facility_Report_Form SHALL 장애인 접근 가능 여부, 24시간 이용 가능 여부 입력 필드를 추가로 표시한다
+8. WHEN 유저가 필수 필드(이름, 카테고리, 위치)를 모두 입력하고 제출 버튼을 클릭할 때, THE Facility_System SHALL 제보 데이터를 저장하고 성공 메시지를 표시한다
+9. IF 유저가 필수 필드를 입력하지 않고 제출 버튼을 클릭한 경우, THEN THE Facility_Report_Form SHALL 미입력 필드에 대한 오류 메시지를 표시한다
+10. THE Facility_System SHALL 편의시설 상세 정보에 Micro_Vote UI를 제공하여(예: "여기에 콘센트가 있나요? 예/아니오") 유저 투표로 데이터를 지속적으로 검증 및 갱신한다
+11. WHEN 특정 편의시설의 downvotes가 upvotes보다 일정 기준(예: 5개) 이상 많아지거나 Verification_Score가 임계치 이하로 떨어질 경우, THEN THE Facility_System SHALL 해당 편의시설을 '확인 필요' 상태로 변경하고 지도 기본 표시 대상에서 제외(숨김)한다
+
+### Requirement 6: 편의시설 데이터 모델 확장
+
+**User Story:** As a 개발자, I want 덕후 특화 편의시설의 상세 정보를 저장할 수 있는 데이터 구조를 갖추기를, so that 카테고리별 특화 정보를 관리할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. THE Facility_System SHALL 기존 NearbyFacility 인터페이스를 확장하여 Otaku_Category 타입을 FacilityType에 추가한다
+2. THE Facility_System SHALL coin_locker 타입에 대해 sizes(크기 목록), prices(가격 정보), operatingHours(이용 시간), hasLargeLocker(대형 로커 유무) 필드를 저장한다
+3. THE Facility_System SHALL solo_dining 타입에 대해 hasCounterSeat(카운터석 유무), hasSoloMenu(1인 메뉴 유무), isQuickMeal(빠른 식사 가능 여부), isLateNight(심야 영업 여부) 필드를 저장한다
+4. THE Facility_System SHALL charging_cafe 타입에 대해 hasCharging(충전 콘센트 유무), hasWifi(무료 와이파이 유무) 필드를 저장한다
+5. THE Facility_System SHALL public_restroom 타입에 대해 isAccessible(장애인 접근 가능 여부), is24Hours(24시간 이용 가능 여부) 필드를 저장한다
+6. THE Facility_System SHALL goods_shop 타입에 대해 subtype(매장 유형: subculture_shop 또는 general_store), operatingHours(영업시간) 필드를 저장한다
+7. THE Facility_System SHALL 기존 Legacy_Category 편의시설 데이터와 하위 호환성을 유지한다
+8. THE Facility_System SHALL 모든 편의시설 데이터에 verificationScore(투표 기반 신뢰도 점수), upvotes(긍정 투표 수), downvotes(부정 투표 수) 필드를 저장하여 Micro_Vote를 통한 정보 신뢰성을 관리한다
+9. THE Facility_System SHALL 모든 편의시설 데이터에 status(상태: active, needs_verification, hidden) 필드를 포함하여, Verification_Score에 따른 지도 표시 여부를 제어한다
+10. THE Facility_System SHALL 기존 외부 지도 서비스(구글맵 등)의 장소와 매핑할 수 있도록 선택적 필드인 googlePlaceId를 제공하여, 중복 장소 생성을 방지하고 기본 정보(주소, 영업시간 등)를 동기화할 수 있는 기반을 마련한다
+
+### Requirement 7: 편의시설 API 확장
+
+**User Story:** As a 개발자, I want 덕후 특화 편의시설을 조회하고 등록할 수 있는 API를 갖추기를, so that 클라이언트에서 편의시설 데이터를 활용할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN GET /api/spots/[id]/facilities 요청에 type 쿼리 파라미터가 포함된 경우, THE Facility_System SHALL 해당 카테고리이면서 Facility_Status가 'active' 또는 'needs_verification'인 편의시설만 필터링하여 반환한다
+2. WHEN GET /api/spots/[id]/facilities 요청에 type 쿼리 파라미터가 없는 경우, THE Facility_System SHALL Facility_Status가 'hidden'인 시설을 제외한 모든 카테고리(Legacy_Category + Otaku_Category)의 편의시설을 반환한다
+3. WHEN POST /api/facilities/report 요청에 유효한 제보 데이터가 포함된 경우, THE Facility_System SHALL 편의시설 데이터를 저장하고 201 상태 코드를 반환한다
+4. IF POST /api/facilities/report 요청에 필수 필드(name, type, coordinates)가 누락된 경우, THEN THE Facility_System SHALL 400 상태 코드와 누락 필드 목록을 반환한다
+5. THE Facility_System SHALL 편의시설 조회 응답에 카테고리별 상세 정보(coin_locker의 크기/가격, solo_dining의 카운터석 유무, charging_cafe의 충전/와이파이 유무, public_restroom의 접근성/24시간 여부, goods_shop의 매장 유형 등)를 포함한다
+6. WHEN POST /api/facilities/[id]/vote 요청에 투표 데이터(예/아니오 및 평가 항목)가 포함된 경우, THE Facility_System SHALL 투표 결과를 반영하고 업데이트된 verificationScore를 반환한다
+7. IF POST /api/facilities/[id]/vote 요청에 평가 항목 또는 투표 값이 누락된 경우, THEN THE Facility_System SHALL 400 상태 코드와 오류 메시지를 반환한다
+8. WHEN 동일한 유저가 이미 투표한 항목에 대해 POST /api/facilities/[id]/vote 요청을 다시 보낼 경우, THE Facility_System SHALL 기존 투표 결과를 새로운 값으로 업데이트하되 중복 누적시키지 않는다

--- a/.kiro/specs/11-otaku-facilities/tasks.md
+++ b/.kiro/specs/11-otaku-facilities/tasks.md
@@ -1,0 +1,186 @@
+# Implementation Plan: 덕후 친화적 편의시설 (Otaku-Friendly Facilities)
+
+## Overview
+
+기존 편의시설 시스템(5개 Legacy_Category)을 확장하여 덕후 특화 5개 카테고리를 추가하고, 유저 제보 및 마이크로 투표 기반 데이터 검증 시스템을 구축합니다. 기존 타입/컴포넌트/API를 하위 호환성을 유지하며 확장하고, 신규 컴포넌트와 API를 추가합니다.
+
+## Tasks
+
+- [-] 1. 데이터 모델 및 타입 정의
+  - [x] 1.1 `src/types/facility.ts` 신규 생성 — 카테고리별 상세 인터페이스 정의
+    - `CoinLockerDetails`, `SoloDiningDetails`, `ChargingCafeDetails`, `PublicRestroomDetails`, `GoodsShopDetails` 인터페이스 작성
+    - `OtakuFacilityDetails` 판별 유니온 타입 정의
+    - `LockerSize`, `GoodsShopSubtype`, `FacilityStatus` 타입 정의
+    - `FacilityVoteDocument` 인터페이스 정의 (facility_votes 컬렉션용)
+    - _Requirements: 6.2, 6.3, 6.4, 6.5, 6.6, 6.8, 6.9_
+
+  - [x] 1.2 `src/types/spot.ts` 확장 — FacilityType 및 NearbyFacility 인터페이스 확장
+    - `LegacyFacilityType`, `OtakuFacilityType` 타입 분리 후 `FacilityType` 유니온으로 통합
+    - `NearbyFacility` 인터페이스에 `status`, `verificationScore`, `upvotes`, `downvotes`, `googlePlaceId`, `otakuDetails`, `reportedBy`, `createdAt`, `updatedAt` 필드 추가
+    - 기존 `Facility` 인터페이스도 동일하게 확장
+    - 기존 Legacy_Category 코드와의 하위 호환성 유지
+    - _Requirements: 1.1, 6.1, 6.7, 6.8, 6.9, 6.10_
+
+  - [-] 1.3 `src/lib/facility-utils.ts` 확장 — 유틸리티 함수 업데이트
+    - `groupFacilitiesByType` 함수에 Otaku_Category 5개 추가
+    - `VALID_FACILITY_TYPES` 배열에 신규 카테고리 추가
+    - 기존 Legacy_Category 분류 로직 유지
+    - _Requirements: 1.1, 6.7_
+
+  - [ ]* 1.4 Property 테스트 — 카테고리 분류 무결성
+    - **Property 1: 카테고리 분류 무결성**
+    - `groupFacilitiesByType` 함수가 모든 시설을 누락 없이 분류하는지 검증
+    - **Validates: Requirements 1.1, 6.7**
+
+  - [ ]* 1.5 Property 테스트 — 하위 호환성
+    - **Property 2: 하위 호환성**
+    - Legacy_Category 편의시설이 `otakuDetails` 없이도 정상 처리되는지 검증
+    - **Validates: Requirements 6.7**
+
+- [ ] 2. Checkpoint — 데이터 모델 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 3. 편의시설 API 확장
+  - [ ] 3.1 `src/app/api/spots/[id]/facilities/route.ts` 확장 — GET API에 type/status 필터 추가
+    - `type` 쿼리 파라미터로 특정 카테고리 필터링 지원
+    - `status`가 `hidden`인 시설 자동 제외
+    - 응답에 `otakuDetails`, `status`, `verificationScore`, `upvotes`, `downvotes` 포함
+    - _Requirements: 7.1, 7.2, 7.5_
+
+  - [ ] 3.2 `src/app/api/facilities/report/route.ts` 신규 생성 — 편의시설 제보 API
+    - POST 핸들러: 필수 필드(`name`, `type`, `coordinates`) 검증
+    - 카테고리별 `otakuDetails` 저장 처리
+    - 기본값 설정: `status: 'active'`, `verificationScore: 50`, `upvotes: 0`, `downvotes: 0`
+    - 성공 시 201, 필수 필드 누락 시 400 + 누락 필드 목록 반환
+    - _Requirements: 7.3, 7.4_
+
+  - [ ] 3.3 `src/app/api/facilities/[id]/vote/route.ts` 신규 생성 — 마이크로 투표 API
+    - POST 핸들러: `value`(boolean) 필드 검증
+    - `facility_votes` 컬렉션에서 `{ facilityId, userId }` 복합 유니크 인덱스 활용
+    - 기존 투표 존재 시 값 업데이트, 신규 시 삽입
+    - `upvotes`/`downvotes` 재계산 및 `verificationScore` 산출
+    - `downvotes - upvotes >= 5` 시 `needs_verification` 상태 전이
+    - `verificationScore < 20` 시 `hidden` 상태 전이
+    - 투표 값 또는 인증 누락 시 400 반환
+    - _Requirements: 7.6, 7.7, 7.8, 5.11_
+
+  - [ ]* 3.4 Property 테스트 — Verification Score 범위 불변식
+    - **Property 4: Verification Score 범위 불변식**
+    - `verificationScore`가 항상 0~100 범위이며, 투표 0건이면 50인지 검증
+    - **Validates: Requirements 6.8, 5.11**
+
+  - [ ]* 3.5 Property 테스트 — 제보 필수 필드 검증
+    - **Property 6: 제보 필수 필드 검증**
+    - `name`, `type`, `coordinates` 중 하나라도 누락 시 400 에러 반환 검증
+    - **Validates: Requirements 7.3, 7.4**
+
+  - [ ]* 3.6 Property 테스트 — Status 필터링 일관성
+    - **Property 5: Status 필터링 일관성**
+    - GET API 응답에 `status: 'hidden'`인 시설이 포함되지 않는지 검증
+    - **Validates: Requirements 7.1, 7.2**
+
+- [ ] 4. Checkpoint — API 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. FacilityFilter 컴포넌트 구현
+  - [ ] 5.1 `src/components/spot/FacilityFilter.tsx` 신규 생성 — 카테고리 필터 칩 UI
+    - Legacy_Category + Otaku_Category 전체 카테고리 필터 칩 렌더링
+    - "전체" 칩 포함, 복수 선택 지원
+    - 칩 클릭 시 해당 카테고리 토글, 전체 해제 시 모든 카테고리 표시
+    - 각 카테고리별 아이콘/라벨 표시 (FACILITY_CONFIG 활용)
+    - _Requirements: 1.4, 1.5_
+
+  - [ ] 5.2 `src/components/spot/NearbyFacilities.tsx` 확장 — FACILITY_CONFIG 및 필터 통합
+    - `FACILITY_CONFIG`에 Otaku_Category 5개 추가 (아이콘, 라벨, 색상)
+    - `FacilityFilter` 컴포넌트를 목록 상단에 통합
+    - 선택된 카테고리에 따라 편의시설 목록 필터링 로직 추가
+    - _Requirements: 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 6. FacilityCard 카테고리별 상세 렌더링 확장
+  - [ ] 6.1 `src/components/spot/FacilityCard.tsx` 확장 — 카테고리별 상세 정보 렌더링
+    - `coin_locker`: 크기별 가격 테이블, 대형 로커 유무 배지, 이용 시간 표시, 미등록 시 "정보 미등록" 텍스트
+    - `solo_dining`: "1인 OK" 태그, 카운터석/1인 메뉴 유무, 빠른 식사/심야 배지, 미등록 시 "정보 미등록" 텍스트
+    - `charging_cafe`: 충전/와이파이 유무 아이콘 표시
+    - `public_restroom`: 접근성/24시간 유무 아이콘 표시
+    - `goods_shop`: 매장 유형 배지(서브컬처/잡화), 영업시간 표시
+    - 신뢰도 점수(`verificationScore`) 및 투표 수(`upvotes`/`downvotes`) 표시
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3_
+
+  - [ ]* 6.2 단위 테스트 — FacilityCard 카테고리별 렌더링
+    - Legacy_Category 시설이 기존과 동일하게 렌더링되는지 확인
+    - 각 Otaku_Category 시설의 상세 정보가 올바르게 표시되는지 확인
+    - 미등록 필드에 "정보 미등록" 텍스트가 표시되는지 확인
+    - _Requirements: 2.4, 3.3, 6.7_
+
+- [ ] 7. MicroVoteButton 컴포넌트 구현
+  - [ ] 7.1 `src/components/spot/MicroVoteButton.tsx` 신규 생성 — 마이크로 투표 UI
+    - "이 정보가 정확한가요?" 텍스트와 👍/👎 버튼 렌더링
+    - `POST /api/facilities/[id]/vote` API 호출 연동
+    - 이미 투표한 경우 선택 상태 하이라이트 표시
+    - 투표 후 `verificationScore` 실시간 업데이트
+    - 비로그인 유저에게 로그인 유도 메시지 표시
+    - _Requirements: 5.10, 7.6_
+
+  - [ ] 7.2 `src/components/spot/FacilityCard.tsx`에 MicroVoteButton 통합
+    - FacilityCard 하단에 MicroVoteButton 배치
+    - _Requirements: 5.10_
+
+  - [ ]* 7.3 Property 테스트 — 투표 중복 방지 불변식
+    - **Property 3: 투표 중복 방지 불변식**
+    - 동일 유저가 동일 시설에 투표 시 `facility_votes`에 최대 1개 문서만 존재하는지 검증
+    - **Validates: Requirements 7.8**
+
+- [ ] 8. Checkpoint — UI 컴포넌트 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 9. FacilityReportForm 제보 폼 구현
+  - [ ] 9.1 `src/components/spot/FacilityReportForm.tsx` 신규 생성 — 제보 폼 모달 기본 구조
+    - 모달 형태의 제보 폼 레이아웃
+    - 장소 입력 방식 선택 UI (구글맵 검색 / 직접 핀 꽂기 투트랙)
+    - 공통 필수 필드: 이름, 카테고리 선택 드롭다운, 위치(좌표)
+    - 필수 필드 미입력 시 오류 메시지 표시
+    - _Requirements: 5.1, 5.2, 5.8, 5.9_
+
+  - [ ] 9.2 FacilityReportForm 카테고리별 동적 필드 구현
+    - `coin_locker` 선택 시: 크기, 가격, 이용 시간, 대형 로커 유무 필드 표시
+    - `solo_dining` 선택 시: 카운터석 유무, 1인 메뉴 유무, 빠른 식사 가능 여부, 심야 영업 여부 필드 표시
+    - `goods_shop` 선택 시: 매장 유형(서브컬처/잡화), 영업시간 필드 표시
+    - `charging_cafe` 선택 시: 충전 콘센트 유무, 무료 와이파이 유무 필드 표시
+    - `public_restroom` 선택 시: 장애인 접근 가능 여부, 24시간 이용 가능 여부 필드 표시
+    - _Requirements: 5.3, 5.4, 5.5, 5.6, 5.7_
+
+  - [ ] 9.3 FacilityReportForm API 연동 및 제출 처리
+    - `POST /api/facilities/report` API 호출 연동
+    - 성공 시 성공 메시지 표시 및 폼 초기화
+    - 에러 시 서버 응답 기반 오류 메시지 표시
+    - _Requirements: 5.8, 5.9, 7.3_
+
+- [ ] 10. 통합 및 와이어링
+  - [ ] 10.1 `src/hooks/useSpotDetail.ts` 확장 — useFacilities 훅에 필터/투표 기능 추가
+    - `type` 파라미터를 활용한 카테고리별 조회 지원
+    - 투표 API 호출 함수 추가
+    - 제보 후 목록 갱신 로직 추가
+    - _Requirements: 1.3, 1.4, 7.1_
+
+  - [ ] 10.2 Spot Detail 페이지에 "편의시설 제보" 버튼 및 FacilityReportForm 연결
+    - NearbyFacilities 영역에 "편의시설 제보" 버튼 추가
+    - 버튼 클릭 시 FacilityReportForm 모달 열기
+    - 제보 완료 후 편의시설 목록 자동 갱신
+    - _Requirements: 5.1_
+
+  - [ ]* 10.3 통합 테스트 — 편의시설 조회/제보/투표 플로우
+    - 편의시설 목록 조회 → 카테고리 필터링 → 상세 정보 표시 플로우 검증
+    - 제보 폼 제출 → API 저장 → 목록 갱신 플로우 검증
+    - 투표 → 점수 업데이트 → 상태 전이 플로우 검증
+    - _Requirements: 1.3, 5.8, 5.10, 5.11_
+
+- [ ] 11. Final Checkpoint — 전체 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- 기존 Legacy_Category 편의시설과의 하위 호환성을 최우선으로 유지합니다
+- 구글맵 Places Autocomplete 연동은 FacilityReportForm 내에서 구현하되, API 키 설정은 환경 변수로 관리합니다
+- `facility_votes` 컬렉션의 `{ facilityId, userId }` 복합 유니크 인덱스는 API 초기화 시 생성합니다
+- Property 테스트는 구현 직후 배치하여 조기 오류 감지를 지원합니다

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -77,6 +77,57 @@ const facilityIcons: Record<FacilityType, Icon> = {
     popupAnchor: [1, -28],
     shadowSize: [33, 33],
   }),
+  // Otaku_Category
+  coin_locker: new Icon({
+    iconUrl:
+      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-violet.png',
+    shadowUrl:
+      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    iconSize: [20, 33],
+    iconAnchor: [10, 33],
+    popupAnchor: [1, -28],
+    shadowSize: [33, 33],
+  }),
+  solo_dining: new Icon({
+    iconUrl:
+      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+    shadowUrl:
+      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    iconSize: [20, 33],
+    iconAnchor: [10, 33],
+    popupAnchor: [1, -28],
+    shadowSize: [33, 33],
+  }),
+  charging_cafe: new Icon({
+    iconUrl:
+      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png',
+    shadowUrl:
+      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    iconSize: [20, 33],
+    iconAnchor: [10, 33],
+    popupAnchor: [1, -28],
+    shadowSize: [33, 33],
+  }),
+  public_restroom: new Icon({
+    iconUrl:
+      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+    shadowUrl:
+      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    iconSize: [20, 33],
+    iconAnchor: [10, 33],
+    popupAnchor: [1, -28],
+    shadowSize: [33, 33],
+  }),
+  goods_shop: new Icon({
+    iconUrl:
+      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-gold.png',
+    shadowUrl:
+      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    iconSize: [20, 33],
+    iconAnchor: [10, 33],
+    popupAnchor: [1, -28],
+    shadowSize: [33, 33],
+  }),
 }
 
 // 편의시설 타입별 한글 라벨
@@ -86,6 +137,12 @@ const facilityTypeLabels: Record<FacilityType, string> = {
   cafe: '카페',
   station: '역/정류장',
   other: '기타',
+  // Otaku_Category
+  coin_locker: '코인 로커',
+  solo_dining: '혼밥 식당',
+  charging_cafe: '충전/와이파이',
+  public_restroom: '화장실',
+  goods_shop: '굿즈/잡화',
 }
 
 export default function SpotDetailMap({
@@ -254,6 +311,12 @@ function getFacilityColor(type: FacilityType): string {
     cafe: 'bg-green-500',
     station: 'bg-purple-500',
     other: 'bg-gray-500',
+    // Otaku_Category
+    coin_locker: 'bg-violet-500',
+    solo_dining: 'bg-rose-500',
+    charging_cafe: 'bg-cyan-500',
+    public_restroom: 'bg-teal-500',
+    goods_shop: 'bg-pink-500',
   }
   return colors[type] || 'bg-gray-500'
 }

--- a/src/components/spot/NearbyFacilities.tsx
+++ b/src/components/spot/NearbyFacilities.tsx
@@ -38,6 +38,32 @@ const FACILITY_CONFIG: Record<
     icon: '📍',
     color: 'bg-gray-100 text-gray-800 border-gray-200',
   },
+  // Otaku_Category
+  coin_locker: {
+    label: '코인 로커',
+    icon: '🔐',
+    color: 'bg-purple-100 text-purple-800 border-purple-200',
+  },
+  solo_dining: {
+    label: '혼밥 식당',
+    icon: '🍜',
+    color: 'bg-rose-100 text-rose-800 border-rose-200',
+  },
+  charging_cafe: {
+    label: '충전/와이파이',
+    icon: '🔌',
+    color: 'bg-cyan-100 text-cyan-800 border-cyan-200',
+  },
+  public_restroom: {
+    label: '화장실',
+    icon: '🚻',
+    color: 'bg-teal-100 text-teal-800 border-teal-200',
+  },
+  goods_shop: {
+    label: '굿즈/잡화',
+    icon: '🛍️',
+    color: 'bg-pink-100 text-pink-800 border-pink-200',
+  },
 }
 
 // 기본 표시 개수

--- a/src/hooks/useSpotDetail.ts
+++ b/src/hooks/useSpotDetail.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { spotKeys, SpotDetailData } from './useSpots'
 import { API_ROUTES } from '@/lib/api-routes'
+import { NearbyFacility } from '@/types'
 
 /**
  * Hook to fetch detailed spot information
@@ -35,22 +36,6 @@ export function useSpotDetail(spotId: string | null) {
 /**
  * Hook to fetch nearby facilities for a specific spot
  */
-export interface NearbyFacility {
-  id: string
-  name: string
-  type: FacilityType
-  distance: number // meters
-  address: string
-  coordinates: [number, number]
-}
-
-export type FacilityType =
-  | 'restaurant'
-  | 'convenience_store'
-  | 'cafe'
-  | 'station'
-  | 'other'
-
 export function useNearbyFacilities(spotId: string | null) {
   return useQuery({
     queryKey: [...spotKeys.detail(spotId || ''), 'facilities'],

--- a/src/lib/facility-utils.ts
+++ b/src/lib/facility-utils.ts
@@ -9,11 +9,18 @@ export function groupFacilitiesByType(
   facilities: NearbyFacility[]
 ): Record<FacilityType, NearbyFacility[]> {
   const grouped: Record<FacilityType, NearbyFacility[]> = {
+    // Legacy_Category
     restaurant: [],
     convenience_store: [],
     cafe: [],
     station: [],
     other: [],
+    // Otaku_Category
+    coin_locker: [],
+    solo_dining: [],
+    charging_cafe: [],
+    public_restroom: [],
+    goods_shop: [],
   }
 
   facilities.forEach((facility) => {
@@ -31,9 +38,16 @@ export function groupFacilitiesByType(
  * 유효한 편의시설 타입 목록
  */
 export const VALID_FACILITY_TYPES: FacilityType[] = [
+  // Legacy_Category
   'restaurant',
   'convenience_store',
   'cafe',
   'station',
   'other',
+  // Otaku_Category
+  'coin_locker',
+  'solo_dining',
+  'charging_cafe',
+  'public_restroom',
+  'goods_shop',
 ]

--- a/src/types/facility.ts
+++ b/src/types/facility.ts
@@ -1,0 +1,64 @@
+// ============================================
+// Otaku Facility Types (덕후 특화 편의시설)
+// ============================================
+
+export type LockerSize = 'small' | 'medium' | 'large'
+export type GoodsShopSubtype = 'subculture_shop' | 'general_store'
+export type FacilityStatus = 'active' | 'needs_verification' | 'hidden'
+
+// ============================================
+// 카테고리별 상세 인터페이스 (Req 6.2~6.6)
+// ============================================
+
+export interface CoinLockerDetails {
+  sizes: LockerSize[]
+  prices: Record<LockerSize, number | null>
+  operatingHours: string | null
+  hasLargeLocker: boolean | null
+}
+
+export interface SoloDiningDetails {
+  hasCounterSeat: boolean | null
+  hasSoloMenu: boolean | null
+  isQuickMeal: boolean | null
+  isLateNight: boolean | null
+}
+
+export interface ChargingCafeDetails {
+  hasCharging: boolean | null
+  hasWifi: boolean | null
+}
+
+export interface PublicRestroomDetails {
+  isAccessible: boolean | null
+  is24Hours: boolean | null
+}
+
+export interface GoodsShopDetails {
+  subtype: GoodsShopSubtype
+  operatingHours: string | null
+}
+
+// ============================================
+// 판별 유니온 타입 (Discriminated Union)
+// ============================================
+
+export type OtakuFacilityDetails =
+  | { type: 'coin_locker'; details: CoinLockerDetails }
+  | { type: 'solo_dining'; details: SoloDiningDetails }
+  | { type: 'charging_cafe'; details: ChargingCafeDetails }
+  | { type: 'public_restroom'; details: PublicRestroomDetails }
+  | { type: 'goods_shop'; details: GoodsShopDetails }
+
+// ============================================
+// 투표 기록 (facility_votes 컬렉션)
+// ============================================
+
+export interface FacilityVoteDocument {
+  _id?: string
+  facilityId: string
+  userId: string
+  value: boolean // true = 정확해요(👍), false = 아니에요(👎)
+  createdAt: Date
+  updatedAt: Date
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 // Re-export all types from separate files
 export * from './spot'
+export * from './facility'
 export * from './community'
 export * from './api'
 export * from './checkin'

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -262,12 +262,23 @@ export interface SpotPreviewData {
 // Facility Types
 // ============================================
 
-export type FacilityType =
+import { FacilityStatus, OtakuFacilityDetails } from './facility'
+
+export type LegacyFacilityType =
   | 'restaurant'
   | 'convenience_store'
   | 'cafe'
   | 'station'
   | 'other'
+
+export type OtakuFacilityType =
+  | 'coin_locker'
+  | 'solo_dining'
+  | 'charging_cafe'
+  | 'public_restroom'
+  | 'goods_shop'
+
+export type FacilityType = LegacyFacilityType | OtakuFacilityType
 
 export interface NearbyFacility {
   id: string
@@ -276,6 +287,16 @@ export interface NearbyFacility {
   distance: number
   address: string
   coordinates: [number, number]
+  // 신규 필드 (Req 6.7~6.10)
+  status?: FacilityStatus
+  verificationScore?: number
+  upvotes?: number
+  downvotes?: number
+  googlePlaceId?: string
+  otakuDetails?: OtakuFacilityDetails
+  reportedBy?: string
+  createdAt?: string
+  updatedAt?: string
 }
 
 export interface Facility {
@@ -284,6 +305,16 @@ export interface Facility {
   type: FacilityType
   address: string
   coordinates: Coordinates
+  // 신규 필드 (Req 6.7~6.10)
+  status?: FacilityStatus
+  verificationScore?: number
+  upvotes?: number
+  downvotes?: number
+  googlePlaceId?: string
+  otakuDetails?: OtakuFacilityDetails
+  reportedBy?: string
+  createdAt?: string
+  updatedAt?: string
 }
 
 // ============================================


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #270

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 덕후 특화 편의시설(Otaku_Category) 5개 카테고리를 위한 데이터 모델 및 타입 정의

---

## 📋 변경 사항

- [x] `src/types/facility.ts` 신규 생성 — 카테고리별 상세 인터페이스 및 투표 문서 타입 정의
- [x] `src/types/spot.ts` 확장 — LegacyFacilityType/OtakuFacilityType 분리, NearbyFacility/Facility에 신규 필드 추가
- [x] `src/types/index.ts` — facility.ts re-export 추가
- [x] `src/lib/facility-utils.ts` 확장 — groupFacilitiesByType 및 VALID_FACILITY_TYPES에 Otaku 카테고리 추가
- [x] `src/hooks/useSpotDetail.ts` — 중복 타입 제거, 중앙 타입 사용으로 변경
- [x] `src/components/spot/NearbyFacilities.tsx` — FACILITY_CONFIG에 Otaku 카테고리 추가
- [x] `src/components/map/SpotDetailMap.tsx` — facilityIcons, facilityTypeLabels, getFacilityColor에 Otaku 카테고리 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` (tsc --noEmit) 통과
- [x] 기존 Legacy_Category 하위 호환성 유지

---

## 📝 추가 정보

- Requirements: 1.1, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 6.10
- 신규 필드(status, verificationScore 등)는 모두 optional로 선언하여 기존 데이터와 호환
- useSpotDetail.ts에 있던 중복 FacilityType/NearbyFacility 정의를 제거하고 중앙 타입으로 통합
