### PR TITLE
Feat 편의시설 훅 확장 및 Spot Detail 페이지에 제보 버튼·모달 통합

### DIFF
--- a/.kiro/specs/11-otaku-facilities/tasks.md
+++ b/.kiro/specs/11-otaku-facilities/tasks.md
@@ -155,14 +155,14 @@
     - 에러 시 서버 응답 기반 오류 메시지 표시
     - _Requirements: 5.8, 5.9, 7.3_
 
-- [ ] 10. 통합 및 와이어링
-  - [ ] 10.1 `src/hooks/useSpotDetail.ts` 확장 — useFacilities 훅에 필터/투표 기능 추가
+- [x] 10. 통합 및 와이어링
+  - [x] 10.1 `src/hooks/useSpotDetail.ts` 확장 — useFacilities 훅에 필터/투표 기능 추가
     - `type` 파라미터를 활용한 카테고리별 조회 지원
     - 투표 API 호출 함수 추가
     - 제보 후 목록 갱신 로직 추가
     - _Requirements: 1.3, 1.4, 7.1_
 
-  - [ ] 10.2 Spot Detail 페이지에 "편의시설 제보" 버튼 및 FacilityReportForm 연결
+  - [x] 10.2 Spot Detail 페이지에 "편의시설 제보" 버튼 및 FacilityReportForm 연결
     - NearbyFacilities 영역에 "편의시설 제보" 버튼 추가
     - 버튼 클릭 시 FacilityReportForm 모달 열기
     - 제보 완료 후 편의시설 목록 자동 갱신

--- a/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
+++ b/src/app/spots/[id]/__tests__/spot-detail-required-info.test.tsx
@@ -140,6 +140,9 @@ jest.mock('@/hooks/useSpotDetail', () => ({
     isLoading: false,
     error: null,
   }),
+  useInvalidateFacilities: () => ({
+    invalidate: jest.fn(),
+  }),
 }))
 
 /**

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -362,7 +362,15 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
       {/* Nearby Facilities and Check-in Section - 2 column layout */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
         {/* Nearby Facilities */}
-        <NearbyFacilities facilities={facilities} />
+        <NearbyFacilities
+          facilities={facilities}
+          spotId={spot.id}
+          spotCoordinates={
+            spot.coordinates
+              ? { lat: spot.coordinates[0], lng: spot.coordinates[1] }
+              : undefined
+          }
+        />
 
         {/* Check-in Section (기존 Community Section 대체) */}
         <SpotCheckInSection

--- a/src/components/spot/NearbyFacilities.tsx
+++ b/src/components/spot/NearbyFacilities.tsx
@@ -3,11 +3,17 @@
 import { NearbyFacility, FacilityType } from '@/types'
 import { useCallback, useMemo, useState } from 'react'
 import { groupFacilitiesByType } from '@/lib/facility-utils'
+import { useInvalidateFacilities } from '@/hooks/useSpotDetail'
 import FacilityFilter from './FacilityFilter'
 import FacilityCard from './FacilityCard'
+import FacilityReportForm from './FacilityReportForm'
 
 interface NearbyFacilitiesProps {
   facilities: NearbyFacility[]
+  /** 스팟 ID — 제보 후 목록 갱신에 사용 */
+  spotId?: string
+  /** 스팟 좌표 — 제보 폼 기본 위치에 사용 */
+  spotCoordinates?: { lat: number; lng: number }
 }
 
 // 편의시설 타입별 한글 라벨과 아이콘
@@ -73,7 +79,12 @@ const DEFAULT_VISIBLE_COUNT = 3
 
 export default function NearbyFacilities({
   facilities,
+  spotId,
+  spotCoordinates,
 }: NearbyFacilitiesProps) {
+  const [showReportForm, setShowReportForm] = useState(false)
+  const { invalidate } = useInvalidateFacilities(spotId ?? null)
+
   // 카테고리 필터 상태 (빈 Set = 전체 표시)
   const [selectedTypes, setSelectedTypes] = useState<Set<FacilityType>>(
     new Set()
@@ -165,20 +176,42 @@ export default function NearbyFacilities({
   if (facilities.length === 0) {
     return (
       <div className="rounded-lg bg-white p-6 shadow-md">
-        <h2 className="mb-4 text-2xl font-bold text-gray-900">근처 편의시설</h2>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-gray-900">근처 편의시설</h2>
+          <button
+            onClick={() => setShowReportForm(true)}
+            className="rounded-lg bg-navy-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+          >
+            편의시설 제보
+          </button>
+        </div>
         <div className="py-8 text-center">
           <div className="mb-2 text-4xl">🏪</div>
           <p className="text-gray-500">근처에 등록된 편의시설이 없습니다.</p>
         </div>
+        <FacilityReportForm
+          isOpen={showReportForm}
+          onClose={() => setShowReportForm(false)}
+          onSuccess={invalidate}
+          spotCoordinates={spotCoordinates}
+        />
       </div>
     )
   }
 
   return (
     <div className="rounded-lg bg-white p-6 shadow-md">
-      <h2 className="mb-6 text-2xl font-bold text-gray-900">
-        근처 편의시설 ({facilities.length}개)
-      </h2>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">
+          근처 편의시설 ({facilities.length}개)
+        </h2>
+        <button
+          onClick={() => setShowReportForm(true)}
+          className="rounded-lg bg-navy-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-navy-700"
+        >
+          편의시설 제보
+        </button>
+      </div>
 
       <FacilityFilter
         availableTypes={availableTypes}
@@ -300,6 +333,13 @@ export default function NearbyFacilities({
           )
         })}
       </div>
+
+      <FacilityReportForm
+        isOpen={showReportForm}
+        onClose={() => setShowReportForm(false)}
+        onSuccess={invalidate}
+        spotCoordinates={spotCoordinates}
+      />
     </div>
   )
 }

--- a/src/hooks/useSpotDetail.ts
+++ b/src/hooks/useSpotDetail.ts
@@ -1,7 +1,8 @@
-import { useQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { spotKeys, SpotDetailData } from './useSpots'
-import { API_ROUTES } from '@/lib/api-routes'
-import { NearbyFacility } from '@/types'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import { NearbyFacility, FacilityType } from '@/types'
 
 /**
  * Hook to fetch detailed spot information
@@ -33,18 +34,33 @@ export function useSpotDetail(spotId: string | null) {
   })
 }
 
+/** 편의시설 쿼리 키 팩토리 */
+const facilityKeys = {
+  base: (spotId: string) => [...spotKeys.detail(spotId), 'facilities'] as const,
+  filtered: (spotId: string, type?: FacilityType) =>
+    [...facilityKeys.base(spotId), { type }] as const,
+}
+
 /**
  * Hook to fetch nearby facilities for a specific spot
+ * @param spotId - 스팟 ID
+ * @param type - 카테고리 필터 (선택) — Requirements 1.3, 1.4, 7.1
  */
-export function useNearbyFacilities(spotId: string | null) {
+export function useNearbyFacilities(
+  spotId: string | null,
+  type?: FacilityType
+) {
   return useQuery({
-    queryKey: [...spotKeys.detail(spotId || ''), 'facilities'],
+    queryKey: facilityKeys.filtered(spotId || '', type),
     queryFn: async (): Promise<NearbyFacility[]> => {
       if (!spotId) {
         throw new Error('Spot ID is required')
       }
 
-      const response = await fetch(API_ROUTES.SPOTS.FACILITIES(spotId))
+      const url = buildUrl(API_ROUTES.SPOTS.FACILITIES(spotId), {
+        type: type || undefined,
+      })
+      const response = await fetch(url)
 
       if (!response.ok) {
         throw new Error(
@@ -52,12 +68,74 @@ export function useNearbyFacilities(spotId: string | null) {
         )
       }
 
-      // API returns array directly (not wrapped in { facilities: ... })
       const data: NearbyFacility[] = await response.json()
       return data
     },
     enabled: !!spotId,
-    staleTime: 15 * 60 * 1000, // 15 minutes for facility data (changes less frequently)
-    gcTime: 20 * 60 * 1000, // 20 minutes cache time
+    staleTime: 15 * 60 * 1000,
+    gcTime: 20 * 60 * 1000,
   })
+}
+
+/** 투표 API 응답 */
+interface VoteResult {
+  verificationScore: number
+  upvotes: number
+  downvotes: number
+}
+
+/**
+ * 편의시설 투표 함수를 반환하는 훅
+ * 투표 후 해당 스팟의 편의시설 캐시를 자동 갱신합니다.
+ * Requirements: 7.6
+ */
+export function useFacilityVote(spotId: string | null) {
+  const queryClient = useQueryClient()
+
+  const vote = useCallback(
+    async (facilityId: string, value: boolean): Promise<VoteResult> => {
+      const res = await fetch(API_ROUTES.FACILITIES.VOTE(facilityId), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value }),
+      })
+
+      if (!res.ok) {
+        throw new Error('투표에 실패했습니다')
+      }
+
+      const result: VoteResult = await res.json()
+
+      // 투표 후 편의시설 목록 캐시 갱신
+      if (spotId) {
+        queryClient.invalidateQueries({
+          queryKey: facilityKeys.base(spotId),
+        })
+      }
+
+      return result
+    },
+    [spotId, queryClient]
+  )
+
+  return { vote }
+}
+
+/**
+ * 편의시설 목록 캐시를 수동으로 갱신하는 훅
+ * 제보 완료 후 목록 갱신에 사용합니다.
+ * Requirements: 5.1
+ */
+export function useInvalidateFacilities(spotId: string | null) {
+  const queryClient = useQueryClient()
+
+  const invalidate = useCallback(() => {
+    if (spotId) {
+      queryClient.invalidateQueries({
+        queryKey: facilityKeys.base(spotId),
+      })
+    }
+  }, [spotId, queryClient])
+
+  return { invalidate }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #282

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 편의시설 훅 확장(필터/투표/갱신) 및 Spot Detail 페이지에 제보 버튼·모달 통합

---

## 📋 변경 사항

- [x] useNearbyFacilities 훅에 type 파라미터 기반 카테고리 필터링 지원 추가
- [x] useFacilityVote 훅 추가 (투표 API 호출 + 캐시 자동 갱신)
- [x] useInvalidateFacilities 훅 추가 (제보 후 목록 갱신)
- [x] NearbyFacilities 컴포넌트에 "편의시설 제보" 버튼 및 FacilityReportForm 모달 통합
- [x] SpotDetailContent에서 NearbyFacilities에 spotId, spotCoordinates props 전달

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 1.3, 1.4, 5.1, 7.1 대응
- Task 10.1, 10.2 완료
- 기존 useNearbyFacilities 호출부(spot detail page)는 하위 호환성 유지 (type 파라미터 optional)
