### PR TITLE
[Feat] 코스/커뮤니티 페이지 Server/Client Component 분리 및 SEO 적용

### DIFF
--- a/src/app/community/[id]/page.tsx
+++ b/src/app/community/[id]/page.tsx
@@ -1,43 +1,61 @@
-'use client'
+import type { Metadata } from 'next'
+import { ObjectId } from 'mongodb'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import {
+  generatePostMetadata,
+  getDefaultMetadata,
+  type PostSeoData,
+} from '@/lib/seo/metadata'
+import PostDetailClient from '@/components/community/PostDetailClient'
 
-import Link from 'next/link'
-import { useParams } from 'next/navigation'
-import PostDetail from '@/components/community/PostDetail'
-import CommentSection from '@/components/community/CommentSection'
+/** 경량 projection으로 게시글 SEO 데이터 조회 */
+async function getPostSeoData(id: string): Promise<PostSeoData | null> {
+  try {
+    if (!ObjectId.isValid(id)) return null
 
-/**
- * 게시글 상세 페이지
- * Requirements 5.3: 게시글 전체 내용 표시 및 댓글 허용
- */
-export default function PostDetailPage() {
-  const params = useParams()
-  const postId = params.id as string
+    const collection = await getCollection(COLLECTIONS.POSTS)
+    const post = await collection.findOne(
+      { _id: new ObjectId(id) },
+      {
+        projection: {
+          title: 1,
+          content: 1,
+        },
+      }
+    )
 
-  return (
-    <main className="min-h-screen bg-navy-50">
-      {/* 페이지 타이틀 */}
-      <div className="border-b border-navy-200 bg-white px-4 py-4">
-        <div className="mx-auto max-w-4xl">
-          <div className="flex items-center gap-2">
-            <Link
-              href="/community"
-              className="text-navy-500 hover:text-navy-700"
-            >
-              ← 커뮤니티
-            </Link>
-          </div>
-          <h1 className="mt-2 text-xl font-bold text-navy-800">게시글</h1>
-        </div>
-      </div>
+    if (!post) return null
 
-      {/* 메인 콘텐츠 */}
-      <div className="mx-auto max-w-4xl px-4 py-6">
-        {/* 게시글 상세 */}
-        <PostDetail postId={postId} className="mb-6" />
+    return {
+      id: post._id.toString(),
+      title: (post.title as string) || '',
+      content: (post.content as string) || '',
+    }
+  } catch {
+    return null
+  }
+}
 
-        {/* 댓글 섹션 */}
-        <CommentSection postId={postId} />
-      </div>
-    </main>
-  )
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const post = await getPostSeoData(id)
+
+  if (!post) {
+    return getDefaultMetadata()
+  }
+
+  return generatePostMetadata(post)
+}
+
+export default async function PostDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  await params
+  return <PostDetailClient />
 }

--- a/src/app/routes/[id]/page.tsx
+++ b/src/app/routes/[id]/page.tsx
@@ -1,97 +1,72 @@
-'use client'
+import type { Metadata } from 'next'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import {
+  generateRouteMetadata,
+  getDefaultMetadata,
+  type RouteSeoData,
+} from '@/lib/seo/metadata'
+import { generateRouteJsonLd } from '@/lib/seo/json-ld'
+import JsonLd from '@/components/seo/JsonLd'
+import RouteDetailClient from '@/components/route/RouteDetailClient'
 
-import { useEffect, useState } from 'react'
-import { useParams, useRouter } from 'next/navigation'
-import Link from 'next/link'
-import { RouteDetailContent } from '@/components/route/RouteDetailContent'
-import { SkeletonBlock } from '@/components/common/SkeletonUI'
-import type { Route } from '@/types/route'
+/** 경량 projection으로 코스 SEO 데이터 조회 */
+async function getRouteSeoData(id: string): Promise<RouteSeoData | null> {
+  try {
+    const collection = await getCollection(COLLECTIONS.ROUTES)
+    const route = await collection.findOne(
+      { id },
+      {
+        projection: {
+          id: 1,
+          name: 1,
+          description: 1,
+          spots: 1,
+        },
+      }
+    )
 
-/** 코스 상세 페이지 스켈레톤 */
-function RouteDetailSkeleton() {
-  return (
-    <div className="space-y-6">
-      <div className="rounded-lg bg-white p-6 shadow-sm">
-        <SkeletonBlock className="mb-2 h-5 w-24" />
-        <SkeletonBlock className="mb-3 h-8 w-2/3" />
-        <SkeletonBlock className="mb-4 h-4 w-full" />
-        <div className="flex gap-3">
-          <SkeletonBlock className="h-4 w-16" />
-          <SkeletonBlock className="h-4 w-20" />
-          <SkeletonBlock className="h-4 w-16" />
-        </div>
-      </div>
-      <div className="flex gap-3">
-        <SkeletonBlock className="h-12 flex-1" />
-        <SkeletonBlock className="h-12 w-24" />
-      </div>
-      <SkeletonBlock className="h-[400px] rounded-lg" />
-    </div>
-  )
+    if (!route) return null
+
+    const spots = (route.spots as Array<{ spotName?: string }>) || []
+
+    return {
+      id: route.id as string,
+      name: route.name as string,
+      description: (route.description as string) || '',
+      spots: spots.map((s) => ({ spotName: s.spotName || '' })),
+    }
+  } catch {
+    return null
+  }
 }
 
-/**
- * 코스 상세 페이지
- * Requirements: 1.4, 2.3, 2.4, 3.1
- */
-export default function RouteDetailPage() {
-  const params = useParams()
-  const router = useRouter()
-  const routeId = params.id as string
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const route = await getRouteSeoData(id)
 
-  const [route, setRoute] = useState<Route | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  if (!route) {
+    return getDefaultMetadata()
+  }
 
-  useEffect(() => {
-    async function fetchRoute() {
-      try {
-        const res = await fetch(`/api/routes/${routeId}`)
-        if (!res.ok) {
-          const data = await res.json()
-          setError(data.error || '코스를 불러올 수 없습니다')
-          return
-        }
-        const data = await res.json()
-        setRoute(data)
-      } catch {
-        setError('코스를 불러올 수 없습니다')
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    fetchRoute()
-  }, [routeId])
+  return generateRouteMetadata(route)
+}
+
+export default async function RouteDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const route = await getRouteSeoData(id)
 
   return (
-    <main className="min-h-screen bg-navy-50 pt-14">
-      <div className="mx-auto max-w-4xl px-4 py-6">
-        {/* 뒤로가기 */}
-        <div className="mb-4">
-          <Link
-            href="/routes"
-            className="text-sm text-navy-500 transition-colors hover:text-navy-700"
-          >
-            ← 코스 목록으로
-          </Link>
-        </div>
-
-        {isLoading ? (
-          <RouteDetailSkeleton />
-        ) : error ? (
-          <div className="py-16 text-center">
-            <p className="text-lg text-red-500">{error}</p>
-            <button
-              onClick={() => router.push('/routes')}
-              className="mt-4 rounded-lg bg-navy-600 px-4 py-2 text-sm text-white hover:bg-navy-700"
-            >
-              코스 목록으로 돌아가기
-            </button>
-          </div>
-        ) : route ? (
-          <RouteDetailContent route={route} />
-        ) : null}
-      </div>
-    </main>
+    <>
+      {route && <JsonLd data={generateRouteJsonLd(route)} />}
+      <RouteDetailClient />
+    </>
   )
 }

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import PostDetail from '@/components/community/PostDetail'
+import CommentSection from '@/components/community/CommentSection'
+
+/**
+ * 게시글 상세 페이지 클라이언트 컴포넌트
+ * Requirements 5.3: 게시글 전체 내용 표시 및 댓글 허용
+ */
+export default function PostDetailClient() {
+  const params = useParams()
+  const postId = params.id as string
+
+  return (
+    <main className="min-h-screen bg-navy-50">
+      {/* 페이지 타이틀 */}
+      <div className="border-b border-navy-200 bg-white px-4 py-4">
+        <div className="mx-auto max-w-4xl">
+          <div className="flex items-center gap-2">
+            <Link
+              href="/community"
+              className="text-navy-500 hover:text-navy-700"
+            >
+              ← 커뮤니티
+            </Link>
+          </div>
+          <h1 className="mt-2 text-xl font-bold text-navy-800">게시글</h1>
+        </div>
+      </div>
+
+      {/* 메인 콘텐츠 */}
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        {/* 게시글 상세 */}
+        <PostDetail postId={postId} className="mb-6" />
+
+        {/* 댓글 섹션 */}
+        <CommentSection postId={postId} />
+      </div>
+    </main>
+  )
+}

--- a/src/components/route/RouteDetailClient.tsx
+++ b/src/components/route/RouteDetailClient.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { RouteDetailContent } from '@/components/route/RouteDetailContent'
+import { SkeletonBlock } from '@/components/common/SkeletonUI'
+import type { Route } from '@/types/route'
+
+/** 코스 상세 페이지 스켈레톤 */
+function RouteDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <SkeletonBlock className="mb-2 h-5 w-24" />
+        <SkeletonBlock className="mb-3 h-8 w-2/3" />
+        <SkeletonBlock className="mb-4 h-4 w-full" />
+        <div className="flex gap-3">
+          <SkeletonBlock className="h-4 w-16" />
+          <SkeletonBlock className="h-4 w-20" />
+          <SkeletonBlock className="h-4 w-16" />
+        </div>
+      </div>
+      <div className="flex gap-3">
+        <SkeletonBlock className="h-12 flex-1" />
+        <SkeletonBlock className="h-12 w-24" />
+      </div>
+      <SkeletonBlock className="h-[400px] rounded-lg" />
+    </div>
+  )
+}
+
+/**
+ * 코스 상세 페이지 클라이언트 컴포넌트
+ * Requirements: 1.4, 2.3, 2.4, 3.1
+ */
+export default function RouteDetailClient() {
+  const params = useParams()
+  const router = useRouter()
+  const routeId = params.id as string
+
+  const [route, setRoute] = useState<Route | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchRoute() {
+      try {
+        const res = await fetch(`/api/routes/${routeId}`)
+        if (!res.ok) {
+          const data = await res.json()
+          setError(data.error || '코스를 불러올 수 없습니다')
+          return
+        }
+        const data = await res.json()
+        setRoute(data)
+      } catch {
+        setError('코스를 불러올 수 없습니다')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchRoute()
+  }, [routeId])
+
+  return (
+    <main className="min-h-screen bg-navy-50 pt-14">
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        {/* 뒤로가기 */}
+        <div className="mb-4">
+          <Link
+            href="/routes"
+            className="text-sm text-navy-500 transition-colors hover:text-navy-700"
+          >
+            ← 코스 목록으로
+          </Link>
+        </div>
+
+        {isLoading ? (
+          <RouteDetailSkeleton />
+        ) : error ? (
+          <div className="py-16 text-center">
+            <p className="text-lg text-red-500">{error}</p>
+            <button
+              onClick={() => router.push('/routes')}
+              className="mt-4 rounded-lg bg-navy-600 px-4 py-2 text-sm text-white hover:bg-navy-700"
+            >
+              코스 목록으로 돌아가기
+            </button>
+          </div>
+        ) : route ? (
+          <RouteDetailContent route={route} />
+        ) : null}
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #335

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 코스(`/routes/[id]`)와 커뮤니티(`/community/[id]`) 상세 페이지를 Server/Client Component로 분리하여 SEO 메타데이터 및 JSON-LD를 지원한다.

---

## 📋 변경 사항

- [x] 코스 상세 페이지 UI 로직을 `RouteDetailClient.tsx`로 추출
- [x] `routes/[id]/page.tsx`를 Server Component로 변환, `generateMetadata` + JSON-LD(TouristTrip) 구현
- [x] 게시글 상세 페이지 UI 로직을 `PostDetailClient.tsx`로 추출
- [x] `community/[id]/page.tsx`를 Server Component로 변환, `generateMetadata` 구현
- [x] `ObjectId.isValid()` 검증으로 잘못된 ID 시 기본 메타데이터 반환

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 2.1, 2.2, 2.3, 2.4, 2.5, 8.1, 8.2, 8.3, 8.4 대응
- 스팟 상세 페이지(Task 3.1)에서 검증된 Server/Client Component 분리 패턴을 동일하게 적용
- 코스 페이지는 경량 projection으로 id, name, description, spots만 조회하여 메타데이터 생성
- 커뮤니티 페이지는 JSON-LD 없이 메타데이터만 적용 (설계 문서 기준)
<img width="268" height="20" alt="image" src="https://github.com/user-attachments/assets/db578232-63f6-479a-be8c-049865dbd2ef" />
<img width="459" height="99" alt="image" src="https://github.com/user-attachments/assets/51c4bd3b-3b24-457f-a083-cbfd661c40c0" />

