### PR TITLE
[Test] 계정 연동 API property/단위 테스트 추가

### DIFF
--- a/src/app/api/account/__tests__/account-api.test.ts
+++ b/src/app/api/account/__tests__/account-api.test.ts
@@ -1,0 +1,402 @@
+/**
+ * 계정 연동 API Property-Based Tests & Unit Tests
+ * Feature: 15-oauth-integration
+ *
+ * Property 8: 미인증 API 거부 (Requirements 6.3, 8.2)
+ * Property 5: 연결 해제 동작 (Requirements 5.5, 6.2)
+ * Property 6: 마지막 로그인 수단 보호 (Requirements 5.6, 6.5)
+ * Property 7: 비밀번호 설정 라운드 트립 (Requirements 5.8)
+ * Property 12: 연결된 계정 목록 완전성 (Requirements 5.1, 6.1)
+ * Unit: 존재하지 않는 프로바이더 해제 시 404 (Requirements 6.4)
+ */
+
+import fc from 'fast-check'
+import { NextRequest } from 'next/server'
+
+// --- Mock state ---
+let mockSession: { user: { id: string } } | null = null
+
+// accounts 컬렉션 mock
+const mockAccountsFindOne = jest.fn()
+const mockAccountsToArray = jest.fn()
+const mockAccountsProject = jest.fn()
+const mockAccountsFind = jest.fn()
+const mockAccountsCountDocuments = jest.fn()
+const mockAccountsDeleteOne = jest.fn()
+
+// users 컬렉션 mock
+const mockUsersFindOne = jest.fn()
+const mockUsersUpdateOne = jest.fn()
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(() => Promise.resolve(mockSession)),
+}))
+
+jest.mock('@/lib/db', () => ({
+  getDb: jest.fn(() =>
+    Promise.resolve({
+      collection: (name: string) => {
+        if (name === 'accounts') {
+          return {
+            findOne: mockAccountsFindOne,
+            find: mockAccountsFind,
+            countDocuments: mockAccountsCountDocuments,
+            deleteOne: mockAccountsDeleteOne,
+          }
+        }
+        if (name === 'users') {
+          return {
+            findOne: mockUsersFindOne,
+            updateOne: mockUsersUpdateOne,
+          }
+        }
+        return {}
+      },
+    })
+  ),
+}))
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(() => Promise.resolve('$2a$12$mockhash')),
+  compare: jest.fn((plain: string, hashed: string) =>
+    Promise.resolve(hashed === '$2a$12$mockhash')
+  ),
+}))
+
+// --- Imports (after mocks) ---
+import { GET, DELETE } from '../linked-accounts/route'
+import { POST } from '../set-password/route'
+
+// --- Arbitraries ---
+const providerArb = fc.constantFrom('google', 'kakao', 'naver', 'twitter')
+const providerAccountIdArb = fc.string({ minLength: 5, maxLength: 30 })
+const validPasswordArb = fc.string({ minLength: 6, maxLength: 72 })
+
+// --- Helpers ---
+function createDeleteRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/account/linked-accounts', {
+    method: 'DELETE',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function createPostRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/account/set-password', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function setupChainedFind(accounts: Array<Record<string, unknown>>) {
+  mockAccountsToArray.mockResolvedValue(accounts)
+  mockAccountsProject.mockReturnValue({ toArray: mockAccountsToArray })
+  mockAccountsFind.mockReturnValue({ project: mockAccountsProject })
+}
+
+// --- Setup ---
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockSession = null
+})
+
+// ============================================================
+// Property 8: 미인증 API 거부
+// Feature: 15-oauth-integration, Property 8: Unauthenticated API rejection
+// Validates: Requirements 6.3, 8.2
+// ============================================================
+describe('Property 8: 미인증 API 거부', () => {
+  test('GET /api/account/linked-accounts — 미인증 시 401 반환', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constant(null), async () => {
+        mockSession = null
+        const res = await GET()
+        const data = await res.json()
+        expect(res.status).toBe(401)
+        expect(data.error).toBe('인증이 필요합니다.')
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  test('DELETE /api/account/linked-accounts — 미인증 시 401 반환', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        providerArb,
+        providerAccountIdArb,
+        async (provider, providerAccountId) => {
+          mockSession = null
+          const req = createDeleteRequest({ provider, providerAccountId })
+          const res = await DELETE(req)
+          const data = await res.json()
+          expect(res.status).toBe(401)
+          expect(data.error).toBe('인증이 필요합니다.')
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  test('POST /api/account/set-password — 미인증 시 401 반환', async () => {
+    await fc.assert(
+      fc.asyncProperty(validPasswordArb, async (password) => {
+        mockSession = null
+        const req = createPostRequest({ password })
+        const res = await POST(req)
+        const data = await res.json()
+        expect(res.status).toBe(401)
+        expect(data.error).toBe('인증이 필요합니다.')
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ============================================================
+// Property 12: 연결된 계정 목록 완전성
+// Feature: 15-oauth-integration, Property 12: Linked accounts API returns complete list
+// Validates: Requirements 5.1, 6.1
+// ============================================================
+describe('Property 12: 연결된 계정 목록 완전성', () => {
+  test('GET — N개 연결된 계정이 있으면 정확히 N개 반환', async () => {
+    const accountArb = fc.record({
+      provider: providerArb,
+      providerAccountId: providerAccountIdArb,
+    })
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(accountArb, { minLength: 0, maxLength: 8 }),
+        fc.boolean(),
+        async (accounts, hasPassword) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+          setupChainedFind(accounts)
+          mockUsersFindOne.mockResolvedValue(
+            hasPassword ? { password: '$2a$12$mockhash' } : { password: null }
+          )
+
+          const res = await GET()
+          const data = await res.json()
+
+          expect(res.status).toBe(200)
+          expect(data.accounts).toHaveLength(accounts.length)
+          expect(data.hasPassword).toBe(hasPassword)
+
+          // 각 계정에 provider와 providerAccountId가 존재하는지 확인
+          for (const account of data.accounts) {
+            expect(account).toHaveProperty('provider')
+            expect(account).toHaveProperty('providerAccountId')
+            expect(typeof account.provider).toBe('string')
+            expect(typeof account.providerAccountId).toBe('string')
+          }
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ============================================================
+// Property 5: 연결 해제 동작
+// Feature: 15-oauth-integration, Property 5: Unlinking removes provider from account
+// Validates: Requirements 5.5, 6.2
+// ============================================================
+describe('Property 5: 연결 해제 동작', () => {
+  test('DELETE — 2개 이상 로그인 수단이 있을 때 연결 해제 성공', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        providerArb,
+        providerAccountIdArb,
+        fc.integer({ min: 2, max: 5 }),
+        async (provider, providerAccountId, accountCount) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+          // 해당 프로바이더 연결 존재
+          mockAccountsFindOne.mockResolvedValue({
+            userId: '507f1f77bcf86cd799439011',
+            provider,
+            providerAccountId,
+          })
+          // 2개 이상 연결된 계정
+          mockAccountsCountDocuments.mockResolvedValue(accountCount)
+          mockUsersFindOne.mockResolvedValue({ password: null })
+          mockAccountsDeleteOne.mockResolvedValue({ deletedCount: 1 })
+
+          const req = createDeleteRequest({ provider, providerAccountId })
+          const res = await DELETE(req)
+          const data = await res.json()
+
+          expect(res.status).toBe(200)
+          expect(data.message).toBe('계정 연결이 해제되었습니다.')
+          expect(mockAccountsDeleteOne).toHaveBeenCalled()
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ============================================================
+// Property 6: 마지막 로그인 수단 보호
+// Feature: 15-oauth-integration, Property 6: Last login method protection
+// Validates: Requirements 5.6, 6.5
+// ============================================================
+describe('Property 6: 마지막 로그인 수단 보호', () => {
+  test('DELETE — 마지막 로그인 수단 해제 시 400 에러', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        providerArb,
+        providerAccountIdArb,
+        async (provider, providerAccountId) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+          // 해당 프로바이더 연결 존재
+          mockAccountsFindOne.mockResolvedValue({
+            userId: '507f1f77bcf86cd799439011',
+            provider,
+            providerAccountId,
+          })
+          // 정확히 1개 계정, 비밀번호 없음 → 마지막 로그인 수단
+          mockAccountsCountDocuments.mockResolvedValue(1)
+          mockUsersFindOne.mockResolvedValue({ password: null })
+
+          const req = createDeleteRequest({ provider, providerAccountId })
+          const res = await DELETE(req)
+          const data = await res.json()
+
+          expect(res.status).toBe(400)
+          expect(data.error).toBe('최소 하나의 로그인 수단이 필요합니다.')
+          expect(mockAccountsDeleteOne).not.toHaveBeenCalled()
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  test('DELETE — 비밀번호가 있으면 마지막 OAuth 계정도 해제 가능', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        providerArb,
+        providerAccountIdArb,
+        async (provider, providerAccountId) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+          mockAccountsFindOne.mockResolvedValue({
+            userId: '507f1f77bcf86cd799439011',
+            provider,
+            providerAccountId,
+          })
+          // 1개 OAuth 계정 + 비밀번호 있음 → totalLoginMethods = 2
+          mockAccountsCountDocuments.mockResolvedValue(1)
+          mockUsersFindOne.mockResolvedValue({ password: '$2a$12$mockhash' })
+          mockAccountsDeleteOne.mockResolvedValue({ deletedCount: 1 })
+
+          const req = createDeleteRequest({ provider, providerAccountId })
+          const res = await DELETE(req)
+          const data = await res.json()
+
+          expect(res.status).toBe(200)
+          expect(data.message).toBe('계정 연결이 해제되었습니다.')
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ============================================================
+// Property 7: 비밀번호 설정 라운드 트립
+// Feature: 15-oauth-integration, Property 7: Password setting round trip
+// Validates: Requirements 5.8
+// ============================================================
+describe('Property 7: 비밀번호 설정 라운드 트립', () => {
+  test('POST — 소셜 전용 계정에 비밀번호 설정 성공', async () => {
+    await fc.assert(
+      fc.asyncProperty(validPasswordArb, async (password) => {
+        mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+        // 비밀번호 미설정 사용자
+        mockUsersFindOne.mockResolvedValue({
+          _id: '507f1f77bcf86cd799439011',
+          password: null,
+        })
+        mockUsersUpdateOne.mockResolvedValue({ modifiedCount: 1 })
+
+        const req = createPostRequest({ password })
+        const res = await POST(req)
+        const data = await res.json()
+
+        expect(res.status).toBe(200)
+        expect(data.message).toBe('비밀번호가 설정되었습니다.')
+        expect(mockUsersUpdateOne).toHaveBeenCalled()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  test('POST — 이미 비밀번호가 설정된 경우 409 반환', async () => {
+    await fc.assert(
+      fc.asyncProperty(validPasswordArb, async (password) => {
+        mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+        // 이미 비밀번호 설정된 사용자
+        mockUsersFindOne.mockResolvedValue({
+          _id: '507f1f77bcf86cd799439011',
+          password: '$2a$12$existinghash',
+        })
+
+        const req = createPostRequest({ password })
+        const res = await POST(req)
+        const data = await res.json()
+
+        expect(res.status).toBe(409)
+        expect(data.error).toBe('이미 비밀번호가 설정되어 있습니다.')
+        expect(mockUsersUpdateOne).not.toHaveBeenCalled()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  test('POST — 6자 미만 비밀번호 시 400 반환', async () => {
+    const shortPasswordArb = fc.string({ minLength: 1, maxLength: 5 })
+
+    await fc.assert(
+      fc.asyncProperty(shortPasswordArb, async (password) => {
+        mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+        const req = createPostRequest({ password })
+        const res = await POST(req)
+        const data = await res.json()
+
+        expect(res.status).toBe(400)
+        expect(data.error).toBe('비밀번호는 최소 6자 이상이어야 합니다.')
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ============================================================
+// Unit Test: 존재하지 않는 프로바이더 해제 시 404 응답
+// Validates: Requirements 6.4
+// ============================================================
+describe('Unit: 존재하지 않는 프로바이더 해제 시 404', () => {
+  test('DELETE — 존재하지 않는 프로바이더 해제 요청 시 404 반환', async () => {
+    mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+
+    // 해당 프로바이더 연결이 존재하지 않음
+    mockAccountsFindOne.mockResolvedValue(null)
+
+    const req = createDeleteRequest({
+      provider: 'twitter',
+      providerAccountId: 'nonexistent-id-12345',
+    })
+    const res = await DELETE(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(data.error).toBe('연결된 계정을 찾을 수 없습니다.')
+    expect(mockAccountsDeleteOne).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/account/linked-accounts/route.ts
+++ b/src/app/api/account/linked-accounts/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import { auth } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+
+/**
+ * GET /api/account/linked-accounts
+ * 인증된 사용자의 연결된 계정 목록 조회
+ * Requirements: 6.1, 6.3, 5.1
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+
+    const [accounts, user] = await Promise.all([
+      db
+        .collection('accounts')
+        .find({ userId })
+        .project({ provider: 1, providerAccountId: 1, _id: 0 })
+        .toArray(),
+      db
+        .collection('users')
+        .findOne({ _id: userId }, { projection: { password: 1 } }),
+    ])
+
+    const linkedAccounts = accounts.map((account) => ({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    }))
+
+    return NextResponse.json({
+      accounts: linkedAccounts,
+      hasPassword: !!user?.password,
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[Account] 연결된 계정 목록 조회 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/account/linked-accounts
+ * 지정된 프로바이더 연결 해제
+ * Requirements: 6.2, 6.3, 6.4, 6.5, 5.5, 5.6, 8.4
+ */
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const { provider, providerAccountId } = await request.json()
+    if (!provider || !providerAccountId) {
+      return NextResponse.json(
+        { error: 'provider와 providerAccountId는 필수입니다.' },
+        { status: 400 }
+      )
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+
+    // 해당 프로바이더 연결 존재 확인
+    const existingAccount = await db
+      .collection('accounts')
+      .findOne({ userId, provider, providerAccountId })
+
+    if (!existingAccount) {
+      return NextResponse.json(
+        { error: '연결된 계정을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    // 마지막 로그인 수단 보호: 연결된 계정 수 + 비밀번호 여부 확인
+    const [accountCount, user] = await Promise.all([
+      db.collection('accounts').countDocuments({ userId }),
+      db
+        .collection('users')
+        .findOne({ _id: userId }, { projection: { password: 1 } }),
+    ])
+
+    const totalLoginMethods = accountCount + (user?.password ? 1 : 0)
+
+    if (totalLoginMethods <= 1) {
+      return NextResponse.json(
+        { error: '최소 하나의 로그인 수단이 필요합니다.' },
+        { status: 400 }
+      )
+    }
+
+    // 프로바이더 연결 해제
+    await db
+      .collection('accounts')
+      .deleteOne({ userId, provider, providerAccountId })
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[Account Linking] 연결 해제 — userId: ${session.user.id}, provider: ${provider}`
+    )
+
+    return NextResponse.json({ message: '계정 연결이 해제되었습니다.' })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[Account] 계정 연결 해제 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/account/set-password/route.ts
+++ b/src/app/api/account/set-password/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import bcrypt from 'bcryptjs'
+import { auth } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+
+/**
+ * POST /api/account/set-password
+ * 소셜 전용 계정에 비밀번호 설정
+ * Requirements: 5.8, 6.3
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const { password } = await request.json()
+
+    // 비밀번호 최소 6자 검증
+    if (!password || typeof password !== 'string' || password.length < 6) {
+      return NextResponse.json(
+        { error: '비밀번호는 최소 6자 이상이어야 합니다.' },
+        { status: 400 }
+      )
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+
+    // 이미 비밀번호가 설정되어 있는지 확인
+    const user = await db
+      .collection('users')
+      .findOne({ _id: userId }, { projection: { password: 1 } })
+
+    if (!user) {
+      return NextResponse.json(
+        { error: '사용자를 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    if (user.password) {
+      return NextResponse.json(
+        { error: '이미 비밀번호가 설정되어 있습니다.' },
+        { status: 409 }
+      )
+    }
+
+    // 비밀번호 해싱 및 저장
+    const hashedPassword = await bcrypt.hash(password, 12)
+
+    await db.collection('users').updateOne(
+      { _id: userId },
+      {
+        $set: {
+          password: hashedPassword,
+          updatedAt: new Date(),
+        },
+      }
+    )
+
+    return NextResponse.json({ message: '비밀번호가 설정되었습니다.' })
+  } catch (error) {
+    console.error('[Account] 비밀번호 설정 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -104,6 +104,8 @@ export const COLLECTIONS = {
   ROUTE_COMPLETIONS: 'route_completions',
   // 편의시설 투표 컬렉션 (11-otaku-facilities)
   FACILITY_VOTES: 'facility_votes',
+  // 인증 시스템 계정 연동 컬렉션 (15-oauth-integration)
+  ACCOUNTS: 'accounts',
 } as const
 
 /**


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #323

---

## 📋 PR 타입

- [x] 🧪 **test**: 테스트 추가

---

## ✨ 작업 개요

> 계정 연동 API 엔드포인트(linked-accounts, set-password)에 대한 Property-Based Test 5건 + 단위 테스트 1건 추가

---

## 📋 변경 사항

- [x] Property 8: 미인증 API 거부 테스트 (GET/DELETE/POST 모두 401 반환 검증)
- [x] Property 12: 연결된 계정 목록 완전성 테스트 (N개 계정 → 정확히 N개 반환)
- [x] Property 5: 연결 해제 동작 테스트 (2개 이상 로그인 수단 시 해제 성공)
- [x] Property 6: 마지막 로그인 수단 보호 테스트 (마지막 수단 해제 시 400, 비밀번호 있으면 해제 가능)
- [x] Property 7: 비밀번호 설정 라운드 트립 테스트 (설정 성공, 중복 409, 6자 미만 400)
- [x] 단위 테스트: 존재하지 않는 프로바이더 해제 시 404 응답

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 테스트 11건 전체 통과 (fast-check 각 100회 반복)

---

## 📝 추가 정보

- Requirements 5.1, 5.5, 5.6, 5.8, 6.1, 6.2, 6.3, 6.4, 6.5, 8.2 대응
- `feat/321--account-linking-api--add` 브랜치를 merge하여 API 엔드포인트 포함
- 테스트 파일: `src/app/api/account/__tests__/account-api.test.ts`
