### PR TITLE
[Feat] Task 8 - 수동 Account Linking 보안 및 프로필 보존 처리

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -19,6 +19,8 @@ const errorMessages: Record<string, string> = {
   EmailSignin: '이메일 전송 중 오류가 발생했습니다.',
   CredentialsSignin: '이메일 또는 비밀번호가 올바르지 않습니다.',
   SessionRequired: '이 페이지에 접근하려면 로그인이 필요합니다.',
+  EmailNotVerified:
+    '이메일이 검증되지 않은 소셜 계정은 연결할 수 없습니다. 해당 소셜 서비스에서 이메일 인증을 완료한 후 다시 시도해주세요.',
 }
 
 function ErrorContent() {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -92,6 +92,28 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         return true
       }
 
+      // 수동 Account Linking 보안 검증 (Requirements: 8.2, 8.3, 8.4)
+      // user.id가 존재하면 기존 사용자에 대한 계정 연결 시도 (Account Linking)
+      if (user.id) {
+        // email_verified: false인 프로바이더의 계정 연결 거부
+        const emailVerified =
+          profile?.email_verified ??
+          (profile as Record<string, unknown>)?.verified_email
+        if (emailVerified === false) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[Account Linking] 거부 — email_verified=false, userId: ${user.id}, provider: ${account?.provider}`
+          )
+          return '/auth/error?error=EmailNotVerified'
+        }
+
+        // Account Linking 이벤트 로그 기록
+        // eslint-disable-next-line no-console
+        console.log(
+          `[Account Linking] 연결 — userId: ${user.id}, provider: ${account?.provider}`
+        )
+      }
+
       // Auth.js 기본 보안 정책 준수:
       // 동일 이메일이 다른 프로바이더로 이미 존재하면 OAuthAccountNotLinked 에러 자동 발생
       // allowDangerousEmailAccountLinking을 사용하지 않으므로 자동 Account Linking 차단됨

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -164,4 +164,41 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return session
     },
   },
+  events: {
+    // 소셜 계정 최초 가입 시 provider 필드 설정 (Requirements: 7.1, 7.3)
+    async createUser({ user }) {
+      if (!user.id) return
+      try {
+        const db = await getDb()
+        // 최초 가입 시 연결된 account에서 프로바이더 정보 조회
+        const account = await db
+          .collection('accounts')
+          .findOne({ userId: new ObjectId(user.id) })
+        if (account?.provider) {
+          await db
+            .collection('users')
+            .updateOne(
+              { _id: new ObjectId(user.id) },
+              { $set: { provider: account.provider } }
+            )
+          // eslint-disable-next-line no-console
+          console.log(
+            `[Auth] 신규 사용자 provider 설정 — userId: ${user.id}, provider: ${account.provider}`
+          )
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('[Auth] createUser 이벤트 처리 실패:', error)
+      }
+    },
+    // Account Linking 시 기존 프로필 보존 확인 로그 (Requirements: 7.2, 7.3)
+    async linkAccount({ user, account }) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Account Linking] 계정 연결 완료 — userId: ${user.id}, provider: ${account.provider}`
+      )
+      // 기존 프로필 정보는 MongoDBAdapter가 변경하지 않으므로 자동 보존됨
+      // provider 필드는 Primary_Account(최초 가입) 프로바이더를 유지
+    },
+  },
 })


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #327

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> Account_Settings_Page에서 수동 Account Linking 시 보안 검증 및 프로필 정보 보존 로직 추가

---

## 📋 변경 사항

- [x] signIn 콜백에 email_verified=false 프로바이더 계정 연결 거부 로직 추가
- [x] Account Linking 이벤트(연결) 서버 로그 기록 추가
- [x] 에러 페이지에 EmailNotVerified 에러 메시지 매핑 추가
- [x] createUser 이벤트에서 최초 가입 시 provider 필드 자동 설정
- [x] linkAccount 이벤트에서 계정 연결 완료 로그 기록

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 7.1, 7.2, 7.3, 8.2, 8.3, 8.4 대응
- Auth.js의 MongoDBAdapter는 linkAccount 시 기존 프로필을 변경하지 않으므로 자동 보존됨
- provider 필드는 createUser 이벤트에서 최초 가입 시에만 설정되어 Primary_Account 유지
