### PR TITLE
[Feat] Task 6.1 - FacilityCard 카테고리별 상세 렌더링 확장

### DIFF
--- a/src/app/test/facility-card/page.tsx
+++ b/src/app/test/facility-card/page.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { NearbyFacility } from '@/types'
+import NearbyFacilities from '@/components/spot/NearbyFacilities'
+
+const MOCK_FACILITIES: NearbyFacility[] = [
+  {
+    id: '1',
+    name: '스키야 아키하바라점',
+    type: 'restaurant',
+    distance: 120,
+    address: '東京都千代田区外神田1-1',
+    coordinates: [35.6984, 139.7731],
+  },
+  {
+    id: '2',
+    name: '세븐일레븐 아키하바라역점',
+    type: 'convenience_store',
+    distance: 50,
+    address: '東京都千代田区外神田1-2',
+    coordinates: [35.6985, 139.7732],
+  },
+  {
+    id: '3',
+    name: '스타벅스 아키하바라점',
+    type: 'cafe',
+    distance: 200,
+    address: '東京都千代田区外神田1-3',
+    coordinates: [35.6986, 139.7733],
+  },
+  {
+    id: '4',
+    name: '아키하바라역',
+    type: 'station',
+    distance: 80,
+    address: '東京都千代田区外神田1-4',
+    coordinates: [35.6987, 139.7734],
+  },
+  // ── Otaku_Category (상세 정보 포함) ──
+  {
+    id: '5',
+    name: '아키하바라역 코인 로커',
+    type: 'coin_locker',
+    distance: 90,
+    address: '東京都千代田区外神田1-5',
+    coordinates: [35.6988, 139.7735],
+    status: 'active',
+    verificationScore: 85,
+    upvotes: 12,
+    downvotes: 2,
+    otakuDetails: {
+      type: 'coin_locker',
+      details: {
+        sizes: ['small', 'medium', 'large'],
+        prices: { small: 300, medium: 500, large: 700 },
+        operatingHours: '05:00-24:00',
+        hasLargeLocker: true,
+      },
+    },
+  },
+  {
+    id: '5b',
+    name: '이케부쿠로역 코인 로커 (미등록)',
+    type: 'coin_locker',
+    distance: 150,
+    address: '東京都豊島区南池袋1-1',
+    coordinates: [35.7295, 139.7109],
+    status: 'active',
+    verificationScore: 50,
+    upvotes: 0,
+    downvotes: 0,
+    otakuDetails: {
+      type: 'coin_locker',
+      details: {
+        sizes: [],
+        prices: { small: null, medium: null, large: null },
+        operatingHours: null,
+        hasLargeLocker: null,
+      },
+    },
+  },
+  {
+    id: '6',
+    name: '이치란 라멘 아키하바라점',
+    type: 'solo_dining',
+    distance: 300,
+    address: '東京都千代田区外神田1-6',
+    coordinates: [35.6989, 139.7736],
+    status: 'active',
+    verificationScore: 72,
+    upvotes: 8,
+    downvotes: 3,
+    otakuDetails: {
+      type: 'solo_dining',
+      details: {
+        hasCounterSeat: true,
+        hasSoloMenu: true,
+        isQuickMeal: true,
+        isLateNight: false,
+      },
+    },
+  },
+  {
+    id: '6b',
+    name: '혼밥 식당 (미등록)',
+    type: 'solo_dining',
+    distance: 400,
+    address: '東京都千代田区外神田2-1',
+    coordinates: [35.699, 139.774],
+    status: 'active',
+    verificationScore: 50,
+    upvotes: 0,
+    downvotes: 0,
+    otakuDetails: {
+      type: 'solo_dining',
+      details: {
+        hasCounterSeat: null,
+        hasSoloMenu: null,
+        isQuickMeal: null,
+        isLateNight: null,
+      },
+    },
+  },
+  {
+    id: '7',
+    name: '도토루 커피 아키하바라점',
+    type: 'charging_cafe',
+    distance: 180,
+    address: '東京都千代田区外神田1-7',
+    coordinates: [35.699, 139.7737],
+    status: 'active',
+    verificationScore: 90,
+    upvotes: 18,
+    downvotes: 2,
+    otakuDetails: {
+      type: 'charging_cafe',
+      details: { hasCharging: true, hasWifi: true },
+    },
+  },
+  {
+    id: '8',
+    name: '아키하바라역 공중화장실',
+    type: 'public_restroom',
+    distance: 100,
+    address: '東京都千代田区外神田1-8',
+    coordinates: [35.6991, 139.7738],
+    status: 'active',
+    verificationScore: 65,
+    upvotes: 6,
+    downvotes: 3,
+    otakuDetails: {
+      type: 'public_restroom',
+      details: { isAccessible: true, is24Hours: false },
+    },
+  },
+  {
+    id: '9',
+    name: '애니메이트 아키하바라점',
+    type: 'goods_shop',
+    distance: 250,
+    address: '東京都千代田区外神田1-9',
+    coordinates: [35.6992, 139.7739],
+    status: 'active',
+    verificationScore: 95,
+    upvotes: 20,
+    downvotes: 1,
+    otakuDetails: {
+      type: 'goods_shop',
+      details: { subtype: 'subculture_shop', operatingHours: '10:00-21:00' },
+    },
+  },
+  {
+    id: '11',
+    name: '돈키호테 아키하바라점',
+    type: 'goods_shop',
+    distance: 350,
+    address: '東京都千代田区外神田3-11',
+    coordinates: [35.6994, 139.7741],
+    status: 'active',
+    verificationScore: 98,
+    upvotes: 45,
+    downvotes: 1,
+    otakuDetails: {
+      type: 'goods_shop',
+      details: { subtype: 'general_store', operatingHours: '24시간' },
+    },
+  },
+]
+
+export default function FacilityCardTestPage() {
+  return (
+    <main className="min-h-screen bg-navy-50 pt-14">
+      <div className="mx-auto max-w-2xl px-4 py-6">
+        <h1 className="mb-4 text-xl font-bold text-navy-900">
+          🧪 FacilityCard 상세 렌더링 테스트
+        </h1>
+
+        <div className="mb-4 rounded-lg bg-white p-4 shadow-sm">
+          <h2 className="mb-2 text-sm font-semibold text-navy-700">
+            테스트 안내
+          </h2>
+          <ul className="space-y-1 text-xs text-navy-500">
+            <li>• 코인 로커: 크기별 가격 테이블, 대형 로커 배지, 이용 시간</li>
+            <li>• 혼밥 식당: 1인 OK 태그, 카운터석/1인 메뉴/빠른 식사/심야</li>
+            <li>• 충전 카페: 충전/와이파이 유무 아이콘</li>
+            <li>• 화장실: 접근성/24시간 유무 아이콘</li>
+            <li>• 굿즈샵: 매장 유형 배지, 영업시간</li>
+            <li>• 미등록 필드에 &quot;정보 미등록&quot; 텍스트 확인</li>
+            <li>• 신뢰도 점수 및 투표 수 표시 확인</li>
+          </ul>
+        </div>
+
+        <NearbyFacilities facilities={MOCK_FACILITIES} />
+      </div>
+    </main>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,7 +43,7 @@ export function Header() {
             스팟 등록
           </Link>
           <Link
-            href="/test/facility-filter"
+            href="/test/facility-card"
             className="text-sm text-yellow-400 transition hover:text-yellow-300"
           >
             🧪 테스트
@@ -147,7 +147,7 @@ export function Header() {
               스팟 등록
             </Link>
             <Link
-              href="/test/facility-filter"
+              href="/test/facility-card"
               onClick={() => setIsMobileMenuOpen(false)}
               className="block rounded-lg px-3 py-2 text-sm text-yellow-400 transition hover:bg-slate-800 hover:text-yellow-300"
             >

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -1,0 +1,385 @@
+'use client'
+
+import { NearbyFacility, OtakuFacilityType } from '@/types'
+import {
+  CoinLockerDetails,
+  SoloDiningDetails,
+  ChargingCafeDetails,
+  PublicRestroomDetails,
+  GoodsShopDetails,
+  LockerSize,
+} from '@/types/facility'
+
+interface FacilityCardProps {
+  facility: NearbyFacility
+  config: { label: string; icon: string; color: string }
+}
+
+const OTAKU_TYPES: OtakuFacilityType[] = [
+  'coin_locker',
+  'solo_dining',
+  'charging_cafe',
+  'public_restroom',
+  'goods_shop',
+]
+
+const LOCKER_SIZE_LABEL: Record<LockerSize, string> = {
+  small: '소형',
+  medium: '중형',
+  large: '대형',
+}
+
+/** "정보 미등록" 표시용 헬퍼 */
+function InfoOrFallback({
+  value,
+  children,
+}: {
+  value: unknown
+  children: React.ReactNode
+}) {
+  if (value === null || value === undefined) {
+    return <span className="text-xs text-gray-400">정보 미등록</span>
+  }
+  return <>{children}</>
+}
+
+/** boolean 필드를 아이콘+라벨로 표시 */
+function BoolBadge({
+  value,
+  trueLabel,
+  falseLabel,
+  trueIcon,
+  falseIcon,
+}: {
+  value: boolean | null
+  trueLabel: string
+  falseLabel?: string
+  trueIcon: string
+  falseIcon?: string
+}) {
+  if (value === null || value === undefined) {
+    return <span className="text-xs text-gray-400">정보 미등록</span>
+  }
+  if (value) {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
+        {trueIcon} {trueLabel}
+      </span>
+    )
+  }
+  return falseLabel ? (
+    <span className="inline-flex items-center gap-0.5 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+      {falseIcon ?? '✕'} {falseLabel}
+    </span>
+  ) : null
+}
+
+// ─── 카테고리별 상세 렌더링 ───
+
+function CoinLockerDetail({ details }: { details: CoinLockerDetails }) {
+  return (
+    <div className="mt-3 space-y-2 rounded-md bg-purple-50/50 p-3 text-sm">
+      {/* 크기별 가격 테이블 */}
+      <div>
+        <span className="mb-1 block text-xs font-semibold text-gray-500">
+          크기 / 가격
+        </span>
+        {details.sizes.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {details.sizes.map((size) => (
+              <div
+                key={size}
+                className="rounded-md border border-purple-200 bg-white px-2 py-1 text-xs"
+              >
+                <span className="font-medium text-purple-700">
+                  {LOCKER_SIZE_LABEL[size]}
+                </span>
+                <span className="ml-1 text-gray-600">
+                  {details.prices[size] != null
+                    ? `¥${details.prices[size]}`
+                    : '가격 미등록'}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-xs text-gray-400">정보 미등록</span>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <BoolBadge
+          value={details.hasLargeLocker}
+          trueLabel="대형 로커 있음"
+          falseLabel="대형 로커 없음"
+          trueIcon="🧳"
+          falseIcon="✕"
+        />
+        <InfoOrFallback value={details.operatingHours}>
+          <span className="inline-flex items-center gap-0.5 text-xs text-gray-600">
+            ⏰ {details.operatingHours}
+          </span>
+        </InfoOrFallback>
+      </div>
+    </div>
+  )
+}
+
+function SoloDiningDetail({ details }: { details: SoloDiningDetails }) {
+  return (
+    <div className="mt-3 space-y-2 rounded-md bg-rose-50/50 p-3 text-sm">
+      {/* 1인 OK 태그 */}
+      <span className="inline-flex items-center rounded-full bg-rose-100 px-2.5 py-0.5 text-xs font-bold text-rose-700">
+        🍜 1인 OK
+      </span>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <BoolBadge
+          value={details.hasCounterSeat}
+          trueLabel="카운터석"
+          trueIcon="🪑"
+        />
+        <BoolBadge
+          value={details.hasSoloMenu}
+          trueLabel="1인 메뉴"
+          trueIcon="📋"
+        />
+        <BoolBadge
+          value={details.isQuickMeal}
+          trueLabel="빠른 식사"
+          trueIcon="⚡"
+        />
+        <BoolBadge
+          value={details.isLateNight}
+          trueLabel="심야 영업"
+          trueIcon="🌙"
+        />
+      </div>
+    </div>
+  )
+}
+
+function ChargingCafeDetail({ details }: { details: ChargingCafeDetails }) {
+  return (
+    <div className="mt-3 flex flex-wrap gap-2 rounded-md bg-cyan-50/50 p-3 text-sm">
+      <BoolBadge
+        value={details.hasCharging}
+        trueLabel="충전 가능"
+        falseLabel="충전 불가"
+        trueIcon="🔌"
+        falseIcon="✕"
+      />
+      <BoolBadge
+        value={details.hasWifi}
+        trueLabel="무료 Wi-Fi"
+        falseLabel="Wi-Fi 없음"
+        trueIcon="📶"
+        falseIcon="✕"
+      />
+    </div>
+  )
+}
+
+function PublicRestroomDetail({ details }: { details: PublicRestroomDetails }) {
+  return (
+    <div className="mt-3 flex flex-wrap gap-2 rounded-md bg-teal-50/50 p-3 text-sm">
+      <BoolBadge
+        value={details.isAccessible}
+        trueLabel="장애인 접근 가능"
+        falseLabel="접근 제한"
+        trueIcon="♿"
+        falseIcon="✕"
+      />
+      <BoolBadge
+        value={details.is24Hours}
+        trueLabel="24시간"
+        falseLabel="시간 제한"
+        trueIcon="🕐"
+        falseIcon="✕"
+      />
+    </div>
+  )
+}
+
+function GoodsShopDetail({ details }: { details: GoodsShopDetails }) {
+  const subtypeLabel =
+    details.subtype === 'subculture_shop' ? '서브컬처 매장' : '대형 잡화점'
+  const subtypeColor =
+    details.subtype === 'subculture_shop'
+      ? 'bg-pink-100 text-pink-700'
+      : 'bg-amber-100 text-amber-700'
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2 rounded-md bg-pink-50/50 p-3 text-sm">
+      <span
+        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${subtypeColor}`}
+      >
+        🛍️ {subtypeLabel}
+      </span>
+      <InfoOrFallback value={details.operatingHours}>
+        <span className="inline-flex items-center gap-0.5 text-xs text-gray-600">
+          ⏰ {details.operatingHours}
+        </span>
+      </InfoOrFallback>
+    </div>
+  )
+}
+
+/** otakuDetails에서 카테고리별 상세 컴포넌트 분기 */
+function OtakuDetailsSection({ facility }: { facility: NearbyFacility }) {
+  const od = facility.otakuDetails
+  if (!od) return null
+
+  switch (od.type) {
+    case 'coin_locker':
+      return <CoinLockerDetail details={od.details} />
+    case 'solo_dining':
+      return <SoloDiningDetail details={od.details} />
+    case 'charging_cafe':
+      return <ChargingCafeDetail details={od.details} />
+    case 'public_restroom':
+      return <PublicRestroomDetail details={od.details} />
+    case 'goods_shop':
+      return <GoodsShopDetail details={od.details} />
+    default:
+      return null
+  }
+}
+
+/** 신뢰도 점수 + 투표 수 표시 (Otaku_Category 전용) */
+function VerificationBadge({ facility }: { facility: NearbyFacility }) {
+  if (
+    facility.verificationScore === undefined ||
+    facility.upvotes === undefined ||
+    facility.downvotes === undefined
+  ) {
+    return null
+  }
+
+  const score = facility.verificationScore
+  const scoreColor =
+    score >= 70
+      ? 'text-green-600'
+      : score >= 40
+        ? 'text-yellow-600'
+        : 'text-red-500'
+
+  return (
+    <div className="mt-2 flex items-center gap-3 text-xs text-gray-500">
+      <span className={`font-semibold ${scoreColor}`}>✅ 신뢰도 {score}%</span>
+      <span>👍{facility.upvotes}</span>
+      <span>👎{facility.downvotes}</span>
+    </div>
+  )
+}
+
+// ─── 메인 FacilityCard ───
+
+export default function FacilityCard({ facility, config }: FacilityCardProps) {
+  const formatDistance = (meters: number): string => {
+    if (meters < 1000) {
+      return `${Math.round(meters)}m`
+    }
+    return `${(meters / 1000).toFixed(1)}km`
+  }
+
+  const handleMapClick = () => {
+    const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(facility.name)}`
+    window.open(googleMapsUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const showAddress = facility.address && facility.address !== '주소 정보 없음'
+  const isOtaku = OTAKU_TYPES.includes(facility.type as OtakuFacilityType)
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-4 transition-all hover:border-gray-300 hover:shadow-md">
+      <div className="flex items-start justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-center space-x-2">
+            <h4 className="truncate font-semibold text-gray-900">
+              {facility.name}
+            </h4>
+            <span
+              className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium ${config.color}`}
+            >
+              {config.label}
+            </span>
+          </div>
+
+          <div className="space-y-1 text-sm text-gray-600">
+            {showAddress && (
+              <div className="flex items-center space-x-1">
+                <svg
+                  className="h-4 w-4 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+                <span className="truncate">{facility.address}</span>
+              </div>
+            )}
+
+            <div className="flex items-center space-x-1">
+              <svg
+                className="h-4 w-4 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                />
+              </svg>
+              <span className="font-medium text-navy-600">
+                {formatDistance(facility.distance)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <button
+          onClick={handleMapClick}
+          className="ml-2 flex-shrink-0 rounded-md bg-navy-50 p-2 text-navy-600 transition-colors hover:bg-navy-100 hover:text-navy-700"
+          title="지도에서 보기"
+          aria-label={`${facility.name} 지도에서 보기`}
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Otaku_Category 상세 정보 */}
+      {isOtaku && <OtakuDetailsSection facility={facility} />}
+
+      {/* 신뢰도 점수 + 투표 수 */}
+      {isOtaku && <VerificationBadge facility={facility} />}
+    </div>
+  )
+}

--- a/src/components/spot/NearbyFacilities.tsx
+++ b/src/components/spot/NearbyFacilities.tsx
@@ -4,6 +4,7 @@ import { NearbyFacility, FacilityType } from '@/types'
 import { useCallback, useMemo, useState } from 'react'
 import { groupFacilitiesByType } from '@/lib/facility-utils'
 import FacilityFilter from './FacilityFilter'
+import FacilityCard from './FacilityCard'
 
 interface NearbyFacilitiesProps {
   facilities: NearbyFacility[]
@@ -298,116 +299,6 @@ export default function NearbyFacilities({
             </div>
           )
         })}
-      </div>
-    </div>
-  )
-}
-
-interface FacilityCardProps {
-  facility: NearbyFacility
-  config: { label: string; icon: string; color: string }
-}
-
-function FacilityCard({ facility, config }: FacilityCardProps) {
-  // 거리를 사용자 친화적 형태로 변환
-  const formatDistance = (meters: number): string => {
-    if (meters < 1000) {
-      return `${Math.round(meters)}m`
-    } else {
-      return `${(meters / 1000).toFixed(1)}km`
-    }
-  }
-
-  // 외부 지도 링크 생성 (Google Maps - 시설명으로 검색)
-  const handleMapClick = () => {
-    const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(facility.name)}`
-    window.open(googleMapsUrl, '_blank', 'noopener,noreferrer')
-  }
-
-  // 주소 표시 여부 (주소 정보 없음이면 숨김)
-  const showAddress = facility.address && facility.address !== '주소 정보 없음'
-
-  return (
-    <div className="rounded-lg border border-gray-200 p-4 transition-all hover:border-gray-300 hover:shadow-md">
-      <div className="flex items-start justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="mb-2 flex items-center space-x-2">
-            <h4 className="truncate font-semibold text-gray-900">
-              {facility.name}
-            </h4>
-            <span
-              className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-medium ${config.color}`}
-            >
-              {config.label}
-            </span>
-          </div>
-
-          <div className="space-y-1 text-sm text-gray-600">
-            {showAddress && (
-              <div className="flex items-center space-x-1">
-                <svg
-                  className="h-4 w-4 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-                <span className="truncate">{facility.address}</span>
-              </div>
-            )}
-
-            <div className="flex items-center space-x-1">
-              <svg
-                className="h-4 w-4 flex-shrink-0"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
-                />
-              </svg>
-              <span className="font-medium text-navy-600">
-                {formatDistance(facility.distance)}
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <button
-          onClick={handleMapClick}
-          className="ml-2 flex-shrink-0 rounded-md bg-navy-50 p-2 text-navy-600 transition-colors hover:bg-navy-100 hover:text-navy-700"
-          title="지도에서 보기"
-        >
-          <svg
-            className="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-            />
-          </svg>
-        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #276

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> FacilityCard를 별도 컴포넌트로 분리하고, Otaku_Category 5개 카테고리별 상세 정보 렌더링 및 신뢰도 점수/투표 수 표시 추가

---

## 📋 변경 사항

- [x] `FacilityCard.tsx` 신규 생성 — 카테고리별 상세 렌더링 (coin_locker, solo_dining, charging_cafe, public_restroom, goods_shop)
- [x] 미등록 필드에 "정보 미등록" 텍스트 표시
- [x] 신뢰도 점수(verificationScore) 및 투표 수(upvotes/downvotes) 표시
- [x] `NearbyFacilities.tsx`에서 인라인 FacilityCard 제거 및 import 연결
- [x] 테스트 페이지 `facility-card` 추가 (otakuDetails mock 데이터 포함)
- [x] Header 테스트 링크 업데이트

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---
<img width="1266" height="962" alt="image" src="https://github.com/user-attachments/assets/e6aef1bf-6e9f-4cb8-be9b-9837a4058457" />

## 📝 추가 정보

- **Requirements**: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3
- 기존 테스트 페이지 `facility-filter`를 `facility-card`로 교체 (otakuDetails mock 데이터 추가)
