### PR TITLE
[Feat] OG 이미지 동적 생성 구현

### DIFF
--- a/.kiro/specs/16-seo-deployment/tasks.md
+++ b/.kiro/specs/16-seo-deployment/tasks.md
@@ -94,8 +94,8 @@
   - Ensure all tests pass, ask the user if questions arise.
   - 모든 동적/정적 페이지의 메타데이터, JSON-LD가 정상 동작하는지 확인
 
-- [ ] 8. OG 이미지 동적 생성 구현
-  - [ ] 8.1 OG 이미지 API 라우트 구현
+- [-] 8. OG 이미지 동적 생성 구현
+  - [x] 8.1 OG 이미지 API 라우트 구현
     - `src/app/api/og/route.tsx` 생성
     - `export const runtime = 'nodejs'` 설정
     - `next/og`의 `ImageResponse` API 사용하여 1200×630px 이미지 생성
@@ -109,7 +109,7 @@
     - 폰트 로드 실패 시 시스템 기본 폰트 폴백
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
 
-  - [ ] 8.2 각 페이지 메타데이터에 OG 이미지 URL 연결
+  - [x] 8.2 각 페이지 메타데이터에 OG 이미지 URL 연결
     - `generateSpotMetadata()`의 openGraph.images에 `/api/og?type=spot&id=xxx` URL 설정
     - `generateRouteMetadata()`의 openGraph.images에 `/api/og?type=route&id=xxx` URL 설정
     - 정적 페이지 metadata의 openGraph.images에 `/api/og?type=default` URL 설정

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,0 +1,443 @@
+import { ImageResponse } from 'next/og'
+import { NextRequest } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { CATEGORY_CONFIG, type SpotCategory } from '@/types/spot'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export const runtime = 'nodejs'
+
+// ============================================
+// 타입 정의
+// ============================================
+
+interface SpotOgData {
+  name: string
+  category?: SpotCategory
+  address: string
+}
+
+interface RouteOgData {
+  name: string
+  spotCount: number
+}
+
+// ============================================
+// 브랜드 상수
+// ============================================
+
+const BRAND_COLOR = '#4164a5'
+const BRAND_BG = '#f0f4fa'
+const IMAGE_WIDTH = 1200
+const IMAGE_HEIGHT = 630
+
+// ============================================
+// 폰트 로드
+// ============================================
+
+async function loadFonts(): Promise<
+  { name: string; data: ArrayBuffer; weight: 400 | 700; style: 'normal' }[]
+> {
+  try {
+    const fontsDir = path.join(process.cwd(), 'src', 'assets', 'fonts')
+    const [regularData, boldData] = await Promise.all([
+      fs.readFile(path.join(fontsDir, 'PretendardRegular.ttf')),
+      fs.readFile(path.join(fontsDir, 'PretendardBold.ttf')),
+    ])
+
+    return [
+      {
+        name: 'Pretendard',
+        data: regularData.buffer as ArrayBuffer,
+        weight: 400,
+        style: 'normal' as const,
+      },
+      {
+        name: 'Pretendard',
+        data: boldData.buffer as ArrayBuffer,
+        weight: 700,
+        style: 'normal' as const,
+      },
+    ]
+  } catch {
+    return []
+  }
+}
+
+// ============================================
+// 데이터 조회
+// ============================================
+
+async function getSpotData(id: string): Promise<SpotOgData | null> {
+  try {
+    const collection = await getCollection(COLLECTIONS.SPOTS)
+    const spot = await collection.findOne(
+      { id },
+      { projection: { name: 1, category: 1, address: 1 } }
+    )
+    if (!spot) return null
+    return {
+      name: spot.name as string,
+      category: spot.category as SpotCategory | undefined,
+      address: (spot.address as string) || '',
+    }
+  } catch {
+    return null
+  }
+}
+
+async function getRouteData(id: string): Promise<RouteOgData | null> {
+  try {
+    const collection = await getCollection(COLLECTIONS.ROUTES)
+    const route = await collection.findOne(
+      { id },
+      { projection: { name: 1, spots: 1 } }
+    )
+    if (!route) return null
+    const spots = (route.spots as Array<unknown>) || []
+    return {
+      name: route.name as string,
+      spotCount: spots.length,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ============================================
+// OG 이미지 컴포넌트
+// ============================================
+
+function DefaultOgImage() {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: BRAND_BG,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '16px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '72px',
+            fontWeight: 700,
+            color: BRAND_COLOR,
+            letterSpacing: '-1px',
+          }}
+        >
+          Not a Trip
+        </div>
+        <div
+          style={{
+            fontSize: '28px',
+            color: '#6b7280',
+          }}
+        >
+          팬들만 아는 특별한 여행지
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SpotOgImage({ spot }: { spot: SpotOgData }) {
+  const categoryLabel = spot.category
+    ? CATEGORY_CONFIG[spot.category].label
+    : null
+  const categoryColor = spot.category
+    ? CATEGORY_CONFIG[spot.category].color
+    : '#6b7280'
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: BRAND_BG,
+        padding: '60px',
+      }}
+    >
+      {/* 상단 브랜드 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          marginBottom: '40px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '24px',
+            fontWeight: 700,
+            color: BRAND_COLOR,
+          }}
+        >
+          Not a Trip
+        </div>
+      </div>
+
+      {/* 메인 콘텐츠 */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          justifyContent: 'center',
+          gap: '20px',
+        }}
+      >
+        {/* 카테고리 뱃지 */}
+        {categoryLabel && (
+          <div style={{ display: 'flex' }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                backgroundColor: categoryColor,
+                color: '#ffffff',
+                fontSize: '20px',
+                fontWeight: 700,
+                padding: '8px 20px',
+                borderRadius: '24px',
+              }}
+            >
+              {categoryLabel}
+            </div>
+          </div>
+        )}
+
+        {/* 스팟 이름 */}
+        <div
+          style={{
+            fontSize: '56px',
+            fontWeight: 700,
+            color: '#1f2937',
+            lineHeight: 1.2,
+            maxWidth: '900px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {spot.name}
+        </div>
+
+        {/* 주소 */}
+        {spot.address && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              fontSize: '24px',
+              color: '#6b7280',
+            }}
+          >
+            <span>📍</span>
+            <span>{spot.address}</span>
+          </div>
+        )}
+      </div>
+
+      {/* 하단 장식 라인 */}
+      <div
+        style={{
+          display: 'flex',
+          width: '100%',
+          height: '6px',
+          backgroundColor: BRAND_COLOR,
+          borderRadius: '3px',
+        }}
+      />
+    </div>
+  )
+}
+
+function RouteOgImage({ route }: { route: RouteOgData }) {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: BRAND_BG,
+        padding: '60px',
+      }}
+    >
+      {/* 상단 브랜드 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          marginBottom: '40px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '24px',
+            fontWeight: 700,
+            color: BRAND_COLOR,
+          }}
+        >
+          Not a Trip
+        </div>
+      </div>
+
+      {/* 메인 콘텐츠 */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          justifyContent: 'center',
+          gap: '20px',
+        }}
+      >
+        {/* 코스 뱃지 */}
+        <div style={{ display: 'flex' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              backgroundColor: BRAND_COLOR,
+              color: '#ffffff',
+              fontSize: '20px',
+              fontWeight: 700,
+              padding: '8px 20px',
+              borderRadius: '24px',
+            }}
+          >
+            🗺️ 코스
+          </div>
+        </div>
+
+        {/* 코스 이름 */}
+        <div
+          style={{
+            fontSize: '56px',
+            fontWeight: 700,
+            color: '#1f2937',
+            lineHeight: 1.2,
+            maxWidth: '900px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {route.name}
+        </div>
+
+        {/* 스팟 수 */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            fontSize: '24px',
+            color: '#6b7280',
+          }}
+        >
+          <span>📍</span>
+          <span>{route.spotCount}개 스팟</span>
+        </div>
+      </div>
+
+      {/* 하단 장식 라인 */}
+      <div
+        style={{
+          display: 'flex',
+          width: '100%',
+          height: '6px',
+          backgroundColor: BRAND_COLOR,
+          borderRadius: '3px',
+        }}
+      />
+    </div>
+  )
+}
+
+// ============================================
+// GET 핸들러
+// ============================================
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl
+  const type = searchParams.get('type') || 'default'
+  const id = searchParams.get('id') || ''
+
+  const fonts = await loadFonts()
+  const fontFamily = fonts.length > 0 ? 'Pretendard' : 'sans-serif'
+
+  try {
+    let element: React.ReactElement
+
+    if (type === 'spot' && id) {
+      const spot = await getSpotData(id)
+      element = spot ? <SpotOgImage spot={spot} /> : <DefaultOgImage />
+    } else if (type === 'route' && id) {
+      const route = await getRouteData(id)
+      element = route ? <RouteOgImage route={route} /> : <DefaultOgImage />
+    } else {
+      element = <DefaultOgImage />
+    }
+
+    // fontFamily를 래퍼에 적용
+    const wrapped = (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          fontFamily,
+        }}
+      >
+        {element}
+      </div>
+    )
+
+    return new ImageResponse(wrapped, {
+      width: IMAGE_WIDTH,
+      height: IMAGE_HEIGHT,
+      ...(fonts.length > 0 ? { fonts } : {}),
+      headers: {
+        'Cache-Control':
+          'public, s-maxage=86400, stale-while-revalidate=604800',
+      },
+    })
+  } catch {
+    // 렌더링 오류 시 기본 브랜드 이미지 반환
+    return new ImageResponse(
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <DefaultOgImage />
+      </div>,
+      {
+        width: IMAGE_WIDTH,
+        height: IMAGE_HEIGHT,
+        headers: {
+          'Cache-Control':
+            'public, s-maxage=86400, stale-while-revalidate=604800',
+        },
+      }
+    )
+  }
+}

--- a/src/app/community/layout.tsx
+++ b/src/app/community/layout.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     url: `${baseUrl}/community`,
     type: 'website',
     siteName: 'Not a Trip',
+    images: [`${baseUrl}/api/og?type=default`],
   },
 }
 

--- a/src/app/gallery/layout.tsx
+++ b/src/app/gallery/layout.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     url: `${baseUrl}/gallery`,
     type: 'website',
     siteName: 'Not a Trip',
+    images: [`${baseUrl}/api/og?type=default`],
   },
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,12 +45,14 @@ export const metadata: Metadata = {
     title: 'Not a Trip - 팬들만 아는 특별한 여행지',
     description:
       '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    images: [`${baseUrl}/api/og?type=default`],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Not a Trip - 팬들만 아는 특별한 여행지',
     description:
       '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    images: [`${baseUrl}/api/og?type=default`],
   },
 }
 

--- a/src/app/routes/layout.tsx
+++ b/src/app/routes/layout.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     url: `${baseUrl}/routes`,
     type: 'website',
     siteName: 'Not a Trip',
+    images: [`${baseUrl}/api/og?type=default`],
   },
 }
 

--- a/src/assets/fonts/README.md
+++ b/src/assets/fonts/README.md
@@ -1,0 +1,8 @@
+# OG Image Fonts
+
+이 디렉토리에 Pretendard TTF 폰트 파일을 배치하세요.
+
+- `PretendardRegular.ttf` (Regular 400)
+- `PretendardBold.ttf` (Bold 700)
+
+폰트 파일이 없으면 시스템 기본 폰트(sans-serif)로 폴백됩니다.

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -40,6 +40,7 @@ export function getBaseUrl(): string {
 /** 기본 메타데이터 생성 (조회 실패 시 폴백용) */
 export function getDefaultMetadata(): Metadata {
   const baseUrl = getBaseUrl()
+  const ogImage = `${baseUrl}/api/og?type=default`
   return {
     title: 'Not a Trip - 팬들만 아는 특별한 여행지',
     description:
@@ -48,6 +49,7 @@ export function getDefaultMetadata(): Metadata {
       title: 'Not a Trip - 팬들만 아는 특별한 여행지',
       description:
         '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+      images: [ogImage],
       url: baseUrl,
       type: 'website',
       siteName: 'Not a Trip',
@@ -57,6 +59,7 @@ export function getDefaultMetadata(): Metadata {
       title: 'Not a Trip - 팬들만 아는 특별한 여행지',
       description:
         '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+      images: [ogImage],
     },
   }
 }
@@ -79,7 +82,7 @@ export function generateSpotMetadata(spot: SpotSeoData): Metadata {
 
   const url = `${baseUrl}/spots/${spot.id}`
   const ogImage = `${baseUrl}/api/og?type=spot&id=${spot.id}`
-  const images = spot.photos.length > 0 ? [spot.photos[0]] : [ogImage]
+  const twitterImages = spot.photos.length > 0 ? [spot.photos[0]] : [ogImage]
 
   return {
     title,
@@ -87,7 +90,7 @@ export function generateSpotMetadata(spot: SpotSeoData): Metadata {
     openGraph: {
       title,
       description,
-      images,
+      images: [ogImage],
       url,
       type: 'website',
       siteName: 'Not a Trip',
@@ -96,7 +99,7 @@ export function generateSpotMetadata(spot: SpotSeoData): Metadata {
       card: 'summary_large_image',
       title,
       description,
-      images,
+      images: twitterImages,
     },
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #339

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> SNS 공유 시 스팟/코스 정보가 포함된 OG 이미지를 동적으로 생성하고, 각 페이지 메타데이터에 OG 이미지 URL을 연결

---

## 📋 변경 사항

- [x] `src/app/api/og/route.tsx` OG 이미지 API 라우트 생성 (Node.js Runtime + ImageResponse)
- [x] 스팟: 이름, 카테고리 뱃지, 주소 포함 1200×630px 이미지 생성
- [x] 코스: 이름, 스팟 수 포함 1200×630px 이미지 생성
- [x] 기본: Not a Trip 브랜드 이미지 생성
- [x] Cache-Control 헤더 설정 (s-maxage=86400)
- [x] 폰트 로드 실패 시 sans-serif 폴백, DB 조회 실패 시 기본 이미지 반환
- [x] `generateSpotMetadata()` openGraph.images에 동적 OG 이미지 URL 연결
- [x] `generateRouteMetadata()` openGraph.images에 동적 OG 이미지 URL 연결
- [x] `getDefaultMetadata()` 및 정적 페이지 layout에 기본 OG 이미지 URL 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---
<img width="1202" height="585" alt="image" src="https://github.com/user-attachments/assets/77460139-d5bb-415b-8e2d-f27e4da4364c" />

## 📝 추가 정보

- **Requirements**: 1.3, 1.4, 4.1, 4.2, 4.3, 4.4, 4.5
- **Task**: 8.1, 8.2
- Pretendard TTF 폰트 파일은 `src/assets/fonts/`에 배치 필요 (없으면 시스템 폰트로 폴백)
