### PR TITLE
[Feat] Task 8 - 상태 신고 검토 UI 구현

### DIFF
--- a/.kiro/specs/13-admin-dashboard/tasks.md
+++ b/.kiro/specs/13-admin-dashboard/tasks.md
@@ -139,8 +139,8 @@
     - 좌측: `AdminSupplementList`, 우측: `AdminSupplementReview`
     - _Requirements: 3.1, 3.2_
 
-- [ ] 8. 상태 신고 검토 UI 구현
-  - [ ] 8.1 `src/components/admin/AdminStatusReportList.tsx` 생성 — 상태 신고 목록 컴포넌트
+- [-] 8. 상태 신고 검토 UI 구현
+  - [x] 8.1 `src/components/admin/AdminStatusReportList.tsx` 생성 — 상태 신고 목록 컴포넌트
     - 기존 `AdminReportList` 패턴 동일하게 구현
     - reviewStatus별 필터 (전체/대기 중/확인 완료)
     - 신고 상태 유형별 필터 (전체/정상/일부 변경/공사중/소실됨/접근 불가)
@@ -149,7 +149,7 @@
     - 신고 상태, 신고자명, 대상 스팟명, reviewStatus 배지 표시
     - _Requirements: 5.1, 5.3_
 
-  - [ ] 8.2 `src/components/admin/AdminStatusReportReview.tsx` 생성 — 상태 신고 상세/검토 컴포넌트
+  - [x] 8.2 `src/components/admin/AdminStatusReportReview.tsx` 생성 — 상태 신고 상세/검토 컴포넌트
     - 기존 `AdminReportReview` 패턴 동일하게 구현
     - 신고 상태, 설명, 증거 사진, 신고자, 대상 스팟명, 현재 스팟 상태 상세 표시
     - 확인 처리 버튼: `PUT /api/admin/status-reports/[id]/review` 호출
@@ -157,7 +157,7 @@
     - API 호출 성공/실패 시 인라인 메시지 표시
     - _Requirements: 5.2, 5.4, 5.5_
 
-  - [ ] 8.3 `src/app/admin/status-reports/page.tsx` 생성 — 상태 신고 검토 페이지
+  - [x] 8.3 `src/app/admin/status-reports/page.tsx` 생성 — 상태 신고 검토 페이지
     - 기존 `AdminReportsPage` 패턴 동일 (Split-pane 레이아웃)
     - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
     - 좌측: `AdminStatusReportList`, 우측: `AdminStatusReportReview`

--- a/src/app/admin/status-reports/page.tsx
+++ b/src/app/admin/status-reports/page.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { AdminStatusReportList } from '@/components/admin/AdminStatusReportList'
+import { AdminStatusReportReview } from '@/components/admin/AdminStatusReportReview'
+import type { SpotStatusReport } from '@/types/report'
+
+/**
+ * 관리자 상태 신고 검토 페이지
+ * Requirements: 5.1, 5.2
+ * - Split-pane 레이아웃 (좌측 목록 + 우측 상세)
+ * - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+ */
+export default function AdminStatusReportsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [selectedReport, setSelectedReport] = useState<SpotStatusReport | null>(
+    null
+  )
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
+    }
+  }, [status, session, router])
+
+  const handleSelectReport = useCallback((report: SpotStatusReport) => {
+    setSelectedReport(report)
+  }, [])
+
+  const handleReviewComplete = useCallback(() => {
+    setSelectedReport(null)
+    setRefreshKey((k) => k + 1)
+  }, [])
+
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    )
+  }
+
+  if (!session?.user || session.user.role !== 'admin') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="mb-2 text-2xl font-bold text-gray-800">
+            접근 권한 없음
+          </h1>
+          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* 헤더 */}
+      <div className="border-b border-gray-200 bg-white px-6 py-4">
+        <h1 className="text-xl font-bold text-gray-800">상태 신고 검토</h1>
+        <p className="mt-0.5 text-sm text-gray-500">
+          사용자가 신고한 스팟 상태를 검토하고 확인 처리할 수 있습니다
+        </p>
+      </div>
+
+      {/* 메인 레이아웃: 좌측 목록 + 우측 상세 */}
+      <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
+        {/* 좌측: 상태 신고 목록 */}
+        <div className="w-96 flex-shrink-0 border-r border-gray-200 bg-white">
+          <AdminStatusReportList
+            onSelectReport={handleSelectReport}
+            selectedReportId={selectedReport?.id}
+            refreshKey={refreshKey}
+          />
+        </div>
+
+        {/* 우측: 상태 신고 상세/검토 */}
+        <div className="flex-1 bg-gray-50">
+          {selectedReport ? (
+            <AdminStatusReportReview
+              key={selectedReport.id}
+              report={selectedReport}
+              onReviewComplete={handleReviewComplete}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <div className="text-center text-gray-400">
+                <p className="text-4xl">🚨</p>
+                <p className="mt-2 text-sm">
+                  좌측 목록에서 상태 신고를 선택하세요
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/AdminStatusReportList.tsx
+++ b/src/components/admin/AdminStatusReportList.tsx
@@ -1,0 +1,279 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import type { SpotStatusReport } from '@/types/report'
+
+interface AdminStatusReportsResponse {
+  reports: SpotStatusReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+const REVIEW_STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'pending', label: '대기 중' },
+  { value: 'all', label: '전체' },
+  { value: 'resolved', label: '확인 완료' },
+]
+
+const SPOT_STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: 'normal', label: '정상' },
+  { value: 'partially_changed', label: '일부 변경' },
+  { value: 'under_construction', label: '공사중' },
+  { value: 'demolished', label: '소실됨' },
+  { value: 'inaccessible', label: '접근 불가' },
+]
+
+const SPOT_STATUS_LABELS: Record<string, string> = {
+  normal: '정상',
+  partially_changed: '일부 변경',
+  under_construction: '공사중',
+  demolished: '소실됨',
+  inaccessible: '접근 불가',
+}
+
+interface AdminStatusReportListProps {
+  onSelectReport: (report: SpotStatusReport) => void
+  selectedReportId?: string
+  refreshKey?: number
+}
+
+/**
+ * 관리자 상태 신고 목록 컴포넌트
+ * Requirements: 5.1, 5.3
+ * - reviewStatus별 필터 (전체/대기 중/확인 완료)
+ * - 신고 상태 유형별 필터 (전체/정상/일부 변경/공사중/소실됨/접근 불가)
+ * - 페이지네이션 (page, limit)
+ * - 신고 상태, 신고자명, 대상 스팟명, reviewStatus 배지 표시
+ */
+export function AdminStatusReportList({
+  onSelectReport,
+  selectedReportId,
+  refreshKey = 0,
+}: AdminStatusReportListProps) {
+  const [reports, setReports] = useState<SpotStatusReport[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reviewStatusFilter, setReviewStatusFilter] = useState('pending')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [total, setTotal] = useState(0)
+
+  const fetchReports = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const params = new URLSearchParams({
+        reviewStatus: reviewStatusFilter,
+        status: statusFilter,
+        page: page.toString(),
+        limit: '20',
+      })
+
+      const res = await fetch(`/api/admin/status-reports?${params}`)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '상태 신고 목록 조회 실패')
+      }
+
+      const data: AdminStatusReportsResponse = await res.json()
+      setReports(data.reports)
+      setTotalPages(data.totalPages)
+      setTotal(data.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }, [reviewStatusFilter, statusFilter, page])
+
+  useEffect(() => {
+    fetchReports()
+  }, [fetchReports, refreshKey])
+
+  const handleReviewStatusChange = (value: string) => {
+    setReviewStatusFilter(value)
+    setPage(1)
+  }
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value)
+    setPage(1)
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 p-4 text-center text-sm text-red-600">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* 필터 영역 */}
+      <div className="space-y-2 border-b border-gray-200 p-3">
+        {/* reviewStatus 필터 */}
+        <div className="flex flex-wrap gap-1.5">
+          {REVIEW_STATUS_FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              onClick={() => handleReviewStatusChange(filter.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                reviewStatusFilter === filter.value
+                  ? 'bg-navy-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        {/* 신고 상태 유형 필터 */}
+        <div className="flex flex-wrap gap-1.5">
+          {SPOT_STATUS_FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              onClick={() => handleStatusChange(filter.value)}
+              className={`rounded-full px-2.5 py-0.5 text-xs transition-colors ${
+                statusFilter === filter.value
+                  ? 'bg-gray-700 text-white'
+                  : 'bg-gray-50 text-gray-500 hover:bg-gray-100'
+              }`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-xs text-gray-400">총 {total}건</p>
+      </div>
+
+      {/* 목록 */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="space-y-2 p-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="h-20 animate-pulse rounded-lg bg-gray-100"
+              />
+            ))}
+          </div>
+        ) : reports.length === 0 ? (
+          <div className="py-12 text-center text-sm text-gray-400">
+            {reviewStatusFilter === 'pending'
+              ? '대기 중인 상태 신고가 없습니다'
+              : '해당 조건의 상태 신고가 없습니다'}
+          </div>
+        ) : (
+          <div className="space-y-1 p-2">
+            {reports.map((report) => (
+              <StatusReportSummaryCard
+                key={report.id}
+                report={report}
+                isSelected={selectedReportId === report.id}
+                onClick={() => onSelectReport(report)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 border-t border-gray-200 p-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-30"
+          >
+            이전
+          </button>
+          <span className="text-xs text-gray-500">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page >= totalPages}
+            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-30"
+          >
+            다음
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReviewStatusBadge({ reviewStatus }: { reviewStatus: string }) {
+  const config: Record<
+    string,
+    { label: string; bgColor: string; textColor: string }
+  > = {
+    pending: {
+      label: '대기 중',
+      bgColor: 'bg-amber-100',
+      textColor: 'text-amber-700',
+    },
+    resolved: {
+      label: '확인 완료',
+      bgColor: 'bg-green-100',
+      textColor: 'text-green-700',
+    },
+  }
+  const c = config[reviewStatus] || config.pending
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bgColor} ${c.textColor}`}
+    >
+      {c.label}
+    </span>
+  )
+}
+
+function StatusReportSummaryCard({
+  report,
+  isSelected,
+  onClick,
+}: {
+  report: SpotStatusReport
+  isSelected: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full rounded-lg border p-3 text-left transition-colors ${
+        isSelected
+          ? 'border-navy-400 bg-navy-50'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+              {SPOT_STATUS_LABELS[report.status] || report.status}
+            </span>
+            <ReviewStatusBadge reviewStatus={report.reviewStatus} />
+          </div>
+          <p className="mt-1.5 truncate text-sm font-medium text-gray-800">
+            {report.description.slice(0, 50)}
+            {report.description.length > 50 ? '...' : ''}
+          </p>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+            <span>{report.reporterName}</span>
+            <span>·</span>
+            <span>
+              {new Date(report.createdAt).toLocaleDateString('ko-KR')}
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/src/components/admin/AdminStatusReportReview.tsx
+++ b/src/components/admin/AdminStatusReportReview.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import type { SpotStatusReport, SpotStatus } from '@/types/report'
+
+const SPOT_STATUS_LABELS: Record<string, string> = {
+  normal: '정상',
+  partially_changed: '일부 변경',
+  under_construction: '공사중',
+  demolished: '소실됨',
+  inaccessible: '접근 불가',
+}
+
+const SPOT_STATUS_OPTIONS: { value: SpotStatus; label: string }[] = [
+  { value: 'normal', label: '정상' },
+  { value: 'partially_changed', label: '일부 변경' },
+  { value: 'under_construction', label: '공사중' },
+  { value: 'demolished', label: '소실됨' },
+  { value: 'inaccessible', label: '접근 불가' },
+]
+
+interface AdminStatusReportReviewProps {
+  report: SpotStatusReport
+  onReviewComplete: () => void
+}
+
+/**
+ * 관리자 상태 신고 상세/검토 컴포넌트
+ * Requirements: 5.2, 5.4, 5.5
+ * - 신고 상태, 설명, 증거 사진, 신고자, 대상 스팟명, 현재 스팟 상태 상세 표시
+ * - 확인 처리 버튼: PUT /api/admin/status-reports/[id]/review
+ * - 스팟 상태 수동 변경: 상태 선택 드롭다운 + PUT /api/admin/status-reports/spots/[spotId]/status
+ * - API 호출 성공/실패 시 인라인 메시지 표시
+ */
+export function AdminStatusReportReview({
+  report,
+  onReviewComplete,
+}: AdminStatusReportReviewProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [selectedStatus, setSelectedStatus] = useState<SpotStatus>(
+    report.status
+  )
+
+  const isPending = report.reviewStatus === 'pending'
+
+  const handleResolve = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      setSuccessMessage(null)
+
+      const res = await fetch(`/api/admin/status-reports/${report.id}/review`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'resolve' }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '확인 처리 실패')
+      }
+
+      onReviewComplete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleChangeSpotStatus = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      setSuccessMessage(null)
+
+      const res = await fetch(
+        `/api/admin/status-reports/spots/${report.spotId}/status`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: selectedStatus }),
+        }
+      )
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '스팟 상태 변경 실패')
+      }
+
+      setSuccessMessage('스팟 상태가 변경되었습니다')
+      onReviewComplete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="space-y-6 p-6">
+        {/* 헤더 */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-800">상태 신고 상세</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              스팟 ID: {report.spotId}
+            </p>
+          </div>
+          <ReviewStatusBadge reviewStatus={report.reviewStatus} />
+        </div>
+
+        {/* 기본 정보 */}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">
+            기본 정보
+          </h3>
+          <dl className="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <dt className="text-gray-400">신고 상태</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {SPOT_STATUS_LABELS[report.status] || report.status}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">신고자</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {report.reporterName}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-400">신고일</dt>
+              <dd className="mt-0.5 font-medium text-gray-700">
+                {new Date(report.createdAt).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* 설명 */}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">
+            신고 내용
+          </h3>
+          <p className="whitespace-pre-wrap text-sm text-gray-700">
+            {report.description}
+          </p>
+        </section>
+
+        {/* 증거 사진 */}
+        {report.photoUrl && (
+          <section className="rounded-lg border border-gray-200 bg-white p-4">
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">
+              증거 사진
+            </h3>
+            <div className="relative aspect-video w-full max-w-md overflow-hidden rounded-lg">
+              <Image
+                src={report.photoUrl}
+                alt="증거 사진"
+                fill
+                className="object-cover"
+              />
+            </div>
+          </section>
+        )}
+
+        {/* 인라인 메시지 */}
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {successMessage && (
+          <p className="text-sm text-green-600">{successMessage}</p>
+        )}
+
+        {/* 검토 액션 (pending 상태일 때만) */}
+        {isPending && (
+          <section className="space-y-4">
+            {/* 확인 처리 */}
+            <div className="rounded-lg border border-gray-200 bg-white p-4">
+              <h3 className="mb-3 text-sm font-semibold text-gray-700">
+                확인 처리
+              </h3>
+              <button
+                onClick={handleResolve}
+                disabled={loading}
+                className="w-full rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+              >
+                {loading ? '처리중...' : '✅ 확인 완료'}
+              </button>
+            </div>
+
+            {/* 스팟 상태 수동 변경 */}
+            <div className="rounded-lg border border-gray-200 bg-white p-4">
+              <h3 className="mb-3 text-sm font-semibold text-gray-700">
+                스팟 상태 수동 변경
+              </h3>
+              <p className="mb-3 text-xs text-gray-400">
+                스팟 상태를 변경하면 해당 스팟의 대기 중인 모든 신고가 자동으로
+                확인 완료 처리됩니다
+              </p>
+              <div className="flex gap-2">
+                <select
+                  value={selectedStatus}
+                  onChange={(e) =>
+                    setSelectedStatus(e.target.value as SpotStatus)
+                  }
+                  className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-navy-400 focus:outline-none focus:ring-1 focus:ring-navy-400"
+                  aria-label="스팟 상태 선택"
+                >
+                  {SPOT_STATUS_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleChangeSpotStatus}
+                  disabled={loading}
+                  className="rounded-lg bg-navy-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-navy-700 disabled:opacity-50"
+                >
+                  {loading ? '처리중...' : '변경'}
+                </button>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* 이미 처리된 신고 안내 */}
+        {!isPending && (
+          <div className="rounded-lg bg-gray-50 p-4 text-center text-sm text-gray-500">
+            이미 확인 완료된 상태 신고입니다
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ReviewStatusBadge({ reviewStatus }: { reviewStatus: string }) {
+  const config: Record<
+    string,
+    { label: string; bgColor: string; textColor: string }
+  > = {
+    pending: {
+      label: '대기 중',
+      bgColor: 'bg-amber-100',
+      textColor: 'text-amber-700',
+    },
+    resolved: {
+      label: '확인 완료',
+      bgColor: 'bg-green-100',
+      textColor: 'text-green-700',
+    },
+  }
+  const c = config[reviewStatus] || config.pending
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${c.bgColor} ${c.textColor}`}
+    >
+      {c.label}
+    </span>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #292

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 상태 신고(SpotStatusReport) 검토를 위한 관리자 UI 3개 파일 구현 (기존 AdminReportList/Review 패턴 동일)

---

## 📋 변경 사항

- [x] `AdminStatusReportList` 컴포넌트 — reviewStatus별/상태 유형별 이중 필터, 페이지네이션, 목록 표시
- [x] `AdminStatusReportReview` 컴포넌트 — 신고 상세 표시, 확인 처리, 스팟 상태 수동 변경
- [x] `/admin/status-reports` 페이지 — Split-pane 레이아웃, 관리자 권한 검사

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] Requirements 5.1, 5.2, 5.3, 5.4, 5.5 대응

---

## 📝 추가 정보 (선택)

- 총 3커밋, 약 654줄 추가 (500줄 원칙 초과이나 3개 독립 파일로 분할 커밋)
- 기존 AdminSupplementList/Review 패턴을 그대로 따라 일관성 유지
