### PR TITLE
[Enhancement] react-query 적용 및 코드 리팩토링

### DIFF
--- a/src/app/admin/content-images/page.tsx
+++ b/src/app/admin/content-images/page.tsx
@@ -1,48 +1,34 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useRef } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 import Image from 'next/image'
 import { ContentTypeIcon } from '@/components/common'
 import { ContentType, CONTENT_TYPE_CONFIG } from '@/types'
-
-interface ContentMaster {
-  id: string
-  normalizedName: string
-  displayName: string
-  imageUrl?: string
-  type?: ContentType
-  year?: number
-  spotCount: number
-  createdAt: string
-  updatedAt: string
-}
-
-interface ContentMastersResponse {
-  items: ContentMaster[]
-  total: number
-  page: number
-  limit: number
-  totalPages: number
-}
+import {
+  useAdminContentImages,
+  useInvalidateAdminContentImages,
+} from '@/hooks/useAdminQueries'
 
 export default function AdminContentImagesPage() {
   const { data: session, status } = useSession()
   const router = useRouter()
+  const invalidateContentImages = useInvalidateAdminContentImages()
 
-  const [contents, setContents] = useState<ContentMaster[]>([])
-  const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [page, setPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(1)
   const [syncing, setSyncing] = useState(false)
 
   // 업로드 모달 상태
   const [showUploadModal, setShowUploadModal] = useState(false)
-  const [selectedContent, setSelectedContent] = useState<ContentMaster | null>(
-    null
-  )
+  const [selectedContent, setSelectedContent] = useState<{
+    id: string
+    normalizedName: string
+    displayName: string
+    type?: ContentType
+  } | null>(null)
   const [uploadFile, setUploadFile] = useState<File | null>(null)
   const [uploadPreview, setUploadPreview] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
@@ -54,142 +40,111 @@ export default function AdminContentImagesPage() {
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // 콘텐츠 목록 조회
-  const fetchContents = useCallback(async () => {
-    try {
-      setLoading(true)
-      const params = new URLSearchParams({
-        page: page.toString(),
-        limit: '20',
-      })
-      if (search) {
-        params.set('search', search)
-      }
+  // React Query로 콘텐츠 목록 조회
+  const { data, isLoading } = useAdminContentImages(search, page)
+  const contents = data?.items ?? []
+  const totalPages = data?.totalPages ?? 1
 
-      const res = await fetch(`/api/admin/content-images?${params}`)
-      if (!res.ok) throw new Error('Failed to fetch')
-
-      const data: ContentMastersResponse = await res.json()
-      setContents(data.items)
-      setTotalPages(data.totalPages)
-    } catch (error) {
-      console.error('Error fetching contents:', error)
-    } finally {
-      setLoading(false)
+  // 권한 체크
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
     }
-  }, [page, search])
+  }, [status, session, router])
 
-  // 콘텐츠 마스터 동기화
   const handleSync = async () => {
     if (syncing) return
-
     try {
       setSyncing(true)
       const res = await fetch('/api/admin/content-images/sync', {
         method: 'POST',
       })
-
       if (!res.ok) throw new Error('Sync failed')
-
       const data = await res.json()
       alert(data.message)
-      fetchContents()
-    } catch (error) {
-      console.error('Error syncing:', error)
+      invalidateContentImages()
+    } catch {
       alert('동기화에 실패했습니다')
     } finally {
       setSyncing(false)
     }
   }
 
-  // 이미지 업로드
   const handleUpload = async () => {
     if (uploading) return
-
     const contentName = selectedContent?.displayName || newContentName.trim()
     if (!contentName) {
       alert('콘텐츠 이름을 입력해주세요')
       return
     }
-
     if (!uploadFile && !selectedContent) {
       alert('이미지를 선택해주세요')
       return
     }
-
     try {
       setUploading(true)
       const formData = new FormData()
       formData.append('contentName', contentName)
-
-      if (uploadFile) {
-        formData.append('file', uploadFile)
-      }
-
+      if (uploadFile) formData.append('file', uploadFile)
       if (!selectedContent) {
         formData.append('contentType', newContentType)
-        if (newContentYear) {
-          formData.append('year', newContentYear)
-        }
+        if (newContentYear) formData.append('year', newContentYear)
       }
-
       const res = await fetch('/api/admin/content-images', {
         method: 'POST',
         body: formData,
       })
-
       if (!res.ok) {
         const error = await res.json()
         throw new Error(error.error || 'Upload failed')
       }
-
       alert('업로드 완료!')
       closeUploadModal()
-      fetchContents()
+      invalidateContentImages()
     } catch (error) {
-      console.error('Error uploading:', error)
       alert(error instanceof Error ? error.message : '업로드에 실패했습니다')
     } finally {
       setUploading(false)
     }
   }
 
-  // 이미지 삭제
   const handleDeleteImage = async (normalizedName: string) => {
     if (!confirm('이미지를 삭제하시겠습니까?')) return
-
     try {
       const res = await fetch(
         `/api/admin/content-images?normalizedName=${encodeURIComponent(normalizedName)}`,
         { method: 'DELETE' }
       )
-
       if (!res.ok) throw new Error('Delete failed')
-
       alert('이미지가 삭제되었습니다')
-      fetchContents()
-    } catch (error) {
-      console.error('Error deleting:', error)
+      invalidateContentImages()
+    } catch {
       alert('삭제에 실패했습니다')
     }
   }
 
-  // 파일 선택 핸들러
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
       setUploadFile(file)
       const reader = new FileReader()
-      reader.onloadend = () => {
-        setUploadPreview(reader.result as string)
-      }
+      reader.onloadend = () => setUploadPreview(reader.result as string)
       reader.readAsDataURL(file)
     }
   }
 
-  // 업로드 모달 열기
-  const openUploadModal = (content?: ContentMaster) => {
-    setSelectedContent(content || null)
+  const openUploadModal = (content?: {
+    id: string
+    normalizedName: string
+    displayName: string
+    type?: string
+  }) => {
+    setSelectedContent(
+      content
+        ? { ...content, type: content.type as ContentType | undefined }
+        : null
+    )
     setUploadFile(null)
     setUploadPreview(null)
     setNewContentName('')
@@ -198,7 +153,6 @@ export default function AdminContentImagesPage() {
     setShowUploadModal(true)
   }
 
-  // 업로드 모달 닫기
   const closeUploadModal = () => {
     setShowUploadModal(false)
     setSelectedContent(null)
@@ -209,33 +163,7 @@ export default function AdminContentImagesPage() {
     setNewContentYear('')
   }
 
-  // 권한 체크 및 데이터 로드
-  useEffect(() => {
-    if (status === 'loading') return
-
-    if (!session?.user || session.user.role !== 'admin') {
-      router.push('/')
-      return
-    }
-
-    fetchContents()
-  }, [status, session, router, fetchContents])
-
-  // 검색 디바운스
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setPage(1)
-      fetchContents()
-    }, 300)
-
-    return () => clearTimeout(timer)
-  }, [search, fetchContents])
-
-  // 로딩 중
-  if (
-    status === 'loading' ||
-    (status === 'authenticated' && loading && contents.length === 0)
-  ) {
+  if (status === 'loading') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50">
         <div className="text-gray-500">로딩 중...</div>
@@ -243,7 +171,6 @@ export default function AdminContentImagesPage() {
     )
   }
 
-  // 권한 없음
   if (!session?.user || session.user.role !== 'admin') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50">
@@ -260,7 +187,6 @@ export default function AdminContentImagesPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="mx-auto max-w-6xl px-4 py-8">
-        {/* 헤더 */}
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold text-gray-800">
@@ -287,19 +213,20 @@ export default function AdminContentImagesPage() {
           </div>
         </div>
 
-        {/* 검색 */}
         <div className="mb-6">
           <input
             type="text"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setPage(1)
+            }}
             placeholder="콘텐츠 이름으로 검색..."
             className="w-full max-w-md rounded-lg border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
-        {/* 콘텐츠 목록 */}
-        {loading ? (
+        {isLoading ? (
           <div className="py-12 text-center text-gray-500">로딩 중...</div>
         ) : contents.length === 0 ? (
           <div className="py-12 text-center">
@@ -323,7 +250,6 @@ export default function AdminContentImagesPage() {
                 className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
               >
                 <div className="flex items-start gap-3">
-                  {/* 이미지 또는 아이콘 */}
                   <div className="flex-shrink-0">
                     {content.imageUrl ? (
                       <div className="relative h-16 w-16 overflow-hidden rounded-full border-2 border-gray-200">
@@ -331,27 +257,31 @@ export default function AdminContentImagesPage() {
                           src={content.imageUrl}
                           alt={content.displayName}
                           fill
+                          sizes="64px"
                           className="object-cover"
                         />
                       </div>
                     ) : (
                       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
                         <ContentTypeIcon
-                          type={content.type || 'other'}
+                          type={(content.type || 'other') as ContentType}
                           size="lg"
                         />
                       </div>
                     )}
                   </div>
-
-                  {/* 정보 */}
                   <div className="min-w-0 flex-1">
                     <h3 className="truncate font-medium text-gray-800">
                       {content.displayName}
                     </h3>
                     <div className="mt-1 flex items-center gap-2 text-sm text-gray-500">
                       {content.type && (
-                        <span>{CONTENT_TYPE_CONFIG[content.type]?.label}</span>
+                        <span>
+                          {
+                            CONTENT_TYPE_CONFIG[content.type as ContentType]
+                              ?.label
+                          }
+                        </span>
                       )}
                       {content.year && <span>({content.year})</span>}
                     </div>
@@ -360,8 +290,6 @@ export default function AdminContentImagesPage() {
                     </p>
                   </div>
                 </div>
-
-                {/* 액션 버튼 */}
                 <div className="mt-3 flex gap-2 border-t border-gray-100 pt-3">
                   <button
                     onClick={() => openUploadModal(content)}
@@ -383,7 +311,6 @@ export default function AdminContentImagesPage() {
           </div>
         )}
 
-        {/* 페이지네이션 */}
         {totalPages > 1 && (
           <div className="mt-8 flex justify-center gap-2">
             <button
@@ -407,15 +334,12 @@ export default function AdminContentImagesPage() {
         )}
       </div>
 
-      {/* 업로드 모달 */}
       {showUploadModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
             <h2 className="mb-4 text-xl font-bold text-gray-800">
               {selectedContent ? '이미지 업로드' : '새 콘텐츠 추가'}
             </h2>
-
-            {/* 기존 콘텐츠 선택 시 */}
             {selectedContent ? (
               <div className="mb-4 rounded-lg bg-gray-50 p-3">
                 <p className="font-medium">{selectedContent.displayName}</p>
@@ -426,7 +350,6 @@ export default function AdminContentImagesPage() {
                 )}
               </div>
             ) : (
-              /* 새 콘텐츠 입력 */
               <div className="mb-4 space-y-4">
                 <div>
                   <label className="mb-1 block text-sm font-medium text-gray-700">
@@ -474,8 +397,6 @@ export default function AdminContentImagesPage() {
                 </div>
               </div>
             )}
-
-            {/* 이미지 업로드 */}
             <div className="mb-6">
               <label className="mb-2 block text-sm font-medium text-gray-700">
                 대표 이미지 {!selectedContent && '(선택)'}
@@ -497,6 +418,7 @@ export default function AdminContentImagesPage() {
                       src={uploadPreview}
                       alt="Preview"
                       fill
+                      sizes="96px"
                       className="object-cover"
                     />
                   </div>
@@ -510,8 +432,6 @@ export default function AdminContentImagesPage() {
                 )}
               </div>
             </div>
-
-            {/* 버튼 */}
             <div className="flex gap-3">
               <button
                 onClick={closeUploadModal}

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -6,21 +6,19 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { AdminReportList } from '@/components/admin/AdminReportList'
 import { AdminReportReview } from '@/components/admin/AdminReportReview'
+import { useInvalidateAdminReports } from '@/hooks/useAdminQueries'
 import type { SpotReport } from '@/types/report'
 
 /**
  * 관리자 제보 관리 페이지
- * Requirements: 5.1, 5.2
- * - AdminReportList + AdminReportReview 통합
- * - 관리자 권한 검사 (미인증/비관리자 접근 차단)
+ * Requirements: 5.1, 5.2, 8.3
  */
 export default function AdminReportsPage() {
   const { data: session, status } = useSession()
   const router = useRouter()
   const [selectedReport, setSelectedReport] = useState<SpotReport | null>(null)
-  const [refreshKey, setRefreshKey] = useState(0)
+  const invalidateReports = useInvalidateAdminReports()
 
-  // 권한 체크
   useEffect(() => {
     if (status === 'loading') return
     if (!session?.user || session.user.role !== 'admin') {
@@ -34,10 +32,9 @@ export default function AdminReportsPage() {
 
   const handleReviewComplete = useCallback(() => {
     setSelectedReport(null)
-    setRefreshKey((k) => k + 1)
-  }, [])
+    invalidateReports()
+  }, [invalidateReports])
 
-  // 로딩
   if (status === 'loading') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50">
@@ -46,7 +43,6 @@ export default function AdminReportsPage() {
     )
   }
 
-  // 권한 없음
   if (!session?.user || session.user.role !== 'admin') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50">
@@ -62,7 +58,6 @@ export default function AdminReportsPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* 헤더 */}
       <div className="border-b border-gray-200 bg-white px-6 py-4">
         <h1 className="text-xl font-bold text-gray-800">제보 관리</h1>
         <p className="mt-0.5 text-sm text-gray-500">
@@ -70,18 +65,14 @@ export default function AdminReportsPage() {
         </p>
       </div>
 
-      {/* 메인 레이아웃: 좌측 목록 + 우측 상세 */}
       <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
-        {/* 좌측: 제보 목록 */}
         <div className="w-96 flex-shrink-0 border-r border-gray-200 bg-white">
           <AdminReportList
             onSelectReport={handleSelectReport}
             selectedReportId={selectedReport?.id}
-            refreshKey={refreshKey}
           />
         </div>
 
-        {/* 우측: 제보 상세/검토 */}
         <div className="flex-1 bg-gray-50">
           {selectedReport ? (
             <AdminReportReview

--- a/src/app/admin/status-reports/page.tsx
+++ b/src/app/admin/status-reports/page.tsx
@@ -6,13 +6,12 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { AdminStatusReportList } from '@/components/admin/AdminStatusReportList'
 import { AdminStatusReportReview } from '@/components/admin/AdminStatusReportReview'
+import { useInvalidateAdminStatusReports } from '@/hooks/useAdminQueries'
 import type { SpotStatusReport } from '@/types/report'
 
 /**
  * 관리자 상태 신고 검토 페이지
- * Requirements: 5.1, 5.2
- * - Split-pane 레이아웃 (좌측 목록 + 우측 상세)
- * - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+ * Requirements: 5.1, 5.2, 8.3
  */
 export default function AdminStatusReportsPage() {
   const { data: session, status } = useSession()
@@ -20,7 +19,7 @@ export default function AdminStatusReportsPage() {
   const [selectedReport, setSelectedReport] = useState<SpotStatusReport | null>(
     null
   )
-  const [refreshKey, setRefreshKey] = useState(0)
+  const invalidateStatusReports = useInvalidateAdminStatusReports()
 
   useEffect(() => {
     if (status === 'loading') return
@@ -35,8 +34,8 @@ export default function AdminStatusReportsPage() {
 
   const handleReviewComplete = useCallback(() => {
     setSelectedReport(null)
-    setRefreshKey((k) => k + 1)
-  }, [])
+    invalidateStatusReports()
+  }, [invalidateStatusReports])
 
   if (status === 'loading') {
     return (
@@ -61,7 +60,6 @@ export default function AdminStatusReportsPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* 헤더 */}
       <div className="border-b border-gray-200 bg-white px-6 py-4">
         <h1 className="text-xl font-bold text-gray-800">상태 신고 검토</h1>
         <p className="mt-0.5 text-sm text-gray-500">
@@ -69,18 +67,14 @@ export default function AdminStatusReportsPage() {
         </p>
       </div>
 
-      {/* 메인 레이아웃: 좌측 목록 + 우측 상세 */}
       <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
-        {/* 좌측: 상태 신고 목록 */}
         <div className="w-96 flex-shrink-0 border-r border-gray-200 bg-white">
           <AdminStatusReportList
             onSelectReport={handleSelectReport}
             selectedReportId={selectedReport?.id}
-            refreshKey={refreshKey}
           />
         </div>
 
-        {/* 우측: 상태 신고 상세/검토 */}
         <div className="flex-1 bg-gray-50">
           {selectedReport ? (
             <AdminStatusReportReview

--- a/src/app/admin/supplements/page.tsx
+++ b/src/app/admin/supplements/page.tsx
@@ -6,20 +6,19 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { AdminSupplementList } from '@/components/admin/AdminSupplementList'
 import { AdminSupplementReview } from '@/components/admin/AdminSupplementReview'
+import { useInvalidateAdminSupplements } from '@/hooks/useAdminQueries'
 import type { SpotSupplement } from '@/types/report'
 
 /**
  * 관리자 정보 보완 검토 페이지
- * Requirements: 3.1, 3.2
- * - Split-pane 레이아웃 (좌측 목록 + 우측 상세)
- * - 관리자 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
+ * Requirements: 3.1, 3.2, 8.3
  */
 export default function AdminSupplementsPage() {
   const { data: session, status } = useSession()
   const router = useRouter()
   const [selectedSupplement, setSelectedSupplement] =
     useState<SpotSupplement | null>(null)
-  const [refreshKey, setRefreshKey] = useState(0)
+  const invalidateSupplements = useInvalidateAdminSupplements()
 
   useEffect(() => {
     if (status === 'loading') return
@@ -34,8 +33,8 @@ export default function AdminSupplementsPage() {
 
   const handleReviewComplete = useCallback(() => {
     setSelectedSupplement(null)
-    setRefreshKey((k) => k + 1)
-  }, [])
+    invalidateSupplements()
+  }, [invalidateSupplements])
 
   if (status === 'loading') {
     return (
@@ -60,7 +59,6 @@ export default function AdminSupplementsPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* 헤더 */}
       <div className="border-b border-gray-200 bg-white px-6 py-4">
         <h1 className="text-xl font-bold text-gray-800">정보 보완 검토</h1>
         <p className="mt-0.5 text-sm text-gray-500">
@@ -68,18 +66,14 @@ export default function AdminSupplementsPage() {
         </p>
       </div>
 
-      {/* 메인 레이아웃: 좌측 목록 + 우측 상세 */}
       <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
-        {/* 좌측: 정보 보완 목록 */}
         <div className="w-96 flex-shrink-0 border-r border-gray-200 bg-white">
           <AdminSupplementList
             onSelectSupplement={handleSelectSupplement}
             selectedSupplementId={selectedSupplement?.id}
-            refreshKey={refreshKey}
           />
         </div>
 
-        {/* 우측: 정보 보완 상세/검토 */}
         <div className="flex-1 bg-gray-50">
           {selectedSupplement ? (
             <AdminSupplementReview

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,23 +1,20 @@
 'use client'
 
-import { useState, useEffect, use } from 'react'
+import { useState, use } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { UserStats, UserBadge, ContentProgress } from '@/types'
 import { CheckInGallery } from '@/components/checkin'
 import { TrophyRoom } from '@/components/profile/TrophyRoom'
 import { ContentProgressCard } from '@/components/profile/ContentProgressCard'
-import { API_ROUTES } from '@/lib/api-routes'
+import {
+  useUserStats,
+  useUserBadges,
+  useUserProgress,
+  useUserReportedSpots,
+} from '@/hooks/useUserQueries'
 
 interface UserProfilePageProps {
   params: Promise<{ id: string }>
-}
-
-interface UserInfo {
-  id: string
-  name: string
-  image?: string
-  email?: string
 }
 
 /**
@@ -29,72 +26,23 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   const [activeTab, setActiveTab] = useState<
     'checkins' | 'badges' | 'progress' | 'reports'
   >('checkins')
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null)
-  const [stats, setStats] = useState<UserStats | null>(null)
-  const [badges, setBadges] = useState<UserBadge[]>([])
-  const [progress, setProgress] = useState<ContentProgress[]>([])
-  const [reportedSpots, setReportedSpots] = useState<
-    { id: string; name: string; address: string }[]
-  >([])
-  const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setIsLoading(true)
-      try {
-        // 유저 통계 조회
-        const statsRes = await fetch(`/api/users/${userId}/stats`)
-        if (statsRes.ok) {
-          const statsData = await statsRes.json()
-          setStats(statsData)
-        }
+  const { data: stats, isLoading: statsLoading } = useUserStats(userId)
+  const { data: badges = [], isLoading: badgesLoading } = useUserBadges(userId)
+  const { data: progress = [], isLoading: progressLoading } =
+    useUserProgress(userId)
+  const { data: reportedSpots = [], isLoading: spotsLoading } =
+    useUserReportedSpots(userId)
 
-        // 유저 뱃지 조회
-        const badgesRes = await fetch(`/api/users/${userId}/badges`)
-        if (badgesRes.ok) {
-          const badgesData = await badgesRes.json()
-          setBadges(badgesData.badges)
-        }
+  const isLoading =
+    statsLoading || badgesLoading || progressLoading || spotsLoading
 
-        // 콘텐츠별 진행률 조회
-        const progressRes = await fetch(`/api/users/${userId}/progress`)
-        if (progressRes.ok) {
-          const progressData = await progressRes.json()
-          setProgress(progressData.progress)
-        }
-
-        // TODO: 유저 정보 조회 API 필요
-        setUserInfo({
-          id: userId,
-          name: '순례자',
-          image: undefined,
-        })
-
-        // 제보한 스팟 목록 조회 (firstReporterId로 필터)
-        const spotsRes = await fetch(
-          `${API_ROUTES.SPOTS.BASE}?firstReporterId=${userId}`
-        )
-        if (spotsRes.ok) {
-          const spotsData = await spotsRes.json()
-          setReportedSpots(
-            (spotsData.spots || []).map(
-              (s: { id: string; name: string; address?: string }) => ({
-                id: s.id,
-                name: s.name,
-                address: s.address || '',
-              })
-            )
-          )
-        }
-      } catch (error) {
-        console.error('Error fetching profile data:', error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchData()
-  }, [userId])
+  // TODO: 유저 정보 조회 API 필요
+  const userInfo = {
+    id: userId,
+    name: '순례자',
+    image: undefined as string | undefined,
+  }
 
   if (isLoading) {
     return (
@@ -125,7 +73,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
         {/* 프로필 헤더 */}
         <div className="mb-8 rounded-xl bg-white p-6 shadow-sm">
           <div className="flex items-center gap-4">
-            {userInfo?.image ? (
+            {userInfo.image ? (
               <Image
                 src={userInfo.image}
                 alt={userInfo.name}
@@ -136,12 +84,12 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
             ) : (
               <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-500">
                 <span className="text-3xl font-bold text-white">
-                  {userInfo?.name?.[0] || '?'}
+                  {userInfo.name?.[0] || '?'}
                 </span>
               </div>
             )}
             <div>
-              <h1 className="text-2xl font-bold">{userInfo?.name}</h1>
+              <h1 className="text-2xl font-bold">{userInfo.name}</h1>
               <p className="text-gray-500">성지순례 탐험가</p>
             </div>
           </div>

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -209,6 +209,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
                       src={pair.captureImageUrl}
                       alt={`캡처 ${i + 1}`}
                       fill
+                      sizes="(max-width: 768px) 50vw, 33vw"
                       className="object-cover"
                     />
                   </div>
@@ -220,6 +221,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
                       src={pair.realPhotoUrl}
                       alt={`현장 ${i + 1}`}
                       fill
+                      sizes="(max-width: 768px) 50vw, 33vw"
                       className="object-cover"
                     />
                   </div>

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -322,9 +322,9 @@ function SpotDetailContent({ spot, facilities }: SpotDetailContentProps) {
                     src={photo}
                     alt={`${spot.name} 사진 ${index + 1}`}
                     fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
                     className="object-cover transition-transform duration-300 hover:scale-105"
                     priority={index === 0}
-                    sizes="(max-width: 1024px) 50vw, 33vw"
                     {...(index === 0 ? {} : blurPlaceholderProps)}
                   />
                 </div>

--- a/src/components/admin/AdminReportList.tsx
+++ b/src/components/admin/AdminReportList.tsx
@@ -1,18 +1,9 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import Image from 'next/image'
-import { ReportStatusBadge } from '@/components/report/ReportStatusBadge'
-import { CATEGORY_CONFIG } from '@/types/spot'
+import { useState } from 'react'
+import { useAdminReports } from '@/hooks/useAdminQueries'
+import { ReportSummaryCard } from './ReportSummaryCard'
 import type { SpotReport } from '@/types/report'
-
-interface AdminReportsResponse {
-  reports: SpotReport[]
-  total: number
-  page: number
-  limit: number
-  totalPages: number
-}
 
 const STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'pending', label: '대기중' },
@@ -25,61 +16,25 @@ const STATUS_FILTERS: { value: string; label: string }[] = [
 interface AdminReportListProps {
   onSelectReport: (report: SpotReport) => void
   selectedReportId?: string
-  /** 외부에서 목록 새로고침을 트리거하기 위한 카운터 */
-  refreshKey?: number
 }
 
 /**
  * 관리자 제보 목록 컴포넌트
- * Requirements: 5.1
- * - 대기중 제보 목록 (상태 필터, 최신순 정렬)
- * - 제보 요약 카드 (장소명, 카테고리, 제보자, 제출일)
+ * Requirements: 5.1, 8.3
  */
 export function AdminReportList({
   onSelectReport,
   selectedReportId,
-  refreshKey = 0,
 }: AdminReportListProps) {
-  const [reports, setReports] = useState<SpotReport[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [statusFilter, setStatusFilter] = useState('pending')
   const [page, setPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(1)
-  const [total, setTotal] = useState(0)
 
-  const fetchReports = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const params = new URLSearchParams({
-        status: statusFilter,
-        page: page.toString(),
-        limit: '20',
-      })
+  const { data, isLoading, error } = useAdminReports(statusFilter, page)
 
-      const res = await fetch(`/api/admin/reports?${params}`)
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.error || '제보 목록 조회 실패')
-      }
+  const reports = data?.reports ?? []
+  const totalPages = data?.totalPages ?? 1
+  const total = data?.total ?? 0
 
-      const data: AdminReportsResponse = await res.json()
-      setReports(data.reports)
-      setTotalPages(data.totalPages)
-      setTotal(data.total)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
-    } finally {
-      setLoading(false)
-    }
-  }, [statusFilter, page])
-
-  useEffect(() => {
-    fetchReports()
-  }, [fetchReports, refreshKey])
-
-  // 필터 변경 시 페이지 초기화
   const handleFilterChange = (value: string) => {
     setStatusFilter(value)
     setPage(1)
@@ -88,7 +43,7 @@ export function AdminReportList({
   if (error) {
     return (
       <div className="rounded-lg bg-red-50 p-4 text-center text-sm text-red-600">
-        {error}
+        {error instanceof Error ? error.message : '오류가 발생했습니다'}
       </div>
     )
   }
@@ -117,7 +72,7 @@ export function AdminReportList({
 
       {/* 제보 목록 */}
       <div className="flex-1 overflow-y-auto">
-        {loading ? (
+        {isLoading ? (
           <div className="space-y-2 p-3">
             {[1, 2, 3, 4].map((i) => (
               <div
@@ -169,67 +124,5 @@ export function AdminReportList({
         </div>
       )}
     </div>
-  )
-}
-
-function ReportSummaryCard({
-  report,
-  isSelected,
-  onClick,
-}: {
-  report: SpotReport
-  isSelected: boolean
-  onClick: () => void
-}) {
-  const categoryConfig = report.category
-    ? CATEGORY_CONFIG[report.category]
-    : null
-  const thumbnail = report.evidencePairs?.[0]?.realPhotoUrl
-
-  return (
-    <button
-      onClick={onClick}
-      className={`w-full rounded-lg border p-3 text-left transition-colors ${
-        isSelected
-          ? 'border-navy-400 bg-navy-50'
-          : 'border-gray-200 bg-white hover:bg-gray-50'
-      }`}
-    >
-      <div className="flex gap-3">
-        {/* 썸네일 */}
-        {thumbnail ? (
-          <div className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg">
-            <Image
-              src={thumbnail}
-              alt={report.name}
-              fill
-              className="object-cover"
-            />
-          </div>
-        ) : (
-          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 text-xl">
-            📍
-          </div>
-        )}
-
-        {/* 정보 */}
-        <div className="min-w-0 flex-1">
-          <div className="flex items-start justify-between gap-2">
-            <p className="truncate text-sm font-medium text-gray-800">
-              {report.name}
-            </p>
-            <ReportStatusBadge status={report.status} />
-          </div>
-          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-            {categoryConfig && <span>{categoryConfig.label}</span>}
-            <span>·</span>
-            <span>{report.reporterName}</span>
-          </div>
-          <p className="mt-0.5 text-xs text-gray-400">
-            {new Date(report.createdAt).toLocaleDateString('ko-KR')}
-          </p>
-        </div>
-      </div>
-    </button>
   )
 }

--- a/src/components/admin/AdminReportReview.tsx
+++ b/src/components/admin/AdminReportReview.tsx
@@ -174,6 +174,7 @@ export function AdminReportReview({
                           src={pair.captureImageUrl}
                           alt={`캡처 ${idx + 1}`}
                           fill
+                          sizes="(max-width: 768px) 50vw, 33vw"
                           className="object-cover"
                         />
                       </div>
@@ -185,6 +186,7 @@ export function AdminReportReview({
                           src={pair.realPhotoUrl}
                           alt={`현장 ${idx + 1}`}
                           fill
+                          sizes="(max-width: 768px) 50vw, 33vw"
                           className="object-cover"
                         />
                       </div>

--- a/src/components/admin/AdminStatusReportList.tsx
+++ b/src/components/admin/AdminStatusReportList.tsx
@@ -1,15 +1,9 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState } from 'react'
+import { useAdminStatusReports } from '@/hooks/useAdminQueries'
+import { StatusReportSummaryCard } from './StatusReportSummaryCard'
 import type { SpotStatusReport } from '@/types/report'
-
-interface AdminStatusReportsResponse {
-  reports: SpotStatusReport[]
-  total: number
-  page: number
-  limit: number
-  totalPages: number
-}
 
 const REVIEW_STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'pending', label: '대기 중' },
@@ -26,73 +20,32 @@ const SPOT_STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'inaccessible', label: '접근 불가' },
 ]
 
-const SPOT_STATUS_LABELS: Record<string, string> = {
-  normal: '정상',
-  partially_changed: '일부 변경',
-  under_construction: '공사중',
-  demolished: '소실됨',
-  inaccessible: '접근 불가',
-}
-
 interface AdminStatusReportListProps {
   onSelectReport: (report: SpotStatusReport) => void
   selectedReportId?: string
-  refreshKey?: number
 }
 
 /**
  * 관리자 상태 신고 목록 컴포넌트
- * Requirements: 5.1, 5.3
- * - reviewStatus별 필터 (전체/대기 중/확인 완료)
- * - 신고 상태 유형별 필터 (전체/정상/일부 변경/공사중/소실됨/접근 불가)
- * - 페이지네이션 (page, limit)
- * - 신고 상태, 신고자명, 대상 스팟명, reviewStatus 배지 표시
+ * Requirements: 5.1, 5.3, 8.3
  */
 export function AdminStatusReportList({
   onSelectReport,
   selectedReportId,
-  refreshKey = 0,
 }: AdminStatusReportListProps) {
-  const [reports, setReports] = useState<SpotStatusReport[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [reviewStatusFilter, setReviewStatusFilter] = useState('pending')
   const [statusFilter, setStatusFilter] = useState('all')
   const [page, setPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(1)
-  const [total, setTotal] = useState(0)
 
-  const fetchReports = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const params = new URLSearchParams({
-        reviewStatus: reviewStatusFilter,
-        status: statusFilter,
-        page: page.toString(),
-        limit: '20',
-      })
+  const { data, isLoading, error } = useAdminStatusReports(
+    reviewStatusFilter,
+    statusFilter,
+    page
+  )
 
-      const res = await fetch(`/api/admin/status-reports?${params}`)
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.error || '상태 신고 목록 조회 실패')
-      }
-
-      const data: AdminStatusReportsResponse = await res.json()
-      setReports(data.reports)
-      setTotalPages(data.totalPages)
-      setTotal(data.total)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
-    } finally {
-      setLoading(false)
-    }
-  }, [reviewStatusFilter, statusFilter, page])
-
-  useEffect(() => {
-    fetchReports()
-  }, [fetchReports, refreshKey])
+  const reports = data?.reports ?? []
+  const totalPages = data?.totalPages ?? 1
+  const total = data?.total ?? 0
 
   const handleReviewStatusChange = (value: string) => {
     setReviewStatusFilter(value)
@@ -107,7 +60,7 @@ export function AdminStatusReportList({
   if (error) {
     return (
       <div className="rounded-lg bg-red-50 p-4 text-center text-sm text-red-600">
-        {error}
+        {error instanceof Error ? error.message : '오류가 발생했습니다'}
       </div>
     )
   }
@@ -116,7 +69,6 @@ export function AdminStatusReportList({
     <div className="flex h-full flex-col">
       {/* 필터 영역 */}
       <div className="space-y-2 border-b border-gray-200 p-3">
-        {/* reviewStatus 필터 */}
         <div className="flex flex-wrap gap-1.5">
           {REVIEW_STATUS_FILTERS.map((filter) => (
             <button
@@ -132,7 +84,6 @@ export function AdminStatusReportList({
             </button>
           ))}
         </div>
-        {/* 신고 상태 유형 필터 */}
         <div className="flex flex-wrap gap-1.5">
           {SPOT_STATUS_FILTERS.map((filter) => (
             <button
@@ -153,7 +104,7 @@ export function AdminStatusReportList({
 
       {/* 목록 */}
       <div className="flex-1 overflow-y-auto">
-        {loading ? (
+        {isLoading ? (
           <div className="space-y-2 p-3">
             {[1, 2, 3, 4].map((i) => (
               <div
@@ -205,75 +156,5 @@ export function AdminStatusReportList({
         </div>
       )}
     </div>
-  )
-}
-
-function ReviewStatusBadge({ reviewStatus }: { reviewStatus: string }) {
-  const config: Record<
-    string,
-    { label: string; bgColor: string; textColor: string }
-  > = {
-    pending: {
-      label: '대기 중',
-      bgColor: 'bg-amber-100',
-      textColor: 'text-amber-700',
-    },
-    resolved: {
-      label: '확인 완료',
-      bgColor: 'bg-green-100',
-      textColor: 'text-green-700',
-    },
-  }
-  const c = config[reviewStatus] || config.pending
-
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bgColor} ${c.textColor}`}
-    >
-      {c.label}
-    </span>
-  )
-}
-
-function StatusReportSummaryCard({
-  report,
-  isSelected,
-  onClick,
-}: {
-  report: SpotStatusReport
-  isSelected: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`w-full rounded-lg border p-3 text-left transition-colors ${
-        isSelected
-          ? 'border-navy-400 bg-navy-50'
-          : 'border-gray-200 bg-white hover:bg-gray-50'
-      }`}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
-              {SPOT_STATUS_LABELS[report.status] || report.status}
-            </span>
-            <ReviewStatusBadge reviewStatus={report.reviewStatus} />
-          </div>
-          <p className="mt-1.5 truncate text-sm font-medium text-gray-800">
-            {report.description.slice(0, 50)}
-            {report.description.length > 50 ? '...' : ''}
-          </p>
-          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-            <span>{report.reporterName}</span>
-            <span>·</span>
-            <span>
-              {new Date(report.createdAt).toLocaleDateString('ko-KR')}
-            </span>
-          </div>
-        </div>
-      </div>
-    </button>
   )
 }

--- a/src/components/admin/AdminStatusReportReview.tsx
+++ b/src/components/admin/AdminStatusReportReview.tsx
@@ -166,6 +166,7 @@ export function AdminStatusReportReview({
                 src={report.photoUrl}
                 alt="증거 사진"
                 fill
+                sizes="(max-width: 768px) 50vw, 384px"
                 className="object-cover"
               />
             </div>

--- a/src/components/admin/AdminSupplementList.tsx
+++ b/src/components/admin/AdminSupplementList.tsx
@@ -1,15 +1,9 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState } from 'react'
+import { useAdminSupplements } from '@/hooks/useAdminQueries'
+import { SupplementSummaryCard } from './SupplementSummaryCard'
 import type { SpotSupplement } from '@/types/report'
-
-interface AdminSupplementsResponse {
-  supplements: SpotSupplement[]
-  total: number
-  page: number
-  limit: number
-  totalPages: number
-}
 
 const STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'pending', label: '대기중' },
@@ -18,69 +12,27 @@ const STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'rejected', label: '반려' },
 ]
 
-const SUPPLEMENT_TYPE_LABELS: Record<string, string> = {
-  scene_info: '씬 정보',
-  description: '설명',
-  photo: '사진',
-  other: '기타',
-}
-
 interface AdminSupplementListProps {
   onSelectSupplement: (supplement: SpotSupplement) => void
   selectedSupplementId?: string
-  refreshKey?: number
 }
 
 /**
  * 관리자 정보 보완 목록 컴포넌트
- * Requirements: 3.1, 3.3
- * - status별 필터 (대기중/승인/반려/전체)
- * - 페이지네이션 (page, limit)
- * - 보완 유형, 기여자명, 대상 스팟명, 상태 배지 표시
+ * Requirements: 3.1, 3.3, 8.3
  */
 export function AdminSupplementList({
   onSelectSupplement,
   selectedSupplementId,
-  refreshKey = 0,
 }: AdminSupplementListProps) {
-  const [supplements, setSupplements] = useState<SpotSupplement[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [statusFilter, setStatusFilter] = useState('pending')
   const [page, setPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(1)
-  const [total, setTotal] = useState(0)
 
-  const fetchSupplements = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const params = new URLSearchParams({
-        status: statusFilter,
-        page: page.toString(),
-        limit: '20',
-      })
+  const { data, isLoading, error } = useAdminSupplements(statusFilter, page)
 
-      const res = await fetch(`/api/admin/supplements?${params}`)
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.error || '정보 보완 목록 조회 실패')
-      }
-
-      const data: AdminSupplementsResponse = await res.json()
-      setSupplements(data.supplements)
-      setTotalPages(data.totalPages)
-      setTotal(data.total)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '오류가 발생했습니다')
-    } finally {
-      setLoading(false)
-    }
-  }, [statusFilter, page])
-
-  useEffect(() => {
-    fetchSupplements()
-  }, [fetchSupplements, refreshKey])
+  const supplements = data?.supplements ?? []
+  const totalPages = data?.totalPages ?? 1
+  const total = data?.total ?? 0
 
   const handleFilterChange = (value: string) => {
     setStatusFilter(value)
@@ -90,7 +42,7 @@ export function AdminSupplementList({
   if (error) {
     return (
       <div className="rounded-lg bg-red-50 p-4 text-center text-sm text-red-600">
-        {error}
+        {error instanceof Error ? error.message : '오류가 발생했습니다'}
       </div>
     )
   }
@@ -119,7 +71,7 @@ export function AdminSupplementList({
 
       {/* 목록 */}
       <div className="flex-1 overflow-y-auto">
-        {loading ? (
+        {isLoading ? (
           <div className="space-y-2 p-3">
             {[1, 2, 3, 4].map((i) => (
               <div
@@ -171,80 +123,5 @@ export function AdminSupplementList({
         </div>
       )}
     </div>
-  )
-}
-
-function SupplementStatusBadge({ status }: { status: string }) {
-  const config: Record<
-    string,
-    { label: string; bgColor: string; textColor: string }
-  > = {
-    pending: {
-      label: '대기중',
-      bgColor: 'bg-amber-100',
-      textColor: 'text-amber-700',
-    },
-    approved: {
-      label: '승인',
-      bgColor: 'bg-green-100',
-      textColor: 'text-green-700',
-    },
-    rejected: {
-      label: '반려',
-      bgColor: 'bg-red-100',
-      textColor: 'text-red-700',
-    },
-  }
-  const c = config[status] || config.pending
-
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bgColor} ${c.textColor}`}
-    >
-      {c.label}
-    </span>
-  )
-}
-
-function SupplementSummaryCard({
-  supplement,
-  isSelected,
-  onClick,
-}: {
-  supplement: SpotSupplement
-  isSelected: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`w-full rounded-lg border p-3 text-left transition-colors ${
-        isSelected
-          ? 'border-navy-400 bg-navy-50'
-          : 'border-gray-200 bg-white hover:bg-gray-50'
-      }`}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
-              {SUPPLEMENT_TYPE_LABELS[supplement.type] || supplement.type}
-            </span>
-            <SupplementStatusBadge status={supplement.status} />
-          </div>
-          <p className="mt-1.5 truncate text-sm font-medium text-gray-800">
-            {supplement.content.slice(0, 50)}
-            {supplement.content.length > 50 ? '...' : ''}
-          </p>
-          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-            <span>{supplement.contributorName}</span>
-            <span>·</span>
-            <span>
-              {new Date(supplement.createdAt).toLocaleDateString('ko-KR')}
-            </span>
-          </div>
-        </div>
-      </div>
-    </button>
   )
 }

--- a/src/components/admin/AdminSupplementReview.tsx
+++ b/src/components/admin/AdminSupplementReview.tsx
@@ -181,6 +181,7 @@ export function AdminSupplementReview({
                       src={supplement.sceneInfo.captureImageUrl}
                       alt="씬 캡처"
                       fill
+                      sizes="(max-width: 768px) 50vw, 33vw"
                       className="object-cover"
                     />
                   </div>
@@ -206,6 +207,7 @@ export function AdminSupplementReview({
                     src={photo}
                     alt={`첨부 사진 ${idx + 1}`}
                     fill
+                    sizes="(max-width: 768px) 50vw, 33vw"
                     className="object-cover"
                   />
                 </div>

--- a/src/components/admin/ReportSummaryCard.tsx
+++ b/src/components/admin/ReportSummaryCard.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import { ReportStatusBadge } from '@/components/report/ReportStatusBadge'
+import { CATEGORY_CONFIG } from '@/types/spot'
+import type { SpotReport } from '@/types/report'
+
+interface ReportSummaryCardProps {
+  report: SpotReport
+  isSelected: boolean
+  onClick: () => void
+}
+
+/**
+ * 제보 요약 카드 컴포넌트
+ * Requirements: 5.1, 8.2
+ */
+export const ReportSummaryCard = React.memo(function ReportSummaryCard({
+  report,
+  isSelected,
+  onClick,
+}: ReportSummaryCardProps) {
+  const categoryConfig = report.category
+    ? CATEGORY_CONFIG[report.category]
+    : null
+  const thumbnail = report.evidencePairs?.[0]?.realPhotoUrl
+
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full rounded-lg border p-3 text-left transition-colors ${
+        isSelected
+          ? 'border-navy-400 bg-navy-50'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      }`}
+    >
+      <div className="flex gap-3">
+        {thumbnail ? (
+          <div className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg">
+            <Image
+              src={thumbnail}
+              alt={report.name}
+              fill
+              sizes="56px"
+              className="object-cover"
+            />
+          </div>
+        ) : (
+          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 text-xl">
+            📍
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <p className="truncate text-sm font-medium text-gray-800">
+              {report.name}
+            </p>
+            <ReportStatusBadge status={report.status} />
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+            {categoryConfig && <span>{categoryConfig.label}</span>}
+            <span>·</span>
+            <span>{report.reporterName}</span>
+          </div>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {new Date(report.createdAt).toLocaleDateString('ko-KR')}
+          </p>
+        </div>
+      </div>
+    </button>
+  )
+})

--- a/src/components/admin/StatusReportSummaryCard.tsx
+++ b/src/components/admin/StatusReportSummaryCard.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import React from 'react'
+import type { SpotStatusReport } from '@/types/report'
+
+const SPOT_STATUS_LABELS: Record<string, string> = {
+  normal: '정상',
+  partially_changed: '일부 변경',
+  under_construction: '공사중',
+  demolished: '소실됨',
+  inaccessible: '접근 불가',
+}
+
+export function ReviewStatusBadge({ reviewStatus }: { reviewStatus: string }) {
+  const config: Record<
+    string,
+    { label: string; bgColor: string; textColor: string }
+  > = {
+    pending: {
+      label: '대기 중',
+      bgColor: 'bg-amber-100',
+      textColor: 'text-amber-700',
+    },
+    resolved: {
+      label: '확인 완료',
+      bgColor: 'bg-green-100',
+      textColor: 'text-green-700',
+    },
+  }
+  const c = config[reviewStatus] || config.pending
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bgColor} ${c.textColor}`}
+    >
+      {c.label}
+    </span>
+  )
+}
+
+interface StatusReportSummaryCardProps {
+  report: SpotStatusReport
+  isSelected: boolean
+  onClick: () => void
+}
+
+/**
+ * 상태 신고 요약 카드 컴포넌트
+ * Requirements: 5.1, 8.2
+ */
+export const StatusReportSummaryCard = React.memo(
+  function StatusReportSummaryCard({
+    report,
+    isSelected,
+    onClick,
+  }: StatusReportSummaryCardProps) {
+    return (
+      <button
+        onClick={onClick}
+        className={`w-full rounded-lg border p-3 text-left transition-colors ${
+          isSelected
+            ? 'border-navy-400 bg-navy-50'
+            : 'border-gray-200 bg-white hover:bg-gray-50'
+        }`}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+                {SPOT_STATUS_LABELS[report.status] || report.status}
+              </span>
+              <ReviewStatusBadge reviewStatus={report.reviewStatus} />
+            </div>
+            <p className="mt-1.5 truncate text-sm font-medium text-gray-800">
+              {report.description.slice(0, 50)}
+              {report.description.length > 50 ? '...' : ''}
+            </p>
+            <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+              <span>{report.reporterName}</span>
+              <span>·</span>
+              <span>
+                {new Date(report.createdAt).toLocaleDateString('ko-KR')}
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+    )
+  }
+)

--- a/src/components/admin/SupplementSummaryCard.tsx
+++ b/src/components/admin/SupplementSummaryCard.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import React from 'react'
+import type { SpotSupplement } from '@/types/report'
+
+const SUPPLEMENT_TYPE_LABELS: Record<string, string> = {
+  scene_info: '씬 정보',
+  description: '설명',
+  photo: '사진',
+  other: '기타',
+}
+
+export function SupplementStatusBadge({ status }: { status: string }) {
+  const config: Record<
+    string,
+    { label: string; bgColor: string; textColor: string }
+  > = {
+    pending: {
+      label: '대기중',
+      bgColor: 'bg-amber-100',
+      textColor: 'text-amber-700',
+    },
+    approved: {
+      label: '승인',
+      bgColor: 'bg-green-100',
+      textColor: 'text-green-700',
+    },
+    rejected: {
+      label: '반려',
+      bgColor: 'bg-red-100',
+      textColor: 'text-red-700',
+    },
+  }
+  const c = config[status] || config.pending
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bgColor} ${c.textColor}`}
+    >
+      {c.label}
+    </span>
+  )
+}
+
+interface SupplementSummaryCardProps {
+  supplement: SpotSupplement
+  isSelected: boolean
+  onClick: () => void
+}
+
+/**
+ * 정보 보완 요약 카드 컴포넌트
+ * Requirements: 3.1, 8.2
+ */
+export const SupplementSummaryCard = React.memo(function SupplementSummaryCard({
+  supplement,
+  isSelected,
+  onClick,
+}: SupplementSummaryCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full rounded-lg border p-3 text-left transition-colors ${
+        isSelected
+          ? 'border-navy-400 bg-navy-50'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+              {SUPPLEMENT_TYPE_LABELS[supplement.type] || supplement.type}
+            </span>
+            <SupplementStatusBadge status={supplement.status} />
+          </div>
+          <p className="mt-1.5 truncate text-sm font-medium text-gray-800">
+            {supplement.content.slice(0, 50)}
+            {supplement.content.length > 50 ? '...' : ''}
+          </p>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+            <span>{supplement.contributorName}</span>
+            <span>·</span>
+            <span>
+              {new Date(supplement.createdAt).toLocaleDateString('ko-KR')}
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+})

--- a/src/components/checkin/CheckInDetailModal.tsx
+++ b/src/components/checkin/CheckInDetailModal.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import Image from 'next/image'
+import { CheckIn } from '@/types'
+import { ComparisonViewer } from './ComparisonViewer'
+
+interface CheckInDetailModalProps {
+  checkIn: CheckIn
+  onClose: () => void
+}
+
+/**
+ * 인증 상세 모달
+ */
+export function CheckInDetailModal({
+  checkIn,
+  onClose,
+}: CheckInDetailModalProps) {
+  const formatDate = (date: Date) => {
+    return new Date(date).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between border-b p-4">
+          <div className="flex items-center gap-3">
+            {checkIn.userImage ? (
+              <Image
+                src={checkIn.userImage}
+                alt={checkIn.userName}
+                width={40}
+                height={40}
+                className="rounded-full"
+              />
+            ) : (
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200">
+                <span className="text-lg font-medium text-gray-600">
+                  {checkIn.userName[0]}
+                </span>
+              </div>
+            )}
+            <div>
+              <p className="font-medium">{checkIn.userName}</p>
+              <p className="text-sm text-gray-500">
+                {formatDate(checkIn.visitedAt)}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1 hover:bg-gray-100"
+          >
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* 이미지 */}
+        <div className="p-4">
+          {checkIn.sceneImageUrl ? (
+            <ComparisonViewer
+              sceneImageUrl={checkIn.sceneImageUrl}
+              userPhotoUrl={checkIn.photoUrl}
+            />
+          ) : (
+            <div className="relative aspect-video overflow-hidden rounded-lg">
+              <Image
+                src={checkIn.photoUrl}
+                alt="인증샷"
+                fill
+                sizes="(max-width: 768px) 100vw, 672px"
+                className="object-cover"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* 코멘트 */}
+        {checkIn.comment && (
+          <div className="border-t px-4 py-3">
+            <p className="text-gray-700">{checkIn.comment}</p>
+          </div>
+        )}
+
+        {/* 좋아요 */}
+        <div className="border-t px-4 py-3">
+          <div className="flex items-center gap-1 text-gray-500">
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+              />
+            </svg>
+            <span className="text-sm">{checkIn.likeCount}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/checkin/CheckInGallery.tsx
+++ b/src/components/checkin/CheckInGallery.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import Image from 'next/image'
 import { CheckIn } from '@/types'
-import { ComparisonViewer } from './ComparisonViewer'
+import { useCheckInGallery } from '@/hooks/useGalleryQueries'
+import { CheckInDetailModal } from './CheckInDetailModal'
 
 interface CheckInGalleryProps {
   spotId?: string
@@ -15,7 +16,7 @@ interface CheckInGalleryProps {
 
 /**
  * 인증샷 갤러리 컴포넌트
- * Requirements: 1.5, 5.3
+ * Requirements: 1.5, 5.3, 8.3
  */
 export function CheckInGallery({
   spotId,
@@ -24,52 +25,35 @@ export function CheckInGallery({
   showLoadMore = true,
   className = '',
 }: CheckInGalleryProps) {
-  const [checkins, setCheckins] = useState<CheckIn[]>([])
-  const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
   const [sortBy, setSortBy] = useState<'latest' | 'popular'>('latest')
-  const [isLoading, setIsLoading] = useState(true)
+  const [allCheckins, setAllCheckins] = useState<CheckIn[]>([])
   const [selectedCheckIn, setSelectedCheckIn] = useState<CheckIn | null>(null)
 
-  const fetchCheckins = async (pageNum: number, append = false) => {
-    setIsLoading(true)
-    try {
-      const params = new URLSearchParams({
-        page: pageNum.toString(),
-        limit: limit.toString(),
-        sortBy,
-      })
-      if (spotId) params.set('spotId', spotId)
-      if (userId) params.set('userId', userId)
+  const { data, isLoading } = useCheckInGallery(
+    spotId,
+    userId,
+    sortBy,
+    page,
+    limit
+  )
 
-      const res = await fetch(`/api/checkins?${params}`)
-      if (!res.ok) throw new Error('Failed to fetch')
-
-      const data = await res.json()
-
-      if (append) {
-        setCheckins((prev) => [...prev, ...data.checkins])
-      } else {
-        setCheckins(data.checkins)
-      }
-      setTotal(data.total)
-    } catch (error) {
-      console.error('Error fetching checkins:', error)
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    setPage(1)
-    fetchCheckins(1)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [spotId, userId, sortBy, limit])
+  // 페이지 변경 시 누적 데이터 관리
+  const checkins =
+    page === 1
+      ? (data?.checkins ?? [])
+      : [...allCheckins, ...(data?.checkins ?? [])]
+  const total = data?.total ?? 0
 
   const handleLoadMore = () => {
-    const nextPage = page + 1
-    setPage(nextPage)
-    fetchCheckins(nextPage, true)
+    setAllCheckins(checkins)
+    setPage((p) => p + 1)
+  }
+
+  const handleSortChange = (newSort: 'latest' | 'popular') => {
+    setSortBy(newSort)
+    setPage(1)
+    setAllCheckins([])
   }
 
   const formatDate = (date: Date) => {
@@ -126,7 +110,7 @@ export function CheckInGallery({
         <p className="text-sm text-gray-500">총 {total}개의 인증</p>
         <div className="flex gap-2">
           <button
-            onClick={() => setSortBy('latest')}
+            onClick={() => handleSortChange('latest')}
             className={`rounded-lg px-3 py-1 text-sm ${
               sortBy === 'latest'
                 ? 'bg-blue-100 text-blue-600'
@@ -136,7 +120,7 @@ export function CheckInGallery({
             최신순
           </button>
           <button
-            onClick={() => setSortBy('popular')}
+            onClick={() => handleSortChange('popular')}
             className={`rounded-lg px-3 py-1 text-sm ${
               sortBy === 'popular'
                 ? 'bg-blue-100 text-blue-600'
@@ -160,6 +144,7 @@ export function CheckInGallery({
               src={checkin.photoUrl}
               alt={`${checkin.userName}의 인증샷`}
               fill
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               className="object-cover transition-transform group-hover:scale-105"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
@@ -193,128 +178,6 @@ export function CheckInGallery({
           onClose={() => setSelectedCheckIn(null)}
         />
       )}
-    </div>
-  )
-}
-
-/**
- * 인증 상세 모달
- */
-function CheckInDetailModal({
-  checkIn,
-  onClose,
-}: {
-  checkIn: CheckIn
-  onClose: () => void
-}) {
-  const formatDate = (date: Date) => {
-    return new Date(date).toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })
-  }
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-      onClick={onClose}
-    >
-      <div
-        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="flex items-center justify-between border-b p-4">
-          <div className="flex items-center gap-3">
-            {checkIn.userImage ? (
-              <Image
-                src={checkIn.userImage}
-                alt={checkIn.userName}
-                width={40}
-                height={40}
-                className="rounded-full"
-              />
-            ) : (
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200">
-                <span className="text-lg font-medium text-gray-600">
-                  {checkIn.userName[0]}
-                </span>
-              </div>
-            )}
-            <div>
-              <p className="font-medium">{checkIn.userName}</p>
-              <p className="text-sm text-gray-500">
-                {formatDate(checkIn.visitedAt)}
-              </p>
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            className="rounded-full p-1 hover:bg-gray-100"
-          >
-            <svg
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        {/* 이미지 */}
-        <div className="p-4">
-          {checkIn.sceneImageUrl ? (
-            <ComparisonViewer
-              sceneImageUrl={checkIn.sceneImageUrl}
-              userPhotoUrl={checkIn.photoUrl}
-            />
-          ) : (
-            <div className="relative aspect-video overflow-hidden rounded-lg">
-              <Image
-                src={checkIn.photoUrl}
-                alt="인증샷"
-                fill
-                className="object-cover"
-              />
-            </div>
-          )}
-        </div>
-
-        {/* 코멘트 */}
-        {checkIn.comment && (
-          <div className="border-t px-4 py-3">
-            <p className="text-gray-700">{checkIn.comment}</p>
-          </div>
-        )}
-
-        {/* 좋아요 */}
-        <div className="border-t px-4 py-3">
-          <div className="flex items-center gap-1 text-gray-500">
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-              />
-            </svg>
-            <span className="text-sm">{checkIn.likeCount}</span>
-          </div>
-        </div>
-      </div>
     </div>
   )
 }

--- a/src/components/checkin/CheckInModal.tsx
+++ b/src/components/checkin/CheckInModal.tsx
@@ -181,6 +181,7 @@ export function CheckInModal({
                   src={sceneImageUrl}
                   alt="참고 장면"
                   fill
+                  sizes="(max-width: 768px) 50vw, 256px"
                   className="object-cover"
                 />
               </div>
@@ -205,6 +206,7 @@ export function CheckInModal({
                   src={photoPreview}
                   alt="인증샷 미리보기"
                   fill
+                  sizes="(max-width: 768px) 50vw, 256px"
                   className="object-cover"
                 />
                 <button

--- a/src/components/checkin/ComparisonViewer.tsx
+++ b/src/components/checkin/ComparisonViewer.tsx
@@ -81,6 +81,7 @@ export function ComparisonViewer({
               src={sceneImageUrl}
               alt="작품 속 장면"
               fill
+              sizes="(max-width: 768px) 50vw, 384px"
               className="object-cover"
             />
             <span className="absolute bottom-2 left-2 rounded bg-black/50 px-2 py-1 text-xs text-white">
@@ -92,6 +93,7 @@ export function ComparisonViewer({
               src={userPhotoUrl}
               alt="인증샷"
               fill
+              sizes="(max-width: 768px) 50vw, 384px"
               className="object-cover"
             />
             <span className="absolute bottom-2 left-2 rounded bg-black/50 px-2 py-1 text-xs text-white">
@@ -133,6 +135,7 @@ export function ComparisonViewer({
             src={userPhotoUrl}
             alt="인증샷"
             fill
+            sizes="(max-width: 768px) 50vw, 384px"
             className="object-cover"
             draggable={false}
           />
@@ -151,6 +154,7 @@ export function ComparisonViewer({
               src={sceneImageUrl}
               alt="작품 속 장면"
               fill
+              sizes="(max-width: 768px) 50vw, 384px"
               className="object-cover"
               draggable={false}
             />

--- a/src/components/checkin/QuickCheckIn.tsx
+++ b/src/components/checkin/QuickCheckIn.tsx
@@ -316,6 +316,7 @@ export function QuickCheckIn({
                     src={photoPreview}
                     alt="인증샷 미리보기"
                     fill
+                    sizes="128px"
                     className="object-cover"
                   />
                   <button

--- a/src/components/gallery/ContentTab.tsx
+++ b/src/components/gallery/ContentTab.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import { CheckIn } from '@/types'
 import { ContentGrid, ContentSummary } from './ContentGrid'
 import { MasonryGrid, MasonryItem } from './MasonryGrid'
 import { ComparisonCard } from './ComparisonCard'
 import { useCheckInFeed } from '@/hooks/useCheckInFeed'
+import { useContentList as useContentListQuery } from '@/hooks/useGalleryQueries'
 
 /**
  * ContentTab 컴포넌트
@@ -15,6 +16,7 @@ import { useCheckInFeed } from '@/hooks/useCheckInFeed'
  * Requirements:
  * - 3.4: 작품별 탭에서 작품 포스터를 대형 카드로 그리드 레이아웃에 표시
  * - 3.5: 작품 선택 시 해당 작품 체크인만 필터링
+ * - 8.3: React Query 전환
  */
 
 export interface ContentTabProps {
@@ -22,9 +24,6 @@ export interface ContentTabProps {
   onCheckInClick?: (checkIn: CheckIn) => void
 }
 
-/**
- * 로딩 스켈레톤 컴포넌트
- */
 function LoadingSkeleton() {
   return (
     <>
@@ -46,9 +45,6 @@ function LoadingSkeleton() {
   )
 }
 
-/**
- * 빈 상태 컴포넌트 (필터링된 결과가 없을 때)
- */
 function EmptyFilteredState({ contentName }: { contentName: string }) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
@@ -63,9 +59,6 @@ function EmptyFilteredState({ contentName }: { contentName: string }) {
   )
 }
 
-/**
- * 에러 상태 컴포넌트
- */
 function ErrorState({ onRetry }: { onRetry: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
@@ -84,9 +77,6 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
   )
 }
 
-/**
- * 콘텐츠 그리드 로딩 스켈레톤
- */
 function ContentGridSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
@@ -103,9 +93,6 @@ function ContentGridSkeleton() {
   )
 }
 
-/**
- * 필터링된 피드 헤더 (뒤로가기 버튼 포함)
- */
 function FilteredFeedHeader({
   contentName,
   onBack,
@@ -140,52 +127,6 @@ function FilteredFeedHeader({
   )
 }
 
-/**
- * useContentList 훅 - 작품 목록 조회
- */
-function useContentList() {
-  const [contents, setContents] = useState<ContentSummary[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  const fetchContents = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-
-    try {
-      // content-names API에서 작품 목록 조회 (type=content로 작품명만)
-      const res = await fetch('/api/content-names?type=content')
-      if (!res.ok) {
-        throw new Error('작품 목록 조회 실패')
-      }
-
-      const data = await res.json()
-
-      // API 응답을 ContentSummary 형식으로 변환
-      const contentSummaries: ContentSummary[] = data.items.map(
-        (item: { name: string; count: number }) => ({
-          title: item.name,
-          imageUrl: undefined, // 이미지 URL은 별도 API 필요
-          checkInCount: item.count,
-          spotCount: 0, // 스팟 수는 별도 계산 필요
-        })
-      )
-
-      setContents(contentSummaries)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : '알 수 없는 오류')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchContents()
-  }, [fetchContents])
-
-  return { contents, isLoading, error, refresh: fetchContents }
-}
-
 export function ContentTab({
   selectedContent,
   onCheckInClick,
@@ -193,13 +134,21 @@ export function ContentTab({
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // 작품 목록 조회
+  // React Query로 작품 목록 조회
   const {
-    contents,
+    data: contentData,
     isLoading: isLoadingContents,
     error: contentsError,
-    refresh: refreshContents,
-  } = useContentList()
+    refetch: refreshContents,
+  } = useContentListQuery()
+
+  // API 응답을 ContentSummary 형식으로 변환
+  const contents: ContentSummary[] = (contentData?.items ?? []).map((item) => ({
+    title: item.name,
+    imageUrl: undefined,
+    checkInCount: item.count,
+    spotCount: 0,
+  }))
 
   // 필터링된 체크인 피드 (작품 선택 시에만 활성화)
   const {
@@ -217,10 +166,6 @@ export function ContentTab({
     enabled: !!selectedContent,
   })
 
-  /**
-   * 작품 선택 핸들러
-   * URL 쿼리 파라미터로 선택된 작품 관리 (Requirements 3.5)
-   */
   const handleSelectContent = useCallback(
     (contentName: string) => {
       const params = new URLSearchParams(searchParams.toString())
@@ -231,9 +176,6 @@ export function ContentTab({
     [router, searchParams]
   )
 
-  /**
-   * 작품 목록으로 돌아가기
-   */
   const handleBack = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString())
     params.set('tab', 'content')
@@ -243,7 +185,6 @@ export function ContentTab({
 
   // 작품이 선택된 경우: 필터링된 체크인 피드 표시
   if (selectedContent) {
-    // 에러 상태
     if (checkInsError && checkIns.length === 0) {
       return (
         <div className="mx-auto max-w-6xl px-4 py-6">
@@ -256,7 +197,6 @@ export function ContentTab({
       )
     }
 
-    // 빈 상태
     if (!isLoadingCheckIns && checkIns.length === 0) {
       return (
         <div className="mx-auto max-w-6xl px-4 py-6">
@@ -272,7 +212,6 @@ export function ContentTab({
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">
         <FilteredFeedHeader contentName={selectedContent} onBack={handleBack} />
-
         <MasonryGrid>
           {checkIns.map((checkIn) => (
             <MasonryItem key={checkIn.id}>
@@ -289,11 +228,8 @@ export function ContentTab({
               />
             </MasonryItem>
           ))}
-
           {isLoadingCheckIns && <LoadingSkeleton />}
         </MasonryGrid>
-
-        {/* 무한 스크롤 트리거 영역 */}
         <div
           ref={loadMoreRef}
           className="flex h-20 items-center justify-center"
@@ -314,16 +250,14 @@ export function ContentTab({
   }
 
   // 작품이 선택되지 않은 경우: 작품 목록 그리드 표시
-  // 에러 상태
   if (contentsError) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">
-        <ErrorState onRetry={refreshContents} />
+        <ErrorState onRetry={() => refreshContents()} />
       </div>
     )
   }
 
-  // 로딩 상태
   if (isLoadingContents) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">

--- a/src/components/gallery/HallOfFameTab.tsx
+++ b/src/components/gallery/HallOfFameTab.tsx
@@ -1,56 +1,28 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { RankingList, SpotRankingItem, CheckInRankingItem } from './RankingList'
-
-/**
- * 랭킹 API 응답 타입
- */
-interface RankingResponse {
-  spotRanking: SpotRankingItem[]
-  checkInRanking: CheckInRankingItem[]
-  period: {
-    start: string
-    end: string
-  }
-}
+import { useHallOfFameRanking } from '@/hooks/useGalleryQueries'
+import { RankingList } from './RankingList'
 
 export interface HallOfFameTabProps {
-  /** 스팟 클릭 시 콜백 (기본: 스팟 상세 페이지로 이동) */
   onSpotClick?: (spotId: string) => void
-  /** 인증샷 클릭 시 콜백 */
   onCheckInClick?: (checkInId: string) => void
 }
 
-/**
- * 날짜를 한국어 형식으로 포맷팅
- */
 function formatPeriod(start: string, end: string): string {
   const startDate = new Date(start)
   const endDate = new Date(end)
-
-  const formatDate = (date: Date) => {
-    const month = date.getMonth() + 1
-    const day = date.getDate()
-    return `${month}/${day}`
-  }
-
+  const formatDate = (date: Date) => `${date.getMonth() + 1}/${date.getDate()}`
   return `${formatDate(startDate)} ~ ${formatDate(endDate)}`
 }
 
-/**
- * 로딩 스켈레톤 컴포넌트
- */
 function LoadingSkeleton() {
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
-      {/* 기간 정보 스켈레톤 */}
       <div className="mb-6 flex items-center justify-center">
         <div className="h-6 w-48 animate-pulse rounded bg-navy-200" />
       </div>
-
-      {/* 스팟 랭킹 스켈레톤 */}
       <div className="mb-8">
         <div className="mb-4 h-6 w-32 animate-pulse rounded bg-navy-200" />
         <div className="space-y-3">
@@ -69,8 +41,6 @@ function LoadingSkeleton() {
           ))}
         </div>
       </div>
-
-      {/* 인증샷 랭킹 스켈레톤 */}
       <div>
         <div className="mb-4 h-6 w-32 animate-pulse rounded bg-navy-200" />
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
@@ -89,98 +59,16 @@ function LoadingSkeleton() {
 }
 
 /**
- * 에러 상태 컴포넌트
- */
-function ErrorState({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div className="mx-auto max-w-4xl px-4 py-6">
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="mb-4 text-5xl">😢</div>
-        <p className="text-lg font-medium text-navy-700">
-          데이터를 불러올 수 없습니다
-        </p>
-        <p className="mt-2 text-sm text-navy-500">잠시 후 다시 시도해주세요</p>
-        <button
-          onClick={onRetry}
-          className="mt-4 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-600"
-        >
-          다시 시도
-        </button>
-      </div>
-    </div>
-  )
-}
-
-/**
- * 빈 상태 컴포넌트
- */
-function EmptyState() {
-  return (
-    <div className="mx-auto max-w-4xl px-4 py-6">
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="mb-4 text-5xl">🏆</div>
-        <p className="text-lg font-medium text-navy-700">
-          아직 랭킹 데이터가 없습니다
-        </p>
-        <p className="mt-2 text-sm text-navy-500">
-          첫 번째 순례 인증을 남겨보세요!
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/**
  * 명예의 전당 탭 컴포넌트
- * 이번 주 인기 스팟과 인기 인증샷 랭킹을 표시합니다.
- *
- * Requirements: 3.3
- * - WHEN the "명예의 전당" tab is active, THE Gallery_System SHALL display
- *   this week's most checked-in spots and most liked check-ins as a ranking
+ * Requirements: 3.3, 8.3
  */
 export function HallOfFameTab({
   onSpotClick,
   onCheckInClick,
 }: HallOfFameTabProps) {
   const router = useRouter()
-  const [spotRanking, setSpotRanking] = useState<SpotRankingItem[]>([])
-  const [checkInRanking, setCheckInRanking] = useState<CheckInRankingItem[]>([])
-  const [period, setPeriod] = useState<{ start: string; end: string } | null>(
-    null
-  )
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const { data, isLoading, error, refetch } = useHallOfFameRanking()
 
-  const fetchRanking = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-
-    try {
-      const response = await fetch('/api/checkins/ranking')
-
-      if (!response.ok) {
-        throw new Error('랭킹 데이터를 불러오는데 실패했습니다')
-      }
-
-      const data: RankingResponse = await response.json()
-
-      setSpotRanking(data.spotRanking)
-      setCheckInRanking(data.checkInRanking)
-      setPeriod(data.period)
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다'
-      )
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchRanking()
-  }, [fetchRanking])
-
-  // 기본 스팟 클릭 핸들러: 스팟 상세 페이지로 이동
   const handleSpotClick = useCallback(
     (spotId: string) => {
       if (onSpotClick) {
@@ -192,25 +80,57 @@ export function HallOfFameTab({
     [onSpotClick, router]
   )
 
-  // 로딩 상태
-  if (isLoading) {
-    return <LoadingSkeleton />
-  }
+  if (isLoading) return <LoadingSkeleton />
 
-  // 에러 상태
   if (error) {
-    return <ErrorState onRetry={fetchRanking} />
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="mb-4 text-5xl">😢</div>
+          <p className="text-lg font-medium text-navy-700">
+            데이터를 불러올 수 없습니다
+          </p>
+          <p className="mt-2 text-sm text-navy-500">
+            잠시 후 다시 시도해주세요
+          </p>
+          <button
+            onClick={() => refetch()}
+            className="mt-4 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-600"
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    )
   }
 
-  // 빈 상태 (스팟 랭킹과 인증샷 랭킹 모두 비어있는 경우)
-  const isEmpty = spotRanking.length === 0 && checkInRanking.length === 0
-  if (isEmpty) {
-    return <EmptyState />
+  const spotRanking = (data?.spotRanking ?? []).map((item) => ({
+    spotId: item.spotId,
+    spotName: item.spotName,
+    spotThumbnail: item.thumbnailUrl,
+    weeklyCheckIns: item.checkInCount,
+  }))
+  const checkInRanking = data?.checkInRanking ?? []
+  const period = data?.period
+
+  if (spotRanking.length === 0 && checkInRanking.length === 0) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="mb-4 text-5xl">🏆</div>
+          <p className="text-lg font-medium text-navy-700">
+            아직 랭킹 데이터가 없습니다
+          </p>
+          <p className="mt-2 text-sm text-navy-500">
+            첫 번째 순례 인증을 남겨보세요!
+          </p>
+        </div>
+      </div>
+    )
   }
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
-      {/* 기간 정보 */}
       {period && (
         <div className="mb-6 flex items-center justify-center">
           <div className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-2 text-sm text-blue-700">
@@ -222,8 +142,6 @@ export function HallOfFameTab({
           </div>
         </div>
       )}
-
-      {/* 랭킹 리스트 */}
       <RankingList
         spotRanking={spotRanking}
         checkInRanking={checkInRanking}

--- a/src/components/gallery/SpotSearchModal.tsx
+++ b/src/components/gallery/SpotSearchModal.tsx
@@ -282,6 +282,7 @@ export function SpotSearchModal({
                           src={spot.thumbnailUrl}
                           alt={spot.name}
                           fill
+                          sizes="48px"
                           className="object-cover"
                         />
                       ) : (

--- a/src/components/mobile/ViewfinderOverlay.tsx
+++ b/src/components/mobile/ViewfinderOverlay.tsx
@@ -185,6 +185,7 @@ export function ViewfinderOverlay({
             src={sceneImageUrl}
             alt="씬 이미지 가이드"
             fill
+            sizes="100vw"
             className="object-cover"
             priority
           />

--- a/src/components/report/ContributorList.tsx
+++ b/src/components/report/ContributorList.tsx
@@ -1,13 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { API_ROUTES } from '@/lib/api-routes'
-
-interface Contributor {
-  contributorId: string
-  contributorName: string
-  count: number
-}
+import { useContributors } from '@/hooks/useGalleryQueries'
 
 interface ContributorListProps {
   spotId: string
@@ -18,25 +11,7 @@ interface ContributorListProps {
  * Requirements: 3.3
  */
 export function ContributorList({ spotId }: ContributorListProps) {
-  const [contributors, setContributors] = useState<Contributor[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    const fetchContributors = async () => {
-      try {
-        const res = await fetch(API_ROUTES.SUPPLEMENTS.BASE(spotId))
-        if (!res.ok) return
-        const data = await res.json()
-        setContributors(data.contributors || [])
-      } catch {
-        // 조용히 실패
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchContributors()
-  }, [spotId])
+  const { data: contributors = [], isLoading } = useContributors(spotId)
 
   if (isLoading) {
     return (

--- a/src/components/report/EvidencePairUpload.tsx
+++ b/src/components/report/EvidencePairUpload.tsx
@@ -262,6 +262,7 @@ export function EvidencePairUpload({
                     src={pair.capturePreview}
                     alt="작품 캡처"
                     fill
+                    sizes="96px"
                     className="object-cover"
                   />
                   <button
@@ -335,6 +336,7 @@ export function EvidencePairUpload({
                     src={pair.realPhotoPreview}
                     alt="현장 사진"
                     fill
+                    sizes="96px"
                     className="object-cover"
                   />
                   <button

--- a/src/components/report/MyReportList.tsx
+++ b/src/components/report/MyReportList.tsx
@@ -103,6 +103,7 @@ function ReportCard({ report }: { report: SpotReport }) {
             src={thumbnail}
             alt={report.name}
             fill
+            sizes="56px"
             className="object-cover"
           />
         </div>

--- a/src/components/report/NearbySpotWarning.tsx
+++ b/src/components/report/NearbySpotWarning.tsx
@@ -72,6 +72,7 @@ export function NearbySpotWarning({
                   src={item.thumbnailUrl}
                   alt={item.name}
                   fill
+                  sizes="48px"
                   className="object-cover"
                 />
               </div>

--- a/src/components/report/StatusReportForm.tsx
+++ b/src/components/report/StatusReportForm.tsx
@@ -208,6 +208,7 @@ export function StatusReportForm({
                 src={photoPreview}
                 alt="증거 사진"
                 fill
+                sizes="128px"
                 className="object-cover"
               />
               <button

--- a/src/components/report/SupplementForm.tsx
+++ b/src/components/report/SupplementForm.tsx
@@ -260,6 +260,7 @@ export function SupplementForm({
                   src={capturePreview}
                   alt="캡처 이미지"
                   fill
+                  sizes="128px"
                   className="object-cover"
                 />
                 <button
@@ -340,6 +341,7 @@ export function SupplementForm({
                 src={photoPreview}
                 alt="첨부 사진"
                 fill
+                sizes="128px"
                 className="object-cover"
               />
               <button

--- a/src/components/route/RelatedRoutes.tsx
+++ b/src/components/route/RelatedRoutes.tsx
@@ -1,18 +1,12 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useRelatedRoutes } from '@/hooks/useRouteQueries'
 import { RouteCard } from '@/components/route/RouteCard'
 import { SkeletonBlock } from '@/components/common/SkeletonUI'
-import type { Route } from '@/types/route'
 
 interface RelatedRoutesProps {
   /** 관련 작품명 목록 */
   contentNames: string[]
-}
-
-interface RecommendedData {
-  official: Route[]
-  popular: Route[]
 }
 
 /**
@@ -21,38 +15,7 @@ interface RecommendedData {
  * Requirements: 4.3
  */
 export function RelatedRoutes({ contentNames }: RelatedRoutesProps) {
-  const [routes, setRoutes] = useState<Route[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    if (contentNames.length === 0) {
-      setIsLoading(false)
-      return
-    }
-
-    async function fetchRelatedRoutes() {
-      try {
-        // 첫 번째 작품명으로 추천 코스 조회
-        const res = await fetch(
-          `/api/routes/recommended?contentName=${encodeURIComponent(contentNames[0])}&limit=4`
-        )
-        if (!res.ok) throw new Error('fetch failed')
-        const data: RecommendedData = await res.json()
-
-        // 공식 + 인기 합쳐서 중복 제거
-        const allRoutes = [...data.official, ...data.popular]
-        const unique = allRoutes.filter(
-          (r, i, arr) => arr.findIndex((x) => x.id === r.id) === i
-        )
-        setRoutes(unique)
-      } catch {
-        // 에러 시 섹션 숨김
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    fetchRelatedRoutes()
-  }, [contentNames])
+  const { data: routes = [], isLoading } = useRelatedRoutes(contentNames)
 
   if (isLoading) {
     return (
@@ -80,9 +43,7 @@ export function RelatedRoutes({ contentNames }: RelatedRoutesProps) {
     )
   }
 
-  if (routes.length === 0) {
-    return null
-  }
+  if (routes.length === 0) return null
 
   return (
     <div className="overflow-hidden rounded-lg bg-white shadow-md">

--- a/src/components/route/RouteListContent.tsx
+++ b/src/components/route/RouteListContent.tsx
@@ -1,17 +1,15 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { RouteCard } from '@/components/route/RouteCard'
 import {
   RouteFilterBar,
   type RouteFilters,
 } from '@/components/route/RouteFilterBar'
 import { SkeletonBlock } from '@/components/common/SkeletonUI'
+import { useRouteList } from '@/hooks/useRouteQueries'
 import type { Route } from '@/types/route'
 
-const PAGE_LIMIT = 12
-
-/** 코스 카드 스켈레톤 */
 function RouteCardSkeleton() {
   return (
     <div className="overflow-hidden rounded-lg border border-navy-200 bg-white shadow-sm">
@@ -30,17 +28,9 @@ function RouteCardSkeleton() {
   )
 }
 
-interface RoutesResponse {
-  routes: Route[]
-  total: number
-  page: number
-  totalPages: number
-}
-
 /**
  * RouteListContent - 코스 목록 콘텐츠
- * RouteCard + RouteFilterBar + 무한 스크롤
- * Requirements: 2.1, 2.2
+ * Requirements: 2.1, 2.2, 8.3
  */
 export function RouteListContent() {
   const [filters, setFilters] = useState<RouteFilters>({
@@ -48,74 +38,42 @@ export function RouteListContent() {
     contentName: '',
     regionTag: '',
   })
-  const [routes, setRoutes] = useState<Route[]>([])
   const [page, setPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(1)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [allRoutes, setAllRoutes] = useState<Route[]>([])
   const observerRef = useRef<HTMLDivElement>(null)
   const debounceRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const [debouncedFilters, setDebouncedFilters] = useState(filters)
 
-  /** API 호출 */
-  const fetchRoutes = useCallback(
-    async (pageNum: number, append: boolean) => {
-      if (append) setIsLoadingMore(true)
-      else setIsLoading(true)
-
-      try {
-        const params = new URLSearchParams({
-          sort: filters.sort,
-          page: String(pageNum),
-          limit: String(PAGE_LIMIT),
-        })
-        if (filters.contentName) params.set('contentName', filters.contentName)
-        if (filters.regionTag) params.set('regionTag', filters.regionTag)
-        if (filters.minDuration)
-          params.set('minDuration', String(filters.minDuration))
-        if (filters.maxDuration)
-          params.set('maxDuration', String(filters.maxDuration))
-
-        const res = await fetch(`/api/routes?${params}`)
-        if (!res.ok) throw new Error('fetch failed')
-        const data: RoutesResponse = await res.json()
-
-        if (append) {
-          setRoutes((prev) => [...prev, ...data.routes])
-        } else {
-          setRoutes(data.routes)
-        }
-        setTotalPages(data.totalPages)
-      } catch {
-        // 에러 시 빈 상태 유지
-      } finally {
-        setIsLoading(false)
-        setIsLoadingMore(false)
-      }
-    },
-    [filters]
-  )
-
-  /** 필터 변경 시 디바운스 후 리셋 */
+  // 필터 디바운스
   useEffect(() => {
     clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
+      setDebouncedFilters(filters)
       setPage(1)
-      fetchRoutes(1, false)
+      setAllRoutes([])
     }, 300)
     return () => clearTimeout(debounceRef.current)
-  }, [fetchRoutes])
+  }, [filters])
 
-  /** 무한 스크롤 IntersectionObserver */
+  const { data, isLoading } = useRouteList(debouncedFilters, page)
+
+  const currentPageRoutes = data?.routes ?? []
+  const totalPages = data?.totalPages ?? 1
+
+  // 페이지 변경 시 누적
+  const routes =
+    page === 1 ? currentPageRoutes : [...allRoutes, ...currentPageRoutes]
+
+  // 무한 스크롤 IntersectionObserver
   useEffect(() => {
     const el = observerRef.current
     if (!el) return
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && !isLoadingMore && page < totalPages) {
-          const nextPage = page + 1
-          setPage(nextPage)
-          fetchRoutes(nextPage, true)
+        if (entries[0].isIntersecting && !isLoading && page < totalPages) {
+          setAllRoutes(routes)
+          setPage((p) => p + 1)
         }
       },
       { threshold: 0.1 }
@@ -123,14 +81,13 @@ export function RouteListContent() {
 
     observer.observe(el)
     return () => observer.disconnect()
-  }, [page, totalPages, isLoadingMore, fetchRoutes])
+  }, [page, totalPages, isLoading, routes])
 
   return (
     <div className="space-y-6">
       <RouteFilterBar filters={filters} onFiltersChange={setFilters} />
 
-      {/* 코스 그리드 */}
-      {isLoading ? (
+      {isLoading && routes.length === 0 ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }, (_, i) => (
             <RouteCardSkeleton key={i} />
@@ -151,10 +108,9 @@ export function RouteListContent() {
             ))}
           </div>
 
-          {/* 무한 스크롤 트리거 */}
           {page < totalPages && (
             <div ref={observerRef} className="flex justify-center py-4">
-              {isLoadingMore && (
+              {isLoading && (
                 <div className="h-8 w-8 animate-spin rounded-full border-4 border-navy-200 border-t-navy-600" />
               )}
             </div>

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -88,6 +88,7 @@ export function RelatedContentItem({
               src={content.imageUrl}
               alt={content.name}
               fill
+              sizes="(max-width: 640px) 100vw, 50vw"
               className="object-cover"
             />
           </div>

--- a/src/components/spot/RelatedContentSection.tsx
+++ b/src/components/spot/RelatedContentSection.tsx
@@ -134,6 +134,7 @@ function RelatedContentCard({ content }: RelatedContentCardProps) {
                 src={content.imageUrl}
                 alt={content.name}
                 fill
+                sizes="(max-width: 640px) 100vw, 50vw"
                 className="object-cover"
               />
             </div>

--- a/src/components/spot/SpotCheckInSection.tsx
+++ b/src/components/spot/SpotCheckInSection.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import {
   CheckInButton,
   CheckInGallery,
   BadgeEarnedModal,
 } from '@/components/checkin'
+import {
+  useCheckInCount,
+  useInvalidateCheckIns,
+  useInvalidateCheckInCount,
+} from '@/hooks/useGalleryQueries'
 import { UserBadge } from '@/types'
 
 interface SpotCheckInSectionProps {
@@ -23,31 +28,16 @@ export function SpotCheckInSection({
   spotName,
   sceneImageUrl,
 }: SpotCheckInSectionProps) {
-  const [checkInCount, setCheckInCount] = useState(0)
-  const [refreshKey, setRefreshKey] = useState(0)
+  const { data: checkInCount = 0 } = useCheckInCount(spotId)
+  const invalidateCheckIns = useInvalidateCheckIns()
+  const invalidateCheckInCount = useInvalidateCheckInCount(spotId)
   const [earnedBadges, setEarnedBadges] = useState<UserBadge[]>([])
 
-  // 인증 수 조회
-  useEffect(() => {
-    const fetchCount = async () => {
-      try {
-        const res = await fetch(`/api/checkins?spotId=${spotId}&limit=1`)
-        if (res.ok) {
-          const data = await res.json()
-          setCheckInCount(data.total)
-        }
-      } catch (error) {
-        console.error('Error fetching checkin count:', error)
-      }
-    }
-    fetchCount()
-  }, [spotId, refreshKey])
-
   const handleCheckInSuccess = (badges?: UserBadge[]) => {
-    // 갤러리 새로고침
-    setRefreshKey((prev) => prev + 1)
+    // React Query 캐시 무효화로 갤러리 + 카운트 새로고침
+    invalidateCheckIns()
+    invalidateCheckInCount()
 
-    // 뱃지 획득 시 모달 표시
     if (badges && badges.length > 0) {
       setEarnedBadges(badges)
     }
@@ -75,12 +65,7 @@ export function SpotCheckInSection({
         </div>
 
         {/* 인증 갤러리 */}
-        <CheckInGallery
-          key={refreshKey}
-          spotId={spotId}
-          limit={8}
-          showLoadMore={true}
-        />
+        <CheckInGallery spotId={spotId} limit={8} showLoadMore={true} />
       </div>
 
       {/* 뱃지 획득 모달 */}

--- a/src/hooks/useGalleryQueries.ts
+++ b/src/hooks/useGalleryQueries.ts
@@ -160,3 +160,36 @@ export function useInvalidateCheckInCount(spotId: string) {
     qc.invalidateQueries({ queryKey: galleryKeys.checkinCount(spotId) })
   }, [qc, spotId])
 }
+
+// ── Contributor Types ───────────────────────────────────────
+
+interface Contributor {
+  contributorId: string
+  contributorName: string
+  count: number
+}
+
+// ── Contributor Query Keys ──────────────────────────────────
+
+export const contributorKeys = {
+  all: ['contributors'] as const,
+  list: (spotId: string) => [...contributorKeys.all, spotId] as const,
+}
+
+/**
+ * 스팟 정보 보완 기여자 목록 조회 훅
+ * Requirements: 8.3
+ */
+export function useContributors(spotId: string) {
+  return useQuery({
+    queryKey: contributorKeys.list(spotId),
+    queryFn: async (): Promise<Contributor[]> => {
+      const res = await fetch(API_ROUTES.SUPPLEMENTS.BASE(spotId))
+      if (!res.ok) throw new Error('기여자 목록 조회 실패')
+      const data = await res.json()
+      return data.contributors || []
+    },
+    enabled: !!spotId,
+    staleTime: 5 * 60 * 1000,
+  })
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #313

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 전체 코드베이스의 useState+useEffect+fetch 패턴을 React Query 훅으로 전환하고, Image fill에 sizes 속성을 보완하며, 대형 컴포넌트를 분리하는 리팩토링

---

## 📋 변경 사항

- [x] useContributors 훅 추가 (useGalleryQueries.ts)
- [x] Admin 카드 컴포넌트 분리 (ReportSummaryCard, StatusReportSummaryCard, SupplementSummaryCard)
- [x] Admin 리스트 3종 React Query 전환 (AdminReportList, AdminStatusReportList, AdminSupplementList)
- [x] Admin 페이지 3종 refreshKey 제거 → invalidation 연동
- [x] AdminContentImagesPage React Query 전환
- [x] CheckInGallery React Query 전환 + CheckInDetailModal 분리
- [x] HallOfFameTab, ContentTab React Query 전환
- [x] RouteListContent, RelatedRoutes React Query 전환
- [x] ContributorList, SpotCheckInSection React Query 전환
- [x] UserProfilePage React Query 전환 (4개 병렬 fetch → 개별 훅)
- [x] 전체 Image fill sizes 속성 누락 보완 (17개 파일)

Requirements: 1.3, 5.1, 8.1, 8.2, 8.3

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Task 12 (14-performance-optimization spec) 전체 완료
- 기존 useState+useEffect+fetch 패턴을 모두 React Query로 전환하여 캐시 관리, 로딩/에러 상태, 자동 재검증 등의 이점 확보
- refreshKey 패턴을 React Query invalidation으로 대체하여 코드 단순화
