### PR TITLE
[enhance] routeCard Link에 prefetch={false} 적용

### DIFF
--- a/src/components/route/RouteCard.tsx
+++ b/src/components/route/RouteCard.tsx
@@ -43,7 +43,7 @@ export const RouteCard = memo(function RouteCard({ route }: RouteCardProps) {
   const availableSpots = route.spots.filter((s) => s.isAvailable !== false)
 
   return (
-    <Link href={`/routes/${route.id}`} className="block">
+    <Link href={`/routes/${route.id}`} prefetch={false} className="block">
       <article className="overflow-hidden rounded-lg border border-navy-200 bg-white shadow-sm transition-shadow hover:shadow-md">
         {/* 썸네일 영역 */}
         <div className="relative h-40 bg-navy-100">


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #307

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

목록 페이지 Link 컴포넌트에 `prefetch={false}`를 적용하여 불필요한 네트워크 요청을 줄이고, hover 시 자동 prefetch로 체감 속도를 유지합니다.

---

## 📋 변경 사항

- [x] RouteCard 컴포넌트의 `<Link>`에 `prefetch={false}` 추가

> PostList와 갤러리 컴포넌트는 `router.push()` 방식을 사용하고 있어 `<Link>` prefetch 제어 대상이 아닙니다.

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (type-check)
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- **Requirements**: 9.1, 9.2
- **Task**: 9.1
- PostList는 `router.push()`, 갤러리 컴포넌트들도 `router.push()` 방식이라 `<Link>` prefetch 제어 대상에서 제외
- Next.js의 hover 시 자동 prefetch 동작으로 체감 속도는 유지됨
