### PR TITLE
[Feat] Task 1 - 타입 정의 확장 및 대시보드 요약 API 구현

### DIFF
--- a/src/app/api/admin/dashboard/summary/route.ts
+++ b/src/app/api/admin/dashboard/summary/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import type { DashboardSummaryResponse } from '@/types/report'
+
+/**
+ * GET /api/admin/dashboard/summary - 대시보드 요약 (대기 항목 count)
+ * Requirements: 6.1, 6.2, 6.3, 6.4
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    if (session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const [reportsCol, supplementsCol, statusReportsCol] = await Promise.all([
+      getCollection(COLLECTIONS.SPOT_REPORTS),
+      getCollection(COLLECTIONS.SPOT_SUPPLEMENTS),
+      getCollection(COLLECTIONS.SPOT_STATUS_REPORTS),
+    ])
+
+    const [pendingReports, pendingSupplements, pendingStatusReports] =
+      await Promise.all([
+        reportsCol.countDocuments({ status: 'pending' }),
+        supplementsCol.countDocuments({ status: 'pending' }),
+        statusReportsCol.countDocuments({ reviewStatus: 'pending' }),
+      ])
+
+    const response: DashboardSummaryResponse = {
+      pendingReports,
+      pendingSupplements,
+      pendingStatusReports,
+    }
+
+    return NextResponse.json(response)
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching dashboard summary:', error)
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/spots/[id]/status-reports/route.ts
+++ b/src/app/api/spots/[id]/status-reports/route.ts
@@ -116,6 +116,7 @@ export async function POST(
       status: body.status,
       description: body.description.trim(),
       photoUrl: body.photoUrl || undefined,
+      reviewStatus: 'pending' as const,
       createdAt: now,
     }
 

--- a/src/app/api/spots/[id]/supplements/route.ts
+++ b/src/app/api/spots/[id]/supplements/route.ts
@@ -153,7 +153,7 @@ export async function POST(
       content: body.content.trim(),
       sceneInfo: body.sceneInfo,
       photos: body.photos || [],
-      approved: false,
+      status: 'pending',
       createdAt: now,
     }
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -119,8 +119,10 @@ export interface SpotSupplement {
   }
   /** 추가 사진 */
   photos?: string[]
-  /** 승인 여부 */
-  approved: boolean
+  /** 처리 상태 (3-state) */
+  status: 'pending' | 'approved' | 'rejected'
+  /** 반려 사유 (status: 'rejected' 시 필수) */
+  rejectionReason?: string
   createdAt: Date
 }
 
@@ -158,6 +160,8 @@ export interface SpotStatusReport {
   description: string
   /** 증거 사진 (선택, 있으면 즉시 '검토 중' 전환 트리거) */
   photoUrl?: string
+  /** 처리 상태 */
+  reviewStatus: 'pending' | 'resolved'
   createdAt: Date
 }
 
@@ -181,4 +185,49 @@ export interface SpotReportExtension {
   spotStatus?: SpotStatus
   /** 상태 신고 누적 수 */
   statusReportCount?: number
+}
+
+// ============================================
+// 관리자 API 요청/응답 인터페이스 (13-admin-dashboard)
+// ============================================
+
+/** PUT /api/admin/supplements/[id]/review 요청 */
+export interface SupplementReviewRequest {
+  action: 'approve' | 'reject'
+  rejectionReason?: string
+}
+
+/** PUT /api/admin/status-reports/[id]/review 요청 */
+export interface StatusReportReviewRequest {
+  action: 'resolve'
+}
+
+/** PUT /api/admin/status-reports/spots/[spotId]/status 요청 */
+export interface SpotStatusUpdateRequest {
+  status: SpotStatus
+}
+
+/** GET /api/admin/dashboard/summary 응답 */
+export interface DashboardSummaryResponse {
+  pendingReports: number
+  pendingSupplements: number
+  pendingStatusReports: number
+}
+
+/** GET /api/admin/supplements 응답 */
+export interface AdminSupplementsResponse {
+  supplements: SpotSupplement[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+/** GET /api/admin/status-reports 응답 */
+export interface AdminStatusReportsResponse {
+  reports: SpotStatusReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #284

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 관리자 대시보드 통합을 위한 타입 확장 및 대시보드 요약 API 구현

---

## 📋 변경 사항

- [x] SpotSupplement 타입: `approved: boolean` → `status: 'pending' | 'approved' | 'rejected'` 3-state 변경
- [x] SpotSupplement 타입: `rejectionReason?: string` 필드 추가
- [x] SpotStatusReport 타입: `reviewStatus: 'pending' | 'resolved'` 필드 추가
- [x] Admin API 요청/응답 인터페이스 6종 추가
- [x] 기존 보완/신고 생성 API에 새 status 필드 반영
- [x] GET /api/admin/dashboard/summary 엔드포인트 구현 (Promise.all 병렬 count)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (tsc --noEmit)
- [x] Requirements 2.2, 2.3, 4.3, 6.1, 6.2, 6.3, 6.4 대응

---

## 📝 추가 정보 (선택)

- SpotSupplement의 `approved: boolean`을 `status` 3-state로 변경하는 breaking change가 포함됩니다
- 기존 DB 데이터 마이그레이션이 필요할 수 있습니다 (approved: true → status: 'approved', approved: false → status: 'pending')
