### PR TITLE
Feat/317  twitter oauth provider  add

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,9 @@ KAKAO_CLIENT_SECRET=your-kakao-client-secret
 NAVER_CLIENT_ID=your-naver-client-id
 NAVER_CLIENT_SECRET=your-naver-client-secret
 
+# X(Twitter) OAuth
+TWITTER_CLIENT_ID=your-twitter-client-id
+TWITTER_CLIENT_SECRET=your-twitter-client-secret
+
 # Google Maps (Places Autocomplete)
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -77,6 +77,17 @@ function SignInForm() {
           <span className="text-lg font-bold">N</span>
           네이버로 로그인
         </button>
+
+        <button
+          onClick={() => loginWithProvider('twitter')}
+          disabled={isLoading}
+          className="flex w-full items-center justify-center gap-3 rounded-lg bg-black px-4 py-3 text-white transition hover:bg-gray-900 disabled:opacity-50"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          X(Twitter)로 로그인
+        </button>
       </div>
 
       <div className="relative">

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -62,7 +62,7 @@ export function useAuth() {
 
   // 소셜 로그인
   const loginWithProvider = useCallback(
-    async (provider: 'google' | 'kakao' | 'naver') => {
+    async (provider: 'google' | 'kakao' | 'naver' | 'twitter') => {
       setIsLoading(true)
       clearAuthError()
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,8 +2,10 @@ import NextAuth from 'next-auth'
 import Google from 'next-auth/providers/google'
 import Kakao from 'next-auth/providers/kakao'
 import Naver from 'next-auth/providers/naver'
+import Twitter from 'next-auth/providers/twitter'
 import Credentials from 'next-auth/providers/credentials'
 import { MongoDBAdapter } from '@auth/mongodb-adapter'
+import { ObjectId } from 'mongodb'
 import bcrypt from 'bcryptjs'
 import clientPromise from './mongodb-client'
 import { getDb } from './db'
@@ -22,6 +24,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     Naver({
       clientId: process.env.NAVER_CLIENT_ID!,
       clientSecret: process.env.NAVER_CLIENT_SECRET!,
+    }),
+    Twitter({
+      clientId: process.env.TWITTER_CLIENT_ID!,
+      clientSecret: process.env.TWITTER_CLIENT_SECRET!,
     }),
     Credentials({
       name: 'credentials',
@@ -77,21 +83,24 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       }
 
       // 매번 DB에서 role 조회 (role 변경 즉시 반영)
-      if (token.email) {
+      if (token.email || token.id) {
         try {
           const db = await getDb()
-          const dbUser = await db.collection('users').findOne({
-            email: token.email,
-          })
+          const query = token.email
+            ? { email: token.email }
+            : { _id: new ObjectId(token.id as string) }
+          const dbUser = await db.collection('users').findOne(query)
           if (dbUser) {
             token.role = dbUser.role || 'user'
             // eslint-disable-next-line no-console
-            console.log(`[Auth] User ${token.email} role: ${token.role}`)
+            console.log(
+              `[Auth] User ${token.email || token.id} role: ${token.role}`
+            )
           } else {
             token.role = 'user'
             // eslint-disable-next-line no-console
             console.log(
-              `[Auth] User ${token.email} not found, default role: user`
+              `[Auth] User ${token.email || token.id} not found, default role: user`
             )
           }
         } catch (error) {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #317

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

X(Twitter) OAuth 프로바이더를 Auth 시스템에 추가하고, 이메일 미제공 시에도 계정 생성이 가능하도록 처리

---

## 📋 변경 사항

- [x] `src/lib/auth.ts`에 Twitter 프로바이더 추가 및 이메일 없는 사용자 DB 조회 지원
- [x] `src/hooks/useAuth.ts`의 `loginWithProvider` 타입에 `'twitter'` 추가
- [x] `.env.example`에 `TWITTER_CLIENT_ID`, `TWITTER_CLIENT_SECRET` 환경변수 추가

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과 (pre-commit hook)
- [x] Requirements 1.1, 1.2, 1.3, 1.4, 1.6 대응

---

## 📝 추가 정보

- X(Twitter)가 이메일을 제공하지 않는 경우, JWT 콜백에서 `token.id`(ObjectId)로 DB 조회하도록 fallback 처리
- `TWITTER_CLIENT_ID`, `TWITTER_CLIENT_SECRET`는 X Developer Portal에서 발급 필요


## 📸 스크린샷 (선택)

<img width="446" height="278" alt="image" src="https://github.com/user-attachments/assets/01afce4b-d79a-417b-901a-78e64fcaf87a" />

