### PR TITLE
[Feat] 상태 신고 관리자 API 구현

### DIFF
--- a/src/app/api/admin/status-reports/[id]/review/route.ts
+++ b/src/app/api/admin/status-reports/[id]/review/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import type { StatusReportReviewRequest } from '@/types/report'
+
+/**
+ * PUT /api/admin/status-reports/[id]/review - 상태 신고 확인 처리
+ * Requirements: 4.3, 4.4
+ * - action: 'resolve' → reviewStatus를 'resolved'로 변경
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    if (session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const { id } = await params
+    const body: StatusReportReviewRequest = await request.json()
+    const { action } = body
+
+    if (!action || action !== 'resolve') {
+      return NextResponse.json(
+        { error: '유효하지 않은 액션입니다' },
+        { status: 400 }
+      )
+    }
+
+    const collection = await getCollection(COLLECTIONS.SPOT_STATUS_REPORTS)
+    const report = await collection.findOne({ id })
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '상태 신고를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    await collection.updateOne({ id }, { $set: { reviewStatus: 'resolved' } })
+
+    return NextResponse.json({
+      id,
+      reviewStatus: 'resolved',
+      message: '상태 신고가 확인 처리되었습니다',
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error reviewing status report:', error)
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/admin/status-reports/route.ts
+++ b/src/app/api/admin/status-reports/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+
+/**
+ * GET /api/admin/status-reports - 관리자 상태 신고 목록 조회
+ * Requirements: 4.1, 4.4
+ * - reviewStatus 필터: pending/resolved/all
+ * - status 필터: normal/partially_changed/under_construction/demolished/inaccessible/all
+ * - 페이지네이션: page, limit
+ * - createdAt 내림차순 정렬
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    if (session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const collection = await getCollection(COLLECTIONS.SPOT_STATUS_REPORTS)
+
+    const { searchParams } = new URL(request.url)
+    const reviewStatus = searchParams.get('reviewStatus') || 'pending'
+    const status = searchParams.get('status') || 'all'
+    const page = parseInt(searchParams.get('page') || '1', 10)
+    const limit = parseInt(searchParams.get('limit') || '20', 10)
+    const skip = (page - 1) * limit
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query: Record<string, any> = {}
+    if (reviewStatus !== 'all') {
+      query.reviewStatus = reviewStatus
+    }
+    if (status !== 'all') {
+      query.status = status
+    }
+
+    const [reports, total] = await Promise.all([
+      collection
+        .find(query)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      collection.countDocuments(query),
+    ])
+
+    return NextResponse.json({
+      reports,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching admin status reports:', error)
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/admin/status-reports/spots/[spotId]/status/route.ts
+++ b/src/app/api/admin/status-reports/spots/[spotId]/status/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import type { SpotStatusUpdateRequest, SpotStatus } from '@/types/report'
+
+const VALID_SPOT_STATUSES: SpotStatus[] = [
+  'normal',
+  'partially_changed',
+  'under_construction',
+  'demolished',
+  'inaccessible',
+]
+
+/**
+ * PUT /api/admin/status-reports/spots/[spotId]/status - 스팟 상태 수동 변경
+ * Requirements: 4.2, 4.4, 4.5, 4.6
+ * - spotStatus를 지정된 상태로 $set
+ * - 해당 spotId의 pending 신고를 모두 resolved로 일괄 updateMany
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ spotId: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    if (session.user.role !== 'admin') {
+      return NextResponse.json(
+        { error: '관리자 권한이 필요합니다' },
+        { status: 403 }
+      )
+    }
+
+    const { spotId } = await params
+    const body: SpotStatusUpdateRequest = await request.json()
+    const { status } = body
+
+    if (!status || !VALID_SPOT_STATUSES.includes(status)) {
+      return NextResponse.json(
+        { error: '유효하지 않은 상태 값입니다' },
+        { status: 400 }
+      )
+    }
+
+    const spotsCol = await getCollection(COLLECTIONS.SPOTS)
+    const spot = await spotsCol.findOne({ id: spotId })
+
+    if (!spot) {
+      return NextResponse.json(
+        { error: '스팟을 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // 스팟 상태 변경
+    await spotsCol.updateOne({ id: spotId }, { $set: { spotStatus: status } })
+
+    // 해당 spotId의 pending 신고를 모두 resolved로 일괄 처리
+    const statusReportsCol = await getCollection(
+      COLLECTIONS.SPOT_STATUS_REPORTS
+    )
+    await statusReportsCol.updateMany(
+      { spotId, reviewStatus: 'pending' },
+      { $set: { reviewStatus: 'resolved' } }
+    )
+
+    return NextResponse.json({
+      spotId,
+      spotStatus: status,
+      message: '스팟 상태가 변경되었습니다',
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error updating spot status:', error)
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #288

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 상태 신고(SpotStatusReport) 관리자 API 3종 구현 (Task 5.1, 5.2, 5.3)

---

## 📋 변경 사항

- [x] `GET /api/admin/status-reports` — 상태 신고 목록 조회 (reviewStatus/status 필터, 페이지네이션)
- [x] `PUT /api/admin/status-reports/[id]/review` — 상태 신고 확인 처리 (resolve)
- [x] `PUT /api/admin/status-reports/spots/[spotId]/status` — 스팟 상태 수동 변경 + pending 신고 일괄 resolved 처리

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6
- 기존 `/api/admin/reports`, `/api/admin/supplements` 패턴과 동일한 구조로 구현
