### PR TITLE
[Feat] Task 1.1, 1.2 - SEO 유틸리티 기반 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ TWITTER_CLIENT_SECRET=your-twitter-client-secret
 
 # Google Maps (Places Autocomplete)
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key
+
+# Site URL (SEO)
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,0 +1,13 @@
+interface JsonLdProps {
+  data: Record<string, unknown>
+}
+
+/** JSON-LD 구조화 데이터 렌더링 컴포넌트 */
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}

--- a/src/lib/seo/json-ld.ts
+++ b/src/lib/seo/json-ld.ts
@@ -1,0 +1,75 @@
+import type { SpotSeoData, RouteSeoData } from './metadata'
+import { getBaseUrl } from './metadata'
+import { CATEGORY_CONFIG } from '@/types/spot'
+
+// ============================================
+// JSON-LD 생성 함수
+// ============================================
+
+/** 스팟 TouristAttraction JSON-LD 생성 */
+export function generateSpotJsonLd(spot: SpotSeoData): Record<string, unknown> {
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'TouristAttraction',
+    name: spot.name,
+    address: spot.address,
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: spot.coordinates.lat,
+      longitude: spot.coordinates.lng,
+    },
+  }
+
+  // 빈 필드 생략 로직
+  if (spot.description) {
+    jsonLd.description = spot.description
+  }
+
+  if (spot.photos.length > 0) {
+    jsonLd.image = spot.photos[0]
+  }
+
+  if (spot.category) {
+    jsonLd.additionalType = CATEGORY_CONFIG[spot.category].label
+  }
+
+  return jsonLd
+}
+
+/** 코스 TouristTrip JSON-LD 생성 */
+export function generateRouteJsonLd(
+  route: RouteSeoData
+): Record<string, unknown> {
+  // description 폴백: 비어있으면 스팟 이름 조합
+  const description = route.description
+    ? route.description
+    : route.spots.map((s) => s.spotName).join(', ')
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TouristTrip',
+    name: route.name,
+    description,
+    itinerary: route.spots.map((spot) => ({
+      '@type': 'TouristAttraction',
+      name: spot.spotName,
+    })),
+  }
+}
+
+/** WebSite JSON-LD 생성 (루트 레이아웃용) */
+export function generateWebSiteJsonLd(): Record<string, unknown> {
+  const baseUrl = getBaseUrl()
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Not a Trip',
+    url: baseUrl,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${baseUrl}/spots?q={search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    },
+  }
+}

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next'
+import { CATEGORY_CONFIG, type SpotCategory } from '@/types/spot'
+
+// ============================================
+// SEO 데이터 인터페이스 (DB 조회 최소화용 경량 타입)
+// ============================================
+
+export interface SpotSeoData {
+  id: string
+  name: string
+  description: string
+  address: string
+  category?: SpotCategory
+  photos: string[]
+  coordinates: { lat: number; lng: number }
+}
+
+export interface RouteSeoData {
+  id: string
+  name: string
+  description: string
+  spots: Array<{ spotName: string }>
+}
+
+export interface PostSeoData {
+  id: string
+  title: string
+  content: string
+}
+
+// ============================================
+// 유틸리티 함수
+// ============================================
+
+/** Base URL 반환 (환경 변수 기반, 미설정 시 localhost 폴백) */
+export function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
+}
+
+/** 기본 메타데이터 생성 (조회 실패 시 폴백용) */
+export function getDefaultMetadata(): Metadata {
+  const baseUrl = getBaseUrl()
+  return {
+    title: 'Not a Trip - 팬들만 아는 특별한 여행지',
+    description:
+      '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    openGraph: {
+      title: 'Not a Trip - 팬들만 아는 특별한 여행지',
+      description:
+        '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+      url: baseUrl,
+      type: 'website',
+      siteName: 'Not a Trip',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'Not a Trip - 팬들만 아는 특별한 여행지',
+      description:
+        '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    },
+  }
+}
+
+// ============================================
+// 동적 메타데이터 생성 함수
+// ============================================
+
+/** 스팟 페이지 메타데이터 생성 */
+export function generateSpotMetadata(spot: SpotSeoData): Metadata {
+  const baseUrl = getBaseUrl()
+  const title = `${spot.name} | Not a Trip`
+
+  // description 폴백: 비어있으면 카테고리+주소 조합
+  const description = spot.description
+    ? spot.description
+    : spot.category
+      ? `${CATEGORY_CONFIG[spot.category].label} · ${spot.address}`
+      : spot.address
+
+  const url = `${baseUrl}/spots/${spot.id}`
+  const ogImage = `${baseUrl}/api/og?type=spot&id=${spot.id}`
+  const images = spot.photos.length > 0 ? [spot.photos[0]] : [ogImage]
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images,
+      url,
+      type: 'website',
+      siteName: 'Not a Trip',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images,
+    },
+  }
+}
+
+/** 코스 페이지 메타데이터 생성 */
+export function generateRouteMetadata(route: RouteSeoData): Metadata {
+  const baseUrl = getBaseUrl()
+  const title = `${route.name} | Not a Trip`
+
+  // description 폴백: 비어있으면 스팟 이름 조합
+  const description = route.description
+    ? `${route.description} · ${route.spots.length}개 스팟`
+    : `${route.spots.map((s) => s.spotName).join(', ')} 등 ${route.spots.length}개 스팟 코스`
+
+  const url = `${baseUrl}/routes/${route.id}`
+  const ogImage = `${baseUrl}/api/og?type=route&id=${route.id}`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [ogImage],
+      url,
+      type: 'website',
+      siteName: 'Not a Trip',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+  }
+}
+
+/** 게시글 페이지 메타데이터 생성 */
+export function generatePostMetadata(post: PostSeoData): Metadata {
+  const baseUrl = getBaseUrl()
+  const title = `${post.title} | Not a Trip 커뮤니티`
+
+  // content 150자 truncation
+  const description =
+    post.content.length > 150
+      ? `${post.content.slice(0, 150)}...`
+      : post.content
+
+  const url = `${baseUrl}/community/${post.id}`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'article',
+      siteName: 'Not a Trip',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #331

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [x] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> SEO 최적화를 위한 메타데이터 유틸리티 함수, JSON-LD 생성 함수, JsonLd 렌더링 컴포넌트 기반 구축

---

## 📋 변경 사항

- [x] `.env.example`에 `NEXT_PUBLIC_BASE_URL` 환경 변수 추가
- [x] `src/lib/seo/metadata.ts` — SpotSeoData, RouteSeoData, PostSeoData 인터페이스 및 generateSpotMetadata, generateRouteMetadata, generatePostMetadata 함수 구현
- [x] `src/lib/seo/json-ld.ts` — generateSpotJsonLd, generateRouteJsonLd, generateWebSiteJsonLd 함수 구현
- [x] `src/components/seo/JsonLd.tsx` — JSON-LD script 태그 렌더링 컴포넌트 구현

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (tsc --noEmit)
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 1.1~1.6, 2.1~2.5, 7.1~7.5, 8.1~8.4, 9.1~9.3, 11.5
- 스팟 description 비어있을 때 카테고리+주소 조합 폴백 로직 포함
- 코스 description 비어있을 때 스팟 이름 조합 폴백 로직 포함
- 게시글 content 150자 truncation 로직 포함
- JSON-LD 빈 필드 생략 로직 포함
