### PR TITLE
계정 연동 관리를 위한 API 엔드포인트 구현(연결된 계정 조회, 연결 해제, 비밀번호 설정)

### DIFF
--- a/src/app/api/account/linked-accounts/route.ts
+++ b/src/app/api/account/linked-accounts/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import { auth } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+
+/**
+ * GET /api/account/linked-accounts
+ * 인증된 사용자의 연결된 계정 목록 조회
+ * Requirements: 6.1, 6.3, 5.1
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+
+    const [accounts, user] = await Promise.all([
+      db
+        .collection('accounts')
+        .find({ userId })
+        .project({ provider: 1, providerAccountId: 1, _id: 0 })
+        .toArray(),
+      db
+        .collection('users')
+        .findOne({ _id: userId }, { projection: { password: 1 } }),
+    ])
+
+    const linkedAccounts = accounts.map((account) => ({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    }))
+
+    return NextResponse.json({
+      accounts: linkedAccounts,
+      hasPassword: !!user?.password,
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[Account] 연결된 계정 목록 조회 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/account/linked-accounts
+ * 지정된 프로바이더 연결 해제
+ * Requirements: 6.2, 6.3, 6.4, 6.5, 5.5, 5.6, 8.4
+ */
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const { provider, providerAccountId } = await request.json()
+    if (!provider || !providerAccountId) {
+      return NextResponse.json(
+        { error: 'provider와 providerAccountId는 필수입니다.' },
+        { status: 400 }
+      )
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+
+    // 해당 프로바이더 연결 존재 확인
+    const existingAccount = await db
+      .collection('accounts')
+      .findOne({ userId, provider, providerAccountId })
+
+    if (!existingAccount) {
+      return NextResponse.json(
+        { error: '연결된 계정을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    // 마지막 로그인 수단 보호: 연결된 계정 수 + 비밀번호 여부 확인
+    const [accountCount, user] = await Promise.all([
+      db.collection('accounts').countDocuments({ userId }),
+      db
+        .collection('users')
+        .findOne({ _id: userId }, { projection: { password: 1 } }),
+    ])
+
+    const totalLoginMethods = accountCount + (user?.password ? 1 : 0)
+
+    if (totalLoginMethods <= 1) {
+      return NextResponse.json(
+        { error: '최소 하나의 로그인 수단이 필요합니다.' },
+        { status: 400 }
+      )
+    }
+
+    // 프로바이더 연결 해제
+    await db
+      .collection('accounts')
+      .deleteOne({ userId, provider, providerAccountId })
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[Account Linking] 연결 해제 — userId: ${session.user.id}, provider: ${provider}`
+    )
+
+    return NextResponse.json({ message: '계정 연결이 해제되었습니다.' })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[Account] 계정 연결 해제 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/account/set-password/route.ts
+++ b/src/app/api/account/set-password/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import bcrypt from 'bcryptjs'
+import { auth } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+
+/**
+ * POST /api/account/set-password
+ * 소셜 전용 계정에 비밀번호 설정
+ * Requirements: 5.8, 6.3
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const { password } = await request.json()
+
+    // 비밀번호 최소 6자 검증
+    if (!password || typeof password !== 'string' || password.length < 6) {
+      return NextResponse.json(
+        { error: '비밀번호는 최소 6자 이상이어야 합니다.' },
+        { status: 400 }
+      )
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+
+    // 이미 비밀번호가 설정되어 있는지 확인
+    const user = await db
+      .collection('users')
+      .findOne({ _id: userId }, { projection: { password: 1 } })
+
+    if (!user) {
+      return NextResponse.json(
+        { error: '사용자를 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    if (user.password) {
+      return NextResponse.json(
+        { error: '이미 비밀번호가 설정되어 있습니다.' },
+        { status: 409 }
+      )
+    }
+
+    // 비밀번호 해싱 및 저장
+    const hashedPassword = await bcrypt.hash(password, 12)
+
+    await db.collection('users').updateOne(
+      { _id: userId },
+      {
+        $set: {
+          password: hashedPassword,
+          updatedAt: new Date(),
+        },
+      }
+    )
+
+    return NextResponse.json({ message: '비밀번호가 설정되었습니다.' })
+  } catch (error) {
+    console.error('[Account] 비밀번호 설정 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -104,6 +104,8 @@ export const COLLECTIONS = {
   ROUTE_COMPLETIONS: 'route_completions',
   // 편의시설 투표 컬렉션 (11-otaku-facilities)
   FACILITY_VOTES: 'facility_votes',
+  // 인증 시스템 계정 연동 컬렉션 (15-oauth-integration)
+  ACCOUNTS: 'accounts',
 } as const
 
 /**


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #321

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 계정 연동 관리를 위한 API 엔드포인트 3개 구현 (연결된 계정 조회, 연결 해제, 비밀번호 설정)

---

## 📋 변경 사항

- [x] `GET /api/account/linked-accounts` — 인증된 사용자의 연결된 계정 목록 및 비밀번호 설정 여부 조회
- [x] `DELETE /api/account/linked-accounts` — 프로바이더 연결 해제 (마지막 로그인 수단 보호, 404 처리, 이벤트 로깅)
- [x] `POST /api/account/set-password` — 소셜 전용 계정 비밀번호 설정 (6자 검증, 중복 설정 409 처리)
- [x] `COLLECTIONS` 상수에 `ACCOUNTS` 추가

**Requirements 대응**: 5.1, 5.5, 5.6, 5.8, 6.1, 6.2, 6.3, 6.4, 6.5, 8.4

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- 미인증 요청 시 모든 엔드포인트에서 401 응답 반환
- 마지막 로그인 수단 해제 시도 시 400 에러로 보호
- Account Linking 해제 이벤트는 서버 로그에 기록
