### PR TITLE
[Feat] Task 9 - 사이트맵 및 robots.txt 구현

### DIFF
--- a/.kiro/specs/16-seo-deployment/tasks.md
+++ b/.kiro/specs/16-seo-deployment/tasks.md
@@ -115,8 +115,8 @@
     - 정적 페이지 metadata의 openGraph.images에 `/api/og?type=default` URL 설정
     - _Requirements: 1.3, 1.4, 4.1, 4.2_
 
-- [ ] 9. 사이트맵 및 robots.txt 구현
-  - [ ] 9.1 사이트맵 생성 구현
+- [x] 9. 사이트맵 및 robots.txt 구현
+  - [x] 9.1 사이트맵 생성 구현
     - `src/app/sitemap.ts` 생성 — Next.js App Router `sitemap.ts` 규약 사용
     - 정적 페이지 URL 포함 (메인, 갤러리, 코스 목록)
     - MongoDB에서 모든 공개 스팟, 공개 코스, 게시글 ID 조회 (경량 projection)
@@ -126,7 +126,7 @@
     - DB 연결 실패 시 정적 페이지만 포함한 최소 사이트맵 반환
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7_
 
-  - [ ] 9.2 robots.txt 생성 구현
+  - [x] 9.2 robots.txt 생성 구현
     - `src/app/robots.ts` 생성 — Next.js App Router `robots.ts` 규약 사용
     - `/api/*`, `/admin/*`, `/auth/*`, `/test/*` 크롤링 차단
     - 공개 페이지 크롤링 허용

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next'
+import { getBaseUrl } from '@/lib/seo/metadata'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = getBaseUrl()
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/*', '/admin/*', '/auth/*', '/test/*'],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,91 @@
+import type { MetadataRoute } from 'next'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { getBaseUrl } from '@/lib/seo/metadata'
+
+/** 정적 페이지 사이트맵 엔트리 생성 */
+function getStaticPages(baseUrl: string): MetadataRoute.Sitemap {
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/gallery`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/routes`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/community`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
+  ]
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = getBaseUrl()
+  const staticPages = getStaticPages(baseUrl)
+
+  try {
+    const [spotsCollection, routesCollection, postsCollection] =
+      await Promise.all([
+        getCollection(COLLECTIONS.SPOTS),
+        getCollection(COLLECTIONS.ROUTES),
+        getCollection(COLLECTIONS.POSTS),
+      ])
+
+    const [spots, routes, posts] = await Promise.all([
+      spotsCollection
+        .find({}, { projection: { id: 1, updatedAt: 1 } })
+        .toArray(),
+      routesCollection
+        .find({ isPublic: true }, { projection: { id: 1, updatedAt: 1 } })
+        .toArray(),
+      postsCollection
+        .find({}, { projection: { _id: 1, updatedAt: 1 } })
+        .toArray(),
+    ])
+
+    const spotEntries: MetadataRoute.Sitemap = spots.map((spot) => ({
+      url: `${baseUrl}/spots/${spot.id}`,
+      lastModified: spot.updatedAt
+        ? new Date(spot.updatedAt as string)
+        : new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.9,
+    }))
+
+    const routeEntries: MetadataRoute.Sitemap = routes.map((route) => ({
+      url: `${baseUrl}/routes/${route.id}`,
+      lastModified: route.updatedAt
+        ? new Date(route.updatedAt as string)
+        : new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    }))
+
+    const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+      url: `${baseUrl}/community/${post._id.toString()}`,
+      lastModified: post.updatedAt
+        ? new Date(post.updatedAt as string)
+        : new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.6,
+    }))
+
+    return [...staticPages, ...spotEntries, ...routeEntries, ...postEntries]
+  } catch (error) {
+    console.error('사이트맵 생성 중 DB 조회 실패:', error)
+    return staticPages
+  }
+}


### PR DESCRIPTION
## 📋 작업 내용

- `src/app/sitemap.ts` — Next.js App Router 규약 기반 XML 사이트맵 생성
- `src/app/robots.ts` — robots.txt 생성

## 🔍 상세 설명

### sitemap.ts
- 정적 페이지 URL 포함 (메인, 갤러리, 코스 목록, 커뮤니티 목록)
- MongoDB에서 공개 스팟, 공개 코스(isPublic: true), 게시글 ID를 경량 projection으로 조회
- 동적 페이지 URL 생성 (`/spots/{id}`, `/routes/{id}`, `/community/{id}`)
- 각 엔트리에 lastModified, changeFrequency, priority 속성 포함
- DB 연결 실패 시 정적 페이지만 포함한 최소 사이트맵 반환 (graceful fallback)

### robots.ts
- `/api/*`, `/admin/*`, `/auth/*`, `/test/*` 크롤링 차단
- 공개 페이지 크롤링 허용
- 사이트맵 URL 명시 (`{Base_URL}/sitemap.xml`)

## 📌 관련 정보

- **Task 번호**: Task 9.1, 9.2
- **Requirements**: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 6.1, 6.2, 6.3, 6.4

Closes #341
<img width="314" height="189" alt="image" src="https://github.com/user-attachments/assets/891746dd-524d-43d3-a035-488180cf2acd" />
<img width="874" height="721" alt="image" src="https://github.com/user-attachments/assets/94014f49-db4d-4c56-961c-9b8954599da5" />
