### PR TITLE
[Refactor] Task 12.1~12.3 - React Query 훅 생성

### DIFF
--- a/src/hooks/useAdminQueries.ts
+++ b/src/hooks/useAdminQueries.ts
@@ -1,0 +1,213 @@
+import { useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import type {
+  SpotReport,
+  SpotStatusReport,
+  SpotSupplement,
+} from '@/types/report'
+
+// ── Response Types ──────────────────────────────────────────
+
+interface AdminReportsResponse {
+  reports: SpotReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+interface AdminStatusReportsResponse {
+  reports: SpotStatusReport[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+interface AdminSupplementsResponse {
+  supplements: SpotSupplement[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+interface ContentMaster {
+  id: string
+  normalizedName: string
+  displayName: string
+  imageUrl?: string
+  type?: string
+  year?: number
+  spotCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+interface ContentMastersResponse {
+  items: ContentMaster[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+// ── Query Key Factory ───────────────────────────────────────
+
+export const adminKeys = {
+  all: ['admin'] as const,
+  reports: () => [...adminKeys.all, 'reports'] as const,
+  reportList: (statusFilter: string, page: number) =>
+    [...adminKeys.reports(), { statusFilter, page }] as const,
+  statusReports: () => [...adminKeys.all, 'statusReports'] as const,
+  statusReportList: (
+    reviewStatusFilter: string,
+    statusFilter: string,
+    page: number
+  ) =>
+    [
+      ...adminKeys.statusReports(),
+      { reviewStatusFilter, statusFilter, page },
+    ] as const,
+  supplements: () => [...adminKeys.all, 'supplements'] as const,
+  supplementList: (statusFilter: string, page: number) =>
+    [...adminKeys.supplements(), { statusFilter, page }] as const,
+  contentImages: () => [...adminKeys.all, 'contentImages'] as const,
+  contentImageList: (search: string, page: number) =>
+    [...adminKeys.contentImages(), { search, page }] as const,
+}
+
+// ── Hooks ───────────────────────────────────────────────────
+
+/**
+ * 관리자 제보 목록 조회 훅
+ * Requirements: 8.3
+ */
+export function useAdminReports(statusFilter: string, page: number) {
+  return useQuery({
+    queryKey: adminKeys.reportList(statusFilter, page),
+    queryFn: async (): Promise<AdminReportsResponse> => {
+      const url = buildUrl(API_ROUTES.ADMIN.REPORTS, {
+        status: statusFilter,
+        page,
+        limit: 20,
+      })
+      const res = await fetch(url)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '제보 목록 조회 실패')
+      }
+      return res.json()
+    },
+  })
+}
+
+/**
+ * 관리자 상태 신고 목록 조회 훅
+ * Requirements: 8.3
+ */
+export function useAdminStatusReports(
+  reviewStatusFilter: string,
+  statusFilter: string,
+  page: number
+) {
+  return useQuery({
+    queryKey: adminKeys.statusReportList(
+      reviewStatusFilter,
+      statusFilter,
+      page
+    ),
+    queryFn: async (): Promise<AdminStatusReportsResponse> => {
+      const url = buildUrl(API_ROUTES.ADMIN.STATUS_REPORTS, {
+        reviewStatus: reviewStatusFilter,
+        status: statusFilter,
+        page,
+        limit: 20,
+      })
+      const res = await fetch(url)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '상태 신고 목록 조회 실패')
+      }
+      return res.json()
+    },
+  })
+}
+
+/**
+ * 관리자 정보 보완 목록 조회 훅
+ * Requirements: 8.3
+ */
+export function useAdminSupplements(statusFilter: string, page: number) {
+  return useQuery({
+    queryKey: adminKeys.supplementList(statusFilter, page),
+    queryFn: async (): Promise<AdminSupplementsResponse> => {
+      const url = buildUrl(API_ROUTES.ADMIN.SUPPLEMENTS, {
+        status: statusFilter,
+        page,
+        limit: 20,
+      })
+      const res = await fetch(url)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '정보 보완 목록 조회 실패')
+      }
+      return res.json()
+    },
+  })
+}
+
+/**
+ * 관리자 콘텐츠 이미지 목록 조회 훅
+ * Requirements: 8.3
+ */
+export function useAdminContentImages(search: string, page: number) {
+  return useQuery({
+    queryKey: adminKeys.contentImageList(search, page),
+    queryFn: async (): Promise<ContentMastersResponse> => {
+      const url = buildUrl(API_ROUTES.ADMIN.CONTENT_IMAGES, {
+        search: search || undefined,
+        page,
+        limit: 20,
+      })
+      const res = await fetch(url)
+      if (!res.ok) throw new Error('콘텐츠 이미지 목록 조회 실패')
+      return res.json()
+    },
+  })
+}
+
+// ── Invalidation Hooks ──────────────────────────────────────
+
+/** 제보 목록 캐시 무효화 */
+export function useInvalidateAdminReports() {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: adminKeys.reports() })
+  }, [qc])
+}
+
+/** 상태 신고 목록 캐시 무효화 */
+export function useInvalidateAdminStatusReports() {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: adminKeys.statusReports() })
+  }, [qc])
+}
+
+/** 정보 보완 목록 캐시 무효화 */
+export function useInvalidateAdminSupplements() {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: adminKeys.supplements() })
+  }, [qc])
+}
+
+/** 콘텐츠 이미지 목록 캐시 무효화 */
+export function useInvalidateAdminContentImages() {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: adminKeys.contentImages() })
+  }, [qc])
+}

--- a/src/hooks/useGalleryQueries.ts
+++ b/src/hooks/useGalleryQueries.ts
@@ -1,0 +1,162 @@
+import { useCallback } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import type { CheckIn } from '@/types'
+
+// ── Response Types ──────────────────────────────────────────
+
+interface CheckInsResponse {
+  checkins: CheckIn[]
+  total: number
+  page: number
+  limit: number
+}
+
+interface SpotRankingItem {
+  spotId: string
+  spotName: string
+  thumbnailUrl: string
+  checkInCount: number
+}
+
+interface CheckInRankingItem {
+  checkInId: string
+  photoUrl: string
+  userName: string
+  likeCount: number
+  spotName: string
+}
+
+interface RankingResponse {
+  spotRanking: SpotRankingItem[]
+  checkInRanking: CheckInRankingItem[]
+  period: { start: string; end: string }
+}
+
+interface ContentNameItem {
+  name: string
+  count: number
+}
+
+interface ContentNamesResponse {
+  items: ContentNameItem[]
+}
+
+// ── Query Key Factory ───────────────────────────────────────
+
+export const galleryKeys = {
+  all: ['gallery'] as const,
+  checkins: () => [...galleryKeys.all, 'checkins'] as const,
+  checkinList: (params: Record<string, unknown>) =>
+    [...galleryKeys.checkins(), params] as const,
+  ranking: () => [...galleryKeys.all, 'ranking'] as const,
+  contentList: () => [...galleryKeys.all, 'contentList'] as const,
+  checkinCount: (spotId: string) =>
+    [...galleryKeys.all, 'checkinCount', spotId] as const,
+}
+
+// ── Hooks ───────────────────────────────────────────────────
+
+/**
+ * 인증샷 갤러리 조회 훅
+ * Requirements: 8.3
+ */
+export function useCheckInGallery(
+  spotId?: string,
+  userId?: string,
+  sortBy: 'latest' | 'popular' = 'latest',
+  page: number = 1,
+  limit: number = 12
+) {
+  return useQuery({
+    queryKey: galleryKeys.checkinList({ spotId, userId, sortBy, page, limit }),
+    queryFn: async (): Promise<CheckInsResponse> => {
+      const url = buildUrl(API_ROUTES.CHECKINS.BASE, {
+        spotId,
+        userId,
+        sortBy,
+        page,
+        limit,
+      })
+      const res = await fetch(url)
+      if (!res.ok) throw new Error('인증샷 조회 실패')
+      return res.json()
+    },
+  })
+}
+
+/**
+ * 명예의 전당 랭킹 조회 훅
+ * Requirements: 8.3
+ */
+export function useHallOfFameRanking() {
+  return useQuery({
+    queryKey: galleryKeys.ranking(),
+    queryFn: async (): Promise<RankingResponse> => {
+      const res = await fetch(API_ROUTES.CHECKINS.RANKING)
+      if (!res.ok) throw new Error('랭킹 데이터 조회 실패')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * 작품 목록 조회 훅 (ContentTab용)
+ * Requirements: 8.3
+ */
+export function useContentList() {
+  return useQuery({
+    queryKey: galleryKeys.contentList(),
+    queryFn: async (): Promise<ContentNamesResponse> => {
+      const res = await fetch(
+        buildUrl(API_ROUTES.CONTENT_NAMES, { type: 'content' })
+      )
+      if (!res.ok) throw new Error('작품 목록 조회 실패')
+      return res.json()
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * 스팟별 인증 수 조회 훅 (SpotCheckInSection용)
+ * Requirements: 8.3
+ */
+export function useCheckInCount(spotId: string) {
+  return useQuery({
+    queryKey: galleryKeys.checkinCount(spotId),
+    queryFn: async (): Promise<number> => {
+      const url = buildUrl(API_ROUTES.CHECKINS.BASE, {
+        spotId,
+        limit: 1,
+      })
+      const res = await fetch(url)
+      if (!res.ok) throw new Error('인증 수 조회 실패')
+      const data = await res.json()
+      return data.total
+    },
+    enabled: !!spotId,
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+  })
+}
+
+// ── Invalidation Hooks ──────────────────────────────────────
+
+/** 인증샷 갤러리 캐시 무효화 */
+export function useInvalidateCheckIns() {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: galleryKeys.checkins() })
+    qc.invalidateQueries({ queryKey: galleryKeys.ranking() })
+  }, [qc])
+}
+
+/** 특정 스팟 인증 수 캐시 무효화 */
+export function useInvalidateCheckInCount(spotId: string) {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: galleryKeys.checkinCount(spotId) })
+  }, [qc, spotId])
+}

--- a/src/hooks/useRouteQueries.ts
+++ b/src/hooks/useRouteQueries.ts
@@ -1,0 +1,92 @@
+import { useQuery } from '@tanstack/react-query'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import type { Route } from '@/types/route'
+
+// ── Response Types ──────────────────────────────────────────
+
+interface RoutesResponse {
+  routes: Route[]
+  total: number
+  page: number
+  totalPages: number
+}
+
+interface RecommendedRoutesResponse {
+  official: Route[]
+  popular: Route[]
+}
+
+// ── Query Key Factory ───────────────────────────────────────
+
+export const routeKeys = {
+  all: ['routes'] as const,
+  lists: () => [...routeKeys.all, 'list'] as const,
+  list: (filters: Record<string, unknown>) =>
+    [...routeKeys.lists(), filters] as const,
+  related: (contentName: string) =>
+    [...routeKeys.all, 'related', contentName] as const,
+}
+
+// ── Hooks ───────────────────────────────────────────────────
+
+/**
+ * 코스 목록 조회 훅 (RouteListContent용)
+ * Requirements: 8.3
+ */
+export function useRouteList(
+  filters: {
+    sort: string
+    contentName?: string
+    regionTag?: string
+    minDuration?: number
+    maxDuration?: number
+  },
+  page: number
+) {
+  return useQuery({
+    queryKey: routeKeys.list({ ...filters, page }),
+    queryFn: async (): Promise<RoutesResponse> => {
+      const url = buildUrl(API_ROUTES.ROUTES.BASE, {
+        sort: filters.sort,
+        contentName: filters.contentName || undefined,
+        regionTag: filters.regionTag || undefined,
+        minDuration: filters.minDuration,
+        maxDuration: filters.maxDuration,
+        page,
+        limit: 12,
+      })
+      const res = await fetch(url)
+      if (!res.ok) throw new Error('코스 목록 조회 실패')
+      return res.json()
+    },
+  })
+}
+
+/**
+ * 관련 코스 조회 훅 (RelatedRoutes용)
+ * Requirements: 8.3
+ */
+export function useRelatedRoutes(contentNames: string[]) {
+  const contentName = contentNames[0] || ''
+  return useQuery({
+    queryKey: routeKeys.related(contentName),
+    queryFn: async (): Promise<Route[]> => {
+      const url = buildUrl(API_ROUTES.ROUTES.RECOMMENDED, {
+        contentName,
+        limit: 4,
+      })
+      const res = await fetch(url)
+      if (!res.ok) throw new Error('관련 코스 조회 실패')
+      const data: RecommendedRoutesResponse = await res.json()
+
+      // 공식 + 인기 합쳐서 중복 제거
+      const allRoutes = [...data.official, ...data.popular]
+      return allRoutes.filter(
+        (r, i, arr) => arr.findIndex((x) => x.id === r.id) === i
+      )
+    },
+    enabled: contentNames.length > 0,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+  })
+}

--- a/src/hooks/useUserQueries.ts
+++ b/src/hooks/useUserQueries.ts
@@ -1,0 +1,108 @@
+import { useQuery } from '@tanstack/react-query'
+import { API_ROUTES, buildUrl } from '@/lib/api-routes'
+import type { UserStats, UserBadge, ContentProgress } from '@/types'
+
+// ── Response Types ──────────────────────────────────────────
+
+interface BadgesResponse {
+  badges: UserBadge[]
+}
+
+interface ProgressResponse {
+  progress: ContentProgress[]
+}
+
+interface ReportedSpot {
+  id: string
+  name: string
+  address: string
+}
+
+// ── Query Key Factory ───────────────────────────────────────
+
+export const userKeys = {
+  all: ['users'] as const,
+  stats: (userId: string) => [...userKeys.all, 'stats', userId] as const,
+  badges: (userId: string) => [...userKeys.all, 'badges', userId] as const,
+  progress: (userId: string) => [...userKeys.all, 'progress', userId] as const,
+  reportedSpots: (userId: string) =>
+    [...userKeys.all, 'reportedSpots', userId] as const,
+}
+
+// ── Hooks ───────────────────────────────────────────────────
+
+/**
+ * 유저 통계 조회 훅
+ * Requirements: 8.3
+ */
+export function useUserStats(userId: string) {
+  return useQuery({
+    queryKey: userKeys.stats(userId),
+    queryFn: async (): Promise<UserStats> => {
+      const res = await fetch(API_ROUTES.USERS.STATS(userId))
+      if (!res.ok) throw new Error('유저 통계 조회 실패')
+      return res.json()
+    },
+    enabled: !!userId,
+  })
+}
+
+/**
+ * 유저 뱃지 조회 훅
+ * Requirements: 8.3
+ */
+export function useUserBadges(userId: string) {
+  return useQuery({
+    queryKey: userKeys.badges(userId),
+    queryFn: async (): Promise<UserBadge[]> => {
+      const res = await fetch(API_ROUTES.USERS.BADGES(userId))
+      if (!res.ok) throw new Error('유저 뱃지 조회 실패')
+      const data: BadgesResponse = await res.json()
+      return data.badges
+    },
+    enabled: !!userId,
+  })
+}
+
+/**
+ * 유저 콘텐츠 진행률 조회 훅
+ * Requirements: 8.3
+ */
+export function useUserProgress(userId: string) {
+  return useQuery({
+    queryKey: userKeys.progress(userId),
+    queryFn: async (): Promise<ContentProgress[]> => {
+      const res = await fetch(API_ROUTES.USERS.PROGRESS(userId))
+      if (!res.ok) throw new Error('유저 진행률 조회 실패')
+      const data: ProgressResponse = await res.json()
+      return data.progress
+    },
+    enabled: !!userId,
+  })
+}
+
+/**
+ * 유저가 제보한 스팟 목록 조회 훅
+ * Requirements: 8.3
+ */
+export function useUserReportedSpots(userId: string) {
+  return useQuery({
+    queryKey: userKeys.reportedSpots(userId),
+    queryFn: async (): Promise<ReportedSpot[]> => {
+      const url = buildUrl(API_ROUTES.SPOTS.BASE, {
+        firstReporterId: userId,
+      })
+      const res = await fetch(url)
+      if (!res.ok) throw new Error('제보 스팟 조회 실패')
+      const data = await res.json()
+      return (data.spots || []).map(
+        (s: { id: string; name: string; address?: string }) => ({
+          id: s.id,
+          name: s.name,
+          address: s.address || '',
+        })
+      )
+    },
+    enabled: !!userId,
+  })
+}

--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -60,8 +60,48 @@ export const API_ROUTES = {
     BASE: (spotId: string) => `/api/spots/${spotId}/status-reports`,
   },
 
+  // Check-ins (순례 인증)
+  CHECKINS: {
+    BASE: '/api/checkins',
+    DETAIL: (id: string) => `/api/checkins/${id}`,
+    RANKING: '/api/checkins/ranking',
+    STATS: '/api/checkins/stats',
+  },
+
+  // Routes (순례 코스)
+  ROUTES: {
+    BASE: '/api/routes',
+    DETAIL: (id: string) => `/api/routes/${id}`,
+    RECOMMENDED: '/api/routes/recommended',
+    BOOKMARK: (id: string) => `/api/routes/${id}/bookmark`,
+    COMPLETE: (id: string) => `/api/routes/${id}/complete`,
+  },
+
+  // Users (유저)
+  USERS: {
+    STATS: (id: string) => `/api/users/${id}/stats`,
+    BADGES: (id: string) => `/api/users/${id}/badges`,
+    PROGRESS: (id: string) => `/api/users/${id}/progress`,
+  },
+
+  // Admin
+  ADMIN: {
+    REPORTS: '/api/admin/reports',
+    REPORT_DETAIL: (id: string) => `/api/admin/reports/${id}`,
+    STATUS_REPORTS: '/api/admin/status-reports',
+    STATUS_REPORT_DETAIL: (id: string) => `/api/admin/status-reports/${id}`,
+    SUPPLEMENTS: '/api/admin/supplements',
+    SUPPLEMENT_DETAIL: (id: string) => `/api/admin/supplements/${id}`,
+    CONTENT_IMAGES: '/api/admin/content-images',
+    CONTENT_IMAGES_SYNC: '/api/admin/content-images/sync',
+    DASHBOARD_SUMMARY: '/api/admin/dashboard/summary',
+  },
+
   // Content Names (자동완성)
   CONTENT_NAMES: '/api/content-names',
+
+  // Content Images (콘텐츠 이미지)
+  CONTENT_IMAGES: '/api/content-images',
 
   // Upload
   UPLOAD: '/api/upload',


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #311

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 전체 코드베이스의 useState+fetch 패턴을 React Query로 전환하기 위한 훅 생성 (Task 12.1~12.3)

---

## 📋 변경 사항

- [x] `api-routes.ts`에 admin/checkins/routes/users 엔드포인트 추가 (Task 12.1)
- [x] `useAdminQueries.ts` 생성 — admin 제보/상태신고/보완/콘텐츠이미지 조회 + invalidation 훅 (Task 12.2)
- [x] `useGalleryQueries.ts` 생성 — 인증샷 갤러리/랭킹/작품목록/인증수 조회 훅 (Task 12.3)
- [x] `useRouteQueries.ts` 생성 — 코스 목록/관련 코스 조회 훅 (Task 12.3)
- [x] `useUserQueries.ts` 생성 — 유저 통계/뱃지/진행률/제보스팟 조회 훅 (Task 12.3)

Requirements: 8.3

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- 이 PR은 훅 생성만 포함하며, 실제 컴포넌트 전환은 Task 12.4~12.17에서 진행
- 기존 코드에 영향 없음 (새 파일 추가만)
- 기존 패턴(spotKeys, reportKeys 등)과 동일한 query key factory 패턴 사용
