### PR TITLE
[Chore] SEO 파일의 타입 안전성 및 표준 문법 개선

### DIFF
--- a/.kiro/specs/16-seo-deployment/tasks.md
+++ b/.kiro/specs/16-seo-deployment/tasks.md
@@ -94,7 +94,7 @@
   - Ensure all tests pass, ask the user if questions arise.
   - 모든 동적/정적 페이지의 메타데이터, JSON-LD가 정상 동작하는지 확인
 
-- [-] 8. OG 이미지 동적 생성 구현
+- [x] 8. OG 이미지 동적 생성 구현
   - [x] 8.1 OG 이미지 API 라우트 구현
     - `src/app/api/og/route.tsx` 생성
     - `export const runtime = 'nodejs'` 설정
@@ -141,12 +141,12 @@
     - **Property 7: 사이트맵 비공개 경로 제외** — 어떤 엔트리 URL도 /admin, /auth, /test, /api 경로를 포함하지 않음 검증
     - **Validates: Requirements 5.7**
 
-- [ ] 10. Checkpoint - OG 이미지 및 사이트맵 검증
+- [x] 10. Checkpoint - OG 이미지 및 사이트맵 검증
   - Ensure all tests pass, ask the user if questions arise.
   - OG 이미지 API 응답, 사이트맵 XML, robots.txt 정상 동작 확인
 
-- [ ] 11. 배포 설정 및 GA4 연동
-  - [ ] 11.1 GA4 컴포넌트 구현 및 환경 변수 추가
+- [x] 11. 배포 설정 및 GA4 연동
+  - [x] 11.1 GA4 컴포넌트 구현 및 환경 변수 추가
     - `.env.example`에 `NEXT_PUBLIC_GA_MEASUREMENT_ID` 추가 (`NEXT_PUBLIC_BASE_URL`은 Task 1.1에서 이미 추가됨)
     - `src/components/seo/GoogleAnalytics.tsx` 생성
     - `NEXT_PUBLIC_GA_MEASUREMENT_ID` 환경 변수 확인, 미설정 시 `null` 반환
@@ -155,7 +155,7 @@
     - `src/app/layout.tsx`에 `GoogleAnalytics` 컴포넌트 삽입
     - _Requirements: 10.3, 10.4, 12.1, 12.2, 12.3, 12.4, 12.5_
 
-- [ ] 12. Final Checkpoint - 전체 빌드 및 최종 검증
+- [x] 12. Final Checkpoint - 전체 빌드 및 최종 검증
   - Ensure all tests pass, ask the user if questions arise.
   - `npm run build` 성공 확인
   - 모든 페이지의 메타데이터, JSON-LD, OG 이미지, 사이트맵, robots.txt 정상 동작 확인

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/*', '/admin/*', '/auth/*', '/test/*'],
+        disallow: ['/api/', '/admin/', '/auth/', '/test/'],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -58,27 +58,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const spotEntries: MetadataRoute.Sitemap = spots.map((spot) => ({
       url: `${baseUrl}/spots/${spot.id}`,
-      lastModified: spot.updatedAt
-        ? new Date(spot.updatedAt as string)
-        : new Date(),
+      lastModified: spot.updatedAt ? new Date(spot.updatedAt) : new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.9,
     }))
 
     const routeEntries: MetadataRoute.Sitemap = routes.map((route) => ({
       url: `${baseUrl}/routes/${route.id}`,
-      lastModified: route.updatedAt
-        ? new Date(route.updatedAt as string)
-        : new Date(),
+      lastModified: route.updatedAt ? new Date(route.updatedAt) : new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.7,
     }))
 
     const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
       url: `${baseUrl}/community/${post._id.toString()}`,
-      lastModified: post.updatedAt
-        ? new Date(post.updatedAt as string)
-        : new Date(),
+      lastModified: post.updatedAt ? new Date(post.updatedAt) : new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.6,
     }))


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #345

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> SEO 파일(sitemap.ts, robots.ts)의 타입 안전성 및 표준 문법 개선

---

## 📋 변경 사항

- [x] sitemap.ts: `updatedAt`의 불필요한 `as string` 타입 단언 제거 (Date 객체/문자열 모두 안전 처리)
- [x] robots.ts: disallow 경로를 와일드카드(`/api/*`) → 표준 후행 슬래시(`/api/`) 방식으로 변경

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- 스팟/게시글 스키마에는 `isPublic`/`isDraft` 같은 비공개 필드가 없어 사이트맵 필터링 추가는 불필요 확인 완료
- 코스만 `isPublic` 필드가 있으며 기존에 이미 `{ isPublic: true }` 조건이 적용되어 있음
