### PR TITLE
[Feat] 기존 OAuth 프로바이더 Account Linking 호환성 정비

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 # 커밋 후 로그 / 알림 등
 
-echo "✅ Commit 완료! 수고했다😎"
+echo "✅ Commit 완료!"

--- a/.kiro/specs/15-oauth-integration/tasks.md
+++ b/.kiro/specs/15-oauth-integration/tasks.md
@@ -66,14 +66,14 @@ X(Twitter) OAuth 프로바이더 추가, Auth.js 기본 보안 정책 준수(자
 - [ ] 4. Checkpoint — 기본 OAuth 플로우 검증
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 5. 계정 연동 API 엔드포인트 구현
-  - [ ] 5.1 `src/app/api/account/linked-accounts/route.ts` 생성 — GET 핸들러
+- [x] 5. 계정 연동 API 엔드포인트 구현
+  - [x] 5.1 `src/app/api/account/linked-accounts/route.ts` 생성 — GET 핸들러
     - 인증된 사용자의 연결된 계정 목록 조회 (accounts 컬렉션에서 userId로 조회)
     - 응답: `{ accounts: LinkedAccount[], hasPassword: boolean }`
     - 미인증 요청 시 401 응답
     - _Requirements: 6.1, 6.3, 5.1_
 
-  - [ ] 5.2 `src/app/api/account/linked-accounts/route.ts` 확장 — DELETE 핸들러
+  - [x] 5.2 `src/app/api/account/linked-accounts/route.ts` 확장 — DELETE 핸들러
     - 지정된 프로바이더 연결 해제 (accounts 컬렉션에서 제거)
     - 마지막 로그인 수단 해제 시 400 에러 반환 ("최소 하나의 로그인 수단이 필요합니다")
     - 존재하지 않는 프로바이더 해제 시 404 응답
@@ -81,49 +81,49 @@ X(Twitter) OAuth 프로바이더 추가, Auth.js 기본 보안 정책 준수(자
     - Account Linking 이벤트(해제) 서버 로그 기록
     - _Requirements: 6.2, 6.3, 6.4, 6.5, 5.5, 5.6, 8.4_
 
-  - [ ] 5.3 `src/app/api/account/set-password/route.ts` 생성 — POST 핸들러
+  - [x] 5.3 `src/app/api/account/set-password/route.ts` 생성 — POST 핸들러
     - 소셜 전용 계정에 비밀번호 설정 (bcrypt 해시 후 users 컬렉션 업데이트)
     - 비밀번호 최소 6자 검증
     - 이미 비밀번호 설정된 경우 409 응답
     - 미인증 요청 시 401 응답
     - _Requirements: 5.8, 6.3_
 
-  - [ ]* 5.4 Property 테스트 — 미인증 API 거부
+  - [x]* 5.4 Property 테스트 — 미인증 API 거부
     - **Property 8: Unauthenticated API rejection**
     - **Validates: Requirements 6.3, 8.2**
 
-  - [ ]* 5.5 Property 테스트 — 연결 해제 동작
+  - [x]* 5.5 Property 테스트 — 연결 해제 동작
     - **Property 5: Unlinking removes provider from account**
     - **Validates: Requirements 5.5, 6.2**
 
-  - [ ]* 5.6 Property 테스트 — 마지막 로그인 수단 보호
+  - [x]* 5.6 Property 테스트 — 마지막 로그인 수단 보호
     - **Property 6: Last login method protection**
     - **Validates: Requirements 5.6, 6.5**
 
-  - [ ]* 5.7 Property 테스트 — 비밀번호 설정 라운드 트립
+  - [x]* 5.7 Property 테스트 — 비밀번호 설정 라운드 트립
     - **Property 7: Password setting round trip**
     - **Validates: Requirements 5.8**
 
-  - [ ]* 5.8 Property 테스트 — 연결된 계정 목록 완전성
+  - [x]* 5.8 Property 테스트 — 연결된 계정 목록 완전성
     - **Property 12: Linked accounts API returns complete list**
     - **Validates: Requirements 5.1, 6.1**
 
-  - [ ]* 5.9 단위 테스트 — 존재하지 않는 프로바이더 해제 시 404 응답
+  - [x]* 5.9 단위 테스트 — 존재하지 않는 프로바이더 해제 시 404 응답
     - 존재하지 않는 프로바이더 해제 시 404 응답 (edge-case: 6.4)
     - _Requirements: 6.4_
 
-- [ ] 6. Checkpoint — API 엔드포인트 검증
+- [x] 6. Checkpoint — API 엔드포인트 검증
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 7. useLinkedAccounts Hook 및 Account_Settings_Page 구현
-  - [ ] 7.1 `src/hooks/useLinkedAccounts.ts` 생성
+- [x] 7. useLinkedAccounts Hook 및 Account_Settings_Page 구현
+  - [x] 7.1 `src/hooks/useLinkedAccounts.ts` 생성
     - React Query 기반 연결된 계정 목록 조회 (`GET /api/account/linked-accounts`)
     - 연결 해제 mutation (`DELETE /api/account/linked-accounts`)
     - 비밀번호 설정 mutation (`POST /api/account/set-password`)
     - 계정 연결 래퍼 함수 (`signIn(provider, { callbackUrl: '/settings/account' })`)
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
 
-  - [ ] 7.2 `src/app/settings/account/page.tsx` 생성 — Account_Settings_Page
+  - [x] 7.2 `src/app/settings/account/page.tsx` 생성 — Account_Settings_Page
     - 로그인된 사용자만 접근 가능 (미인증 시 로그인 페이지로 리다이렉트)
     - 연결된 모든 Linked_Account 목록 표시 (프로바이더 이름, 연결 상태)
     - 미연결 OAuth_Provider에 "연결하기" 버튼 표시
@@ -132,7 +132,7 @@ X(Twitter) OAuth 프로바이더 추가, Auth.js 기본 보안 정책 준수(자
     - 연결 해제 실패 시 기존 상태 유지 및 에러 메시지 표시
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7_
 
-  - [ ] 7.3 Account_Settings_Page에 비밀번호 설정 폼 추가
+  - [x] 7.3 Account_Settings_Page에 비밀번호 설정 폼 추가
     - 소셜 전용 계정(비밀번호 미설정)인 경우 비밀번호 설정 폼 표시
     - 비밀번호 입력 및 확인 필드, 최소 6자 클라이언트 검증
     - 설정 성공/실패 시 toast 메시지 표시
@@ -146,14 +146,14 @@ X(Twitter) OAuth 프로바이더 추가, Auth.js 기본 보안 정책 준수(자
     - **Property 4: Duplicate linking is idempotent**
     - **Validates: Requirements 4.4**
 
-- [ ] 8. 수동 Account Linking 보안 및 프로필 보존 처리
-  - [ ] 8.1 `src/lib/auth.ts`의 `signIn` 콜백에 Account Linking 보안 로직 추가
+- [x] 8. 수동 Account Linking 보안 및 프로필 보존 처리
+  - [x] 8.1 `src/lib/auth.ts`의 `signIn` 콜백에 Account Linking 보안 로직 추가
     - 로그인된 세션이 유효한 경우에만 계정 연결 허용
     - `email_verified: false`인 프로바이더의 계정 연결 거부
     - Account Linking 이벤트(연결, 해제) 서버 로그 기록
     - _Requirements: 8.2, 8.3, 8.4_
 
-  - [ ] 8.2 프로필 정보 동기화 로직 구현
+  - [x] 8.2 프로필 정보 동기화 로직 구현
     - 소셜 계정 최초 가입 시 OAuth_Provider 프로필 정보(이름, 이미지) 저장
     - 기존 프로필 정보가 있는 사용자가 새 프로바이더 연결 시 기존 정보 유지
     - users 컬렉션의 `provider` 필드에 Primary_Account 프로바이더 저장
@@ -171,8 +171,8 @@ X(Twitter) OAuth 프로바이더 추가, Auth.js 기본 보안 정책 준수(자
     - **Property 3: Linked account enables dual login**
     - **Validates: Requirements 4.2, 4.3**
 
-- [ ] 9. 기존 OAuth 프로바이더 정비 및 데이터 정합성
-  - [ ] 9.1 기존 Google, Kakao, Naver 프로바이더 Account Linking 호환성 확인
+- [x] 9. 기존 OAuth 프로바이더 정비 및 데이터 정합성
+  - [x] 9.1 기존 Google, Kakao, Naver 프로바이더 Account Linking 호환성 확인
     - 모든 OAuth_Provider에 동일한 Account_Linking 로직 적용 확인
     - 기존 소셜 로그인 사용자 로그인 시 accounts 컬렉션에 연결 정보 존재 확인, 없으면 자동 생성
     - users 컬렉션의 `provider` 필드와 accounts 컬렉션 데이터 정합성 유지
@@ -182,7 +182,7 @@ X(Twitter) OAuth 프로바이더 추가, Auth.js 기본 보안 정책 준수(자
     - **Property 13: Provider data consistency invariant**
     - **Validates: Requirements 9.3**
 
-- [ ] 10. Final Checkpoint — 전체 통합 검증
+- [x] 10. Final Checkpoint — 전체 통합 검증
   - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes

--- a/src/app/api/account/__tests__/account-api.test.ts
+++ b/src/app/api/account/__tests__/account-api.test.ts
@@ -71,6 +71,14 @@ import { POST } from '../set-password/route'
 const providerArb = fc.constantFrom('google', 'kakao', 'naver', 'twitter')
 const providerAccountIdArb = fc.string({ minLength: 5, maxLength: 30 })
 const validPasswordArb = fc.string({ minLength: 6, maxLength: 72 })
+const validEmailArb = fc
+  .tuple(
+    fc
+      .string({ minLength: 3, maxLength: 10, unit: 'grapheme' })
+      .filter((s) => !s.includes('@') && s.trim().length > 0),
+    fc.constantFrom('test.com', 'example.com', 'mail.org')
+  )
+  .map(([local, domain]) => `${local}@${domain}`)
 
 // --- Helpers ---
 function createDeleteRequest(body: Record<string, unknown>): NextRequest {
@@ -313,47 +321,57 @@ describe('Property 6: 마지막 로그인 수단 보호', () => {
 describe('Property 7: 비밀번호 설정 라운드 트립', () => {
   test('POST — 소셜 전용 계정에 비밀번호 설정 성공', async () => {
     await fc.assert(
-      fc.asyncProperty(validPasswordArb, async (password) => {
-        mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+      fc.asyncProperty(
+        validEmailArb,
+        validPasswordArb,
+        async (email, password) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
 
-        // 비밀번호 미설정 사용자
-        mockUsersFindOne.mockResolvedValue({
-          _id: '507f1f77bcf86cd799439011',
-          password: null,
-        })
-        mockUsersUpdateOne.mockResolvedValue({ modifiedCount: 1 })
+          // 비밀번호 미설정 사용자
+          mockUsersFindOne
+            .mockResolvedValueOnce({
+              _id: '507f1f77bcf86cd799439011',
+              password: null,
+            })
+            .mockResolvedValueOnce(null) // 이메일 중복 없음
+          mockUsersUpdateOne.mockResolvedValue({ modifiedCount: 1 })
 
-        const req = createPostRequest({ password })
-        const res = await POST(req)
-        const data = await res.json()
+          const req = createPostRequest({ email, password })
+          const res = await POST(req)
+          const data = await res.json()
 
-        expect(res.status).toBe(200)
-        expect(data.message).toBe('비밀번호가 설정되었습니다.')
-        expect(mockUsersUpdateOne).toHaveBeenCalled()
-      }),
+          expect(res.status).toBe(200)
+          expect(data.message).toBe('이메일과 비밀번호가 설정되었습니다.')
+          expect(mockUsersUpdateOne).toHaveBeenCalled()
+        }
+      ),
       { numRuns: 100 }
     )
   })
 
   test('POST — 이미 비밀번호가 설정된 경우 409 반환', async () => {
     await fc.assert(
-      fc.asyncProperty(validPasswordArb, async (password) => {
-        mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+      fc.asyncProperty(
+        validEmailArb,
+        validPasswordArb,
+        async (email, password) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
 
-        // 이미 비밀번호 설정된 사용자
-        mockUsersFindOne.mockResolvedValue({
-          _id: '507f1f77bcf86cd799439011',
-          password: '$2a$12$existinghash',
-        })
+          // 이미 비밀번호 설정된 사용자
+          mockUsersFindOne.mockResolvedValue({
+            _id: '507f1f77bcf86cd799439011',
+            password: '$2a$12$existinghash',
+          })
 
-        const req = createPostRequest({ password })
-        const res = await POST(req)
-        const data = await res.json()
+          const req = createPostRequest({ email, password })
+          const res = await POST(req)
+          const data = await res.json()
 
-        expect(res.status).toBe(409)
-        expect(data.error).toBe('이미 비밀번호가 설정되어 있습니다.')
-        expect(mockUsersUpdateOne).not.toHaveBeenCalled()
-      }),
+          expect(res.status).toBe(409)
+          expect(data.error).toBe('이미 비밀번호가 설정되어 있습니다.')
+          expect(mockUsersUpdateOne).not.toHaveBeenCalled()
+        }
+      ),
       { numRuns: 100 }
     )
   })
@@ -362,16 +380,20 @@ describe('Property 7: 비밀번호 설정 라운드 트립', () => {
     const shortPasswordArb = fc.string({ minLength: 1, maxLength: 5 })
 
     await fc.assert(
-      fc.asyncProperty(shortPasswordArb, async (password) => {
-        mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+      fc.asyncProperty(
+        validEmailArb,
+        shortPasswordArb,
+        async (email, password) => {
+          mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
 
-        const req = createPostRequest({ password })
-        const res = await POST(req)
-        const data = await res.json()
+          const req = createPostRequest({ email, password })
+          const res = await POST(req)
+          const data = await res.json()
 
-        expect(res.status).toBe(400)
-        expect(data.error).toBe('비밀번호는 최소 6자 이상이어야 합니다.')
-      }),
+          expect(res.status).toBe(400)
+          expect(data.error).toBe('비밀번호는 최소 6자 이상이어야 합니다.')
+        }
+      ),
       { numRuns: 100 }
     )
   })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -114,6 +114,59 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         )
       }
 
+      // 기존 소셜 로그인 사용자 정합성 확인 (Requirements: 9.1, 9.2, 9.3)
+      // 레거시 사용자의 accounts 컬렉션에 연결 정보가 없으면 자동 생성
+      if (user.id && account) {
+        try {
+          const db = await getDb()
+          const userId = new ObjectId(user.id)
+
+          const existingAccount = await db
+            .collection('accounts')
+            .findOne({ userId, provider: account.provider })
+
+          if (!existingAccount) {
+            await db.collection('accounts').insertOne({
+              userId,
+              type: account.type || 'oauth',
+              provider: account.provider,
+              providerAccountId: account.providerAccountId,
+              access_token: account.access_token,
+              refresh_token: account.refresh_token,
+              expires_at: account.expires_at,
+              token_type: account.token_type,
+              scope: account.scope,
+              id_token: account.id_token,
+            })
+            // eslint-disable-next-line no-console
+            console.log(
+              `[Auth] 레거시 계정 정합성 복구 — userId: ${user.id}, provider: ${account.provider}`
+            )
+          }
+
+          // users 컬렉션의 provider 필드 정합성 유지
+          const dbUser = await db
+            .collection('users')
+            .findOne({ _id: userId }, { projection: { provider: 1 } })
+          if (dbUser && !dbUser.provider) {
+            await db
+              .collection('users')
+              .updateOne(
+                { _id: userId },
+                { $set: { provider: account.provider } }
+              )
+            // eslint-disable-next-line no-console
+            console.log(
+              `[Auth] 레거시 사용자 provider 필드 설정 — userId: ${user.id}, provider: ${account.provider}`
+            )
+          }
+        } catch (error) {
+          // 정합성 복구 실패해도 로그인은 허용
+          // eslint-disable-next-line no-console
+          console.error('[Auth] 레거시 계정 정합성 복구 실패:', error)
+        }
+      }
+
       // Auth.js 기본 보안 정책 준수:
       // 동일 이메일이 다른 프로바이더로 이미 존재하면 OAuthAccountNotLinked 에러 자동 발생
       // allowDangerousEmailAccountLinking을 사용하지 않으므로 자동 Account Linking 차단됨


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #329

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 기존 소셜 로그인 사용자(레거시)가 로그인 시 accounts 컬렉션에 연결 정보가 없으면 자동 생성하여 Account Linking 호환성 확보

---

## 📋 변경 사항

- [x] signIn 콜백에서 OAuth 로그인 시 accounts 컬렉션 연결 정보 존재 확인 및 자동 생성 로직 추가
- [x] users 컬렉션 provider 필드 미설정 시 자동 설정 로직 추가
- `account-api.test.ts`의 Property 7 테스트에 `email` 필드 및 `validEmailArb` arbitrary 추가
- 응답 메시지를 실제 API 구현에 맞게 업데이트

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 9.1, 9.2, 9.3 대응
- 정합성 복구 실패 시에도 로그인은 정상 허용 (에러 로그만 기록)
- 모든 OAuth 프로바이더(Google, Kakao, Naver, Twitter)에 동일하게 적용
