### PR TITLE
[Enhancement] Task 7 - 렌더링 최적화

### DIFF
--- a/src/components/gallery/ComparisonCard.tsx
+++ b/src/components/gallery/ComparisonCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, memo } from 'react'
 import Image from 'next/image'
 import { CheckIn, Badge } from '@/types'
 
@@ -24,7 +24,7 @@ export interface ComparisonCardProps {
  * - 2.3: 유저 닉네임, 스팟 이름, 뱃지 아이콘 표시
  * - 2.4: 호버 시 스케일 애니메이션 및 오버레이
  */
-export function ComparisonCard({
+export const ComparisonCard = memo(function ComparisonCard({
   checkIn,
   spot,
   badges = [],
@@ -188,4 +188,4 @@ export function ComparisonCard({
       </div>
     </div>
   )
-}
+})

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { SpotCategory, CATEGORY_CONFIG } from '@/types'
+import { useShallow } from 'zustand/react/shallow'
 import {
   useFilterStore,
   useSelectedCategories,
@@ -16,7 +17,13 @@ import { CategoryIcon } from '@/components/common'
 export default function CategoryFilter() {
   const selectedCategories = useSelectedCategories()
   const { toggleCategory, selectAllCategories, clearCategories } =
-    useFilterStore()
+    useFilterStore(
+      useShallow((state) => ({
+        toggleCategory: state.toggleCategory,
+        selectAllCategories: state.selectAllCategories,
+        clearCategories: state.clearCategories,
+      }))
+    )
 
   const handleCategoryToggle = (category: SpotCategory) => {
     toggleCategory(category)

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback, useRef, useEffect, useId } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { useFilterStore, useSearchQuery } from '@/stores/filterStore'
 import { useAutocomplete, AutocompleteItem } from '@/hooks/useAutocomplete'
 import AutocompleteDropdown from './AutocompleteDropdown'
@@ -18,7 +19,12 @@ export default function ContentSearchFilter({
 }: ContentSearchFilterProps) {
   const dropdownId = useId()
   const searchQuery = useSearchQuery()
-  const { setSearchQuery, clearSearchQuery } = useFilterStore()
+  const { setSearchQuery, clearSearchQuery } = useFilterStore(
+    useShallow((state) => ({
+      setSearchQuery: state.setSearchQuery,
+      clearSearchQuery: state.clearSearchQuery,
+    }))
+  )
   const [inputValue, setInputValue] = useState(searchQuery)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -5,6 +5,7 @@ import { MapContainer, TileLayer } from 'react-leaflet'
 import { Map as LeafletMap } from 'leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import { useShallow } from 'zustand/react/shallow'
 import { useMapStore } from '@/stores/mapStore'
 import { SpotPin as SpotPinType } from '@/types'
 import SpotPin from './SpotPin'
@@ -30,7 +31,14 @@ export default function PilgrimageMap({
   onSpotSelect,
 }: PilgrimageMapProps) {
   const mapRef = useRef<LeafletMap | null>(null)
-  const { center, zoom, setCenter, setZoom } = useMapStore()
+  const { center, zoom, setCenter, setZoom } = useMapStore(
+    useShallow((state) => ({
+      center: state.center,
+      zoom: state.zoom,
+      setCenter: state.setCenter,
+      setZoom: state.setZoom,
+    }))
+  )
   const [gpsError, setGpsError] = useState<{
     code: string
     message: string

--- a/src/components/map/SearchInput.tsx
+++ b/src/components/map/SearchInput.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { useFilterStore, useSearchQuery } from '@/stores/filterStore'
 
 /**
@@ -24,9 +25,13 @@ export default function SearchInput({
   placeholder = '작품명, 팀명, 아티스트명 검색...',
   className = '',
 }: SearchInputProps) {
-  // filterStore에서 검색어 상태 가져오기
   const searchQuery = useSearchQuery()
-  const { setSearchQuery, clearSearchQuery } = useFilterStore()
+  const { setSearchQuery, clearSearchQuery } = useFilterStore(
+    useShallow((state) => ({
+      setSearchQuery: state.setSearchQuery,
+      clearSearchQuery: state.clearSearchQuery,
+    }))
+  )
 
   // 로컬 입력 상태 (실시간 반영용)
   const [inputValue, setInputValue] = useState(searchQuery)

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { Marker, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import { SpotPin as SpotPinType, CATEGORY_CONFIG, SpotCategory } from '@/types'
+import { useShallow } from 'zustand/react/shallow'
 import { useMapStore } from '@/stores/mapStore'
 import { useUIStore, useIsPreviewHovered } from '@/stores/uiStore'
 import { useBottomSheetStore } from '@/stores/bottomSheetStore'
@@ -266,10 +267,22 @@ const createImagePinIcon = (
 
 export default function SpotPin({ spot, onSelect }: SpotPinProps) {
   const map = useMap()
-  const { selectedSpotId, setSelectedSpot } = useMapStore()
-  const { openPreview, closePreview } = useUIStore()
+  const { selectedSpotId, setSelectedSpot } = useMapStore(
+    useShallow((state) => ({
+      selectedSpotId: state.selectedSpotId,
+      setSelectedSpot: state.setSelectedSpot,
+    }))
+  )
+  const { openPreview, closePreview } = useUIStore(
+    useShallow((state) => ({
+      openPreview: state.openPreview,
+      closePreview: state.closePreview,
+    }))
+  )
   const isPreviewHovered = useIsPreviewHovered()
-  const { open: openBottomSheet } = useBottomSheetStore()
+  const { open: openBottomSheet } = useBottomSheetStore(
+    useShallow((state) => ({ open: state.open }))
+  )
   const [isHovered, setIsHovered] = useState(false)
 
   // isPreviewHovered의 최신 값을 참조하기 위한 ref

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { useState, useCallback, useMemo, useRef, useEffect, memo } from 'react'
 import { Marker, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import { SpotPin as SpotPinType, CATEGORY_CONFIG, SpotCategory } from '@/types'
@@ -265,7 +265,7 @@ const createImagePinIcon = (
   })
 }
 
-export default function SpotPin({ spot, onSelect }: SpotPinProps) {
+export default memo(function SpotPin({ spot, onSelect }: SpotPinProps) {
   const map = useMap()
   const { selectedSpotId, setSelectedSpot } = useMapStore(
     useShallow((state) => ({
@@ -472,4 +472,4 @@ export default function SpotPin({ spot, onSelect }: SpotPinProps) {
       }}
     />
   )
-}
+})

--- a/src/components/map/SpotPreview.tsx
+++ b/src/components/map/SpotPreview.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
+import { useShallow } from 'zustand/react/shallow'
 import {
   useUIStore,
   useIsPreviewOpen,
@@ -36,7 +37,12 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
   const isPreviewOpen = useIsPreviewOpen()
   const previewSpotId = usePreviewSpotId()
   const previewPosition = usePreviewPosition()
-  const { closePreview, setPreviewHovered } = useUIStore()
+  const { closePreview, setPreviewHovered } = useUIStore(
+    useShallow((state) => ({
+      closePreview: state.closePreview,
+      setPreviewHovered: state.setPreviewHovered,
+    }))
+  )
 
   // 스팟 미리보기 데이터 조회
   const { data: spot, isLoading, error } = useSpotPreview(previewSpotId)

--- a/src/components/route/RouteCard.tsx
+++ b/src/components/route/RouteCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { memo } from 'react'
 import Link from 'next/link'
 import { OptimizedImage } from '@/components/common'
 import type { Route, RouteDifficulty } from '@/types/route'
@@ -37,7 +38,7 @@ function formatDistance(meters: number): string {
  * 코스 목록에서 각 코스를 카드 형태로 표시
  * Requirements: 2.1
  */
-export function RouteCard({ route }: RouteCardProps) {
+export const RouteCard = memo(function RouteCard({ route }: RouteCardProps) {
   const difficulty = DIFFICULTY_CONFIG[route.difficulty]
   const availableSpots = route.spots.filter((s) => s.isAvailable !== false)
 
@@ -126,4 +127,4 @@ export function RouteCard({ route }: RouteCardProps) {
       </article>
     </Link>
   )
-}
+})

--- a/src/components/spot/ExternalLinkCard.tsx
+++ b/src/components/spot/ExternalLinkCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { memo } from 'react'
 import { ExternalLink, LINK_TYPE_CONFIG } from '@/types'
 
 /**
@@ -22,7 +23,10 @@ interface ExternalLinkCardProps {
  * - 2.3: 외부 링크를 클릭 가능한 버튼/카드로 표시
  * - 2.4: 새 탭에서 열기
  */
-export function ExternalLinkCard({ link, onClick }: ExternalLinkCardProps) {
+export const ExternalLinkCard = memo(function ExternalLinkCard({
+  link,
+  onClick,
+}: ExternalLinkCardProps) {
   const config = LINK_TYPE_CONFIG[link.type]
 
   const handleClick = () => {
@@ -70,4 +74,4 @@ export function ExternalLinkCard({ link, onClick }: ExternalLinkCardProps) {
       </svg>
     </button>
   )
-}
+})

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, memo } from 'react'
 import { NearbyFacility, OtakuFacilityType } from '@/types'
 import {
   CoinLockerDetails,
@@ -277,7 +277,10 @@ function VerificationBadge({ facility }: { facility: NearbyFacility }) {
 
 // ─── 메인 FacilityCard ───
 
-export default function FacilityCard({ facility, config }: FacilityCardProps) {
+export default memo(function FacilityCard({
+  facility,
+  config,
+}: FacilityCardProps) {
   const [voteData, setVoteData] = useState({
     verificationScore: facility.verificationScore,
     upvotes: facility.upvotes,
@@ -409,4 +412,4 @@ export default function FacilityCard({ facility, config }: FacilityCardProps) {
       )}
     </div>
   )
-}
+})

--- a/src/hooks/useScenes.ts
+++ b/src/hooks/useScenes.ts
@@ -73,8 +73,6 @@ export function useScenesBySpot(spotId: string | null) {
       }))
     },
     enabled: !!spotId,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
   })
 }
 

--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -134,8 +134,6 @@ export function useSpots(
       return data.spots
     },
     enabled,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
   })
 }
 
@@ -173,6 +171,7 @@ export function useSpotPreview(spotId: string | null) {
     },
     enabled: !!spotId,
     staleTime: 10 * 60 * 1000, // 10 minutes for individual spots
+    gcTime: 15 * 60 * 1000, // 15 minutes cache time
   })
 }
 

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -25,8 +25,8 @@ export function Providers({ children }: ProvidersProps) {
             // Retry delay with exponential backoff
             retryDelay: (attemptIndex) =>
               Math.min(1000 * 2 ** attemptIndex, 30000),
-            // Refetch on window focus for fresh data
-            refetchOnWindowFocus: true,
+            // Refetch on window focus disabled for performance
+            refetchOnWindowFocus: false,
             // Don't refetch on reconnect to avoid excessive requests
             refetchOnReconnect: false,
           },


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #305

---

## 📋 PR 타입

- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)

---

## ✨ 작업 개요

Zustand useShallow selector, React.memo, React Query 캐시 설정 최적화를 통한 렌더링 성능 개선

---

## 📋 변경 사항

- [x] SpotPin, PilgrimageMap, SpotPreview, SearchInput, CategoryFilter, ContentSearchFilter에 useShallow selector 적용
- [x] SpotPin, RouteCard, FacilityCard, ExternalLinkCard, ComparisonCard에 React.memo 적용
- [x] React Query 전역 refetchOnWindowFocus: false 설정
- [x] 전역 기본값과 중복된 개별 훅 staleTime/gcTime 제거
- [x] useSpotPreview에 gcTime 15분 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 8.1, 8.2, 8.3 대응
- 기능 변경 없이 렌더링 최적화만 적용한 비파괴적 리팩토링
