### PR TITLE
[Feat] Task 1.2 - 로컬 폰트 최적화 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,7 +29,17 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: var(--font-geist-sans), sans-serif;
+  font-family:
+    var(--font-pretendard),
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    sans-serif;
+}
+
+code,
+pre {
+  font-family: 'Courier New', Courier, monospace;
 }
 
 /* Smooth scrolling */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,16 @@
 import type { Metadata, Viewport } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import localFont from 'next/font/local'
 import './globals.css'
 import { Providers } from '@/lib/providers'
 import { Header } from '@/components/layout'
 import { ServiceWorkerRegistrar } from '@/components/mobile/ServiceWorkerRegistrar'
 import { IosPwaPrompt } from '@/components/mobile/IosPwaPrompt'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
+const pretendard = localFont({
+  src: '../../public/fonts/PretendardVariable.woff2',
+  variable: '--font-pretendard',
   display: 'swap',
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-  display: 'swap',
+  weight: '45 920',
 })
 
 export const viewport: Viewport = {
@@ -52,9 +47,7 @@ export default function RootLayout({
         />
         <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${pretendard.variable} antialiased`}>
         <Providers>
           <Header />
           <main className="pt-14">{children}</main>


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #299

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

Task 1.2 - Pretendard 로컬 폰트 최적화 적용 (next/font/local 사용)

---

## 📋 변경 사항

- [x] `src/app/layout.tsx`: Geist 폰트 제거 → Pretendard 로컬 폰트로 교체
- [x] `next/font/local`로 `public/fonts/PretendardVariable.woff2` 로드
- [x] CSS 변수 `--font-pretendard` 생성 및 적용
- [x] `display: 'swap'` 옵션 적용하여 FOIT 방지
- [x] `src/app/globals.css`: 폰트 패밀리를 CSS 변수로 변경
- [x] 시스템 폰트 폴백 추가 (-apple-system, BlinkMacSystemFont, system-ui)
- [x] code/pre 태그 폰트 설정 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

**Requirements**: 3.1, 3.2, 3.3, 3.4

**최적화 효과**:
- 외부 Google Fonts CDN 요청 제거 (Geist → Pretendard 로컬)
- 폰트 파일 셀프 호스팅으로 네트워크 의존성 감소
- `display: 'swap'`으로 FOIT(Flash of Invisible Text) 방지
- Variable 폰트 사용으로 다양한 weight 지원 (45-920)

**커밋 내역**:
1. `feat: pretendard 로컬 폰트 로드 설정 추가`
2. `style: pretendard css 변수 적용 및 폴백 폰트 추가`
