### PR TITLE
[Feat] Task 6 - 정적 페이지 메타데이터 및 WebSite JSON-LD 적용

### DIFF
--- a/.kiro/specs/16-seo-deployment/tasks.md
+++ b/.kiro/specs/16-seo-deployment/tasks.md
@@ -55,27 +55,27 @@
     - Server Component에서 `<SpotDetailClient />` import 및 렌더링
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 7.1, 7.2, 7.3, 7.4, 7.5_
 
-- [ ] 4. Checkpoint - 스팟 페이지 SEO 검증
+- [x] 4. Checkpoint - 스팟 페이지 SEO 검증
   - Ensure all tests pass, ask the user if questions arise.
   - 스팟 상세 페이지에서 메타데이터와 JSON-LD가 정상 렌더링되는지 확인
 
-- [ ] 5. 코스/커뮤니티 페이지 Server/Client Component 분리 및 SEO 적용
-  - [ ] 5.1 코스 상세 페이지 리팩토링 — Server Component 래퍼 + Client Component 분리
+- [x] 5. 코스/커뮤니티 페이지 Server/Client Component 분리 및 SEO 적용
+  - [x] 5.1 코스 상세 페이지 리팩토링 — Server Component 래퍼 + Client Component 분리
     - 기존 `src/app/routes/[id]/page.tsx`의 UI 로직을 `src/components/route/RouteDetailClient.tsx`로 추출 (`'use client'` 유지)
     - `src/app/routes/[id]/page.tsx`를 Server Component로 변환
     - `generateMetadata` 함수 구현 — MongoDB에서 경량 projection으로 코스 SEO 데이터 조회, `generateRouteMetadata()` 호출
     - Server Component에서 `JsonLd` 컴포넌트로 코스 JSON-LD 렌더링
     - _Requirements: 2.1, 2.2, 2.5, 8.1, 8.2, 8.3, 8.4_
 
-  - [ ] 5.2 커뮤니티 게시글 상세 페이지 리팩토링 — Server Component 래퍼 + Client Component 분리
+  - [x] 5.2 커뮤니티 게시글 상세 페이지 리팩토링 — Server Component 래퍼 + Client Component 분리
     - 기존 `src/app/community/[id]/page.tsx`의 UI 로직을 `src/components/community/PostDetailClient.tsx`로 추출 (`'use client'` 유지)
     - `src/app/community/[id]/page.tsx`를 Server Component로 변환
     - `generateMetadata` 함수 구현 — MongoDB에서 경량 projection으로 게시글 SEO 데이터 조회, `generatePostMetadata()` 호출
     - `ObjectId.isValid()` 검증 후 잘못된 ID 시 기본 메타데이터 반환
     - _Requirements: 2.3, 2.4, 2.5_
 
-- [ ] 6. 정적 페이지 메타데이터 및 WebSite JSON-LD 적용
-  - [ ] 6.1 정적 페이지 메타데이터 설정 — 공통 템플릿 + 페이지별 분리
+- [x] 6. 정적 페이지 메타데이터 및 WebSite JSON-LD 적용
+  - [x] 6.1 정적 페이지 메타데이터 설정 — 공통 템플릿 + 페이지별 분리
     - 루트 `src/app/layout.tsx`의 metadata를 공통 템플릿으로 변경: `title: { template: '%s | Not a Trip', default: 'Not a Trip - 팬들만 아는 특별한 여행지' }`, 공통 description, 공통 openGraph 설정
     - 메인 페이지(`/`): `src/app/(home)/layout.tsx` Route Group 생성 또는 `src/app/page.tsx`와 짝을 이루는 별도 metadata export 방식으로 메인 전용 메타데이터 설정 (루트 layout에 메인 페이지 메타데이터를 하드코딩하면 하위 페이지가 상속받아 원치 않는 메타데이터가 노출될 수 있으므로 분리)
     - 갤러리(`/gallery`): `src/app/gallery/layout.tsx` 생성, metadata export
@@ -85,12 +85,12 @@
     - 참고: `page.tsx`가 `'use client'`여도 같은 디렉토리의 `layout.tsx`에서 metadata를 export할 수 있음
     - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
 
-  - [ ] 6.2 루트 레이아웃에 WebSite JSON-LD 삽입
+  - [x] 6.2 루트 레이아웃에 WebSite JSON-LD 삽입
     - `src/app/layout.tsx`에 `JsonLd` 컴포넌트로 `generateWebSiteJsonLd()` 결과 렌더링
     - SearchAction의 target URL 패턴 설정
     - _Requirements: 9.1, 9.2, 9.3_
 
-- [ ] 7. Checkpoint - 전체 메타데이터 검증
+- [x] 7. Checkpoint - 전체 메타데이터 검증
   - Ensure all tests pass, ask the user if questions arise.
   - 모든 동적/정적 페이지의 메타데이터, JSON-LD가 정상 동작하는지 확인
 

--- a/src/app/community/layout.tsx
+++ b/src/app/community/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+import { getBaseUrl } from '@/lib/seo/metadata'
+
+const baseUrl = getBaseUrl()
+
+export const metadata: Metadata = {
+  title: '커뮤니티',
+  description:
+    '팬들과 함께 여행 경험을 나누고 정보를 공유하세요. 스팟 후기, 여행 팁, 작품 이야기를 자유롭게 나눌 수 있습니다.',
+  openGraph: {
+    title: '커뮤니티 | Not a Trip',
+    description:
+      '팬들과 함께 여행 경험을 나누고 정보를 공유하세요. 스팟 후기, 여행 팁, 작품 이야기를 자유롭게 나눌 수 있습니다.',
+    url: `${baseUrl}/community`,
+    type: 'website',
+    siteName: 'Not a Trip',
+  },
+}
+
+export default function CommunityLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/gallery/layout.tsx
+++ b/src/app/gallery/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+import { getBaseUrl } from '@/lib/seo/metadata'
+
+const baseUrl = getBaseUrl()
+
+export const metadata: Metadata = {
+  title: '갤러리',
+  description:
+    '팬들의 순례 인증샷과 명예의 전당을 확인하세요. 애니메이션 성지순례, 콘서트, 스포츠 직관 등 특별한 순간을 공유합니다.',
+  openGraph: {
+    title: '갤러리 | Not a Trip',
+    description:
+      '팬들의 순례 인증샷과 명예의 전당을 확인하세요. 애니메이션 성지순례, 콘서트, 스포츠 직관 등 특별한 순간을 공유합니다.',
+    url: `${baseUrl}/gallery`,
+    type: 'website',
+    siteName: 'Not a Trip',
+  },
+}
+
+export default function GalleryLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,9 @@ import { Providers } from '@/lib/providers'
 import { Header } from '@/components/layout'
 import { ServiceWorkerRegistrar } from '@/components/mobile/ServiceWorkerRegistrar'
 import { IosPwaPrompt } from '@/components/mobile/IosPwaPrompt'
+import JsonLd from '@/components/seo/JsonLd'
+import { generateWebSiteJsonLd } from '@/lib/seo/json-ld'
+import { getBaseUrl } from '@/lib/seo/metadata'
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -20,14 +23,34 @@ export const viewport: Viewport = {
   themeColor: '#4164a5',
 }
 
+const baseUrl = getBaseUrl()
+
 export const metadata: Metadata = {
-  title: 'Not a Trip',
-  description: '특별한 여행지를 공유하고 탐색하는 플랫폼',
+  title: {
+    template: '%s | Not a Trip',
+    default: 'Not a Trip - 팬들만 아는 특별한 여행지',
+  },
+  description:
+    '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
   manifest: '/manifest.json',
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',
     title: 'Not a Trip',
+  },
+  openGraph: {
+    siteName: 'Not a Trip',
+    type: 'website',
+    url: baseUrl,
+    title: 'Not a Trip - 팬들만 아는 특별한 여행지',
+    description:
+      '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Not a Trip - 팬들만 아는 특별한 여행지',
+    description:
+      '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
   },
 }
 
@@ -42,6 +65,7 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
       </head>
       <body className={`${pretendard.variable} antialiased`}>
+        <JsonLd data={generateWebSiteJsonLd()} />
         <Providers>
           <Header />
           <main className="pt-14">{children}</main>

--- a/src/app/routes/layout.tsx
+++ b/src/app/routes/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+import { getBaseUrl } from '@/lib/seo/metadata'
+
+const baseUrl = getBaseUrl()
+
+export const metadata: Metadata = {
+  title: '코스',
+  description:
+    '다른 순례자들이 만든 코스를 탐색하고 따라가보세요. 애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 테마별 코스를 제공합니다.',
+  openGraph: {
+    title: '코스 | Not a Trip',
+    description:
+      '다른 순례자들이 만든 코스를 탐색하고 따라가보세요. 애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 테마별 코스를 제공합니다.',
+    url: `${baseUrl}/routes`,
+    type: 'website',
+    siteName: 'Not a Trip',
+  },
+}
+
+export default function RoutesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #337

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 루트 레이아웃에 공통 metadata 템플릿과 WebSite JSON-LD를 적용하고, 갤러리/커뮤니티/코스 목록 페이지별 layout.tsx에 개별 메타데이터를 설정

---

## 📋 변경 사항

- [x] 루트 layout.tsx metadata를 title.template 기반 공통 템플릿으로 변경
- [x] 루트 layout.tsx에 공통 openGraph, twitter 메타 태그 추가
- [x] 루트 layout.tsx에 WebSite JSON-LD (SearchAction 포함) 삽입
- [x] 갤러리 페이지 layout.tsx 생성 및 metadata export
- [x] 커뮤니티 페이지 layout.tsx 생성 및 metadata export
- [x] 코스 목록 페이지 layout.tsx 생성 및 metadata export

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 9.1, 9.2, 9.3 대응
- 메인 페이지(`/`)는 루트 layout의 `title.default`를 그대로 사용하여 별도 route group 없이 처리
- `page.tsx`가 `'use client'`인 페이지들은 같은 디렉토리의 `layout.tsx`에서 metadata를 export하는 Next.js 패턴 활용
- 동적 페이지(`/spots/[id]`, `/routes/[id]`, `/community/[id]`)는 이미 `generateMetadata`가 구현되어 있어 layout metadata보다 우선 적용됨
