### PR TITLE
[Enhancement] Task 11 - Google Places API 온디맨드 스크립트 로딩

### DIFF
--- a/src/components/spot/GooglePlacesSearch.tsx
+++ b/src/components/spot/GooglePlacesSearch.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { useLoadScript } from '@react-google-maps/api'
+import { useGooglePlacesLoader } from '@/hooks/useGooglePlacesLoader'
 
-const LIBRARIES: 'places'[] = ['places']
 const DEBOUNCE_MS = 500
 
 interface PlaceResult {
@@ -35,12 +34,7 @@ export default function GooglePlacesSearch({
   onSelect,
   biasCenter,
 }: GooglePlacesSearchProps) {
-  const { isLoaded, loadError } = useLoadScript({
-    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? '',
-    libraries: LIBRARIES,
-    language: 'ja',
-    region: 'JP',
-  })
+  const { isLoaded, loadError, loadScript } = useGooglePlacesLoader()
 
   const [query, setQuery] = useState('')
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
@@ -200,23 +194,14 @@ export default function GooglePlacesSearch({
 
   if (!isLoaded) {
     return (
-      <div className="flex items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-400">
-        <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-          />
-        </svg>
-        구글맵 로딩 중...
+      <div className="relative">
+        <input
+          type="text"
+          onFocus={loadScript}
+          placeholder="장소 이름으로 검색 (포커스 시 구글맵 로드)"
+          className="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-400 transition-colors focus:border-navy-400 focus:outline-none focus:ring-1 focus:ring-navy-400"
+          readOnly
+        />
       </div>
     )
   }

--- a/src/hooks/useGooglePlacesLoader.ts
+++ b/src/hooks/useGooglePlacesLoader.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState, useCallback, useRef } from 'react'
+
+const GOOGLE_MAPS_SCRIPT_ID = 'google-maps-places-script'
+
+interface UseGooglePlacesLoaderReturn {
+  isLoaded: boolean
+  loadError: Error | null
+  loadScript: () => void
+}
+
+/**
+ * Google Places API 스크립트를 온디맨드로 로드하는 훅
+ *
+ * - 초기 상태: isLoaded=false, loadError=null
+ * - loadScript() 호출 시 <script> 태그 동적 삽입
+ * - 이미 로드된 경우 중복 삽입 방지 (멱등성)
+ * - 로드 실패 시 loadError 상태 설정
+ */
+export function useGooglePlacesLoader(): UseGooglePlacesLoaderReturn {
+  const [isLoaded, setIsLoaded] = useState<boolean>(
+    () => typeof google !== 'undefined' && !!google.maps?.places
+  )
+  const [loadError, setLoadError] = useState<Error | null>(null)
+  const isLoadingRef = useRef(false)
+
+  const loadScript = useCallback(() => {
+    // 이미 로드 완료
+    if (typeof google !== 'undefined' && google.maps?.places) {
+      setIsLoaded(true)
+      return
+    }
+
+    // 이미 로딩 중이거나 스크립트 태그가 존재
+    if (
+      isLoadingRef.current ||
+      document.getElementById(GOOGLE_MAPS_SCRIPT_ID)
+    ) {
+      return
+    }
+
+    const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+    if (!apiKey) {
+      setLoadError(new Error('Google Maps API 키가 설정되지 않았습니다'))
+      return
+    }
+
+    isLoadingRef.current = true
+
+    const script = document.createElement('script')
+    script.id = GOOGLE_MAPS_SCRIPT_ID
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&language=ja&region=JP`
+    script.async = true
+    script.defer = true
+
+    script.onload = () => {
+      isLoadingRef.current = false
+      setIsLoaded(true)
+      setLoadError(null)
+    }
+
+    script.onerror = () => {
+      isLoadingRef.current = false
+      setLoadError(new Error('Google Maps 스크립트 로드에 실패했습니다'))
+      // 실패한 스크립트 태그 제거하여 재시도 가능하게
+      script.remove()
+    }
+
+    document.head.appendChild(script)
+  }, [])
+
+  return { isLoaded, loadError, loadScript }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #309

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> Google Places API 스크립트를 즉시 로드에서 온디맨드 로드로 전환하여 초기 페이지 로딩 성능 개선

---

## 📋 변경 사항

- [x] `src/hooks/useGooglePlacesLoader.ts` 생성 — 온디맨드 스크립트 로더 훅
- [x] `GooglePlacesSearch`에서 `useLoadScript`(`@react-google-maps/api`)를 `useGooglePlacesLoader`로 교체
- [x] 스크립트 미로드 상태에서 포커스 시 `loadScript()` 호출
- [x] 멱등성 보장 (중복 삽입 방지, 이미 로드된 경우 즉시 반환)
- [x] 로드 실패 시 에러 UI 표시 (기존 동작 유지)

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- **Requirements**: 7.1
- **Task 번호**: Task 11.1, 11.2
- 기존 `@react-google-maps/api`의 `useLoadScript`는 컴포넌트 마운트 즉시 스크립트를 로드했으나, 새 훅은 사용자가 검색 입력창에 포커스할 때만 로드하여 TTI 개선
