### PR TITLE
[Feat] 관리자 대시보드 랜딩 페이지 구현

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { AdminDashboardCard } from '@/components/admin/AdminDashboardCard'
+import type { DashboardSummaryResponse } from '@/types/report'
+
+/**
+ * 관리자 대시보드 랜딩 페이지
+ * Requirements: 1.1, 1.2, 1.3, 1.4
+ * - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+ * - GET /api/admin/dashboard/summary 호출하여 대기 항목 수 로드
+ * - 4개 AdminDashboardCard 렌더링
+ */
+export default function AdminDashboardPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [summary, setSummary] = useState<DashboardSummaryResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // 권한 체크
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
+    }
+  }, [status, session, router])
+
+  // 대시보드 요약 데이터 로드
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session?.user || session.user.role !== 'admin') return
+
+    const fetchSummary = async () => {
+      try {
+        setLoading(true)
+        const res = await fetch('/api/admin/dashboard/summary')
+        if (!res.ok) throw new Error('요약 데이터를 불러올 수 없습니다')
+        const data: DashboardSummaryResponse = await res.json()
+        setSummary(data)
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : '서버 오류가 발생했습니다'
+        )
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchSummary()
+  }, [status, session])
+
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    )
+  }
+
+  if (!session?.user || session.user.role !== 'admin') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="mb-2 text-2xl font-bold text-gray-800">
+            접근 권한 없음
+          </h1>
+          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* 헤더 */}
+      <div className="border-b border-gray-200 bg-white px-6 py-4">
+        <h1 className="text-xl font-bold text-gray-800">관리자 대시보드</h1>
+        <p className="mt-0.5 text-sm text-gray-500">
+          모든 관리 기능의 현황을 확인하고 빠르게 이동할 수 있습니다
+        </p>
+      </div>
+
+      {/* 카드 그리드 */}
+      <div className="mx-auto max-w-4xl px-6 py-8">
+        {error && (
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            {[...Array(4)].map((_, i) => (
+              <div
+                key={i}
+                className="h-40 animate-pulse rounded-xl border border-gray-200 bg-white"
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            <AdminDashboardCard
+              title="제보 관리"
+              description="사용자가 제출한 성지 제보를 검토하고 승인/반려합니다"
+              icon="📋"
+              pendingCount={summary?.pendingReports ?? 0}
+              href="/admin/reports"
+            />
+            <AdminDashboardCard
+              title="정보 보완 검토"
+              description="사용자가 제출한 정보 보완을 검토하고 승인/반려합니다"
+              icon="📝"
+              pendingCount={summary?.pendingSupplements ?? 0}
+              href="/admin/supplements"
+            />
+            <AdminDashboardCard
+              title="상태 신고 검토"
+              description="사용자가 신고한 스팟 상태를 검토하고 확인 처리합니다"
+              icon="🚨"
+              pendingCount={summary?.pendingStatusReports ?? 0}
+              href="/admin/status-reports"
+            />
+            <AdminDashboardCard
+              title="콘텐츠 이미지 관리"
+              description="콘텐츠 마스터 이미지를 관리합니다"
+              icon="🖼️"
+              pendingCount={0}
+              href="/admin/content-images"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/dashboard/summary/route.ts
+++ b/src/app/api/admin/dashboard/summary/route.ts
@@ -33,8 +33,18 @@ export async function GET(): Promise<NextResponse> {
     const [pendingReports, pendingSupplements, pendingStatusReports] =
       await Promise.all([
         reportsCol.countDocuments({ status: 'pending' }),
-        supplementsCol.countDocuments({ status: 'pending' }),
-        statusReportsCol.countDocuments({ reviewStatus: 'pending' }),
+        supplementsCol.countDocuments({
+          $or: [
+            { status: 'pending' },
+            { status: { $exists: false }, approved: { $ne: true } },
+          ],
+        }),
+        statusReportsCol.countDocuments({
+          $or: [
+            { reviewStatus: 'pending' },
+            { reviewStatus: { $exists: false } },
+          ],
+        }),
       ])
 
     const response: DashboardSummaryResponse = {

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -37,7 +37,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const query: Record<string, any> = {}
     if (status !== 'all') {
-      query.status = status
+      if (status === 'pending') {
+        // 하위 호환: status 필드가 없는 기존 데이터도 pending으로 취급
+        query.$or = [{ status: 'pending' }, { status: { $exists: false } }]
+      } else {
+        query.status = status
+      }
     }
 
     const [reports, total] = await Promise.all([

--- a/src/app/api/admin/status-reports/route.ts
+++ b/src/app/api/admin/status-reports/route.ts
@@ -39,7 +39,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const query: Record<string, any> = {}
     if (reviewStatus !== 'all') {
-      query.reviewStatus = reviewStatus
+      if (reviewStatus === 'pending') {
+        // 하위 호환: reviewStatus 필드가 없는 기존 데이터도 pending으로 취급
+        query.$or = [
+          { reviewStatus: 'pending' },
+          { reviewStatus: { $exists: false } },
+        ]
+      } else {
+        query.reviewStatus = reviewStatus
+      }
     }
     if (status !== 'all') {
       query.status = status

--- a/src/app/api/admin/supplements/route.ts
+++ b/src/app/api/admin/supplements/route.ts
@@ -37,7 +37,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const query: Record<string, any> = {}
     if (status !== 'all') {
-      query.status = status
+      if (status === 'pending') {
+        // 하위 호환: status 필드가 없거나 approved: false인 기존 데이터도 pending으로 취급
+        query.$or = [
+          { status: 'pending' },
+          { status: { $exists: false }, approved: { $ne: true } },
+        ]
+      } else {
+        query.status = status
+      }
     }
 
     const [supplements, total] = await Promise.all([

--- a/src/components/admin/AdminDashboardCard.tsx
+++ b/src/components/admin/AdminDashboardCard.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+
+/**
+ * 대시보드 네비게이션 카드 컴포넌트
+ * Requirements: 1.1, 1.4
+ * - 카드 클릭 시 해당 관리 페이지로 이동 (Next.js Link)
+ * - 대기 중 항목 수 배지 표시
+ */
+
+interface AdminDashboardCardProps {
+  title: string
+  description: string
+  icon: string
+  pendingCount: number
+  href: string
+}
+
+export function AdminDashboardCard({
+  title,
+  description,
+  icon,
+  pendingCount,
+  href,
+}: AdminDashboardCardProps) {
+  return (
+    <Link
+      href={href}
+      className="group block rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-all hover:border-blue-300 hover:shadow-md"
+    >
+      <div className="flex items-start justify-between">
+        <span className="text-3xl" role="img" aria-label={title}>
+          {icon}
+        </span>
+        {pendingCount > 0 && (
+          <span className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-semibold text-red-700">
+            {pendingCount}건 대기
+          </span>
+        )}
+      </div>
+      <h2 className="mt-4 text-lg font-bold text-gray-800 group-hover:text-blue-600">
+        {title}
+      </h2>
+      <p className="mt-1 text-sm text-gray-500">{description}</p>
+    </Link>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -48,6 +48,14 @@ export function Header() {
           >
             🧪 테스트
           </Link>
+          {isAuthenticated && user?.role === 'admin' && (
+            <Link
+              href="/admin"
+              className="text-sm text-orange-400 transition hover:text-orange-300"
+            >
+              ⚙️ 관리자
+            </Link>
+          )}
         </nav>
 
         {/* 인증 영역 + 모바일 메뉴 버튼 */}
@@ -153,6 +161,15 @@ export function Header() {
             >
               🧪 테스트
             </Link>
+            {isAuthenticated && user?.role === 'admin' && (
+              <Link
+                href="/admin"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="block rounded-lg px-3 py-2 text-sm text-orange-400 transition hover:bg-slate-800 hover:text-orange-300"
+              >
+                ⚙️ 관리자
+              </Link>
+            )}
           </div>
         </nav>
       )}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #294

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 관리자 대시보드 랜딩 페이지(`/admin`)와 네비게이션 카드 컴포넌트를 구현하여 모든 관리 기능을 통합 관리할 수 있도록 합니다.

---

## 📋 변경 사항

- [x] `AdminDashboardCard` 네비게이션 카드 컴포넌트 생성 (Task 10.1)
- [x] `/admin` 대시보드 랜딩 페이지 생성 (Task 10.2)
- [x] 대시보드 요약 API 연동 (대기 항목 수 배지 표시)
- [x] 4개 관리 기능 카드 렌더링 (제보 관리, 정보 보완 검토, 상태 신고 검토, 콘텐츠 이미지 관리)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---
<img width="26" height="8" alt="image" src="https://github.com/user-attachments/assets/a9bdf9fe-e27f-4cf3-94fa-2a539f4dd5cb" />
<img width="1883" height="757" alt="image" src="https://github.com/user-attachments/assets/7b64ee9c-8302-41f9-afda-9b60011d1a68" />

## 📝 추가 정보

- Requirements 1.1, 1.2, 1.3, 1.4 대응
- 기존 admin 페이지 패턴(권한 검사, 로딩/에러 상태)을 동일하게 적용
