### PR TITLE
[Feat] MicroVoteButton 마이크로 투표 컴포넌트 구현

### DIFF
--- a/src/app/test/facility-card/page.tsx
+++ b/src/app/test/facility-card/page.tsx
@@ -207,6 +207,7 @@ export default function FacilityCardTestPage() {
             <li>• 굿즈샵: 매장 유형 배지, 영업시간</li>
             <li>• 미등록 필드에 &quot;정보 미등록&quot; 텍스트 확인</li>
             <li>• 신뢰도 점수 및 투표 수 표시 확인</li>
+            <li>• 마이크로 투표 버튼 (👍/👎) 표시 및 클릭 확인</li>
           </ul>
         </div>
 

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { NearbyFacility, OtakuFacilityType } from '@/types'
 import {
   CoinLockerDetails,
@@ -9,6 +10,7 @@ import {
   GoodsShopDetails,
   LockerSize,
 } from '@/types/facility'
+import MicroVoteButton from './MicroVoteButton'
 
 interface FacilityCardProps {
   facility: NearbyFacility
@@ -276,6 +278,12 @@ function VerificationBadge({ facility }: { facility: NearbyFacility }) {
 // ─── 메인 FacilityCard ───
 
 export default function FacilityCard({ facility, config }: FacilityCardProps) {
+  const [voteData, setVoteData] = useState({
+    verificationScore: facility.verificationScore,
+    upvotes: facility.upvotes,
+    downvotes: facility.downvotes,
+  })
+
   const formatDistance = (meters: number): string => {
     if (meters < 1000) {
       return `${Math.round(meters)}m`
@@ -288,8 +296,19 @@ export default function FacilityCard({ facility, config }: FacilityCardProps) {
     window.open(googleMapsUrl, '_blank', 'noopener,noreferrer')
   }
 
+  const handleVoteComplete = (result: {
+    verificationScore: number
+    upvotes: number
+    downvotes: number
+  }) => {
+    setVoteData(result)
+  }
+
   const showAddress = facility.address && facility.address !== '주소 정보 없음'
   const isOtaku = OTAKU_TYPES.includes(facility.type as OtakuFacilityType)
+
+  // VerificationBadge에 실시간 투표 데이터 반영
+  const displayFacility = isOtaku ? { ...facility, ...voteData } : facility
 
   return (
     <div className="rounded-lg border border-gray-200 p-4 transition-all hover:border-gray-300 hover:shadow-md">
@@ -378,8 +397,16 @@ export default function FacilityCard({ facility, config }: FacilityCardProps) {
       {/* Otaku_Category 상세 정보 */}
       {isOtaku && <OtakuDetailsSection facility={facility} />}
 
-      {/* 신뢰도 점수 + 투표 수 */}
-      {isOtaku && <VerificationBadge facility={facility} />}
+      {/* 신뢰도 점수 + 투표 수 (실시간 반영) */}
+      {isOtaku && <VerificationBadge facility={displayFacility} />}
+
+      {/* 마이크로 투표 버튼 */}
+      {isOtaku && (
+        <MicroVoteButton
+          facilityId={facility.id}
+          onVoteComplete={handleVoteComplete}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/spot/MicroVoteButton.tsx
+++ b/src/components/spot/MicroVoteButton.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { LoginRequiredModal } from '@/components/common'
+import { API_ROUTES } from '@/lib/api-routes'
+
+interface MicroVoteButtonProps {
+  facilityId: string
+  /** 현재 유저의 기존 투표 값 (null = 미투표) */
+  currentVote?: boolean | null
+  onVoteComplete?: (result: {
+    verificationScore: number
+    upvotes: number
+    downvotes: number
+  }) => void
+}
+
+/**
+ * 마이크로 투표 버튼 컴포넌트
+ *
+ * "이 정보가 정확한가요?" 텍스트와 👍/👎 버튼을 렌더링합니다.
+ * - 로그인 유저: 투표 API 호출
+ * - 비로그인 유저: 로그인 유도 모달 표시
+ * - 이미 투표한 경우: 선택 상태 하이라이트
+ *
+ * Requirements: 5.10, 7.6
+ */
+export default function MicroVoteButton({
+  facilityId,
+  currentVote = null,
+  onVoteComplete,
+}: MicroVoteButtonProps) {
+  const { data: session } = useSession()
+  const router = useRouter()
+  const [vote, setVote] = useState<boolean | null>(currentVote)
+  const [isLoading, setIsLoading] = useState(false)
+  const [showLoginModal, setShowLoginModal] = useState(false)
+
+  const handleVote = async (value: boolean) => {
+    if (!session?.user) {
+      setShowLoginModal(true)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const res = await fetch(API_ROUTES.FACILITIES.VOTE(facilityId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value }),
+      })
+
+      if (!res.ok) {
+        throw new Error('투표에 실패했습니다')
+      }
+
+      const result = await res.json()
+      setVote(value)
+      onVoteComplete?.(result)
+    } catch {
+      // 조용히 실패 — 유저에게 재시도 가능하도록 상태 유지
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="mt-3 flex items-center gap-2 border-t border-gray-100 pt-3">
+        <span className="text-xs text-gray-500">이 정보가 정확한가요?</span>
+        <div className="flex gap-1">
+          <button
+            onClick={() => handleVote(true)}
+            disabled={isLoading}
+            className={`inline-flex items-center gap-0.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+              vote === true
+                ? 'bg-green-100 text-green-700 ring-1 ring-green-300'
+                : 'bg-gray-50 text-gray-500 hover:bg-green-50 hover:text-green-600'
+            } disabled:opacity-50`}
+            aria-label="정확해요"
+            aria-pressed={vote === true}
+          >
+            👍 정확해요
+          </button>
+          <button
+            onClick={() => handleVote(false)}
+            disabled={isLoading}
+            className={`inline-flex items-center gap-0.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+              vote === false
+                ? 'bg-red-100 text-red-700 ring-1 ring-red-300'
+                : 'bg-gray-50 text-gray-500 hover:bg-red-50 hover:text-red-600'
+            } disabled:opacity-50`}
+            aria-label="아니에요"
+            aria-pressed={vote === false}
+          >
+            👎 아니에요
+          </button>
+        </div>
+      </div>
+
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onConfirm={() => {
+          setShowLoginModal(false)
+          router.push('/auth/signin')
+        }}
+        description="투표하려면 로그인이 필요합니다."
+      />
+    </>
+  )
+}

--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -32,6 +32,11 @@ export const API_ROUTES = {
       `/api/posts/${postId}/comments/${commentId}`,
   },
 
+  // Facilities
+  FACILITIES: {
+    VOTE: (id: string) => `/api/facilities/${id}/vote`,
+  },
+
   // Media
   MEDIA: {
     COMMUNITY_SUMMARY: '/api/media/community-summary',


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #278

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 편의시설 정보 정확성을 유저 투표로 검증하는 MicroVoteButton 컴포넌트 구현 및 FacilityCard 통합

---

## 📋 변경 사항

- [x] `MicroVoteButton.tsx` 신규 생성 — "이 정보가 정확한가요?" 👍/👎 투표 UI
- [x] `FacilityCard.tsx`에 MicroVoteButton 통합 — Otaku_Category 시설 하단에 배치
- [x] `api-routes.ts`에 facilities 투표 API 라우트 상수 추가
- [x] 투표 후 verificationScore 실시간 업데이트 반영
- [x] 비로그인 유저 로그인 유도 모달 표시
- [x] 테스트 페이지 안내 항목 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- Requirements: 5.10, 7.6
- Task: 7.1, 7.2
- 투표 API(`POST /api/facilities/[id]/vote`)는 Task 3.3에서 구현 예정이므로, 현재는 프론트엔드 컴포넌트만 구현된 상태입니다
