### PR TITLE
Feat ]정보 보완(SpotSupplement) 검토 UI 구현 

### DIFF
--- a/.kiro/specs/13-admin-dashboard/.config.kiro
+++ b/.kiro/specs/13-admin-dashboard/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a3f8c2d1-5e94-4b7a-8c3f-1d2e4f6a8b0c", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/13-admin-dashboard/design.md
+++ b/.kiro/specs/13-admin-dashboard/design.md
@@ -1,0 +1,415 @@
+# Design Document: 관리자 대시보드 통합 (Admin Dashboard Integration)
+
+## Overview
+
+현재 관리자 시스템에는 성지 제보(SpotReport) 관리와 콘텐츠 이미지 관리 페이지만 존재합니다. 이 설계는 누락된 두 가지 관리 기능(정보 보완 검토, 상태 신고 검토)과 대시보드 랜딩 페이지를 추가하여, 모든 관리 기능을 `/admin` 경로 아래에서 통합 관리할 수 있도록 합니다.
+
+핵심 설계 원칙:
+- 기존 `AdminReportList + AdminReportReview` 패턴을 그대로 따라 일관성 유지
+- 기존 `/api/admin/reports` API 패턴(인증/페이지네이션/필터)을 동일하게 적용
+- 정보 보완 승인 시 Append 방식 병합 (기존 데이터 보존)
+- React 상태 관리는 컴포넌트 로컬 state + fetch 패턴 (기존 admin 페이지와 동일)
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "Admin Pages"
+        Dashboard["/admin<br/>대시보드 랜딩"]
+        Reports["/admin/reports<br/>제보 관리 (기존)"]
+        Supplements["/admin/supplements<br/>정보 보완 검토"]
+        StatusReports["/admin/status-reports<br/>상태 신고 검토"]
+        ContentImages["/admin/content-images<br/>콘텐츠 이미지 (기존)"]
+    end
+
+    subgraph "Admin APIs"
+        SummaryAPI["GET /api/admin/dashboard/summary"]
+        SupListAPI["GET /api/admin/supplements"]
+        SupReviewAPI["PUT /api/admin/supplements/[id]/review"]
+        SRListAPI["GET /api/admin/status-reports"]
+        SRReviewAPI["PUT /api/admin/status-reports/[id]/review"]
+        SpotStatusAPI["PUT /api/admin/status-reports/spots/[spotId]/status"]
+    end
+
+    subgraph "MongoDB Collections"
+        SpotReports["spot_reports"]
+        SpotSupplements["spot_supplements"]
+        SpotStatusReportsDB["spot_status_reports"]
+        Spots["spots"]
+        Scenes["scenes"]
+    end
+
+    Dashboard --> SummaryAPI
+    SummaryAPI -->|"Promise.all로 병렬 count"| SpotReports & SpotSupplements & SpotStatusReportsDB
+
+    Supplements --> SupListAPI & SupReviewAPI
+    SupListAPI --> SpotSupplements
+    SupReviewAPI --> SpotSupplements & Spots & Scenes
+
+    StatusReports --> SRListAPI & SRReviewAPI & SpotStatusAPI
+    SRListAPI --> SpotStatusReportsDB
+    SRReviewAPI --> SpotStatusReportsDB
+    SpotStatusAPI --> Spots & SpotStatusReportsDB
+```
+
+### 병합 전략 (Supplement Merge)
+
+정보 보완 승인 시 타입별 병합 로직:
+
+```mermaid
+flowchart TD
+    A[승인 요청] --> B{supplement.type?}
+    B -->|photo| C["Spot.photos 배열에 append"]
+    B -->|scene_info| D["scenes 컬렉션에 새 문서 추가"]
+    B -->|description| E["Spot.description에 보완 내용 append"]
+    B -->|other| F["status를 'approved'로 변경<br/>자동 병합 없음"]
+    C & D & E & F --> G["supplement.status = 'approved'"]
+```
+
+## Components and Interfaces
+
+### 페이지 컴포넌트
+
+| 컴포넌트 | 경로 | 설명 |
+|---------|------|------|
+| `AdminDashboardPage` | `src/app/admin/page.tsx` | 대시보드 랜딩 (요약 카드 + 네비게이션) |
+| `AdminSupplementsPage` | `src/app/admin/supplements/page.tsx` | 정보 보완 검토 (Split-pane) |
+| `AdminStatusReportsPage` | `src/app/admin/status-reports/page.tsx` | 상태 신고 검토 (Split-pane) |
+
+### UI 컴포넌트
+
+| 컴포넌트 | 경로 | 설명 |
+|---------|------|------|
+| `AdminDashboardCard` | `src/components/admin/AdminDashboardCard.tsx` | 대시보드 네비게이션 카드 (아이콘, 제목, 대기 수, 링크) |
+| `AdminSupplementList` | `src/components/admin/AdminSupplementList.tsx` | 정보 보완 목록 (필터 + 페이지네이션) |
+| `AdminSupplementReview` | `src/components/admin/AdminSupplementReview.tsx` | 정보 보완 상세/검토 (승인/반려 액션) |
+| `AdminStatusReportList` | `src/components/admin/AdminStatusReportList.tsx` | 상태 신고 목록 (필터 + 페이지네이션) |
+| `AdminStatusReportReview` | `src/components/admin/AdminStatusReportReview.tsx` | 상태 신고 상세/검토 (확인 처리 + 상태 변경) |
+
+### API Route Handlers
+
+| 엔드포인트 | 메서드 | 경로 | 설명 |
+|-----------|--------|------|------|
+| 대시보드 요약 | GET | `/api/admin/dashboard/summary/route.ts` | 각 컬렉션 대기 항목 count (Promise.all로 3개 쿼리 병렬 실행) |
+| 정보 보완 목록 | GET | `/api/admin/supplements/route.ts` | 페이지네이션 + status 필터 |
+| 정보 보완 검토 | PUT | `/api/admin/supplements/[id]/review/route.ts` | 승인(병합) / 반려 |
+| 상태 신고 목록 | GET | `/api/admin/status-reports/route.ts` | 페이지네이션 + reviewStatus 필터 |
+| 상태 신고 확인 | PUT | `/api/admin/status-reports/[id]/review/route.ts` | reviewStatus → resolved |
+| 스팟 상태 변경 | PUT | `/api/admin/status-reports/spots/[spotId]/status/route.ts` | spotStatus 수동 변경 + 일괄 resolved |
+
+### 컴포넌트 인터페이스
+
+```typescript
+// AdminDashboardCard
+interface AdminDashboardCardProps {
+  title: string
+  description: string
+  icon: string
+  pendingCount: number
+  href: string
+}
+
+// AdminSupplementList (AdminReportList 패턴 동일)
+interface AdminSupplementListProps {
+  onSelectSupplement: (supplement: SpotSupplement) => void
+  selectedSupplementId?: string
+  refreshKey?: number
+}
+
+// AdminSupplementReview (AdminReportReview 패턴 동일)
+interface AdminSupplementReviewProps {
+  supplement: SpotSupplement
+  onReviewComplete: () => void
+}
+
+// AdminStatusReportList
+interface AdminStatusReportListProps {
+  onSelectReport: (report: SpotStatusReport) => void
+  selectedReportId?: string
+  refreshKey?: number
+}
+
+// AdminStatusReportReview
+interface AdminStatusReportReviewProps {
+  report: SpotStatusReport
+  onReviewComplete: () => void
+}
+```
+
+### API 요청/응답 인터페이스
+
+```typescript
+// GET /api/admin/supplements 응답
+interface AdminSupplementsResponse {
+  supplements: SpotSupplement[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+// PUT /api/admin/supplements/[id]/review 요청
+interface SupplementReviewRequest {
+  action: 'approve' | 'reject'
+  rejectionReason?: string  // 반려 시 필수
+}
+
+// GET /api/admin/status-reports 응답
+interface AdminStatusReportsResponse {
+  reports: SpotStatusReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+// PUT /api/admin/status-reports/[id]/review 요청
+interface StatusReportReviewRequest {
+  action: 'resolve'
+}
+
+// PUT /api/admin/status-reports/spots/[spotId]/status 요청
+interface SpotStatusUpdateRequest {
+  status: SpotStatus  // 'normal' | 'partially_changed' | 'under_construction' | 'demolished' | 'inaccessible'
+}
+
+// GET /api/admin/dashboard/summary 응답
+interface DashboardSummaryResponse {
+  pendingReports: number      // spot_reports에서 status: 'pending'
+  pendingSupplements: number  // spot_supplements에서 status: 'pending'
+  pendingStatusReports: number // spot_status_reports에서 reviewStatus: 'pending'
+}
+```
+
+
+## Data Models
+
+### 기존 타입 변경 사항
+
+#### SpotSupplement (rejectionReason 필드 추가)
+
+```typescript
+// src/types/report.ts - 기존 SpotSupplement에 필드 추가
+export interface SpotSupplement {
+  id: string
+  spotId: string
+  contributorId: string
+  contributorName: string
+  type: SupplementType  // 'scene_info' | 'description' | 'photo' | 'other'
+  content: string
+  sceneInfo?: {
+    animeTitle: string
+    episodeInfo?: string
+    captureImageUrl?: string
+  }
+  photos?: string[]
+  status: 'pending' | 'approved' | 'rejected'  // 🆕 3-state 명시적 상태 관리
+  rejectionReason?: string  // 반려 사유 (status: 'rejected' 시 필수)
+  createdAt: Date
+}
+```
+
+#### SpotStatusReport (reviewStatus 필드 추가)
+
+```typescript
+// src/types/report.ts - 기존 SpotStatusReport에 필드 추가
+export interface SpotStatusReport {
+  id: string
+  spotId: string
+  reporterId: string
+  reporterName: string
+  status: SpotStatus
+  description: string
+  photoUrl?: string
+  reviewStatus: 'pending' | 'resolved'  // 🆕 처리 상태
+  createdAt: Date
+}
+```
+
+### 병합 로직 상세 (Supplement Merge)
+
+승인 시 `supplement.type`에 따른 MongoDB 업데이트 연산:
+
+| type | 대상 컬렉션 | MongoDB 연산 | 설명 |
+|------|------------|-------------|------|
+| `photo` | spots | `$push: { photos: { $each: supplement.photos } }` | 사진 배열에 append |
+| `scene_info` | scenes | `insertOne({ spotId, imageUrl, animeTitle, ... })` | 새 Scene 문서 생성 |
+| `description` | spots | `$set: { description: existingDesc + '\n\n' + supplement.content }` | 기존 설명 뒤에 append |
+| `other` | - | 없음 (status를 'approved'로 변경) | 관리자 수동 판단 |
+
+### 스팟 상태 수동 변경 시 일괄 처리
+
+```
+1. spots 컬렉션: spotStatus를 지정된 상태로 $set
+2. spot_status_reports 컬렉션: 해당 spotId의 reviewStatus: 'pending'인 문서를 모두 'resolved'로 $set (updateMany)
+```
+
+### 데이터 흐름
+
+```mermaid
+sequenceDiagram
+    participant Admin as 관리자
+    participant UI as Supplement Review UI
+    participant API as /api/admin/supplements/[id]/review
+    participant SupDB as spot_supplements
+    participant SpotDB as spots
+    participant SceneDB as scenes
+
+    Admin->>UI: 승인 버튼 클릭
+    UI->>API: PUT { action: 'approve' }
+    API->>SupDB: findOne({ id })
+    API->>SpotDB: findOne({ id: supplement.spotId })
+
+    alt type === 'photo'
+        API->>SpotDB: updateOne($push photos)
+    else type === 'scene_info'
+        API->>SceneDB: insertOne(new scene)
+    else type === 'description'
+        API->>SpotDB: updateOne($set description append)
+    else type === 'other'
+        Note over API: 자동 병합 없음
+    end
+
+    API->>SupDB: updateOne({ status: 'approved' })
+    API-->>UI: 200 OK
+    UI-->>Admin: 목록 갱신
+```
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: 비관리자 접근 차단
+
+*For any* admin API 엔드포인트(supplements, status-reports, dashboard/summary)와 *for any* 비관리자 세션(미인증 또는 role !== 'admin'), 해당 API에 요청을 보내면 반드시 401 또는 403 상태 코드를 반환하고, 응답 body에 데이터가 포함되지 않아야 한다.
+
+**Validates: Requirements 2.4, 4.4, 6.4**
+
+### Property 2: 정보 보완 목록 필터링 및 페이지네이션
+
+*For any* spot_supplements 컬렉션의 데이터셋과 *for any* 유효한 필터 조건(status: pending/approved/rejected/all)과 페이지 파라미터(page, limit), GET /api/admin/supplements가 반환하는 supplements 배열의 모든 항목은 필터 조건을 만족하고, 배열 길이는 limit 이하이며, total은 필터 조건을 만족하는 전체 문서 수와 일치하고, 결과는 createdAt 내림차순으로 정렬되어야 한다.
+
+**Validates: Requirements 2.1**
+
+### Property 3: 정보 보완 승인 시 Append 병합
+
+*For any* SpotSupplement와 대상 Spot에 대해, 승인 처리 후:
+- `type: 'photo'`이면 기존 Spot.photos 배열의 모든 원소가 보존되고, supplement.photos의 모든 원소가 추가되어야 한다
+- `type: 'scene_info'`이면 scenes 컬렉션에 해당 spotId로 새 문서가 추가되어야 한다
+- `type: 'description'`이면 기존 Spot.description이 결과 description의 접두사로 포함되고, supplement.content가 결과에 포함되어야 한다
+- `type: 'other'`이면 Spot 데이터가 변경되지 않아야 한다
+- 모든 타입에서 supplement.status는 'approved'로 변경되어야 한다
+
+**Validates: Requirements 2.2**
+
+### Property 4: 정보 보완 반려 시 상태 유지 및 사유 기록
+
+*For any* SpotSupplement와 *for any* 비어있지 않은 반려 사유 문자열에 대해, 반려 처리 후 supplement.status는 'rejected'이고, supplement.rejectionReason은 입력된 사유와 일치하며, 대상 Spot 데이터는 변경되지 않아야 한다.
+
+**Validates: Requirements 2.3**
+
+### Property 5: 상태 신고 목록 필터링 및 페이지네이션
+
+*For any* spot_status_reports 컬렉션의 데이터셋과 *for any* 유효한 필터 조건(reviewStatus: pending/resolved/all)과 페이지 파라미터(page, limit), GET /api/admin/status-reports가 반환하는 reports 배열의 모든 항목은 필터 조건을 만족하고, 배열 길이는 limit 이하이며, total은 필터 조건을 만족하는 전체 문서 수와 일치하고, 결과는 createdAt 내림차순으로 정렬되어야 한다.
+
+**Validates: Requirements 4.1**
+
+### Property 6: 스팟 상태 수동 변경 및 일괄 resolved 처리
+
+*For any* Spot과 *for any* 유효한 SpotStatus 값과 해당 스팟에 대한 임의 개수의 pending SpotStatusReport에 대해, 스팟 상태를 수동으로 변경하면: 해당 Spot의 spotStatus가 지정된 상태로 업데이트되고, 해당 spotId의 reviewStatus가 'pending'이었던 모든 SpotStatusReport의 reviewStatus가 'resolved'로 변경되어야 한다.
+
+**Validates: Requirements 4.2, 4.6**
+
+### Property 7: 상태 신고 확인 처리
+
+*For any* reviewStatus가 'pending'인 SpotStatusReport에 대해, 확인 처리 후 해당 신고의 reviewStatus는 'resolved'로 변경되어야 한다.
+
+**Validates: Requirements 4.3**
+
+### Property 8: 대시보드 요약 count 정확성
+
+*For any* 데이터베이스 상태(spot_reports, spot_supplements, spot_status_reports 컬렉션의 임의 데이터)에 대해, GET /api/admin/dashboard/summary가 반환하는 pendingReports는 spot_reports에서 status: 'pending'인 문서 수와 일치하고, pendingSupplements는 spot_supplements에서 status: 'pending'인 문서 수와 일치하고, pendingStatusReports는 spot_status_reports에서 reviewStatus: 'pending'인 문서 수와 일치해야 한다.
+
+**Validates: Requirements 6.1, 6.2, 6.3**
+
+## Error Handling
+
+### API 레벨 에러 처리
+
+| 상황 | HTTP 상태 | 응답 메시지 | 해당 Requirements |
+|------|----------|------------|-------------------|
+| 미인증 사용자 | 401 | `로그인이 필요합니다` | 2.4, 4.4, 6.4 |
+| 비관리자 접근 | 403 | `관리자 권한이 필요합니다` | 2.4, 4.4, 6.4 |
+| 존재하지 않는 supplement ID | 404 | `정보 보완을 찾을 수 없습니다` | 2.5 |
+| 존재하지 않는 status report ID | 404 | `상태 신고를 찾을 수 없습니다` | - |
+| 존재하지 않는 spot ID | 404 | `스팟을 찾을 수 없습니다` | 4.5 |
+| 이미 처리된(approved/rejected) supplement 재처리 | 400 | `이미 처리된 정보 보완입니다` | - |
+| 반려 시 사유 미입력 | 400 | `반려 사유를 입력해주세요` | 2.3 |
+| 유효하지 않은 action 값 | 400 | `유효하지 않은 액션입니다` | - |
+| 유효하지 않은 SpotStatus 값 | 400 | `유효하지 않은 상태 값입니다` | - |
+| 병합 대상 스팟 미존재 | 404 | `대상 스팟을 찾을 수 없습니다` | - |
+| DB 연결 실패 / 내부 오류 | 500 | `서버 오류가 발생했습니다` | - |
+
+### UI 레벨 에러 처리
+
+- API 호출 실패 시 에러 메시지를 인라인으로 표시 (기존 AdminReportReview 패턴과 동일)
+- 목록 로딩 실패 시 에러 상태 표시 (기존 AdminReportList 패턴과 동일)
+- 권한 없는 사용자 접근 시 메인 페이지로 리다이렉트 (기존 AdminReportsPage 패턴과 동일)
+
+### 병합 실패 시 처리
+
+- supplement 승인 API에서 병합 중 오류 발생 시, supplement의 status를 변경하지 않고 500 에러 반환
+- 트랜잭션이 필요하지만 MongoDB native driver에서는 replica set 없이 트랜잭션 사용이 제한적이므로, 병합 연산을 먼저 수행하고 성공 시에만 status를 'approved'로 변경하는 순서로 처리
+
+## Testing Strategy
+
+### Property-Based Testing
+
+라이브러리: `fast-check` (TypeScript/JavaScript용 property-based testing 라이브러리)
+
+각 property test는 최소 100회 반복 실행하며, 설계 문서의 property 번호를 태그로 참조합니다.
+
+태그 형식: `Feature: 13-admin-dashboard, Property {number}: {property_text}`
+
+각 correctness property는 하나의 property-based test로 구현합니다:
+
+| Property | 테스트 대상 | 생성할 데이터 |
+|----------|-----------|-------------|
+| Property 1 | 비관리자 접근 차단 | 임의의 비관리자 세션 + 임의의 admin API 엔드포인트 |
+| Property 2 | 정보 보완 목록 필터/페이지네이션 | 임의의 SpotSupplement 배열 + 필터/페이지 파라미터 |
+| Property 3 | 정보 보완 승인 병합 | 임의의 SpotSupplement(각 type) + 대상 Spot |
+| Property 4 | 정보 보완 반려 | 임의의 SpotSupplement + 반려 사유 문자열 |
+| Property 5 | 상태 신고 목록 필터/페이지네이션 | 임의의 SpotStatusReport 배열 + 필터/페이지 파라미터 |
+| Property 6 | 스팟 상태 변경 + 일괄 resolved | 임의의 Spot + SpotStatus + pending 신고 배열 |
+| Property 7 | 상태 신고 확인 처리 | 임의의 pending SpotStatusReport |
+| Property 8 | 대시보드 요약 count | 임의의 3개 컬렉션 데이터셋 |
+
+### Unit Testing
+
+단위 테스트는 property test가 커버하지 않는 구체적 예제와 edge case에 집중합니다:
+
+- 존재하지 않는 ID로 요청 시 404 반환 (Requirements 2.5, 4.5)
+- 이미 승인된 supplement 재승인 시 400 반환
+- 반려 시 사유 미입력 시 400 반환
+- 유효하지 않은 action/status 값 시 400 반환
+- 병합 대상 스팟이 삭제된 경우 404 반환
+- `type: 'photo'`에서 photos 배열이 빈 경우 처리
+- `type: 'scene_info'`에서 sceneInfo가 없는 경우 처리
+- 대시보드 요약에서 컬렉션이 비어있는 경우 0 반환
+
+### 테스트 구조
+
+```
+src/
+├── __tests__/
+│   ├── api/
+│   │   ├── admin/
+│   │   │   ├── supplements.test.ts          # Property 2, 3, 4 + unit tests
+│   │   │   ├── status-reports.test.ts       # Property 5, 6, 7 + unit tests
+│   │   │   ├── dashboard-summary.test.ts    # Property 8 + unit tests
+│   │   │   └── admin-auth.test.ts           # Property 1
+│   │   └── ...
+│   └── ...
+└── ...
+```

--- a/.kiro/specs/13-admin-dashboard/requirements.md
+++ b/.kiro/specs/13-admin-dashboard/requirements.md
@@ -1,0 +1,89 @@
+# Requirements Document: 관리자 대시보드 통합 (Admin Dashboard Integration)
+
+## Introduction
+
+현재 관리자 시스템에는 성지 제보(SpotReport) 관리와 콘텐츠 이미지 관리 페이지만 존재합니다. 사용자가 제출한 정보 보완(SpotSupplement)과 상태 신고(SpotStatusReport)에 대한 관리자 검토 UI/API가 누락되어 있어, 관리자가 이를 검토하거나 승인/반려할 수 없는 상태입니다. 이 기능은 관리자 대시보드 랜딩 페이지를 추가하고, 누락된 두 가지 관리 기능(정보 보완 검토, 상태 신고 검토)을 구현하여 모든 관리 기능을 하나의 대시보드에서 통합 관리할 수 있도록 합니다.
+
+## Glossary
+
+- **Admin_Dashboard (관리자 대시보드)**: `/admin` 경로의 랜딩 페이지로, 모든 관리 기능으로의 네비게이션과 대기 항목 요약을 제공하는 페이지
+- **Supplement_Review_Page (정보 보완 검토 페이지)**: 사용자가 제출한 SpotSupplement를 관리자가 검토/승인/반려할 수 있는 관리 페이지
+- **StatusReport_Review_Page (상태 신고 검토 페이지)**: 사용자가 제출한 SpotStatusReport를 관리자가 검토하고 스팟 상태를 수동으로 관리할 수 있는 관리 페이지
+- **Supplement_Admin_API (정보 보완 관리자 API)**: 관리자 전용으로 정보 보완 목록 조회, 승인, 반려 기능을 제공하는 API 엔드포인트
+- **StatusReport_Admin_API (상태 신고 관리자 API)**: 관리자 전용으로 상태 신고 목록 조회 및 스팟 상태 수동 변경 기능을 제공하는 API 엔드포인트
+- **SpotSupplement (정보 보완)**: 사용자가 기존 스팟에 대해 추가 정보(씬 정보, 설명, 사진 등)를 제출하는 데이터. `approved: boolean` 필드로 승인 여부를 관리
+- **SpotStatusReport (상태 신고)**: 사용자가 스팟의 현재 상태(정상, 일부 변경, 공사중, 소실됨, 접근 불가)를 신고하는 데이터. 처리 상태를 나타내는 `reviewStatus` (`'pending'` | `'resolved'`) 필드로 관리
+- **Admin (관리자)**: `session.user.role === 'admin'`인 인증된 사용자
+
+## Requirements
+
+### Requirement 1: 관리자 대시보드 랜딩 페이지
+
+**User Story:** As a 관리자, I want `/admin` 경로에 대시보드 랜딩 페이지가 있기를, so that 모든 관리 기능의 현황을 한눈에 파악하고 빠르게 이동할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관리자가 `/admin` 경로에 접근할 때, THE Admin_Dashboard SHALL 각 관리 기능(제보 관리, 정보 보완 검토, 상태 신고 검토, 콘텐츠 이미지 관리)으로의 네비게이션 카드를 표시한다
+2. WHEN Admin_Dashboard가 로드될 때, THE Admin_Dashboard SHALL 각 관리 기능별 대기 중인 항목 수를 요약하여 표시한다
+3. WHEN 비관리자 또는 미인증 사용자가 `/admin` 경로에 접근할 때, THE Admin_Dashboard SHALL 접근을 차단하고 메인 페이지로 리다이렉트한다
+4. WHEN 관리자가 네비게이션 카드를 클릭할 때, THE Admin_Dashboard SHALL 해당 관리 페이지(`/admin/reports`, `/admin/supplements`, `/admin/status-reports`, `/admin/content-images`)로 이동한다
+
+### Requirement 2: 정보 보완 관리자 API
+
+**User Story:** As a 관리자, I want 정보 보완 제보를 조회하고 승인/반려할 수 있는 API가 있기를, so that 사용자가 제출한 정보 보완을 체계적으로 관리할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관리자가 정보 보완 목록을 요청할 때, THE Supplement_Admin_API SHALL 페이지네이션(page, limit)이 적용된 SpotSupplement 목록을 승인 상태별로 필터링하여 반환한다
+2. WHEN 관리자가 정보 보완을 승인할 때, THE Supplement_Admin_API SHALL 해당 SpotSupplement의 `approved` 필드를 `true`로 변경하고, 제출된 보완 데이터(사진, 설명, 씬 정보 등)를 대상 스팟(Spot) 데이터에 병합(Merge)하여 업데이트한다
+3. WHEN 관리자가 정보 보완을 반려할 때, THE Supplement_Admin_API SHALL 해당 SpotSupplement의 `approved` 필드를 `false`로 유지하고 반려 사유를 기록한다
+4. IF 비관리자가 Supplement_Admin_API에 접근하면, THEN THE Supplement_Admin_API SHALL 403 상태 코드를 반환한다
+5. IF 존재하지 않는 SpotSupplement ID로 요청하면, THEN THE Supplement_Admin_API SHALL 404 상태 코드를 반환한다
+
+### Requirement 3: 정보 보완 검토 UI
+
+**User Story:** As a 관리자, I want 정보 보완 제보를 검토할 수 있는 관리 페이지가 있기를, so that 사용자가 제출한 추가 정보를 효율적으로 검토하고 승인/반려할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관리자가 `/admin/supplements` 페이지에 접근할 때, THE Supplement_Review_Page SHALL 대기 중인 정보 보완 목록을 좌측에 표시한다
+2. WHEN 관리자가 목록에서 정보 보완 항목을 선택할 때, THE Supplement_Review_Page SHALL 우측에 해당 항목의 상세 정보(보완 유형, 내용, 씬 정보, 사진, 기여자, 대상 스팟명)를 표시한다
+3. THE Supplement_Review_Page SHALL 승인 상태별 필터(미승인/승인/전체)를 제공한다
+4. WHEN 관리자가 승인 버튼을 클릭할 때, THE Supplement_Review_Page SHALL Supplement_Admin_API를 호출하여 해당 항목을 승인 처리하고 목록을 갱신한다
+5. WHEN 관리자가 반려 버튼을 클릭할 때, THE Supplement_Review_Page SHALL 반려 사유 입력 필드를 표시하고, 사유 입력 후 Supplement_Admin_API를 호출하여 반려 처리한다
+
+### Requirement 4: 상태 신고 관리자 API
+
+**User Story:** As a 관리자, I want 상태 신고를 조회하고 스팟 상태를 수동으로 변경할 수 있는 API가 있기를, so that 자동 전환 로직 외에도 관리자가 직접 스팟 상태를 관리할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관리자가 상태 신고 목록을 요청할 때, THE StatusReport_Admin_API SHALL 페이지네이션(page, limit)이 적용된 SpotStatusReport 목록을 처리 상태(`reviewStatus`)별로 필터링하여 최신순으로 반환한다
+2. WHEN 관리자가 특정 스팟의 상태를 수동으로 변경할 때, THE StatusReport_Admin_API SHALL 해당 스팟의 `spotStatus` 필드를 지정된 상태로 업데이트한다
+3. WHEN 관리자가 상태 신고를 확인 처리할 때, THE StatusReport_Admin_API SHALL 해당 신고의 `reviewStatus`를 `'resolved'`로 변경한다
+4. IF 비관리자가 StatusReport_Admin_API에 접근하면, THEN THE StatusReport_Admin_API SHALL 403 상태 코드를 반환한다
+5. IF 존재하지 않는 스팟 ID로 상태 변경을 요청하면, THEN THE StatusReport_Admin_API SHALL 404 상태 코드를 반환한다
+6. WHEN 관리자가 특정 스팟의 상태를 수동으로 변경할 때, THE StatusReport_Admin_API SHALL 해당 스팟에 대해 대기 중(`reviewStatus: 'pending'`)인 모든 SpotStatusReport를 자동으로 `'resolved'` 상태로 일괄 업데이트한다
+
+### Requirement 5: 상태 신고 검토 UI
+
+**User Story:** As a 관리자, I want 상태 신고를 검토할 수 있는 관리 페이지가 있기를, so that 사용자가 신고한 스팟 상태 변경을 확인하고 필요 시 수동으로 상태를 조정할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관리자가 `/admin/status-reports` 페이지에 접근할 때, THE StatusReport_Review_Page SHALL 상태 신고 목록을 좌측에 표시한다
+2. WHEN 관리자가 목록에서 상태 신고 항목을 선택할 때, THE StatusReport_Review_Page SHALL 우측에 해당 항목의 상세 정보(신고 상태, 설명, 증거 사진, 신고자, 대상 스팟명, 현재 스팟 상태)를 표시한다
+3. THE StatusReport_Review_Page SHALL 처리 상태별 필터(전체/대기 중/확인 완료)와 신고된 상태 유형별 필터(전체/정상/일부 변경/공사중/소실됨/접근 불가)를 제공한다
+4. WHEN 관리자가 스팟 상태를 수동으로 변경할 때, THE StatusReport_Review_Page SHALL 상태 선택 드롭다운을 제공하고 StatusReport_Admin_API를 호출하여 스팟 상태를 업데이트한다
+5. WHEN 관리자가 신고를 확인 처리할 때, THE StatusReport_Review_Page SHALL 해당 신고의 `reviewStatus`를 `'resolved'`로 변경하고 목록을 갱신한다
+
+### Requirement 6: 관리자 대시보드 요약 API
+
+**User Story:** As a 관리자, I want 대시보드에서 각 관리 기능의 대기 항목 수를 확인할 수 있기를, so that 어떤 항목에 우선적으로 대응해야 하는지 빠르게 판단할 수 있습니다.
+
+#### Acceptance Criteria
+
+1. WHEN 관리자가 대시보드 요약 API를 호출할 때, THE Admin_Dashboard SHALL 대기 중인 성지 제보 수(status: 'pending')를 반환한다
+2. WHEN 관리자가 대시보드 요약 API를 호출할 때, THE Admin_Dashboard SHALL 미승인 정보 보완 수(approved: false)를 반환한다
+3. WHEN 관리자가 대시보드 요약 API를 호출할 때, THE Admin_Dashboard SHALL 미확인 상태 신고 수(`reviewStatus: 'pending'`)를 반환한다
+4. IF 비관리자가 대시보드 요약 API에 접근하면, THEN THE Admin_Dashboard SHALL 403 상태 코드를 반환한다

--- a/.kiro/specs/13-admin-dashboard/tasks.md
+++ b/.kiro/specs/13-admin-dashboard/tasks.md
@@ -1,0 +1,204 @@
+# Implementation Plan: 관리자 대시보드 통합 (Admin Dashboard Integration)
+
+## Overview
+
+관리자 대시보드 랜딩 페이지와 누락된 두 가지 관리 기능(정보 보완 검토, 상태 신고 검토)을 구현합니다. 기존 `AdminReportList + AdminReportReview` 패턴과 `/api/admin/reports` API 패턴을 그대로 따르며, 대시보드 요약 API는 `Promise.all`로 병렬 count 쿼리를 실행합니다.
+
+## Tasks
+
+- [x] 1. 타입 정의 확장 및 대시보드 요약 API 구현
+  - [x] 1.1 `src/types/report.ts` 확장 — SpotSupplement, SpotStatusReport 타입 업데이트
+    - SpotSupplement에 `status: 'pending' | 'approved' | 'rejected'` 필드 추가 (기존 `approved: boolean` 대체)
+    - SpotSupplement에 `rejectionReason?: string` 필드 추가
+    - SpotStatusReport에 `reviewStatus: 'pending' | 'resolved'` 필드 추가
+    - API 요청/응답 인터페이스 추가: `SupplementReviewRequest`, `StatusReportReviewRequest`, `SpotStatusUpdateRequest`, `DashboardSummaryResponse`, `AdminSupplementsResponse`, `AdminStatusReportsResponse`
+    - _Requirements: 2.2, 2.3, 4.3, 6.1, 6.2, 6.3_
+
+  - [x] 1.2 `src/app/api/admin/dashboard/summary/route.ts` 생성 — 대시보드 요약 API
+    - GET 핸들러: 관리자 인증 검사 (401/403)
+    - `Promise.all`로 3개 컬렉션 병렬 count 쿼리 실행
+    - `pendingReports`: spot_reports에서 `status: 'pending'` count
+    - `pendingSupplements`: spot_supplements에서 `status: 'pending'` count
+    - `pendingStatusReports`: spot_status_reports에서 `reviewStatus: 'pending'` count
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+
+  - [ ]* 1.3 Property 테스트 — 대시보드 요약 count 정확성
+    - **Property 8: 대시보드 요약 count 정확성**
+    - 임의의 3개 컬렉션 데이터셋에 대해 반환되는 count가 실제 pending 문서 수와 일치하는지 검증
+    - **Validates: Requirements 6.1, 6.2, 6.3**
+
+  - [ ]* 1.4 Property 테스트 — 비관리자 접근 차단
+    - **Property 1: 비관리자 접근 차단**
+    - 임의의 비관리자 세션으로 admin API 호출 시 401/403 반환 및 데이터 미포함 검증
+    - **Validates: Requirements 2.4, 4.4, 6.4**
+
+- [ ] 2. Checkpoint — 타입 및 요약 API 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 3. 정보 보완 관리자 API 구현
+  - [x] 3.1 `src/app/api/admin/supplements/route.ts` 생성 — 정보 보완 목록 API
+    - GET 핸들러: 관리자 인증 검사 (401/403)
+    - `status` 쿼리 파라미터로 필터링 (pending/approved/rejected/all)
+    - `page`, `limit` 쿼리 파라미터로 페이지네이션
+    - `createdAt` 내림차순 정렬
+    - 응답: `{ supplements, total, page, limit, totalPages }`
+    - _Requirements: 2.1, 2.4_
+
+  - [x] 3.2 `src/app/api/admin/supplements/[id]/review/route.ts` 생성 — 정보 보완 검토 API
+    - PUT 핸들러: 관리자 인증 검사 (401/403)
+    - 존재하지 않는 ID → 404, 이미 처리된 supplement → 400
+    - `action: 'approve'` 시: type별 Append 병합 로직 실행 후 `status: 'approved'`로 변경
+      - `photo`: Spot.photos 배열에 `$push`
+      - `scene_info`: scenes 컬렉션에 새 문서 `insertOne`
+      - `description`: 기존 description 뒤에 append
+      - `other`: 자동 병합 없음
+    - `action: 'reject'` 시: `rejectionReason` 필수 검증, `status: 'rejected'`로 변경
+    - 병합 연산 먼저 수행, 성공 시에만 status 변경
+    - _Requirements: 2.2, 2.3, 2.4, 2.5_
+
+  - [ ]* 3.3 Property 테스트 — 정보 보완 목록 필터링 및 페이지네이션
+    - **Property 2: 정보 보완 목록 필터링 및 페이지네이션**
+    - 임의의 SpotSupplement 배열과 필터/페이지 파라미터에 대해 결과가 필터 조건을 만족하고 limit 이하이며 createdAt 내림차순인지 검증
+    - **Validates: Requirements 2.1**
+
+  - [ ]* 3.4 Property 테스트 — 정보 보완 승인 시 Append 병합
+    - **Property 3: 정보 보완 승인 시 Append 병합**
+    - 각 type별로 기존 데이터가 보존되고 보완 데이터가 올바르게 추가되며 status가 'approved'로 변경되는지 검증
+    - **Validates: Requirements 2.2**
+
+  - [ ]* 3.5 Property 테스트 — 정보 보완 반려 시 상태 유지 및 사유 기록
+    - **Property 4: 정보 보완 반려 시 상태 유지 및 사유 기록**
+    - 반려 후 status가 'rejected'이고 rejectionReason이 입력 사유와 일치하며 Spot 데이터가 변경되지 않는지 검증
+    - **Validates: Requirements 2.3**
+
+- [x] 4. Checkpoint — 정보 보완 API 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. 상태 신고 관리자 API 구현
+  - [x] 5.1 `src/app/api/admin/status-reports/route.ts` 생성 — 상태 신고 목록 API
+    - GET 핸들러: 관리자 인증 검사 (401/403)
+    - `reviewStatus` 쿼리 파라미터로 필터링 (pending/resolved/all)
+    - `status` 쿼리 파라미터로 신고 상태 유형별 필터링 (normal/partially_changed/under_construction/demolished/inaccessible/all)
+    - `page`, `limit` 쿼리 파라미터로 페이지네이션
+    - `createdAt` 내림차순 정렬
+    - 응답: `{ reports, total, page, limit, totalPages }`
+    - _Requirements: 4.1, 4.4_
+
+  - [x] 5.2 `src/app/api/admin/status-reports/[id]/review/route.ts` 생성 — 상태 신고 확인 처리 API
+    - PUT 핸들러: 관리자 인증 검사 (401/403)
+    - 존재하지 않는 ID → 404
+    - `action: 'resolve'` 시: `reviewStatus`를 `'resolved'`로 변경
+    - _Requirements: 4.3, 4.4_
+
+  - [x] 5.3 `src/app/api/admin/status-reports/spots/[spotId]/status/route.ts` 생성 — 스팟 상태 수동 변경 API
+    - PUT 핸들러: 관리자 인증 검사 (401/403)
+    - 존재하지 않는 spotId → 404
+    - 유효하지 않은 SpotStatus 값 → 400
+    - 해당 Spot의 `spotStatus`를 지정된 상태로 `$set`
+    - 해당 spotId의 `reviewStatus: 'pending'`인 모든 SpotStatusReport를 `'resolved'`로 일괄 `updateMany`
+    - _Requirements: 4.2, 4.4, 4.5, 4.6_
+
+  - [ ]* 5.4 Property 테스트 — 상태 신고 목록 필터링 및 페이지네이션
+    - **Property 5: 상태 신고 목록 필터링 및 페이지네이션**
+    - 임의의 SpotStatusReport 배열과 필터/페이지 파라미터에 대해 결과가 필터 조건을 만족하고 limit 이하이며 createdAt 내림차순인지 검증
+    - **Validates: Requirements 4.1**
+
+  - [ ]* 5.5 Property 테스트 — 스팟 상태 수동 변경 및 일괄 resolved 처리
+    - **Property 6: 스팟 상태 수동 변경 및 일괄 resolved 처리**
+    - 임의의 Spot과 SpotStatus 값에 대해 spotStatus가 업데이트되고 해당 spotId의 pending 신고가 모두 resolved로 변경되는지 검증
+    - **Validates: Requirements 4.2, 4.6**
+
+  - [ ]* 5.6 Property 테스트 — 상태 신고 확인 처리
+    - **Property 7: 상태 신고 확인 처리**
+    - 임의의 pending SpotStatusReport에 대해 확인 처리 후 reviewStatus가 'resolved'로 변경되는지 검증
+    - **Validates: Requirements 4.3**
+
+- [x] 6. Checkpoint — 상태 신고 API 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. 정보 보완 검토 UI 구현
+  - [ ] 7.1 `src/components/admin/AdminSupplementList.tsx` 생성 — 정보 보완 목록 컴포넌트
+    - 기존 `AdminReportList` 패턴 동일하게 구현
+    - status별 필터 (미승인/승인/반려/전체)
+    - 페이지네이션 (page, limit)
+    - 항목 선택 시 `onSelectSupplement` 콜백 호출
+    - 보완 유형, 기여자명, 대상 스팟명, 상태 배지 표시
+    - _Requirements: 3.1, 3.3_
+
+  - [ ] 7.2 `src/components/admin/AdminSupplementReview.tsx` 생성 — 정보 보완 상세/검토 컴포넌트
+    - 기존 `AdminReportReview` 패턴 동일하게 구현
+    - 보완 유형, 내용, 씬 정보, 사진, 기여자, 대상 스팟명 상세 표시
+    - 승인 버튼: `PUT /api/admin/supplements/[id]/review` 호출 (`action: 'approve'`)
+    - 반려 버튼: 반려 사유 입력 필드 표시 후 `action: 'reject'` 호출
+    - API 호출 성공/실패 시 인라인 메시지 표시
+    - _Requirements: 3.2, 3.4, 3.5_
+
+  - [ ] 7.3 `src/app/admin/supplements/page.tsx` 생성 — 정보 보완 검토 페이지
+    - 기존 `AdminReportsPage` 패턴 동일 (Split-pane 레이아웃)
+    - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+    - 좌측: `AdminSupplementList`, 우측: `AdminSupplementReview`
+    - _Requirements: 3.1, 3.2_
+
+- [ ] 8. 상태 신고 검토 UI 구현
+  - [ ] 8.1 `src/components/admin/AdminStatusReportList.tsx` 생성 — 상태 신고 목록 컴포넌트
+    - 기존 `AdminReportList` 패턴 동일하게 구현
+    - reviewStatus별 필터 (전체/대기 중/확인 완료)
+    - 신고 상태 유형별 필터 (전체/정상/일부 변경/공사중/소실됨/접근 불가)
+    - 페이지네이션 (page, limit)
+    - 항목 선택 시 `onSelectReport` 콜백 호출
+    - 신고 상태, 신고자명, 대상 스팟명, reviewStatus 배지 표시
+    - _Requirements: 5.1, 5.3_
+
+  - [ ] 8.2 `src/components/admin/AdminStatusReportReview.tsx` 생성 — 상태 신고 상세/검토 컴포넌트
+    - 기존 `AdminReportReview` 패턴 동일하게 구현
+    - 신고 상태, 설명, 증거 사진, 신고자, 대상 스팟명, 현재 스팟 상태 상세 표시
+    - 확인 처리 버튼: `PUT /api/admin/status-reports/[id]/review` 호출
+    - 스팟 상태 수동 변경: 상태 선택 드롭다운 + `PUT /api/admin/status-reports/spots/[spotId]/status` 호출
+    - API 호출 성공/실패 시 인라인 메시지 표시
+    - _Requirements: 5.2, 5.4, 5.5_
+
+  - [ ] 8.3 `src/app/admin/status-reports/page.tsx` 생성 — 상태 신고 검토 페이지
+    - 기존 `AdminReportsPage` 패턴 동일 (Split-pane 레이아웃)
+    - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+    - 좌측: `AdminStatusReportList`, 우측: `AdminStatusReportReview`
+    - _Requirements: 5.1, 5.2_
+
+- [ ] 9. Checkpoint — 검토 UI 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 10. 관리자 대시보드 랜딩 페이지 구현 및 통합
+  - [ ] 10.1 `src/components/admin/AdminDashboardCard.tsx` 생성 — 대시보드 네비게이션 카드 컴포넌트
+    - props: `title`, `description`, `icon`, `pendingCount`, `href`
+    - 카드 클릭 시 해당 관리 페이지로 이동 (Next.js Link)
+    - 대기 중 항목 수 배지 표시
+    - _Requirements: 1.1, 1.4_
+
+  - [ ] 10.2 `src/app/admin/page.tsx` 생성 — 대시보드 랜딩 페이지
+    - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+    - `GET /api/admin/dashboard/summary` 호출하여 대기 항목 수 로드
+    - 4개 `AdminDashboardCard` 렌더링:
+      - 제보 관리 (`/admin/reports`, pendingReports)
+      - 정보 보완 검토 (`/admin/supplements`, pendingSupplements)
+      - 상태 신고 검토 (`/admin/status-reports`, pendingStatusReports)
+      - 콘텐츠 이미지 관리 (`/admin/content-images`, count 없음)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [ ]* 10.3 단위 테스트 — 대시보드 및 검토 UI edge case
+    - 존재하지 않는 ID로 요청 시 404 반환 (Requirements 2.5, 4.5)
+    - 이미 승인된 supplement 재승인 시 400 반환
+    - 반려 시 사유 미입력 시 400 반환
+    - 유효하지 않은 action/status 값 시 400 반환
+    - 대시보드 요약에서 컬렉션이 비어있는 경우 0 반환
+    - _Requirements: 2.3, 2.5, 4.5_
+
+- [ ] 11. Final Checkpoint — 전체 기능 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- 기존 `AdminReportList + AdminReportReview` 패턴을 그대로 따라 일관성을 유지합니다
+- SpotSupplement의 `approved: boolean`을 `status: 'pending' | 'approved' | 'rejected'` 3-state로 변경합니다
+- 정보 보완 승인 시 Append 방식 병합으로 기존 데이터를 보존합니다
+- 병합 연산을 먼저 수행하고 성공 시에만 status를 변경하여 데이터 정합성을 보장합니다
+- Property 테스트는 `fast-check` 라이브러리를 사용합니다

--- a/.kiro/specs/13-admin-dashboard/tasks.md
+++ b/.kiro/specs/13-admin-dashboard/tasks.md
@@ -116,8 +116,8 @@
 - [x] 6. Checkpoint — 상태 신고 API 검증
   - Ensure all tests pass, ask the user if questions arise.
 
-- [x] 7. 정보 보완 검토 UI 구현
-  - [ ] 7.1 `src/components/admin/AdminSupplementList.tsx` 생성 — 정보 보완 목록 컴포넌트
+- [-] 7. 정보 보완 검토 UI 구현
+  - [x] 7.1 `src/components/admin/AdminSupplementList.tsx` 생성 — 정보 보완 목록 컴포넌트
     - 기존 `AdminReportList` 패턴 동일하게 구현
     - status별 필터 (미승인/승인/반려/전체)
     - 페이지네이션 (page, limit)
@@ -125,7 +125,7 @@
     - 보완 유형, 기여자명, 대상 스팟명, 상태 배지 표시
     - _Requirements: 3.1, 3.3_
 
-  - [ ] 7.2 `src/components/admin/AdminSupplementReview.tsx` 생성 — 정보 보완 상세/검토 컴포넌트
+  - [x] 7.2 `src/components/admin/AdminSupplementReview.tsx` 생성 — 정보 보완 상세/검토 컴포넌트
     - 기존 `AdminReportReview` 패턴 동일하게 구현
     - 보완 유형, 내용, 씬 정보, 사진, 기여자, 대상 스팟명 상세 표시
     - 승인 버튼: `PUT /api/admin/supplements/[id]/review` 호출 (`action: 'approve'`)
@@ -133,7 +133,7 @@
     - API 호출 성공/실패 시 인라인 메시지 표시
     - _Requirements: 3.2, 3.4, 3.5_
 
-  - [ ] 7.3 `src/app/admin/supplements/page.tsx` 생성 — 정보 보완 검토 페이지
+  - [-] 7.3 `src/app/admin/supplements/page.tsx` 생성 — 정보 보완 검토 페이지
     - 기존 `AdminReportsPage` 패턴 동일 (Split-pane 레이아웃)
     - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
     - 좌측: `AdminSupplementList`, 우측: `AdminSupplementReview`

--- a/src/app/admin/supplements/page.tsx
+++ b/src/app/admin/supplements/page.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { AdminSupplementList } from '@/components/admin/AdminSupplementList'
+import { AdminSupplementReview } from '@/components/admin/AdminSupplementReview'
+import type { SpotSupplement } from '@/types/report'
+
+/**
+ * 관리자 정보 보완 검토 페이지
+ * Requirements: 3.1, 3.2
+ * - Split-pane 레이아웃 (좌측 목록 + 우측 상세)
+ * - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+ */
+export default function AdminSupplementsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [selectedSupplement, setSelectedSupplement] =
+    useState<SpotSupplement | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
+    }
+  }, [status, session, router])
+
+  const handleSelectSupplement = useCallback((supplement: SpotSupplement) => {
+    setSelectedSupplement(supplement)
+  }, [])
+
+  const handleReviewComplete = useCallback(() => {
+    setSelectedSupplement(null)
+    setRefreshKey((k) => k + 1)
+  }, [])
+
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    )
+  }
+
+  if (!session?.user || session.user.role !== 'admin') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="mb-2 text-2xl font-bold text-gray-800">
+            접근 권한 없음
+          </h1>
+          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* 헤더 */}
+      <div className="border-b border-gray-200 bg-white px-6 py-4">
+        <h1 className="text-xl font-bold text-gray-800">정보 보완 검토</h1>
+        <p className="mt-0.5 text-sm text-gray-500">
+          사용자가 제출한 정보 보완을 검토하고 승인/반려할 수 있습니다
+        </p>
+      </div>
+
+      {/* 메인 레이아웃: 좌측 목록 + 우측 상세 */}
+      <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
+        {/* 좌측: 정보 보완 목록 */}
+        <div className="w-96 flex-shrink-0 border-r border-gray-200 bg-white">
+          <AdminSupplementList
+            onSelectSupplement={handleSelectSupplement}
+            selectedSupplementId={selectedSupplement?.id}
+            refreshKey={refreshKey}
+          />
+        </div>
+
+        {/* 우측: 정보 보완 상세/검토 */}
+        <div className="flex-1 bg-gray-50">
+          {selectedSupplement ? (
+            <AdminSupplementReview
+              key={selectedSupplement.id}
+              supplement={selectedSupplement}
+              onReviewComplete={handleReviewComplete}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <div className="text-center text-gray-400">
+                <p className="text-4xl">📝</p>
+                <p className="mt-2 text-sm">
+                  좌측 목록에서 정보 보완을 선택하세요
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/AdminSupplementList.tsx
+++ b/src/components/admin/AdminSupplementList.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import type { SpotSupplement } from '@/types/report'
+
+interface AdminSupplementsResponse {
+  supplements: SpotSupplement[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+const STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'pending', label: '대기중' },
+  { value: 'all', label: '전체' },
+  { value: 'approved', label: '승인' },
+  { value: 'rejected', label: '반려' },
+]
+
+const SUPPLEMENT_TYPE_LABELS: Record<string, string> = {
+  scene_info: '씬 정보',
+  description: '설명',
+  photo: '사진',
+  other: '기타',
+}
+
+interface AdminSupplementListProps {
+  onSelectSupplement: (supplement: SpotSupplement) => void
+  selectedSupplementId?: string
+  refreshKey?: number
+}
+
+/**
+ * 관리자 정보 보완 목록 컴포넌트
+ * Requirements: 3.1, 3.3
+ * - status별 필터 (대기중/승인/반려/전체)
+ * - 페이지네이션 (page, limit)
+ * - 보완 유형, 기여자명, 대상 스팟명, 상태 배지 표시
+ */
+export function AdminSupplementList({
+  onSelectSupplement,
+  selectedSupplementId,
+  refreshKey = 0,
+}: AdminSupplementListProps) {
+  const [supplements, setSupplements] = useState<SpotSupplement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [statusFilter, setStatusFilter] = useState('pending')
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [total, setTotal] = useState(0)
+
+  const fetchSupplements = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const params = new URLSearchParams({
+        status: statusFilter,
+        page: page.toString(),
+        limit: '20',
+      })
+
+      const res = await fetch(`/api/admin/supplements?${params}`)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '정보 보완 목록 조회 실패')
+      }
+
+      const data: AdminSupplementsResponse = await res.json()
+      setSupplements(data.supplements)
+      setTotalPages(data.totalPages)
+      setTotal(data.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }, [statusFilter, page])
+
+  useEffect(() => {
+    fetchSupplements()
+  }, [fetchSupplements, refreshKey])
+
+  const handleFilterChange = (value: string) => {
+    setStatusFilter(value)
+    setPage(1)
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 p-4 text-center text-sm text-red-600">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* 상태 필터 */}
+      <div className="border-b border-gray-200 p-3">
+        <div className="flex flex-wrap gap-1.5">
+          {STATUS_FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              onClick={() => handleFilterChange(filter.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                statusFilter === filter.value
+                  ? 'bg-navy-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-gray-400">총 {total}건</p>
+      </div>
+
+      {/* 목록 */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="space-y-2 p-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="h-20 animate-pulse rounded-lg bg-gray-100"
+              />
+            ))}
+          </div>
+        ) : supplements.length === 0 ? (
+          <div className="py-12 text-center text-sm text-gray-400">
+            {statusFilter === 'pending'
+              ? '대기중인 정보 보완이 없습니다'
+              : '해당 상태의 정보 보완이 없습니다'}
+          </div>
+        ) : (
+          <div className="space-y-1 p-2">
+            {supplements.map((supplement) => (
+              <SupplementSummaryCard
+                key={supplement.id}
+                supplement={supplement}
+                isSelected={selectedSupplementId === supplement.id}
+                onClick={() => onSelectSupplement(supplement)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 border-t border-gray-200 p-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-30"
+          >
+            이전
+          </button>
+          <span className="text-xs text-gray-500">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page >= totalPages}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-30"
+          >
+            다음
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SupplementStatusBadge({ status }: { status: string }) {
+  const config: Record<
+    string,
+    { label: string; bgColor: string; textColor: string }
+  > = {
+    pending: {
+      label: '대기중',
+      bgColor: 'bg-amber-100',
+      textColor: 'text-amber-700',
+    },
+    approved: {
+      label: '승인',
+      bgColor: 'bg-green-100',
+      textColor: 'text-green-700',
+    },
+    rejected: {
+      label: '반려',
+      bgColor: 'bg-red-100',
+      textColor: 'text-red-700',
+    },
+  }
+  const c = config[status] || config.pending
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bgColor} ${c.textColor}`}
+    >
+      {c.label}
+    </span>
+  )
+}
+
+function SupplementSummaryCard({
+  supplement,
+  isSelected,
+  onClick,
+}: {
+  supplement: SpotSupplement
+  isSelected: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full rounded-lg border p-3 text-left transition-colors ${
+        isSelected
+          ? 'border-navy-400 bg-navy-50'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+              {SUPPLEMENT_TYPE_LABELS[supplement.type] || supplement.type}
+            </span>
+            <SupplementStatusBadge status={supplement.status} />
+          </div>
+          <p className="mt-1.5 truncate text-sm font-medium text-gray-800">
+            {supplement.content.slice(0, 50)}
+            {supplement.content.length > 50 ? '...' : ''}
+          </p>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+            <span>{supplement.contributorName}</span>
+            <span>·</span>
+            <span>
+              {new Date(supplement.createdAt).toLocaleDateString('ko-KR')}
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/src/components/admin/AdminSupplementReview.tsx
+++ b/src/components/admin/AdminSupplementReview.tsx
@@ -1,0 +1,329 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import type { SpotSupplement } from '@/types/report'
+
+const SUPPLEMENT_TYPE_LABELS: Record<string, string> = {
+  scene_info: '씬 정보',
+  description: '설명',
+  photo: '사진',
+  other: '기타',
+}
+
+interface AdminSupplementReviewProps {
+  supplement: SpotSupplement
+  onReviewComplete: () => void
+}
+
+/**
+ * 관리자 정보 보완 상세/검토 컴포넌트
+ * Requirements: 3.2, 3.4, 3.5
+ * - 보완 유형, 내용, 씬 정보, 사진, 기여자, 대상 스팟명 상세 표시
+ * - 승인/반려 액션 + 반려 사유 입력
+ * - API 호출 성공/실패 시 인라인 메시지 표시
+ */
+export function AdminSupplementReview({
+  supplement,
+  onReviewComplete,
+}: AdminSupplementReviewProps) {
+  const [rejectionReason, setRejectionReason] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showRejectForm, setShowRejectForm] = useState(false)
+
+  const isPending = supplement.status === 'pending'
+
+  const handleApprove = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      const res = await fetch(
+        `/api/admin/supplements/${supplement.id}/review`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'approve' }),
+        }
+      )
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '승인 처리 실패')
+      }
+
+      onReviewComplete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleReject = async () => {
+    if (!rejectionReason.trim()) {
+      setError('반려 사유를 입력해주세요')
+      return
+    }
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const res = await fetch(
+        `/api/admin/supplements/${supplement.id}/review`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'reject',
+            rejectionReason: rejectionReason.trim(),
+          }),
+        }
+      )
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '반려 처리 실패')
+      }
+
+      setRejectionReason('')
+      onReviewComplete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="space-y-6 p-6">
+        {/* 헤더 */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-800">정보 보완 상세</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              스팟 ID: {supplement.spotId}
+            </p>
+          </div>
+          <SupplementStatusBadge status={supplement.status} />
+        </div>
+
+        {/* 기본 정보 */}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">
+            기본 정보
+          </h3>
+          <dl className="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <dt className="text-gray-400">보완 유형</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {SUPPLEMENT_TYPE_LABELS[supplement.type] || supplement.type}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">기여자</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {supplement.contributorName}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">제출일</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {new Date(supplement.createdAt).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* 보완 내용 */}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">
+            보완 내용
+          </h3>
+          <p className="whitespace-pre-wrap text-sm text-gray-700">
+            {supplement.content}
+          </p>
+        </section>
+
+        {/* 씬 정보 (scene_info 타입) */}
+        {supplement.type === 'scene_info' && supplement.sceneInfo && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">
+              씬 정보
+            </h3>
+            <dl className="space-y-2 text-sm">
+              <div>
+                <dt className="text-gray-400">작품명</dt>
+                <dd className="mt-0.5 font-medium text-gray-700">
+                  {supplement.sceneInfo.animeTitle}
+                </dd>
+              </div>
+              {supplement.sceneInfo.episodeInfo && (
+                <div>
+                  <dt className="text-gray-400">에피소드</dt>
+                  <dd className="mt-0.5 font-medium text-gray-700">
+                    {supplement.sceneInfo.episodeInfo}
+                  </dd>
+                </div>
+              )}
+              {supplement.sceneInfo.captureImageUrl && (
+                <div>
+                  <dt className="mb-1 text-gray-400">캡처 이미지</dt>
+                  <div className="relative aspect-video w-full max-w-md overflow-hidden rounded-lg">
+                    <Image
+                      src={supplement.sceneInfo.captureImageUrl}
+                      alt="씬 캡처"
+                      fill
+                      className="object-cover"
+                    />
+                  </div>
+                </div>
+              )}
+            </dl>
+          </section>
+        )}
+
+        {/* 사진 (photo 타입) */}
+        {supplement.photos && supplement.photos.length > 0 && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">
+              첨부 사진 ({supplement.photos.length}장)
+            </h3>
+            <div className="grid grid-cols-2 gap-3">
+              {supplement.photos.map((photo, idx) => (
+                <div
+                  key={idx}
+                  className="relative aspect-video overflow-hidden rounded-lg"
+                >
+                  <Image
+                    src={photo}
+                    alt={`첨부 사진 ${idx + 1}`}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* 반려 사유 (이미 반려된 경우) */}
+        {supplement.status === 'rejected' && supplement.rejectionReason && (
+          <div className="rounded-lg bg-red-50 p-4">
+            <p className="text-sm font-medium text-red-700">반려 사유</p>
+            <p className="mt-1 text-sm text-red-600">
+              {supplement.rejectionReason}
+            </p>
+          </div>
+        )}
+
+        {/* 검토 액션 (pending 상태일 때만) */}
+        {isPending && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">검토</h3>
+
+            {error && <p className="mb-3 text-sm text-red-500">{error}</p>}
+
+            {showRejectForm ? (
+              <div className="space-y-3">
+                <textarea
+                  value={rejectionReason}
+                  onChange={(e) => {
+                    setRejectionReason(e.target.value)
+                    setError(null)
+                  }}
+                  placeholder="반려 사유를 입력하세요 (필수)"
+                  rows={3}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none focus:ring-1 focus:ring-navy-400"
+                />
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleReject}
+                    disabled={loading}
+                    className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                  >
+                    {loading ? '처리중...' : '❌ 반려 확인'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowRejectForm(false)
+                      setRejectionReason('')
+                      setError(null)
+                    }}
+                    disabled={loading}
+                    className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:opacity-50"
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <button
+                  onClick={handleApprove}
+                  disabled={loading}
+                  className="flex-1 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                >
+                  {loading ? '처리중...' : '✅ 승인'}
+                </button>
+                <button
+                  onClick={() => setShowRejectForm(true)}
+                  disabled={loading}
+                  className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                >
+                  ❌ 반려
+                </button>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* 이미 처리된 보완 안내 */}
+        {!isPending && supplement.status !== 'rejected' && (
+          <div className="rounded-lg bg-gray-50 p-4 text-center text-sm text-gray-500">
+            이미 처리된 정보 보완입니다
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SupplementStatusBadge({ status }: { status: string }) {
+  const config: Record<
+    string,
+    { label: string; bgColor: string; textColor: string }
+  > = {
+    pending: {
+      label: '대기중',
+      bgColor: 'bg-amber-100',
+      textColor: 'text-amber-700',
+    },
+    approved: {
+      label: '승인',
+      bgColor: 'bg-green-100',
+      textColor: 'text-green-700',
+    },
+    rejected: {
+      label: '반려',
+      bgColor: 'bg-red-100',
+      textColor: 'text-red-700',
+    },
+  }
+  const c = config[status] || config.pending
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${c.bgColor} ${c.textColor}`}
+    >
+      {c.label}
+    </span>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #290

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 정보 보완(SpotSupplement) 검토 UI 구현 (Task 7.1, 7.2, 7.3)

---

## 📋 변경 사항

- [x] AdminSupplementList 목록 컴포넌트 구현 (status 필터, 페이지네이션)
- [x] AdminSupplementReview 상세/검토 컴포넌트 구현 (승인/반려 액션)
- [x] 정보 보완 검토 페이지 구현 (Split-pane 레이아웃, 권한 검사)
- [x] 관리자 대시보드 spec 문서 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---
<img width="1900" height="626" alt="image" src="https://github.com/user-attachments/assets/4c3a668f-d43c-4eda-a69d-cb31be298af5" />

## 📝 추가 정보

- Requirements 3.1, 3.2, 3.3, 3.4, 3.5 대응
- 기존 AdminReportList + AdminReportReview 패턴 동일하게 구현
