### PR TITLE
[Refactor] Task 8.1 - useSpotDetailViewModel 훅 구현

### DIFF
--- a/src/hooks/useSpotDetailViewModel.ts
+++ b/src/hooks/useSpotDetailViewModel.ts
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { useQueryClient } from '@tanstack/react-query'
+import { spotKeys } from '@/hooks/useSpots'
+
+interface UseSpotDetailViewModelProps {
+  spotId: string
+  authorId?: string | null
+}
+
+interface UseSpotDetailViewModelReturn {
+  // 권한
+  hasEditPermission: boolean
+  hasDeletePermission: boolean
+
+  // 삭제
+  isDeleting: boolean
+  handleDelete: () => Promise<void>
+
+  // 정보 보완 폼
+  showSupplementForm: boolean
+  handleSupplementClick: () => void
+  handleSupplementSuccess: () => void
+  supplementKey: number
+
+  // 상태 신고 폼
+  showStatusReportForm: boolean
+  handleStatusReportClick: () => void
+
+  // 로그인 모달
+  showLoginModal: boolean
+  loginModalContext: 'supplement' | 'status'
+}
+
+export function useSpotDetailViewModel({
+  spotId,
+  authorId,
+}: UseSpotDetailViewModelProps): UseSpotDetailViewModelReturn {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { user, isAuthenticated } = useAuth()
+
+  // 권한 확인: 관리자이거나 본인 스팟인 경우
+  const isAdmin = user?.role === 'admin'
+  const isOwner = !!(authorId && user?.id && authorId === user.id)
+  const hasEditPermission = isAdmin || isOwner
+  const hasDeletePermission = isAdmin || isOwner
+
+  // 삭제 상태
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  // 정보 보완 폼 상태
+  const [showSupplementForm, setShowSupplementForm] = useState(false)
+  const [supplementKey, setSupplementKey] = useState(0)
+
+  // 상태 신고 폼 상태
+  const [showStatusReportForm, setShowStatusReportForm] = useState(false)
+
+  // 로그인 모달 상태
+  const [showLoginModal, setShowLoginModal] = useState(false)
+  const [loginModalContext, setLoginModalContext] = useState<
+    'supplement' | 'status'
+  >('supplement')
+
+  // 스팟 삭제 핸들러
+  const handleDelete = useCallback(async () => {
+    if (
+      !confirm(
+        '정말로 이 스팟을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'
+      )
+    ) {
+      return
+    }
+
+    setIsDeleting(true)
+    try {
+      const response = await fetch(`/api/spots/${spotId}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        alert(data.error || '스팟 삭제에 실패했습니다')
+        return
+      }
+
+      // 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: spotKeys.all })
+
+      // 메인 페이지로 이동
+      router.push('/')
+    } catch {
+      alert('스팟 삭제에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [spotId, queryClient, router])
+
+  // 정보 보완 클릭 핸들러
+  const handleSupplementClick = useCallback(() => {
+    if (!isAuthenticated) {
+      setLoginModalContext('supplement')
+      setShowLoginModal(true)
+      return
+    }
+    setShowSupplementForm((prev) => !prev)
+  }, [isAuthenticated])
+
+  // 정보 보완 성공 핸들러
+  const handleSupplementSuccess = useCallback(() => {
+    setShowSupplementForm(false)
+    setSupplementKey((prev) => prev + 1)
+  }, [])
+
+  // 상태 신고 클릭 핸들러
+  const handleStatusReportClick = useCallback(() => {
+    if (!isAuthenticated) {
+      setLoginModalContext('status')
+      setShowLoginModal(true)
+      return
+    }
+    setShowStatusReportForm((prev) => !prev)
+  }, [isAuthenticated])
+
+  return {
+    hasEditPermission,
+    hasDeletePermission,
+    isDeleting,
+    handleDelete,
+    showSupplementForm,
+    handleSupplementClick,
+    handleSupplementSuccess,
+    supplementKey,
+    showStatusReportForm,
+    handleStatusReportClick,
+    showLoginModal,
+    loginModalContext,
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #357

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> SpotDetailClient의 인라인 도메인 로직을 useSpotDetailViewModel 훅으로 추출

---

## 📋 변경 사항

- [x] `src/hooks/useSpotDetailViewModel.ts` 생성
- [x] 스팟 삭제 핸들러, 권한 확인(hasEditPermission, hasDeletePermission), 삭제 진행 상태 캡슐화
- [x] 정보 보완 폼 토글, 상태 신고 폼 토글, 로그인 모달 상태 캡슐화

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (tsc --noEmit 통과)
- [x] Requirements 6.1, 6.2 대응

---

## 📝 추가 정보 (선택)

- 이 훅은 아직 SpotDetailClient에 적용하지 않음 (Task 13.1에서 적용 예정)
- SpotDetailClient와 SpotDetailContent 양쪽의 로직을 하나의 훅으로 통합
