### PR TITLE
[Feat] useRouteDetailViewModel 훅 생성(RouteDetailClient)

### DIFF
--- a/src/hooks/useRouteDetailViewModel.ts
+++ b/src/hooks/useRouteDetailViewModel.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query'
+import { API_ROUTES } from '@/lib/api-routes'
+import { routeKeys } from '@/hooks/useRouteQueries'
+import type { Route } from '@/types/route'
+
+// ── Types ───────────────────────────────────────────────────
+
+interface UseRouteDetailViewModelProps {
+  routeId: string
+}
+
+interface UseRouteDetailViewModelReturn {
+  route: Route | null
+  isLoading: boolean
+  error: string | null
+}
+
+// ── Hook ────────────────────────────────────────────────────
+
+/**
+ * 코스 상세 데이터 패칭 ViewModel 훅
+ * useState/useEffect 기반 수동 fetch를 React Query로 전환
+ * Requirements: 7.1, 7.2
+ */
+export function useRouteDetailViewModel({
+  routeId,
+}: UseRouteDetailViewModelProps): UseRouteDetailViewModelReturn {
+  const { data, isLoading, error } = useQuery({
+    queryKey: routeKeys.detail(routeId),
+    queryFn: async (): Promise<Route> => {
+      const res = await fetch(API_ROUTES.ROUTES.DETAIL(routeId))
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || '코스를 불러올 수 없습니다')
+      }
+      return res.json()
+    },
+    enabled: !!routeId,
+  })
+
+  return {
+    route: data ?? null,
+    isLoading,
+    error: error ? error.message : null,
+  }
+}

--- a/src/hooks/useRouteQueries.ts
+++ b/src/hooks/useRouteQueries.ts
@@ -23,6 +23,7 @@ export const routeKeys = {
   lists: () => [...routeKeys.all, 'list'] as const,
   list: (filters: Record<string, unknown>) =>
     [...routeKeys.lists(), filters] as const,
+  detail: (routeId: string) => [...routeKeys.all, 'detail', routeId] as const,
   related: (contentName: string) =>
     [...routeKeys.all, 'related', contentName] as const,
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #359

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> RouteDetailClient의 useState/useEffect 기반 수동 데이터 패칭을 React Query 기반 ViewModel 훅으로 분리

---

## 📋 변경 사항

- [x] `routeKeys` 팩토리에 `detail(routeId)` 키 추가
- [x] `useRouteDetailViewModel` 훅 생성 (useQuery 기반)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 7.1, 7.2 대응
- Task 9.1 완료
- 후속 Task 14.1에서 RouteDetailClient에 이 훅을 실제 적용 예정
