### PR TITLE
[Enhancement] Task 13.1 - 무거운 모달 컴포넌트 dynamic import 적용

### DIFF
--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -15,9 +15,23 @@ import NearbyFacilities from '@/components/spot/NearbyFacilities'
 import { SpotContentSection } from '@/components/spot/SpotContentSection'
 import { RelatedContentSection } from '@/components/spot/RelatedContentSection'
 import { SpotCheckInSection } from '@/components/spot/SpotCheckInSection'
-import { SupplementForm } from '@/components/report/SupplementForm'
 import { ContributorList } from '@/components/report/ContributorList'
-import { StatusReportForm } from '@/components/report/StatusReportForm'
+
+const SupplementForm = dynamic(
+  () =>
+    import('@/components/report/SupplementForm').then(
+      (mod) => mod.SupplementForm
+    ),
+  { loading: () => null }
+)
+
+const StatusReportForm = dynamic(
+  () =>
+    import('@/components/report/StatusReportForm').then(
+      (mod) => mod.StatusReportForm
+    ),
+  { loading: () => null }
+)
 import { SpotStatusIndicator } from '@/components/report/SpotStatusIndicator'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import { CategoryIcon } from '@/components/common'

--- a/src/components/spot/NearbyFacilities.tsx
+++ b/src/components/spot/NearbyFacilities.tsx
@@ -4,9 +4,13 @@ import { NearbyFacility, FacilityType } from '@/types'
 import { useCallback, useMemo, useState } from 'react'
 import { groupFacilitiesByType } from '@/lib/facility-utils'
 import { useInvalidateFacilities } from '@/hooks/useSpotDetail'
+import dynamic from 'next/dynamic'
 import FacilityFilter from './FacilityFilter'
 import FacilityCard from './FacilityCard'
-import FacilityReportForm from './FacilityReportForm'
+
+const FacilityReportForm = dynamic(() => import('./FacilityReportForm'), {
+  loading: () => null,
+})
 
 interface NearbyFacilitiesProps {
   facilities: NearbyFacility[]


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #315

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 사용자 상호작용 시에만 필요한 무거운 모달/폼 컴포넌트를 next/dynamic으로 지연 로딩 전환하여 초기 번들 크기 감소

---

## 📋 변경 사항

- [x] NearbyFacilities에서 FacilityReportForm을 next/dynamic으로 전환
- [x] spots/[id]/page에서 SupplementForm을 next/dynamic으로 전환
- [x] spots/[id]/page에서 StatusReportForm을 next/dynamic으로 전환

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 6.1, 6.2
- SpotReportForm(reports/new/page)은 페이지 전용 컴포넌트로 dynamic import 대상에서 제외
- 모든 dynamic import에 `loading: () => null` 설정 (모달/폼이 조건부 렌더링되므로 별도 로딩 UI 불필요)
