### PR TITLE
[Feat] Task 1.1 - SVG 아이콘 컴포넌트 생성

### DIFF
--- a/.kiro/specs/17-declarative-refactoring/.config.kiro
+++ b/.kiro/specs/17-declarative-refactoring/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4cd01406-28d0-4d48-af5a-64eac13920ee", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/17-declarative-refactoring/design.md
+++ b/.kiro/specs/17-declarative-refactoring/design.md
@@ -1,0 +1,441 @@
+# 설계 문서: 선언적 리팩토링 (Declarative Refactoring)
+
+## 개요
+
+Not a Trip 프로젝트에 Toss 스타일의 선언적 프로그래밍 패턴을 도입하는 리팩토링이다. 현재 코드베이스에는 다음과 같은 문제가 존재한다:
+
+1. **명령형 비동기 처리**: `isLoading`/`error` 상태를 컴포넌트 내부에서 직접 분기 처리하여 비즈니스 로직과 UI 로직이 혼재
+2. **추상화 수준 불일치**: `page.tsx` 최상위 컴포넌트에 인라인 SVG, 스켈레톤 UI 등 저수준 코드가 혼재
+3. **관심사 미분리**: 관리자 페이지 4곳에 동일한 세션 확인/권한 검사/리다이렉트 코드가 중복
+4. **도메인 로직 결합**: SpotDetailClient, RouteDetailClient에 데이터 패칭, 권한 확인, 상태 관리 로직이 렌더링 코드와 결합
+
+이 설계는 4가지 영역을 독립적으로 진행 가능하도록 구성하며, 기존 기능을 유지하면서 점진적으로 코드 구조를 개선한다.
+
+### 기술 스택 참고
+
+- **TanStack Query v5**: `useSuspenseQuery` 네이티브 지원 (v5.0+)
+- **React 18+**: `<Suspense>` 컴포넌트 안정화
+- **Next.js 15 App Router**: `loading.tsx`, `error.tsx` 파일 기반 경계와의 공존 고려
+
+## 아키텍처
+
+### 전체 구조 변경 개요
+
+```mermaid
+graph TB
+    subgraph "Before: 명령형 패턴"
+        A[Page Component] --> B{isLoading?}
+        B -->|yes| C[Skeleton UI]
+        B -->|no| D{error?}
+        D -->|yes| E[Error UI]
+        D -->|no| F[Content]
+    end
+
+    subgraph "After: 선언적 패턴"
+        G[Page Component] --> H[ErrorBoundary]
+        H --> I[Suspense + Fallback]
+        I --> J[Content Component]
+        J --> K[useSuspenseQuery]
+    end
+```
+
+### Suspense & ErrorBoundary vs Next.js loading.tsx/error.tsx
+
+Next.js App Router는 파일 기반 `loading.tsx`와 `error.tsx`를 제공하지만, 이 프로젝트에서는 컴포넌트 레벨 Suspense/ErrorBoundary를 사용한다:
+
+| 구분 | Next.js 파일 기반 | 컴포넌트 레벨 (채택) |
+|------|-------------------|---------------------|
+| 적용 범위 | 라우트 세그먼트 단위 | 컴포넌트 트리 단위 |
+| 세분화 | 페이지 전체 로딩/에러 | 섹션별 독립 로딩/에러 |
+| 재시도 | 별도 구현 필요 | QueryErrorResetBoundary 연동 |
+| SSR 호환 | 자동 처리 | useIsMounted 훅으로 클라이언트 마운트 후 렌더링 지연 |
+
+**설계 결정**: 컴포넌트 레벨 경계를 사용하여 페이지 내 개별 섹션이 독립적으로 로딩/에러 상태를 관리할 수 있도록 한다. Next.js의 `loading.tsx`/`error.tsx`는 전체 페이지 수준의 폴백으로 유지한다.
+
+### QueryErrorResetBoundary를 활용한 선언적 에러 복구
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ErrorBoundary
+    participant QueryErrorResetBoundary
+    participant useSuspenseQuery
+
+    useSuspenseQuery->>ErrorBoundary: throw Error
+    ErrorBoundary->>User: 에러 UI + 재시도 버튼 표시
+    User->>ErrorBoundary: 재시도 클릭
+    ErrorBoundary->>QueryErrorResetBoundary: reset()
+    QueryErrorResetBoundary->>useSuspenseQuery: 쿼리 재실행
+    useSuspenseQuery->>User: 성공 시 콘텐츠 표시
+```
+
+TanStack Query의 `QueryErrorResetBoundary`는 ErrorBoundary의 `onReset` 콜백과 연동하여, 재시도 시 실패한 쿼리의 에러 상태를 자동으로 초기화한다. 이를 통해 사용자가 "다시 시도" 버튼을 클릭하면 쿼리가 자동으로 재실행된다.
+
+### SSR 하이드레이션 방어 전략
+
+`useSuspenseQuery`는 SSR 환경에서 서버 렌더링 시 데이터를 기다리므로 하이드레이션 불일치가 발생할 수 있다. 대상 컴포넌트들이 `'use client'` 지시어를 사용하더라도, Next.js App Router는 최초 접속 시 서버에서 1회 프리렌더링(SSR)을 시도한다. 이때 내부에 `useSuspenseQuery`가 있으면 서버가 데이터를 기다리다가 에러를 발생시키거나 Suspense fallback을 HTML에 하드코딩하는 문제가 생긴다.
+
+**해결 전략: `useIsMounted` 훅 도입**
+
+`AsyncBoundary` 내부에 클라이언트 마운트 여부를 추적하는 `useIsMounted` 훅을 추가하여, 마운트가 완료된 후에만 `useSuspenseQuery`가 포함된 자식 컴포넌트를 렌더링하도록 지연시킨다. 마운트 전에는 `pendingFallback`을 표시한다.
+
+```typescript
+// src/hooks/useIsMounted.ts
+function useIsMounted(): boolean
+```
+
+내부 동작:
+1. `useState(false)`로 초기화
+2. `useEffect`에서 `setIsMounted(true)` 호출 (클라이언트에서만 실행)
+3. 서버 렌더링 시 항상 `false` 반환 → `pendingFallback` 표시
+4. 클라이언트 마운트 완료 후 `true` 반환 → 자식 컴포넌트(useSuspenseQuery 포함) 렌더링
+
+**AsyncBoundary 내부 적용**:
+```tsx
+function AsyncBoundary({ children, pendingFallback, rejectedFallback }: AsyncBoundaryProps) {
+  const isMounted = useIsMounted()
+
+  if (!isMounted) return <>{pendingFallback}</>
+
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} renderFallback={rejectedFallback}>
+          <Suspense fallback={pendingFallback}>
+            {children}
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}
+```
+
+## 컴포넌트 및 인터페이스
+
+### 1. ErrorBoundary 컴포넌트
+
+**파일**: `src/components/common/ErrorBoundary.tsx`
+
+```typescript
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+  // 단순 UI 폴백 (ReactNode)
+  fallback?: React.ReactNode
+  // Render Props 패턴 — 에러 정보와 reset 함수를 받아 커스텀 에러 UI를 렌더링
+  renderFallback?: (props: { error: Error; reset: () => void }) => React.ReactNode
+  onReset?: () => void
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+```
+
+React 클래스 컴포넌트로 구현하며, `getDerivedStateFromError`와 `componentDidCatch`를 사용한다.
+
+**fallback 우선순위**: `renderFallback` > `fallback` > 기본 에러 UI(에러 메시지 + 재시도 버튼). `renderFallback`이 제공되면 함수형 Render Props로 에러와 reset을 전달하고, `fallback`만 있으면 정적 ReactNode를 표시한다. 둘 다 없으면 기본 에러 UI를 표시한다. 이 분리를 통해 TypeScript가 `typeof fallback === 'function'` 분기 없이 타입을 명확하게 추론할 수 있다.
+
+### 2. AsyncBoundary 컴포넌트 (편의 래퍼)
+
+**파일**: `src/components/common/AsyncBoundary.tsx`
+
+```typescript
+interface AsyncBoundaryProps {
+  children: React.ReactNode
+  pendingFallback: React.ReactNode
+  rejectedFallback?: (props: { error: Error; reset: () => void }) => React.ReactNode
+}
+```
+
+`QueryErrorResetBoundary` + `ErrorBoundary` + `Suspense` + `useIsMounted`를 조합한 편의 컴포넌트. SSR 환경에서 마운트 전에는 `pendingFallback`을 표시하고, 마운트 후에만 자식 컴포넌트를 렌더링한다. 사용 예:
+
+```tsx
+<AsyncBoundary pendingFallback={<SpotDetailSkeleton />}>
+  <SpotDetailContent spotId={spotId} />
+</AsyncBoundary>
+```
+
+### 3. SVG 아이콘 컴포넌트
+
+**디렉토리**: `src/components/icons/`
+
+```typescript
+interface IconProps {
+  size?: 'sm' | 'md' | 'lg' | number  // sm=16, md=24, lg=32
+  color?: string                        // CSS color 값, 기본값 'currentColor'
+  className?: string
+}
+```
+
+분리 대상 인라인 SVG 아이콘:
+
+| 컴포넌트명 | 출처 | 용도 |
+|-----------|------|------|
+| `AlertTriangleIcon` | `page.tsx`, `SpotDetailClient.tsx` | 에러 상태 표시 |
+| `SearchIcon` | `page.tsx` | 검색 결과 없음 |
+| `FilterIcon` | `page.tsx` | 카테고리 필터 해제 |
+| `MapPinIcon` | `SpotDetailClient.tsx` | 주소/위치 표시 |
+| `ArrowLeftIcon` | `SpotDetailClient.tsx`, `RouteDetailClient.tsx` | 뒤로가기 |
+| `SpinnerIcon` | `page.tsx` | 로딩 스피너 |
+
+**배럴 파일**: `src/components/icons/index.ts`에서 모든 아이콘을 re-export한다.
+
+### 4. 프레젠테이셔널 컴포넌트 분리
+
+**디렉토리**: `src/components/common/` (기존 디렉토리 활용)
+
+| 컴포넌트명 | 파일 | 출처 |
+|-----------|------|------|
+| `SpotLoadingSkeleton` | `SpotLoadingSkeleton.tsx` | `page.tsx` 내부 함수 |
+| `SpotErrorDisplay` | `SpotErrorDisplay.tsx` | `page.tsx` 내부 함수 |
+| `EmptySearchOverlay` | `EmptySearchOverlay.tsx` | `page.tsx` 인라인 JSX |
+| `EmptyFilterOverlay` | `EmptyFilterOverlay.tsx` | `page.tsx` 인라인 JSX |
+
+### 5. Headless 훅 (ViewModel) 인터페이스
+
+#### useAdminAuth
+
+**파일**: `src/hooks/useAdminAuth.ts`
+
+```typescript
+interface UseAdminAuthReturn {
+  isLoading: boolean       // 세션 로딩 중 여부
+  isAuthorized: boolean    // 관리자 권한 확인 결과
+  session: Session | null  // NextAuth 세션 객체
+}
+
+function useAdminAuth(): UseAdminAuthReturn
+```
+
+내부 동작:
+1. `useSession()`으로 세션 상태 확인
+2. `status === 'loading'`이면 `{ isLoading: true, isAuthorized: false, session: null }` 반환
+3. 세션이 없거나 `role !== 'admin'`이면 `router.push('/')`로 리다이렉트 후 `{ isLoading: false, isAuthorized: false, session: null }` 반환
+4. 관리자이면 `{ isLoading: false, isAuthorized: true, session }` 반환
+
+#### useSpotDetailViewModel
+
+**파일**: `src/hooks/useSpotDetailViewModel.ts`
+
+```typescript
+interface UseSpotDetailViewModelProps {
+  spotId: string
+}
+
+interface UseSpotDetailViewModelReturn {
+  // 권한
+  hasEditPermission: boolean
+  hasDeletePermission: boolean
+
+  // 삭제
+  isDeleting: boolean
+  handleDelete: () => Promise<void>
+
+  // 정보 보완 폼
+  showSupplementForm: boolean
+  handleSupplementClick: () => void
+  handleSupplementSuccess: () => void
+  supplementKey: number
+
+  // 상태 신고 폼
+  showStatusReportForm: boolean
+  handleStatusReportClick: () => void
+
+  // 로그인 모달
+  showLoginModal: boolean
+  loginModalContext: 'supplement' | 'status'
+}
+
+function useSpotDetailViewModel(props: UseSpotDetailViewModelProps): UseSpotDetailViewModelReturn
+```
+
+#### useRouteDetailViewModel
+
+**파일**: `src/hooks/useRouteDetailViewModel.ts`
+
+```typescript
+interface UseRouteDetailViewModelProps {
+  routeId: string
+}
+
+interface UseRouteDetailViewModelReturn {
+  route: Route | null
+  isLoading: boolean
+  error: string | null
+}
+
+function useRouteDetailViewModel(props: UseRouteDetailViewModelProps): UseRouteDetailViewModelReturn
+```
+
+이 훅은 기존 `useState`/`useEffect` 기반 수동 fetch를 React Query(`useQuery`)로 전환한다. `routeKeys` 팩토리 패턴을 활용하여 기존 `useRouteQueries.ts`와 캐시 호환성을 유지한다.
+
+### 6. Admin 데이터 Fetching 설계
+
+#### adminKeys 팩토리 패턴 확장
+
+기존 `useAdminQueries.ts`의 `adminKeys`에 대시보드 요약 키를 추가한다:
+
+```typescript
+export const adminKeys = {
+  all: ['admin'] as const,
+  // ... 기존 키 유지
+  dashboard: () => [...adminKeys.all, 'dashboard'] as const,
+  dashboardSummary: () => [...adminKeys.dashboard(), 'summary'] as const,
+}
+```
+
+#### useAdminDashboardSummary 훅
+
+**파일**: `src/hooks/useAdminQueries.ts` (기존 파일에 추가)
+
+```typescript
+function useAdminDashboardSummary(): UseQueryResult<DashboardSummaryResponse>
+```
+
+기존 `AdminDashboardPage`의 `useState`/`useEffect` 기반 수동 fetch를 대체한다. `adminKeys.dashboardSummary()` queryKey를 사용하여 캐시 관리를 통일한다.
+
+#### Admin 페이지 useQuery 전환 가이드
+
+Admin Reports, Supplements, StatusReports 페이지는 이미 `useAdminReports`, `useAdminSupplements`, `useAdminStatusReports` 훅이 존재하지만, 페이지 컴포넌트 자체에서는 아직 `useSession`/`useEffect` 기반 권한 검사를 수동으로 수행하고 있다. 이를 `useAdminAuth` 훅으로 통일한다.
+
+## 데이터 모델
+
+이 리팩토링은 새로운 데이터 모델을 도입하지 않는다. 기존 데이터 모델(`Spot`, `Route`, `SpotReport`, `SpotStatusReport`, `SpotSupplement`, `DashboardSummaryResponse`)을 그대로 사용하며, 데이터 접근 패턴만 변경한다.
+
+### 변경되는 데이터 접근 패턴
+
+| 컴포넌트 | Before | After |
+|---------|--------|-------|
+| `AdminDashboardPage` | `useState` + `useEffect` + `fetch` | `useAdminDashboardSummary()` (useQuery) |
+| `RouteDetailClient` | `useState` + `useEffect` + `fetch` | `useRouteDetailViewModel()` (useQuery) |
+| `SpotDetailClient` | `useSpotDetail()` (useQuery) | `useSpotDetail()` (useSuspenseQuery 전환 가능) |
+| `Main Page (Home)` | `useSpots()` (useQuery) | `useSpots()` (useSuspenseQuery 전환 가능) |
+
+### Query Key 구조
+
+```
+admin
+├── dashboard
+│   └── summary          ← 신규
+├── reports
+│   └── { statusFilter, page }
+├── statusReports
+│   └── { reviewStatusFilter, statusFilter, page }
+├── supplements
+│   └── { statusFilter, page }
+└── contentImages
+    └── { search, page }
+
+routes
+├── list
+│   └── { filters, page }
+└── related
+    └── { contentName }
+```
+
+## 정확성 속성 (Correctness Properties)
+
+*속성(Property)이란 시스템의 모든 유효한 실행에서 참이어야 하는 특성 또는 동작이다. 속성은 사람이 읽을 수 있는 명세와 기계가 검증할 수 있는 정확성 보장 사이의 다리 역할을 한다.*
+
+### Property 1: ErrorBoundary 에러 포착 및 대체 UI 표시
+
+*For any* 에러를 throw하는 자식 컴포넌트와 임의의 에러 메시지에 대해, ErrorBoundary로 감싸면 자식 대신 에러 메시지가 포함된 대체 UI가 렌더링되어야 한다.
+
+**Validates: Requirements 1.1**
+
+### Property 2: ErrorBoundary 에러→리셋 라운드트립
+
+*For any* 에러를 throw하는 자식 컴포넌트에 대해, ErrorBoundary가 에러를 포착한 후 reset을 호출하면 에러 상태가 초기화되어 자식 컴포넌트가 다시 렌더링을 시도해야 한다.
+
+**Validates: Requirements 1.3, 8.1**
+
+### Property 3: ErrorBoundary 투명성
+
+*For any* 에러를 throw하지 않는 자식 컴포넌트에 대해, ErrorBoundary는 자식 컴포넌트의 렌더링 결과를 변경 없이 그대로 통과시켜야 한다.
+
+**Validates: Requirements 1.4**
+
+### Property 4: useAdminAuth 세션-권한 매핑
+
+*For any* 세션 상태(로딩 중, 관리자 세션, 비관리자 세션, 세션 없음)에 대해, useAdminAuth는 다음을 만족해야 한다: 로딩 중이면 `isLoading: true`, 관리자이면 `isAuthorized: true`와 유효한 session, 비관리자이거나 세션이 없으면 `isAuthorized: false`.
+
+**Validates: Requirements 4.1, 8.2**
+
+### Property 5: useSpotDetailViewModel 권한 및 상태 관리 일관성
+
+*For any* 사용자(관리자/일반/비인증)와 스팟(본인 작성/타인 작성) 조합에 대해, useSpotDetailViewModel은 다음을 만족해야 한다: (1) 관리자이거나 본인 스팟이면 `hasEditPermission`과 `hasDeletePermission`이 true, (2) 토글 핸들러 호출 시 해당 상태가 반전되어야 하며, (3) 비인증 사용자의 토글 핸들러 호출 시 로그인 모달이 표시되어야 한다.
+
+**Validates: Requirements 6.1, 6.2**
+
+## 에러 처리
+
+### ErrorBoundary 계층 구조
+
+```
+App Layout
+├── Next.js error.tsx (최상위 폴백)
+└── Page Component
+    └── AsyncBoundary (QueryErrorResetBoundary + ErrorBoundary + Suspense)
+        └── Content Component (useSuspenseQuery)
+```
+
+### 에러 유형별 처리 전략
+
+| 에러 유형 | 처리 방식 | 사용자 경험 |
+|----------|----------|------------|
+| API 네트워크 에러 | ErrorBoundary → 재시도 버튼 | 에러 메시지 + "다시 시도" 버튼 |
+| 404 (데이터 없음) | 컴포넌트 내부 조건부 렌더링 | "찾을 수 없습니다" UI |
+| 권한 없음 (403) | useAdminAuth → 리다이렉트 | 메인 페이지로 자동 이동 |
+| 렌더링 에러 | ErrorBoundary → 기본 에러 UI | 에러 메시지 + 재시도 버튼 |
+
+### 재시도 메커니즘
+
+`QueryErrorResetBoundary`와 `ErrorBoundary`의 `onReset`을 연동하여:
+1. 사용자가 "다시 시도" 클릭
+2. `ErrorBoundary.onReset` → `QueryErrorResetBoundary.reset()` 호출
+3. 실패한 쿼리의 에러 상태 초기화
+4. 컴포넌트 재렌더링 → `useSuspenseQuery` 재실행
+5. 성공 시 콘텐츠 표시, 실패 시 다시 ErrorBoundary 포착
+
+## 테스트 전략
+
+### 이중 테스트 접근법
+
+이 프로젝트는 단위 테스트와 속성 기반 테스트를 병행한다:
+
+- **단위 테스트**: 특정 예제, 엣지 케이스, 에러 조건 검증
+- **속성 기반 테스트**: 모든 입력에 대한 보편적 속성 검증
+
+### 속성 기반 테스트 설정
+
+- **라이브러리**: `fast-check` (TypeScript/JavaScript용 PBT 라이브러리)
+- **테스트 프레임워크**: Jest (기존 프로젝트 설정 활용)
+- **최소 반복 횟수**: 각 속성 테스트당 100회
+- **각 테스트에 설계 문서 속성 참조 태그 포함**
+- **태그 형식**: `Feature: 17-declarative-refactoring, Property {number}: {property_text}`
+- **각 정확성 속성은 단일 속성 기반 테스트로 구현**
+
+### 단위 테스트 범위
+
+| 테스트 대상 | 테스트 유형 | 검증 내용 |
+|-----------|-----------|----------|
+| ErrorBoundary | 단위 + 속성 | 에러 포착, 대체 UI, 리셋, 투명성 |
+| AsyncBoundary | 단위 | Suspense + ErrorBoundary 조합 동작 |
+| useAdminAuth | 단위 + 속성 | 세션 상태별 반환값, 리다이렉트 |
+| useSpotDetailViewModel | 단위 + 속성 | 권한 확인, 토글 상태, 핸들러 동작 |
+| useRouteDetailViewModel | 단위 | React Query 전환 후 데이터 패칭 |
+| useAdminDashboardSummary | 단위 | 데이터 패칭, 에러 처리 |
+| SVG 아이콘 컴포넌트 | 단위 | props(size, color) 적용, 렌더링 |
+| 프레젠테이셔널 컴포넌트 | 단위 | 분리 전후 렌더링 동일성 |
+
+### 속성 기반 테스트 매핑
+
+| 속성 | 테스트 파일 | Generator |
+|-----|-----------|-----------|
+| Property 1 | `ErrorBoundary.property.test.tsx` | 임의의 에러 메시지 문자열 |
+| Property 2 | `ErrorBoundary.property.test.tsx` | 임의의 에러 메시지 문자열 |
+| Property 3 | `ErrorBoundary.property.test.tsx` | 임의의 자식 텍스트 콘텐츠 |
+| Property 4 | `useAdminAuth.property.test.ts` | 임의의 세션 상태 (loading/admin/non-admin/null) |
+| Property 5 | `useSpotDetailViewModel.property.test.ts` | 임의의 사용자 역할 × 스팟 소유자 조합 |

--- a/.kiro/specs/17-declarative-refactoring/requirements.md
+++ b/.kiro/specs/17-declarative-refactoring/requirements.md
@@ -1,0 +1,122 @@
+# Requirements Document
+
+## Introduction
+
+Toss 스타일의 선언적 프로그래밍 패턴을 도입하여 Not a Trip 프로젝트의 코드 품질을 개선하는 리팩토링 spec이다. 4가지 핵심 영역(비동기 처리의 선언적 전환, 추상화 수준 맞추기, 관심사의 분리, 헤드리스 컴포넌트화)을 독립적으로 진행하며, 기존 기능을 유지하면서 점진적으로 코드 구조를 개선한다.
+
+## Glossary
+
+- **Suspense_Boundary**: React의 `<Suspense>` 컴포넌트로, 비동기 데이터 로딩 중 fallback UI를 선언적으로 표시하는 경계 컴포넌트
+- **Error_Boundary**: React의 에러 경계 컴포넌트로, 하위 컴포넌트 트리에서 발생한 렌더링 에러를 선언적으로 포착하고 대체 UI를 표시하는 컴포넌트
+- **useSuspenseQuery**: TanStack Query가 제공하는 훅으로, Suspense 모드에서 데이터를 패칭하여 로딩/에러 상태를 컴포넌트 외부(Suspense_Boundary, Error_Boundary)로 위임하는 훅
+- **ViewModel_Hook**: UI 렌더링에 필요한 상태와 이벤트 핸들러를 캡슐화한 커스텀 훅으로, 컴포넌트에서 도메인 로직을 분리하여 컴포넌트가 렌더링만 담당하도록 하는 패턴
+- **Admin_Auth_Hook**: 관리자 페이지의 세션 확인, 권한 검사, 미인증 리다이렉트 로직을 캡슐화한 커스텀 훅 (`useAdminAuth`)
+- **Presentational_Component**: 로직 없이 props만 받아 UI를 렌더링하는 컴포넌트 (예: 아이콘, 빈 상태 UI, 스켈레톤)
+- **SVG_Icon_Component**: 하드코딩된 인라인 SVG를 로컬 파일(`src/components/icons/`)로 분리하고, SVGR 또는 React 컴포넌트로 모듈화한 아이콘 컴포넌트 (예: `<BookmarkIcon />`, `<SearchIcon />`)
+- **HydrationBoundary**: TanStack Query가 제공하는 컴포넌트로, 서버에서 프리페치한 쿼리 데이터를 클라이언트로 전달하여 SSR/CSR 간 하이드레이션 불일치를 방지하는 경계 컴포넌트
+- **Main_Page**: 메인 지도 페이지 (`src/app/page.tsx`)
+- **Admin_Dashboard**: 관리자 대시보드 페이지 (`src/app/admin/page.tsx`)
+- **Admin_Reports_Page**: 관리자 제보 관리 페이지 (`src/app/admin/reports/page.tsx`)
+- **Admin_Supplements_Page**: 관리자 정보 보완 검토 페이지 (`src/app/admin/supplements/page.tsx`)
+- **Admin_StatusReports_Page**: 관리자 상태 신고 검토 페이지 (`src/app/admin/status-reports/page.tsx`)
+- **Spot_Detail_Client**: 스팟 상세 페이지 클라이언트 컴포넌트 (`src/components/spot/SpotDetailClient.tsx`)
+- **Route_Detail_Client**: 코스 상세 페이지 클라이언트 컴포넌트 (`src/components/route/RouteDetailClient.tsx`)
+
+## Requirements
+
+### Requirement 1: 비동기 처리의 선언적 전환 — Error Boundary 도입
+
+**User Story:** As a 개발자, I want 공통 Error_Boundary 컴포넌트를 도입하여 에러 처리를 선언적으로 관리하고 싶다, so that 각 컴포넌트 내부의 명령형 에러 분기 코드를 제거하고 일관된 에러 UI를 제공할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Error_Boundary SHALL 하위 컴포넌트 트리에서 발생한 렌더링 에러를 포착하고 에러 메시지와 재시도 버튼이 포함된 대체 UI를 표시한다
+2. THE Error_Boundary SHALL `fallback` prop을 통해 커스텀 에러 UI를 주입받을 수 있도록 지원한다
+3. THE Error_Boundary SHALL `onReset` 콜백을 통해 재시도 시 에러 상태를 초기화한다
+4. WHEN 에러가 발생하지 않을 때, THE Error_Boundary SHALL 하위 컴포넌트 트리를 변경 없이 그대로 렌더링한다
+
+### Requirement 2: 비동기 처리의 선언적 전환 — Suspense + useSuspenseQuery 적용
+
+**User Story:** As a 개발자, I want 명령형 `isLoading`/`error` 분기 처리를 Suspense_Boundary와 useSuspenseQuery로 전환하고 싶다, so that 컴포넌트가 데이터가 있는 상태만 다루는 선언적 코드가 된다.
+
+#### Acceptance Criteria
+
+1. WHEN Main_Page가 렌더링될 때, THE Main_Page SHALL Suspense_Boundary와 Error_Boundary로 감싸진 내부 콘텐츠 컴포넌트를 렌더링하고, 컴포넌트 내부에서 `isLoading`/`error` 분기를 제거한다
+2. WHEN Admin_Dashboard가 렌더링될 때, THE Admin_Dashboard SHALL Suspense_Boundary와 Error_Boundary로 감싸진 내부 콘텐츠 컴포넌트를 렌더링하고, 컴포넌트 내부의 `useState`/`useEffect` 기반 데이터 패칭을 useSuspenseQuery로 전환한다
+3. WHEN Spot_Detail_Client가 렌더링될 때, THE Spot_Detail_Client SHALL Suspense_Boundary와 Error_Boundary로 감싸진 내부 콘텐츠 컴포넌트를 렌더링하고, 기존 `useSpotDetail` 훅을 Suspense 모드로 전환한다
+4. WHEN Route_Detail_Client가 렌더링될 때, THE Route_Detail_Client SHALL Suspense_Boundary와 Error_Boundary로 감싸진 내부 콘텐츠 컴포넌트를 렌더링하고, `useState`/`useEffect` 기반 데이터 패칭을 useSuspenseQuery로 전환한다
+5. THE useSuspenseQuery 기반 훅 SHALL 기존 useQuery 훅과 동일한 queryKey와 queryFn을 사용하여 캐시 호환성을 유지한다
+6. THE Suspense_Boundary 적용 시, Next.js의 SSR 환경에서 useSuspenseQuery로 인한 하이드레이션 불일치 에러를 방지하기 위해 React Query의 HydrationBoundary를 활용하거나, 클라이언트 마운트 이후에만 쿼리를 실행하도록 처리한다
+
+### Requirement 3: 추상화 수준(Level of Abstraction) 맞추기
+
+**User Story:** As a 개발자, I want Main_Page에 혼재된 raw SVG/HTML 코드를 별도의 Presentational_Component 및 SVG_Icon_Component로 분리하고 싶다, so that 최상위 컴포넌트가 높은 수준의 조합만 담당하고 가독성이 향상된다.
+
+#### Acceptance Criteria
+
+1. THE Main_Page SHALL 인라인 SVG가 포함된 `SpotLoadingSkeleton` 함수를 별도의 Presentational_Component 파일로 분리하여 import한다
+2. THE Main_Page SHALL 인라인 SVG가 포함된 `SpotErrorDisplay` 함수를 별도의 Presentational_Component 파일로 분리하여 import한다
+3. THE Main_Page SHALL 검색 결과 없음 오버레이와 카테고리 필터 해제 오버레이를 별도의 Presentational_Component로 분리하여 import한다
+4. WHEN 분리된 Presentational_Component가 렌더링될 때, THE Presentational_Component SHALL 분리 전과 동일한 HTML 구조와 스타일을 출력한다
+5. THE 프로젝트 SHALL 하드코딩된 인라인 SVG 아이콘(맵 마커, 북마크, 빈 상태 아이콘, 로딩 스피너 등)을 `src/components/icons/` 디렉토리에 개별 SVG_Icon_Component 파일로 분리하여 저장한다
+6. THE 컴포넌트 SHALL 인라인 SVG 대신 분리된 SVG_Icon_Component를 직관적인 이름(예: `<BookmarkIcon />`, `<SearchIcon />`, `<SpinnerIcon />`)으로 import하여 렌더링한다
+
+### Requirement 4: 관심사의 분리 — useAdminAuth 훅 추출
+
+**User Story:** As a 개발자, I want 관리자 페이지들에 중복된 권한 검사 로직을 Admin_Auth_Hook으로 추출하고 싶다, so that 권한 검사 로직이 한 곳에서 관리되고 관리자 페이지 컴포넌트가 UI 렌더링에 집중할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Admin_Auth_Hook SHALL 세션 로딩 상태, 관리자 권한 확인, 비관리자 리다이렉트 로직을 캡슐화하고 `{ isLoading, isAuthorized, session }` 객체를 반환한다
+2. WHEN 세션이 로딩 중일 때, THE Admin_Auth_Hook SHALL `isLoading`을 `true`로 반환한다
+3. WHEN 사용자가 관리자가 아닐 때, THE Admin_Auth_Hook SHALL 메인 페이지(`/`)로 리다이렉트를 수행하고 `isAuthorized`를 `false`로 반환한다
+4. WHEN 사용자가 관리자일 때, THE Admin_Auth_Hook SHALL `isAuthorized`를 `true`로, `session`을 현재 세션 객체로 반환한다
+5. THE Admin_Dashboard SHALL Admin_Auth_Hook을 사용하여 기존의 인라인 권한 검사 코드를 대체한다
+6. THE Admin_Reports_Page SHALL Admin_Auth_Hook을 사용하여 기존의 인라인 권한 검사 코드를 대체한다
+7. THE Admin_Supplements_Page SHALL Admin_Auth_Hook을 사용하여 기존의 인라인 권한 검사 코드를 대체한다
+8. THE Admin_StatusReports_Page SHALL Admin_Auth_Hook을 사용하여 기존의 인라인 권한 검사 코드를 대체한다
+
+### Requirement 5: 관심사의 분리 — 관리자 페이지 데이터 패칭 통일
+
+**User Story:** As a 개발자, I want 관리자 페이지들의 수동 fetch 호출을 React Query 훅으로 일괄 전환하고 싶다, so that 모든 관리자 페이지의 데이터 패칭 패턴이 통일되고 캐시 관리가 일관된다.
+
+#### Acceptance Criteria
+
+1. THE Admin_Dashboard SHALL `useState`/`useEffect` 기반의 수동 fetch 호출을 `useAdminDashboardSummary` React Query 훅으로 대체한다
+2. THE `useAdminDashboardSummary` 훅 SHALL `adminKeys` 팩토리 패턴을 따르는 queryKey를 사용한다
+3. WHEN 대시보드 요약 데이터 로딩에 실패할 때, THE `useAdminDashboardSummary` 훅 SHALL 에러 객체를 반환하여 Error_Boundary 또는 인라인 에러 UI에서 처리할 수 있도록 한다
+4. THE Admin_Reports_Page, Admin_Supplements_Page, Admin_StatusReports_Page SHALL 기존 `useState`/`useEffect` 기반의 수동 데이터 패칭을 각각의 전용 React Query 훅(예: `useAdminReports`, `useAdminSupplements`, `useAdminStatusReports`)으로 대체한다
+5. THE 전용 React Query 훅들 SHALL `adminKeys` 팩토리 패턴을 따르는 queryKey를 사용하여 기존 `useAdminQueries.ts`의 패턴과 일관성을 유지한다
+
+### Requirement 6: 도메인 로직의 헤드리스 컴포넌트화 — SpotDetail ViewModel
+
+**User Story:** As a 개발자, I want Spot_Detail_Client의 도메인 로직(삭제, 권한 확인, 정보 보완/상태 신고 토글, 로그인 모달)을 ViewModel_Hook으로 분리하고 싶다, so that 컴포넌트가 렌더링만 담당하고 로직을 독립적으로 테스트할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE ViewModel_Hook (`useSpotDetailViewModel`) SHALL 스팟 삭제 핸들러, 권한 확인 결과(`hasEditPermission`, `hasDeletePermission`), 삭제 진행 상태(`isDeleting`)를 캡슐화하여 반환한다
+2. THE ViewModel_Hook (`useSpotDetailViewModel`) SHALL 정보 보완 폼 토글, 상태 신고 폼 토글, 로그인 필요 모달 상태를 캡슐화하여 반환한다
+3. THE Spot_Detail_Client SHALL ViewModel_Hook을 사용하여 기존의 인라인 상태 관리 및 이벤트 핸들러 코드를 대체한다
+4. WHEN ViewModel_Hook이 반환한 핸들러가 호출될 때, THE ViewModel_Hook SHALL 기존 인라인 로직과 동일한 동작(삭제 확인, 캐시 무효화, 리다이렉트)을 수행한다
+
+### Requirement 7: 도메인 로직의 헤드리스 컴포넌트화 — RouteDetail ViewModel
+
+**User Story:** As a 개발자, I want Route_Detail_Client의 데이터 패칭과 에러 처리 로직을 ViewModel_Hook으로 분리하고 싶다, so that 컴포넌트가 렌더링만 담당하고 코드 구조가 명확해진다.
+
+#### Acceptance Criteria
+
+1. THE ViewModel_Hook (`useRouteDetailViewModel`) SHALL 코스 데이터 패칭, 로딩 상태, 에러 상태를 캡슐화하여 `{ route, isLoading, error }` 객체를 반환한다
+2. THE ViewModel_Hook (`useRouteDetailViewModel`) SHALL `useState`/`useEffect` 기반의 수동 fetch를 React Query 훅으로 전환한다
+3. THE Route_Detail_Client SHALL ViewModel_Hook을 사용하여 기존의 인라인 데이터 패칭 코드를 대체한다
+4. WHEN 코스 데이터 로딩에 실패할 때, THE ViewModel_Hook SHALL 에러 객체를 반환하여 컴포넌트가 에러 UI를 렌더링할 수 있도록 한다
+
+### Requirement 8: 리팩토링 안전성 보장
+
+**User Story:** As a 개발자, I want 리팩토링 후에도 기존 기능이 동일하게 동작함을 보장하고 싶다, so that 사용자 경험에 영향 없이 코드 품질을 개선할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Error_Boundary SHALL 에러 발생 시 대체 UI를 렌더링하고, 재시도 시 에러 상태를 초기화하는 속성을 만족한다
+2. THE Admin_Auth_Hook SHALL 관리자 세션에 대해 `isAuthorized: true`를, 비관리자 세션에 대해 `isAuthorized: false`를 반환하는 속성을 만족한다
+3. WHEN 각 리팩토링 영역이 완료될 때, THE 리팩토링된 컴포넌트 SHALL 리팩토링 전과 동일한 사용자 인터랙션 결과를 생성한다
+4. THE 각 리팩토링 영역 SHALL 다른 영역과 독립적으로 진행 가능하며, 하나의 영역 완료가 다른 영역의 기존 코드에 영향을 주지 않는다

--- a/.kiro/specs/17-declarative-refactoring/tasks.md
+++ b/.kiro/specs/17-declarative-refactoring/tasks.md
@@ -1,0 +1,205 @@
+# 구현 계획: 선언적 리팩토링 (Declarative Refactoring)
+
+## 개요
+
+Bottom-up 접근법으로 가장 작고 독립적인 컴포넌트부터 시작하여, 인프라 컴포넌트 → 커스텀 훅 → 페이지 레벨 통합 순서로 진행한다. 각 레이어는 이전 레이어에 의존하므로 순서를 지켜야 한다.
+
+## Tasks
+
+- [x] 1. Layer 1: SVG 아이콘 컴포넌트 분리
+  - [x] 1.1 SVG 아이콘 컴포넌트 생성 (`src/components/icons/`)
+    - `AlertTriangleIcon`, `SearchIcon`, `FilterIcon`, `MapPinIcon`, `ArrowLeftIcon`, `SpinnerIcon` 컴포넌트 생성
+    - 공통 `IconProps` 인터페이스 정의 (`size`, `color`, `className`)
+    - 배럴 파일 `src/components/icons/index.ts` 생성
+    - _Requirements: 3.5, 3.6_
+
+  - [ ]* 1.2 SVG 아이콘 컴포넌트 단위 테스트
+    - size, color, className props 적용 검증
+    - 기본값(currentColor, md 사이즈) 렌더링 검증
+    - _Requirements: 3.6_
+
+- [ ] 2. Layer 1: 프레젠테이셔널 컴포넌트 분리
+  - [ ] 2.1 `SpotLoadingSkeleton` 컴포넌트 분리
+    - `src/app/page.tsx` 내부의 `SpotLoadingSkeleton` 함수를 `src/components/common/SpotLoadingSkeleton.tsx`로 분리
+    - 인라인 SVG를 `SpinnerIcon`으로 교체
+    - `page.tsx`에서 import로 교체
+    - _Requirements: 3.1, 3.6_
+
+  - [ ] 2.2 `SpotErrorDisplay` 컴포넌트 분리
+    - `src/app/page.tsx` 내부의 `SpotErrorDisplay` 함수를 `src/components/common/SpotErrorDisplay.tsx`로 분리
+    - 인라인 SVG를 `AlertTriangleIcon`으로 교체
+    - `page.tsx`에서 import로 교체
+    - _Requirements: 3.2, 3.6_
+
+  - [ ] 2.3 `EmptySearchOverlay`, `EmptyFilterOverlay` 컴포넌트 분리
+    - `src/app/page.tsx`의 검색 결과 없음 오버레이를 `src/components/common/EmptySearchOverlay.tsx`로 분리
+    - 카테고리 필터 해제 오버레이를 `src/components/common/EmptyFilterOverlay.tsx`로 분리
+    - 인라인 SVG를 `SearchIcon`, `FilterIcon`으로 교체
+    - `page.tsx`에서 import로 교체
+    - _Requirements: 3.3, 3.6_
+
+  - [ ]* 2.4 프레젠테이셔널 컴포넌트 단위 테스트
+    - 분리 전후 동일한 HTML 구조/스타일 출력 검증
+    - props 전달 검증 (error, onRetry, searchQuery 등)
+    - _Requirements: 3.4_
+
+- [ ] 3. Checkpoint - Layer 1 완료 확인
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Layer 2: ErrorBoundary 컴포넌트 구현
+  - [ ] 4.1 `ErrorBoundary` 클래스 컴포넌트 구현
+    - `src/components/common/ErrorBoundary.tsx` 생성
+    - `getDerivedStateFromError`, `componentDidCatch` 구현
+    - `fallback` (ReactNode) / `renderFallback` (Render Props) / 기본 에러 UI 우선순위 처리
+    - `onReset` 콜백으로 에러 상태 초기화
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [ ]* 4.2 ErrorBoundary 속성 기반 테스트 — Property 1: 에러 포착 및 대체 UI 표시
+    - **Property 1: ErrorBoundary 에러 포착 및 대체 UI 표시**
+    - **Validates: Requirements 1.1**
+    - `Feature: 17-declarative-refactoring, Property 1: ErrorBoundary 에러 포착 및 대체 UI 표시`
+    - Generator: 임의의 에러 메시지 문자열
+
+  - [ ]* 4.3 ErrorBoundary 속성 기반 테스트 — Property 2: 에러→리셋 라운드트립
+    - **Property 2: ErrorBoundary 에러→리셋 라운드트립**
+    - **Validates: Requirements 1.3, 8.1**
+    - `Feature: 17-declarative-refactoring, Property 2: ErrorBoundary 에러→리셋 라운드트립`
+    - Generator: 임의의 에러 메시지 문자열
+
+  - [ ]* 4.4 ErrorBoundary 속성 기반 테스트 — Property 3: ErrorBoundary 투명성
+    - **Property 3: ErrorBoundary 투명성**
+    - **Validates: Requirements 1.4**
+    - `Feature: 17-declarative-refactoring, Property 3: ErrorBoundary 투명성`
+    - Generator: 임의의 자식 텍스트 콘텐츠
+
+- [ ] 5. Layer 2: useIsMounted 훅 및 AsyncBoundary 구현
+  - [ ] 5.1 `useIsMounted` 훅 구현
+    - `src/hooks/useIsMounted.ts` 생성
+    - `useState(false)` + `useEffect`로 클라이언트 마운트 감지
+    - SSR 환경에서 항상 `false` 반환
+    - _Requirements: 2.6_
+
+  - [ ] 5.2 `AsyncBoundary` 컴포넌트 구현
+    - `src/components/common/AsyncBoundary.tsx` 생성
+    - `QueryErrorResetBoundary` + `ErrorBoundary` + `Suspense` + `useIsMounted` 조합
+    - 마운트 전 `pendingFallback` 표시, 마운트 후 자식 렌더링
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.6_
+
+  - [ ]* 5.3 AsyncBoundary 단위 테스트
+    - Suspense + ErrorBoundary 조합 동작 검증
+    - SSR 환경에서 pendingFallback 표시 검증
+    - _Requirements: 2.6, 8.3_
+
+- [ ] 6. Checkpoint - Layer 2 완료 확인
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 7. Layer 3: useAdminAuth 훅 추출
+  - [ ] 7.1 `useAdminAuth` 훅 구현
+    - `src/hooks/useAdminAuth.ts` 생성
+    - `useSession()` 기반 세션 로딩, 권한 확인, 비관리자 리다이렉트 캡슐화
+    - `{ isLoading, isAuthorized, session }` 반환
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [ ]* 7.2 useAdminAuth 속성 기반 테스트 — Property 4: 세션-권한 매핑
+    - **Property 4: useAdminAuth 세션-권한 매핑**
+    - **Validates: Requirements 4.1, 8.2**
+    - `Feature: 17-declarative-refactoring, Property 4: useAdminAuth 세션-권한 매핑`
+    - Generator: 임의의 세션 상태 (loading/admin/non-admin/null)
+
+- [ ] 8. Layer 3: useSpotDetailViewModel 훅 추출
+  - [ ] 8.1 `useSpotDetailViewModel` 훅 구현
+    - `src/hooks/useSpotDetailViewModel.ts` 생성
+    - 스팟 삭제 핸들러, 권한 확인, 삭제 진행 상태 캡슐화
+    - 정보 보완 폼 토글, 상태 신고 폼 토글, 로그인 모달 상태 캡슐화
+    - _Requirements: 6.1, 6.2_
+
+  - [ ]* 8.2 useSpotDetailViewModel 속성 기반 테스트 — Property 5: 권한 및 상태 관리 일관성
+    - **Property 5: useSpotDetailViewModel 권한 및 상태 관리 일관성**
+    - **Validates: Requirements 6.1, 6.2**
+    - `Feature: 17-declarative-refactoring, Property 5: useSpotDetailViewModel 권한 및 상태 관리 일관성`
+    - Generator: 임의의 사용자 역할 × 스팟 소유자 조합
+
+- [ ] 9. Layer 3: useRouteDetailViewModel 훅 추출
+  - [ ] 9.1 `useRouteDetailViewModel` 훅 구현
+    - `src/hooks/useRouteDetailViewModel.ts` 생성
+    - `useState`/`useEffect` 기반 수동 fetch를 React Query(`useQuery`)로 전환
+    - `routeKeys` 팩토리 패턴 활용하여 캐시 호환성 유지
+    - `{ route, isLoading, error }` 반환
+    - _Requirements: 7.1, 7.2_
+
+  - [ ]* 9.2 useRouteDetailViewModel 단위 테스트
+    - React Query 전환 후 데이터 패칭 검증
+    - 에러 상태 반환 검증
+    - _Requirements: 7.4_
+
+- [ ] 10. Layer 3: useAdminDashboardSummary 훅 및 adminKeys 확장
+  - [ ] 10.1 `useAdminDashboardSummary` 훅 구현 및 서브 페이지 React Query 훅 점검
+    - `src/hooks/useAdminQueries.ts`에 `dashboard`, `dashboardSummary` 키 추가
+    - `useAdminDashboardSummary` 훅 추가 (기존 파일에 추가)
+    - `adminKeys` 팩토리 패턴 확장
+    - 기존 `useAdminReports`, `useAdminSupplements`, `useAdminStatusReports` 훅이 `adminKeys` 팩토리 패턴을 따르는지 점검하고, 누락된 훅이 있으면 추가
+    - _Requirements: 5.1, 5.2, 5.4, 5.5_
+
+  - [ ]* 10.2 useAdminDashboardSummary 단위 테스트
+    - 데이터 패칭, 에러 처리 검증
+    - _Requirements: 5.3_
+
+- [ ] 11. Checkpoint - Layer 3 완료 확인
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 12. Layer 4: 관리자 페이지 useAdminAuth 적용
+  - [ ] 12.1 Admin Dashboard에 useAdminAuth + useAdminDashboardSummary 적용
+    - `src/app/admin/page.tsx`의 인라인 권한 검사를 `useAdminAuth`로 교체
+    - `useState`/`useEffect` 기반 데이터 패칭을 `useAdminDashboardSummary`로 교체
+    - _Requirements: 4.5, 5.1_
+
+  - [ ] 12.2 Admin Reports, Supplements, StatusReports 페이지에 useAdminAuth + React Query 훅 적용
+    - `src/app/admin/reports/page.tsx`의 인라인 권한 검사를 `useAdminAuth`로 교체하고, `useState`/`useEffect` 기반 수동 데이터 패칭을 `useAdminReports` 훅으로 교체
+    - `src/app/admin/supplements/page.tsx`의 인라인 권한 검사를 `useAdminAuth`로 교체하고, 수동 데이터 패칭을 `useAdminSupplements` 훅으로 교체
+    - `src/app/admin/status-reports/page.tsx`의 인라인 권한 검사를 `useAdminAuth`로 교체하고, 수동 데이터 패칭을 `useAdminStatusReports` 훅으로 교체
+    - _Requirements: 4.6, 4.7, 4.8, 5.4, 5.5_
+
+- [ ] 13. Layer 4: SpotDetailClient에 ViewModel + AsyncBoundary 적용
+  - [ ] 13.1 SpotDetailClient에 useSpotDetailViewModel 적용
+    - `src/components/spot/SpotDetailClient.tsx`의 인라인 상태 관리/이벤트 핸들러를 `useSpotDetailViewModel`로 교체
+    - 인라인 SVG를 아이콘 컴포넌트로 교체 (`ArrowLeftIcon`, `MapPinIcon`, `AlertTriangleIcon`)
+    - _Requirements: 6.3, 6.4, 3.6_
+
+  - [ ] 13.2 SpotDetailClient에 AsyncBoundary 적용
+    - Suspense_Boundary + Error_Boundary로 감싸기
+    - 기존 `useSpotDetail` 훅을 `useSuspenseQuery` 모드로 전환
+    - `isLoading`/`error` 분기 제거, 데이터가 있는 상태만 다루도록 변경
+    - _Requirements: 2.3, 2.5, 2.6_
+
+- [ ] 14. Layer 4: RouteDetailClient에 ViewModel + AsyncBoundary 적용
+  - [ ] 14.1 RouteDetailClient에 useRouteDetailViewModel 적용
+    - `src/components/route/RouteDetailClient.tsx`의 인라인 데이터 패칭을 `useRouteDetailViewModel`로 교체
+    - 인라인 SVG를 아이콘 컴포넌트로 교체
+    - _Requirements: 7.3, 3.6_
+
+  - [ ] 14.2 RouteDetailClient에 AsyncBoundary 적용
+    - Suspense_Boundary + Error_Boundary로 감싸기
+    - `useRouteDetailViewModel`을 `useSuspenseQuery` 모드로 전환
+    - `isLoading`/`error` 분기 제거
+    - _Requirements: 2.4, 2.5, 2.6_
+
+- [ ] 15. Layer 4: Main Page에 AsyncBoundary 적용
+  - [ ] 15.1 Main Page에 AsyncBoundary + useSuspenseQuery 적용
+    - `src/app/page.tsx`에 AsyncBoundary 적용
+    - `useSpots` 훅을 `useSuspenseQuery` 모드로 전환
+    - `isLoading`/`error` 분기 제거, 분리된 프레젠테이셔널 컴포넌트를 fallback으로 사용
+    - _Requirements: 2.1, 2.5, 2.6_
+
+- [ ] 16. Final Checkpoint - 전체 리팩토링 완료 확인
+  - Ensure all tests pass, ask the user if questions arise.
+  - 리팩토링 전후 동일한 사용자 인터랙션 결과 확인
+  - _Requirements: 8.3, 8.4_
+
+## Notes
+
+- `*` 표시된 태스크는 선택 사항이며 빠른 MVP를 위해 건너뛸 수 있습니다
+- 각 태스크는 특정 요구사항을 참조하여 추적 가능합니다
+- 체크포인트에서 점진적 검증을 수행합니다
+- 속성 기반 테스트는 `fast-check` 라이브러리를 사용하며, 각 속성당 최소 100회 반복합니다
+- 단위 테스트는 Jest 프레임워크를 사용합니다
+- 각 Layer는 이전 Layer에 의존하므로 순서를 지켜야 합니다

--- a/src/components/icons/AlertTriangleIcon.tsx
+++ b/src/components/icons/AlertTriangleIcon.tsx
@@ -1,0 +1,26 @@
+import { IconProps, getIconSize } from './types'
+
+export function AlertTriangleIcon({
+  size = 'md',
+  color = 'currentColor',
+  className,
+}: IconProps) {
+  const s = getIconSize(size)
+  return (
+    <svg
+      width={s}
+      height={s}
+      className={className}
+      fill="none"
+      stroke={color}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+      />
+    </svg>
+  )
+}

--- a/src/components/icons/ArrowLeftIcon.tsx
+++ b/src/components/icons/ArrowLeftIcon.tsx
@@ -1,0 +1,26 @@
+import { IconProps, getIconSize } from './types'
+
+export function ArrowLeftIcon({
+  size = 'md',
+  color = 'currentColor',
+  className,
+}: IconProps) {
+  const s = getIconSize(size)
+  return (
+    <svg
+      width={s}
+      height={s}
+      className={className}
+      fill="none"
+      stroke={color}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 19l-7-7m0 0l7-7m-7 7h18"
+      />
+    </svg>
+  )
+}

--- a/src/components/icons/FilterIcon.tsx
+++ b/src/components/icons/FilterIcon.tsx
@@ -1,0 +1,26 @@
+import { IconProps, getIconSize } from './types'
+
+export function FilterIcon({
+  size = 'md',
+  color = 'currentColor',
+  className,
+}: IconProps) {
+  const s = getIconSize(size)
+  return (
+    <svg
+      width={s}
+      height={s}
+      className={className}
+      fill="none"
+      stroke={color}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+      />
+    </svg>
+  )
+}

--- a/src/components/icons/MapPinIcon.tsx
+++ b/src/components/icons/MapPinIcon.tsx
@@ -1,0 +1,32 @@
+import { IconProps, getIconSize } from './types'
+
+export function MapPinIcon({
+  size = 'md',
+  color = 'currentColor',
+  className,
+}: IconProps) {
+  const s = getIconSize(size)
+  return (
+    <svg
+      width={s}
+      height={s}
+      className={className}
+      fill="none"
+      stroke={color}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  )
+}

--- a/src/components/icons/SearchIcon.tsx
+++ b/src/components/icons/SearchIcon.tsx
@@ -1,0 +1,26 @@
+import { IconProps, getIconSize } from './types'
+
+export function SearchIcon({
+  size = 'md',
+  color = 'currentColor',
+  className,
+}: IconProps) {
+  const s = getIconSize(size)
+  return (
+    <svg
+      width={s}
+      height={s}
+      className={className}
+      fill="none"
+      stroke={color}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+      />
+    </svg>
+  )
+}

--- a/src/components/icons/SpinnerIcon.tsx
+++ b/src/components/icons/SpinnerIcon.tsx
@@ -1,0 +1,34 @@
+import { IconProps, getIconSize } from './types'
+
+export function SpinnerIcon({
+  size = 'md',
+  color = 'currentColor',
+  className,
+}: IconProps) {
+  const s = getIconSize(size)
+  return (
+    <svg
+      width={s}
+      height={s}
+      className={className}
+      fill="none"
+      stroke={color}
+      viewBox="0 0 24 24"
+      aria-label="로딩 중"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke={color}
+        strokeWidth={4}
+      />
+      <path
+        className="opacity-75"
+        fill={color}
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  )
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,0 +1,9 @@
+export type { IconProps } from './types'
+export { getIconSize } from './types'
+
+export { AlertTriangleIcon } from './AlertTriangleIcon'
+export { ArrowLeftIcon } from './ArrowLeftIcon'
+export { FilterIcon } from './FilterIcon'
+export { MapPinIcon } from './MapPinIcon'
+export { SearchIcon } from './SearchIcon'
+export { SpinnerIcon } from './SpinnerIcon'

--- a/src/components/icons/types.ts
+++ b/src/components/icons/types.ts
@@ -1,0 +1,11 @@
+export interface IconProps {
+  size?: 'sm' | 'md' | 'lg' | number
+  color?: string
+  className?: string
+}
+
+const SIZE_MAP = { sm: 16, md: 24, lg: 32 } as const
+
+export function getIconSize(size: IconProps['size'] = 'md'): number {
+  return typeof size === 'number' ? size : SIZE_MAP[size]
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #347

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 인라인 SVG를 재사용 가능한 아이콘 컴포넌트로 분리하여 추상화 수준 향상

---

## 📋 변경 사항

- [x] 공통 `IconProps` 인터페이스 정의 (`size`, `color`, `className`)
- [x] `AlertTriangleIcon`, `SearchIcon`, `FilterIcon`, `MapPinIcon`, `ArrowLeftIcon`, `SpinnerIcon` 컴포넌트 생성
- [x] 배럴 파일 `src/components/icons/index.ts` 생성

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (tsc --noEmit)
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- **Task 번호**: Task 1.1
- **Requirements**: 3.5, 3.6
- 각 아이콘은 `page.tsx`, `SpotDetailClient.tsx`의 기존 인라인 SVG path를 그대로 추출
- 후속 Task(2.x)에서 기존 인라인 SVG를 이 컴포넌트로 교체 예정
