### PR TITLE
[Feat] 소셜 계정 연동 관리 페이지 추가

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -107,6 +107,11 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url)
 
+  // http/https 이외의 스킴(chrome-extension 등)은 캐싱 불가 — 무시
+  if (!url.protocol.startsWith('http')) {
+    return
+  }
+
   // 지도 타일: Cache First 전략
   if (isTileRequest(url)) {
     event.respondWith(handleTileRequest(event.request))

--- a/src/app/api/account/linked-accounts/route.ts
+++ b/src/app/api/account/linked-accounts/route.ts
@@ -26,7 +26,7 @@ export async function GET(): Promise<NextResponse> {
         .toArray(),
       db
         .collection('users')
-        .findOne({ _id: userId }, { projection: { password: 1 } }),
+        .findOne({ _id: userId }, { projection: { password: 1, email: 1 } }),
     ])
 
     const linkedAccounts = accounts.map((account) => ({
@@ -37,6 +37,7 @@ export async function GET(): Promise<NextResponse> {
     return NextResponse.json({
       accounts: linkedAccounts,
       hasPassword: !!user?.password,
+      email: user?.email || null,
     })
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/app/api/account/set-password/route.ts
+++ b/src/app/api/account/set-password/route.ts
@@ -6,7 +6,7 @@ import { getDb } from '@/lib/db'
 
 /**
  * POST /api/account/set-password
- * 소셜 전용 계정에 비밀번호 설정
+ * 소셜 전용 계정에 이메일(ID) + 비밀번호 설정
  * Requirements: 5.8, 6.3
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -16,7 +16,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
     }
 
-    const { password } = await request.json()
+    const { email, password } = await request.json()
+
+    // 이메일 검증
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
+      return NextResponse.json(
+        { error: '유효한 이메일 주소를 입력해주세요.' },
+        { status: 400 }
+      )
+    }
 
     // 비밀번호 최소 6자 검증
     if (!password || typeof password !== 'string' || password.length < 6) {
@@ -29,21 +37,26 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const db = await getDb()
     const userId = new ObjectId(session.user.id)
 
-    // 이미 비밀번호가 설정되어 있는지 확인
-    const user = await db
+    // 이미 비밀번호가 설정된 경우
+    const currentUser = await db
       .collection('users')
       .findOne({ _id: userId }, { projection: { password: 1 } })
 
-    if (!user) {
+    if (currentUser?.password) {
       return NextResponse.json(
-        { error: '사용자를 찾을 수 없습니다.' },
-        { status: 404 }
+        { error: '이미 비밀번호가 설정되어 있습니다.' },
+        { status: 409 }
       )
     }
 
-    if (user.password) {
+    // 이메일 중복 확인 (다른 사용자가 이미 사용 중인지)
+    const emailDuplicate = await db
+      .collection('users')
+      .findOne({ email, _id: { $ne: userId } }, { projection: { _id: 1 } })
+
+    if (emailDuplicate) {
       return NextResponse.json(
-        { error: '이미 비밀번호가 설정되어 있습니다.' },
+        { error: '이미 사용 중인 이메일(ID)입니다.' },
         { status: 409 }
       )
     }
@@ -55,14 +68,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { _id: userId },
       {
         $set: {
+          email,
           password: hashedPassword,
           updatedAt: new Date(),
         },
       }
     )
 
-    return NextResponse.json({ message: '비밀번호가 설정되었습니다.' })
+    // eslint-disable-next-line no-console
+    console.log(`[Account] 이메일/비밀번호 설정 — userId: ${session.user.id}`)
+
+    return NextResponse.json({ message: '이메일과 비밀번호가 설정되었습니다.' })
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('[Account] 비밀번호 설정 실패:', error)
     return NextResponse.json(
       { error: '처리 중 오류가 발생했습니다.' },

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -1,0 +1,347 @@
+'use client'
+
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useLinkedAccounts } from '@/hooks/useLinkedAccounts'
+
+// 지원하는 OAuth 프로바이더 목록
+const OAUTH_PROVIDERS = [
+  {
+    id: 'google',
+    name: 'Google',
+    color: 'bg-white text-gray-700 hover:bg-gray-100',
+  },
+  {
+    id: 'kakao',
+    name: '카카오',
+    color: 'bg-[#FEE500] text-[#191919] hover:bg-[#FDD800]',
+  },
+  {
+    id: 'naver',
+    name: '네이버',
+    color: 'bg-[#03C75A] text-white hover:bg-[#02B350]',
+  },
+  {
+    id: 'twitter',
+    name: 'X(Twitter)',
+    color: 'bg-black text-white hover:bg-gray-900',
+  },
+] as const
+
+export default function AccountSettingsPage() {
+  const { status } = useSession()
+  const router = useRouter()
+
+  // 미인증 시 로그인 페이지로 리다이렉트
+  if (status === 'unauthenticated') {
+    router.push('/auth/signin?callbackUrl=/settings/account')
+    return null
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-900">
+        <p className="text-slate-400">로딩 중...</p>
+      </div>
+    )
+  }
+
+  return <AccountSettingsContent />
+}
+
+// ── 프로바이더 아이콘 ────────────────────────────────────────
+
+function ProviderIcon({ provider }: { provider: string }) {
+  switch (provider) {
+    case 'google':
+      return (
+        <svg className="h-5 w-5" viewBox="0 0 24 24">
+          <path
+            fill="#4285F4"
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+          />
+          <path
+            fill="#34A853"
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          />
+          <path
+            fill="#EA4335"
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          />
+        </svg>
+      )
+    case 'kakao':
+      return (
+        <svg className="h-5 w-5" viewBox="0 0 24 24" fill="#191919">
+          <path d="M12 3C6.48 3 2 6.48 2 10.5c0 2.52 1.64 4.74 4.12 6.03-.18.65-.65 2.35-.74 2.72-.12.47.17.46.36.34.15-.1 2.37-1.6 3.32-2.25.62.09 1.26.14 1.94.14 5.52 0 10-3.48 10-7.98S17.52 3 12 3z" />
+        </svg>
+      )
+    case 'naver':
+      return <span className="text-lg font-bold text-[#03C75A]">N</span>
+    case 'twitter':
+      return (
+        <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      )
+    default:
+      return <span className="text-lg">🔑</span>
+  }
+}
+
+// ── 비밀번호 설정 폼 ────────────────────────────────────────
+
+function SetPasswordForm({
+  onSubmit,
+  isPending,
+  error,
+}: {
+  onSubmit: (password: string) => Promise<void>
+  isPending: boolean
+  error: string | null
+}) {
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setValidationError(null)
+    setSuccess(false)
+
+    if (password.length < 6) {
+      setValidationError('비밀번호는 최소 6자 이상이어야 합니다.')
+      return
+    }
+    if (password !== confirmPassword) {
+      setValidationError('비밀번호가 일치하지 않습니다.')
+      return
+    }
+
+    try {
+      await onSubmit(password)
+      setPassword('')
+      setConfirmPassword('')
+      setSuccess(true)
+    } catch {
+      // error는 상위에서 처리
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="new-password"
+          className="mb-1 block text-sm font-medium text-slate-300"
+        >
+          비밀번호
+        </label>
+        <input
+          id="new-password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={6}
+          className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="최소 6자 이상"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="confirm-password"
+          className="mb-1 block text-sm font-medium text-slate-300"
+        >
+          비밀번호 확인
+        </label>
+        <input
+          id="confirm-password"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          minLength={6}
+          className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="비밀번호 재입력"
+        />
+      </div>
+
+      {(validationError || error) && (
+        <p className="rounded-lg border border-red-500 bg-red-500/20 p-3 text-sm text-red-400">
+          {validationError || error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-lg border border-green-500 bg-green-500/20 p-3 text-sm text-green-400">
+          비밀번호가 설정되었습니다.
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-full rounded-lg bg-blue-600 py-3 text-white transition hover:bg-blue-700 disabled:opacity-50"
+      >
+        {isPending ? '설정 중...' : '비밀번호 설정'}
+      </button>
+    </form>
+  )
+}
+
+// ── 메인 콘텐츠 ─────────────────────────────────────────────
+
+function AccountSettingsContent() {
+  const {
+    accounts,
+    hasPassword,
+    isLoading,
+    linkAccount,
+    unlinkAccount,
+    isUnlinking,
+    unlinkError,
+    setPassword,
+    isSettingPassword,
+    setPasswordError,
+  } = useLinkedAccounts()
+
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const handleUnlink = async (provider: string, providerAccountId: string) => {
+    setActionError(null)
+    try {
+      await unlinkAccount(provider, providerAccountId)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : '연결 해제 실패')
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-900">
+        <p className="text-slate-400">로딩 중...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-900 px-4 pb-20 pt-20">
+      <div className="mx-auto max-w-lg space-y-6">
+        {/* 헤더 */}
+        <div>
+          <h1 className="text-2xl font-bold text-white">계정 설정</h1>
+          <p className="mt-1 text-sm text-slate-400">
+            연결된 소셜 계정을 관리하고 로그인 수단을 설정합니다.
+          </p>
+        </div>
+
+        {/* 에러 메시지 */}
+        {(actionError || unlinkError) && (
+          <div className="rounded-lg border border-red-500 bg-red-500/20 p-3 text-sm text-red-400">
+            {actionError || unlinkError}
+          </div>
+        )}
+
+        {/* 연결된 계정 목록 */}
+        <div className="rounded-lg bg-slate-800 p-6">
+          <h2 className="mb-4 text-lg font-semibold text-white">연결된 계정</h2>
+          <div className="space-y-3">
+            {OAUTH_PROVIDERS.map((provider) => {
+              const linked = accounts.find((a) => a.provider === provider.id)
+              const isLinked = !!linked
+
+              return (
+                <div
+                  key={provider.id}
+                  className="flex items-center justify-between rounded-lg border border-slate-700 p-4"
+                >
+                  <div className="flex items-center gap-3">
+                    <ProviderIcon provider={provider.id} />
+                    <div>
+                      <p className="text-sm font-medium text-white">
+                        {provider.name}
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        {isLinked ? '연결됨' : '미연결'}
+                      </p>
+                    </div>
+                  </div>
+
+                  {isLinked ? (
+                    <button
+                      onClick={() =>
+                        handleUnlink(provider.id, linked.providerAccountId)
+                      }
+                      disabled={isUnlinking}
+                      className="rounded-lg border border-red-500/50 px-3 py-1.5 text-sm text-red-400 transition hover:bg-red-500/10 disabled:opacity-50"
+                    >
+                      {isUnlinking ? '해제 중...' : '연결 해제'}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => linkAccount(provider.id)}
+                      className="rounded-lg border border-blue-500/50 px-3 py-1.5 text-sm text-blue-400 transition hover:bg-blue-500/10"
+                    >
+                      연결하기
+                    </button>
+                  )}
+                </div>
+              )
+            })}
+
+            {/* 이메일/비밀번호 상태 표시 */}
+            <div className="flex items-center justify-between rounded-lg border border-slate-700 p-4">
+              <div className="flex items-center gap-3">
+                <span className="text-lg">🔑</span>
+                <div>
+                  <p className="text-sm font-medium text-white">
+                    이메일/비밀번호
+                  </p>
+                  <p className="text-xs text-slate-400">
+                    {hasPassword ? '설정됨' : '미설정'}
+                  </p>
+                </div>
+              </div>
+              {hasPassword && (
+                <span className="rounded-lg bg-green-500/20 px-3 py-1.5 text-sm text-green-400">
+                  활성
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* 비밀번호 설정 폼 (소셜 전용 계정만) */}
+        {!hasPassword && (
+          <div className="rounded-lg bg-slate-800 p-6">
+            <h2 className="mb-2 text-lg font-semibold text-white">
+              비밀번호 설정
+            </h2>
+            <p className="mb-4 text-sm text-slate-400">
+              비밀번호를 설정하면 이메일/비밀번호로도 로그인할 수 있습니다.
+            </p>
+            <SetPasswordForm
+              onSubmit={setPassword}
+              isPending={isSettingPassword}
+              error={setPasswordError}
+            />
+          </div>
+        )}
+
+        {/* 돌아가기 링크 */}
+        <div className="text-center">
+          <Link href="/" className="text-sm text-slate-400 hover:text-white">
+            ← 메인으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -102,11 +102,14 @@ function SetPasswordForm({
   onSubmit,
   isPending,
   error,
+  defaultEmail,
 }: {
-  onSubmit: (password: string) => Promise<void>
+  onSubmit: (email: string, password: string) => Promise<void>
   isPending: boolean
   error: string | null
+  defaultEmail: string
 }) {
+  const [email, setEmail] = useState(defaultEmail)
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [validationError, setValidationError] = useState<string | null>(null)
@@ -117,6 +120,10 @@ function SetPasswordForm({
     setValidationError(null)
     setSuccess(false)
 
+    if (!email || !email.includes('@')) {
+      setValidationError('유효한 이메일 주소를 입력해주세요.')
+      return
+    }
     if (password.length < 6) {
       setValidationError('비밀번호는 최소 6자 이상이어야 합니다.')
       return
@@ -127,7 +134,7 @@ function SetPasswordForm({
     }
 
     try {
-      await onSubmit(password)
+      await onSubmit(email, password)
       setPassword('')
       setConfirmPassword('')
       setSuccess(true)
@@ -138,6 +145,23 @@ function SetPasswordForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="set-email"
+          className="mb-1 block text-sm font-medium text-slate-300"
+        >
+          이메일 (로그인 ID)
+        </label>
+        <input
+          id="set-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="example@email.com"
+        />
+      </div>
       <div>
         <label
           htmlFor="new-password"
@@ -182,7 +206,7 @@ function SetPasswordForm({
       )}
       {success && (
         <p className="rounded-lg border border-green-500 bg-green-500/20 p-3 text-sm text-green-400">
-          비밀번호가 설정되었습니다.
+          이메일과 비밀번호가 설정되었습니다.
         </p>
       )}
 
@@ -191,7 +215,7 @@ function SetPasswordForm({
         disabled={isPending}
         className="w-full rounded-lg bg-blue-600 py-3 text-white transition hover:bg-blue-700 disabled:opacity-50"
       >
-        {isPending ? '설정 중...' : '비밀번호 설정'}
+        {isPending ? '설정 중...' : '이메일/비밀번호 설정'}
       </button>
     </form>
   )
@@ -205,6 +229,7 @@ function AccountSettingsContent() {
   const {
     accounts,
     hasPassword,
+    email: accountEmail,
     isLoading,
     linkAccount,
     unlinkAccount,
@@ -342,15 +367,17 @@ function AccountSettingsContent() {
         {!hasPassword && (
           <div className="rounded-lg bg-slate-800 p-6">
             <h2 className="mb-2 text-lg font-semibold text-white">
-              비밀번호 설정
+              이메일/비밀번호 설정
             </h2>
             <p className="mb-4 text-sm text-slate-400">
-              비밀번호를 설정하면 이메일/비밀번호로도 로그인할 수 있습니다.
+              이메일(ID)과 비밀번호를 설정하면 이메일/비밀번호로도 로그인할 수
+              있습니다.
             </p>
             <SetPasswordForm
               onSubmit={setPassword}
               isPending={isSettingPassword}
               error={setPasswordError}
+              defaultEmail={accountEmail || user?.email || ''}
             />
           </div>
         )}

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
+import Image from 'next/image'
 import { useLinkedAccounts } from '@/hooks/useLinkedAccounts'
 
 // 지원하는 OAuth 프로바이더 목록
@@ -199,6 +200,8 @@ function SetPasswordForm({
 // ── 메인 콘텐츠 ─────────────────────────────────────────────
 
 function AccountSettingsContent() {
+  const { data: session } = useSession()
+  const user = session?.user
   const {
     accounts,
     hasPassword,
@@ -234,12 +237,29 @@ function AccountSettingsContent() {
   return (
     <div className="min-h-screen bg-slate-900 px-4 pb-20 pt-20">
       <div className="mx-auto max-w-lg space-y-6">
-        {/* 헤더 */}
-        <div>
-          <h1 className="text-2xl font-bold text-white">계정 설정</h1>
-          <p className="mt-1 text-sm text-slate-400">
-            연결된 소셜 계정을 관리하고 로그인 수단을 설정합니다.
-          </p>
+        {/* 프로필 카드 */}
+        <div className="flex items-center gap-4 rounded-lg bg-slate-800 p-6">
+          {user?.image ? (
+            <Image
+              src={user.image}
+              alt={user.name || '프로필'}
+              width={64}
+              height={64}
+              className="h-16 w-16 rounded-full object-cover"
+              referrerPolicy="no-referrer"
+              unoptimized
+            />
+          ) : (
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-600 text-2xl font-bold text-white">
+              {(user?.name || user?.email || '?').charAt(0).toUpperCase()}
+            </div>
+          )}
+          <div>
+            <h1 className="text-xl font-bold text-white">
+              {user?.name || '사용자'}
+            </h1>
+            <p className="text-sm text-slate-400">{user?.email || ''}</p>
+          </div>
         </div>
 
         {/* 에러 메시지 */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -64,9 +64,26 @@ export function Header() {
             <div className="h-8 w-20 animate-pulse rounded bg-slate-700" />
           ) : isAuthenticated && user ? (
             <div className="flex items-center gap-3">
-              <span className="hidden text-sm text-slate-300 sm:block">
-                {user.name || user.email}
-              </span>
+              <Link
+                href="/settings/account"
+                className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-slate-700"
+              >
+                {user.image ? (
+                  <img
+                    src={user.image}
+                    alt={user.name || '프로필'}
+                    className="h-7 w-7 rounded-full object-cover"
+                    referrerPolicy="no-referrer"
+                  />
+                ) : (
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-blue-600 text-xs font-bold text-white">
+                    {(user.name || user.email || '?').charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <span className="hidden text-sm text-slate-300 sm:block">
+                  {user.name || user.email}
+                </span>
+              </Link>
               <button
                 onClick={() => logout()}
                 className="rounded-lg bg-slate-700 px-3 py-1.5 text-sm text-white transition hover:bg-slate-600"
@@ -168,6 +185,15 @@ export function Header() {
                 className="block rounded-lg px-3 py-2 text-sm text-orange-400 transition hover:bg-slate-800 hover:text-orange-300"
               >
                 ⚙️ 관리자
+              </Link>
+            )}
+            {isAuthenticated && (
+              <Link
+                href="/settings/account"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+              >
+                👤 계정 설정
               </Link>
             )}
           </div>

--- a/src/hooks/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts.ts
@@ -15,6 +15,7 @@ interface LinkedAccount {
 interface LinkedAccountsResponse {
   accounts: LinkedAccount[]
   hasPassword: boolean
+  email: string | null
 }
 
 interface UnlinkError {
@@ -75,13 +76,19 @@ export function useLinkedAccounts() {
     },
   })
 
-  // 비밀번호 설정 mutation
+  // 이메일/비밀번호 설정 mutation
   const setPasswordMutation = useMutation({
-    mutationFn: async (password: string) => {
+    mutationFn: async ({
+      email,
+      password,
+    }: {
+      email: string
+      password: string
+    }) => {
       const res = await fetch(API_ROUTES.ACCOUNT.SET_PASSWORD, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ password }),
+        body: JSON.stringify({ email, password }),
       })
       if (!res.ok) {
         const data: UnlinkError = await res.json()
@@ -109,8 +116,8 @@ export function useLinkedAccounts() {
 
   // 비밀번호 설정 래퍼
   const setPassword = useCallback(
-    async (password: string) => {
-      await setPasswordMutation.mutateAsync(password)
+    async (email: string, password: string) => {
+      await setPasswordMutation.mutateAsync({ email, password })
     },
     [setPasswordMutation]
   )
@@ -118,6 +125,7 @@ export function useLinkedAccounts() {
   return {
     accounts: data?.accounts ?? [],
     hasPassword: data?.hasPassword ?? false,
+    email: data?.email ?? null,
     isLoading,
     error,
     linkAccount,

--- a/src/hooks/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts.ts
@@ -1,0 +1,131 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { signIn } from 'next-auth/react'
+import { API_ROUTES } from '@/lib/api-routes'
+
+// ── Types ───────────────────────────────────────────────────
+
+interface LinkedAccount {
+  provider: string
+  providerAccountId: string
+}
+
+interface LinkedAccountsResponse {
+  accounts: LinkedAccount[]
+  hasPassword: boolean
+}
+
+interface UnlinkError {
+  error: string
+}
+
+// ── Query Keys ──────────────────────────────────────────────
+
+export const linkedAccountKeys = {
+  all: ['linkedAccounts'] as const,
+  list: () => [...linkedAccountKeys.all, 'list'] as const,
+}
+
+// ── Hook ────────────────────────────────────────────────────
+
+/**
+ * 계정 연동 관리 훅
+ * Requirements: 5.1, 5.2, 5.3, 5.4, 5.5
+ */
+export function useLinkedAccounts() {
+  const queryClient = useQueryClient()
+
+  // 연결된 계정 목록 조회
+  const { data, isLoading, error } = useQuery({
+    queryKey: linkedAccountKeys.list(),
+    queryFn: async (): Promise<LinkedAccountsResponse> => {
+      const res = await fetch(API_ROUTES.ACCOUNT.LINKED_ACCOUNTS)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '계정 목록 조회 실패')
+      }
+      return res.json()
+    },
+  })
+
+  // 연결 해제 mutation
+  const unlinkMutation = useMutation({
+    mutationFn: async ({
+      provider,
+      providerAccountId,
+    }: {
+      provider: string
+      providerAccountId: string
+    }) => {
+      const res = await fetch(API_ROUTES.ACCOUNT.LINKED_ACCOUNTS, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider, providerAccountId }),
+      })
+      if (!res.ok) {
+        const data: UnlinkError = await res.json()
+        throw new Error(data.error || '연결 해제 실패')
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: linkedAccountKeys.all })
+    },
+  })
+
+  // 비밀번호 설정 mutation
+  const setPasswordMutation = useMutation({
+    mutationFn: async (password: string) => {
+      const res = await fetch(API_ROUTES.ACCOUNT.SET_PASSWORD, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      })
+      if (!res.ok) {
+        const data: UnlinkError = await res.json()
+        throw new Error(data.error || '비밀번호 설정 실패')
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: linkedAccountKeys.all })
+    },
+  })
+
+  // 계정 연결 래퍼 (signIn 호출)
+  const linkAccount = useCallback((provider: string) => {
+    signIn(provider, { callbackUrl: '/settings/account' })
+  }, [])
+
+  // 연결 해제 래퍼
+  const unlinkAccount = useCallback(
+    async (provider: string, providerAccountId: string) => {
+      await unlinkMutation.mutateAsync({ provider, providerAccountId })
+    },
+    [unlinkMutation]
+  )
+
+  // 비밀번호 설정 래퍼
+  const setPassword = useCallback(
+    async (password: string) => {
+      await setPasswordMutation.mutateAsync(password)
+    },
+    [setPasswordMutation]
+  )
+
+  return {
+    accounts: data?.accounts ?? [],
+    hasPassword: data?.hasPassword ?? false,
+    isLoading,
+    error,
+    linkAccount,
+    unlinkAccount,
+    isUnlinking: unlinkMutation.isPending,
+    unlinkError: unlinkMutation.error?.message ?? null,
+    setPassword,
+    isSettingPassword: setPasswordMutation.isPending,
+    setPasswordError: setPasswordMutation.error?.message ?? null,
+  }
+}

--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -84,6 +84,12 @@ export const API_ROUTES = {
     PROGRESS: (id: string) => `/api/users/${id}/progress`,
   },
 
+  // Account
+  ACCOUNT: {
+    LINKED_ACCOUNTS: '/api/account/linked-accounts',
+    SET_PASSWORD: '/api/account/set-password',
+  },
+
   // Admin
   ADMIN: {
     REPORTS: '/api/admin/reports',


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #325

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> useLinkedAccounts 훅과 Account_Settings_Page를 구현하여 사용자가 소셜 계정 연동을 관리할 수 있도록 함

---

## 📋 변경 사항

- [x] `src/hooks/useLinkedAccounts.ts` — React Query 기반 계정 연동 관리 훅 (조회/해제/이메일, 비밀번호 설정/연결)
- [x] `src/app/settings/account/page.tsx` — Account_Settings_Page (연결된 계정 목록, 연결/해제 버튼, 비밀번호 설정 폼)
- [x] `src/lib/api-routes.ts` — ACCOUNT 엔드포인트 상수 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

<img width="1244" height="965" alt="image" src="https://github.com/user-attachments/assets/76e29ca6-15d9-46a2-9b39-6a644e90747e" />

## 📝 추가 정보

- Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8 대응
- 미인증 사용자는 로그인 페이지로 리다이렉트
- 소셜 전용 계정
