### PR TITLE
[Feat] useAdminAuth 관리자 인증 훅 구현

### DIFF
--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import type { Session } from 'next-auth'
+
+interface UseAdminAuthReturn {
+  /** 세션 로딩 중 여부 */
+  isLoading: boolean
+  /** 관리자 권한 확인 결과 */
+  isAuthorized: boolean
+  /** NextAuth 세션 객체 */
+  session: Session | null
+}
+
+/**
+ * 관리자 페이지 공통 인증/권한 훅
+ *
+ * - useSession() 기반 세션 로딩 상태 관리
+ * - 관리자 권한 확인 (role === 'admin')
+ * - 비관리자 자동 리다이렉트 ('/')
+ *
+ * Requirements: 4.1, 4.2, 4.3, 4.4
+ */
+export function useAdminAuth(): UseAdminAuthReturn {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+
+  const isLoading = status === 'loading'
+  const isAuthorized =
+    !isLoading && !!session?.user && session.user.role === 'admin'
+
+  // 비관리자 리다이렉트
+  useEffect(() => {
+    if (isLoading) return
+    if (!session?.user || session.user.role !== 'admin') {
+      router.push('/')
+    }
+  }, [isLoading, session, router])
+
+  return { isLoading, isAuthorized, session }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #355

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 관리자 페이지 4곳에 중복된 세션 확인/권한 검사/리다이렉트 로직을 `useAdminAuth` 커스텀 훅으로 추출

---

## 📋 변경 사항

- [x] `src/hooks/useAdminAuth.ts` 생성
- [x] `useSession()` 기반 세션 로딩, 권한 확인, 비관리자 리다이렉트 캡슐화
- [x] `{ isLoading, isAuthorized, session }` 반환 인터페이스 구현

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- **Task 번호**: Task 7.1
- **Requirements**: 4.1, 4.2, 4.3, 4.4
- 이 훅은 아직 관리자 페이지에 적용하지 않음 (Task 12에서 적용 예정)
