### PR TITLE
[Feat] Task 3 - 편의시설 API 확장

### DIFF
--- a/src/app/api/facilities/[id]/vote/route.ts
+++ b/src/app/api/facilities/[id]/vote/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { FacilityVoteDocument } from '@/types/facility'
+
+/**
+ * POST /api/facilities/[id]/vote — 마이크로 투표 API
+ * Requirements: 7.6, 7.7, 7.8, 5.11
+ *
+ * value: true = 정확해요(👍), false = 아니에요(👎)
+ * 동일 유저가 동일 시설에 투표 시 기존 값 업데이트 (중복 누적 방지)
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    // 1. 인증 확인
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 400 }
+      )
+    }
+
+    const { id: facilityId } = await params
+    const userId = session.user.id
+
+    // 2. value 필드 검증
+    const body = await request.json()
+    if (typeof body.value !== 'boolean') {
+      return NextResponse.json(
+        { error: '투표 값(value)은 boolean이어야 합니다' },
+        { status: 400 }
+      )
+    }
+
+    const { value } = body
+    const now = new Date()
+
+    const votesCollection = await getCollection<FacilityVoteDocument>(
+      COLLECTIONS.FACILITY_VOTES
+    )
+
+    // 3. { facilityId, userId } 복합 유니크 인덱스 보장
+    await votesCollection.createIndex(
+      { facilityId: 1, userId: 1 },
+      { unique: true }
+    )
+
+    // 4. 기존 투표 조회
+    const existingVote = await votesCollection.findOne({ facilityId, userId })
+
+    if (existingVote) {
+      // 기존 투표 업데이트
+      await votesCollection.updateOne(
+        { facilityId, userId },
+        { $set: { value, updatedAt: now } }
+      )
+    } else {
+      // 신규 투표 삽입
+      await votesCollection.insertOne({
+        facilityId,
+        userId,
+        value,
+        createdAt: now,
+        updatedAt: now,
+      } as FacilityVoteDocument)
+    }
+
+    // 5. upvotes/downvotes 재계산
+    const upvotes = await votesCollection.countDocuments({
+      facilityId,
+      value: true,
+    })
+    const downvotes = await votesCollection.countDocuments({
+      facilityId,
+      value: false,
+    })
+
+    // 6. verificationScore 산출
+    const totalVotes = upvotes + downvotes
+    const verificationScore =
+      totalVotes > 0 ? Math.round((upvotes / totalVotes) * 100) : 50
+
+    // 7. 상태 전이 결정
+    const facilitiesCollection = await getCollection(COLLECTIONS.FACILITIES)
+    const facility = await facilitiesCollection.findOne({
+      _id: new ObjectId(facilityId),
+    })
+
+    let status = facility?.status || 'active'
+
+    if (downvotes - upvotes >= 5) {
+      status = 'needs_verification'
+    }
+    if (verificationScore < 20) {
+      status = 'hidden'
+    }
+
+    // 8. facility 문서 업데이트
+    await facilitiesCollection.updateOne(
+      { _id: new ObjectId(facilityId) },
+      {
+        $set: {
+          upvotes,
+          downvotes,
+          verificationScore,
+          status,
+          updatedAt: now,
+        },
+      }
+    )
+
+    // 9. 응답
+    return NextResponse.json({ verificationScore, upvotes, downvotes })
+  } catch (error) {
+    console.error('Error voting on facility:', error)
+    return NextResponse.json(
+      { error: '투표 처리에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/facilities/report/route.ts
+++ b/src/app/api/facilities/report/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection } from '@/lib/db'
+import { FacilityType, OtakuFacilityType } from '@/types'
+import { OtakuFacilityDetails } from '@/types/facility'
+import { VALID_FACILITY_TYPES } from '@/lib/facility-utils'
+
+const OTAKU_FACILITY_TYPES: OtakuFacilityType[] = [
+  'coin_locker',
+  'solo_dining',
+  'charging_cafe',
+  'public_restroom',
+  'goods_shop',
+]
+
+/**
+ * POST /api/facilities/report — 편의시설 제보 API
+ * Requirements: 7.3, 7.4
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json()
+
+    // 필수 필드 검증
+    const missingFields: string[] = []
+
+    if (!body.name || typeof body.name !== 'string') {
+      missingFields.push('name')
+    }
+
+    if (
+      !body.type ||
+      typeof body.type !== 'string' ||
+      !VALID_FACILITY_TYPES.includes(body.type as FacilityType)
+    ) {
+      missingFields.push('type')
+    }
+
+    if (
+      !body.coordinates ||
+      typeof body.coordinates !== 'object' ||
+      typeof body.coordinates.lat !== 'number' ||
+      typeof body.coordinates.lng !== 'number'
+    ) {
+      missingFields.push('coordinates')
+    }
+
+    if (missingFields.length > 0) {
+      return NextResponse.json(
+        { error: '필수 필드가 누락되었습니다', missingFields },
+        { status: 400 }
+      )
+    }
+
+    // otakuDetails 처리: OtakuFacilityType이면서 otakuDetails가 제공된 경우
+    let otakuDetails: OtakuFacilityDetails | undefined
+    if (
+      OTAKU_FACILITY_TYPES.includes(body.type as OtakuFacilityType) &&
+      body.otakuDetails
+    ) {
+      otakuDetails = {
+        type: body.type as OtakuFacilityType,
+        details: body.otakuDetails,
+      } as OtakuFacilityDetails
+    }
+
+    const now = new Date()
+
+    const facilityDoc = {
+      name: body.name,
+      type: body.type,
+      coordinates: {
+        lat: body.coordinates.lat,
+        lng: body.coordinates.lng,
+      },
+      address: body.address || '',
+      googlePlaceId: body.googlePlaceId || undefined,
+      otakuDetails,
+      status: 'active' as const,
+      verificationScore: 50,
+      upvotes: 0,
+      downvotes: 0,
+      reportedBy: body.reportedBy || undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const collection = await getCollection('facilities')
+    const result = await collection.insertOne(facilityDoc)
+
+    return NextResponse.json(
+      {
+        id: result.insertedId.toString(),
+        ...facilityDoc,
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    console.error('Error reporting facility:', error)
+    return NextResponse.json(
+      { error: '편의시설 제보에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/spots/[id]/facilities/route.ts
+++ b/src/app/api/spots/[id]/facilities/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { ObjectId } from 'mongodb'
 import { getCollection } from '@/lib/db'
-import { NearbyFacility, FacilityType } from '@/types'
+import {
+  NearbyFacility,
+  FacilityType,
+  FacilityStatus,
+  OtakuFacilityDetails,
+} from '@/types'
+import { VALID_FACILITY_TYPES } from '@/lib/facility-utils'
 
 // MongoDB document interfaces
 interface SpotDocument {
@@ -21,6 +27,15 @@ interface FacilityDocument {
     lat: number
     lng: number
   }
+  status?: FacilityStatus
+  verificationScore?: number
+  upvotes?: number
+  downvotes?: number
+  googlePlaceId?: string
+  otakuDetails?: OtakuFacilityDetails
+  reportedBy?: string
+  createdAt?: Date
+  updatedAt?: Date
 }
 
 /**
@@ -50,7 +65,7 @@ function calculateDistance(
 
 /**
  * GET /api/spots/[id]/facilities - 근처 편의시설 조회
- * Requirements: 4.1, 4.2
+ * Requirements: 4.1, 4.2, 7.1, 7.2, 7.5
  */
 export async function GET(
   request: NextRequest,
@@ -61,6 +76,7 @@ export async function GET(
     const { searchParams } = new URL(request.url)
     const radiusKm = parseFloat(searchParams.get('radius') || '2') // Default 2km radius
     const maxResults = parseInt(searchParams.get('limit') || '50') // Default 50 results
+    const typeFilter = searchParams.get('type')
 
     // Get spot coordinates using custom id field
     const spotsCollection = await getCollection<SpotDocument>('spots')
@@ -73,10 +89,23 @@ export async function GET(
       return NextResponse.json({ error: 'Spot not found' }, { status: 404 })
     }
 
-    // Get all facilities (in a real app, you'd use geospatial queries)
+    // Build MongoDB query filter
+    // Req 7.2: status가 'hidden'인 시설 자동 제외
+    const query: Record<string, unknown> = {
+      status: { $ne: 'hidden' },
+    }
+
+    // Req 7.1: type 파라미터로 특정 카테고리 필터링
+    if (
+      typeFilter &&
+      VALID_FACILITY_TYPES.includes(typeFilter as FacilityType)
+    ) {
+      query.type = typeFilter
+    }
+
     const facilitiesCollection =
       await getCollection<FacilityDocument>('facilities')
-    const allFacilities = await facilitiesCollection.find({}).toArray()
+    const allFacilities = await facilitiesCollection.find(query).toArray()
 
     // Calculate distances and filter by radius
     const nearbyFacilities: NearbyFacility[] = allFacilities
@@ -98,6 +127,15 @@ export async function GET(
             number,
             number,
           ],
+          status: facility.status,
+          verificationScore: facility.verificationScore,
+          upvotes: facility.upvotes,
+          downvotes: facility.downvotes,
+          googlePlaceId: facility.googlePlaceId,
+          otakuDetails: facility.otakuDetails,
+          reportedBy: facility.reportedBy,
+          createdAt: facility.createdAt?.toISOString(),
+          updatedAt: facility.updatedAt?.toISOString(),
         }
       })
       .filter((facility) => facility.distance <= radiusKm * 1000) // Convert km to meters

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -102,6 +102,8 @@ export const COLLECTIONS = {
   ROUTES: 'routes',
   ROUTE_BOOKMARKS: 'route_bookmarks',
   ROUTE_COMPLETIONS: 'route_completions',
+  // 편의시설 투표 컬렉션 (11-otaku-facilities)
+  FACILITY_VOTES: 'facility_votes',
 } as const
 
 /**


### PR DESCRIPTION
## 📋 변경 사항

### 3.1 GET /api/spots/[id]/facilities 확장
- `type` 쿼리 파라미터로 카테고리 필터링 지원
- `status: 'hidden'` 시설 자동 제외
- 응답에 otakuDetails, status, verificationScore, upvotes, downvotes 포함

### 3.2 POST /api/facilities/report 신규
- 필수 필드(name, type, coordinates) 검증 → 누락 시 400 + missingFields
- OtakuFacilityType일 때 otakuDetails discriminated union 형태 저장
- 기본값: status='active', verificationScore=50, upvotes=0, downvotes=0

### 3.3 POST /api/facilities/[id]/vote 신규
- 인증 필수, value(boolean) 검증
- { facilityId, userId } 복합 유니크 인덱스로 1인 1투표 보장
- upvotes/downvotes 재계산 → verificationScore 산출
- downvotes - upvotes >= 5 → needs_verification, verificationScore < 20 → hidden

## 📌 관련 정보
- **Requirements**: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 5.11

Closes #272
