### PR TITLE
[Feat] Task 10.1 - useAdminDashboardSummary 훅 구현 및 adminKeys 확장

### DIFF
--- a/src/hooks/useAdminQueries.ts
+++ b/src/hooks/useAdminQueries.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { API_ROUTES, buildUrl } from '@/lib/api-routes'
 import type {
+  DashboardSummaryResponse,
   SpotReport,
   SpotStatusReport,
   SpotSupplement,
@@ -57,6 +58,8 @@ interface ContentMastersResponse {
 
 export const adminKeys = {
   all: ['admin'] as const,
+  dashboard: () => [...adminKeys.all, 'dashboard'] as const,
+  dashboardSummary: () => [...adminKeys.dashboard(), 'summary'] as const,
   reports: () => [...adminKeys.all, 'reports'] as const,
   reportList: (statusFilter: string, page: number) =>
     [...adminKeys.reports(), { statusFilter, page }] as const,
@@ -79,6 +82,24 @@ export const adminKeys = {
 }
 
 // ── Hooks ───────────────────────────────────────────────────
+
+/**
+ * 관리자 대시보드 요약 데이터 조회 훅
+ * Requirements: 5.1, 5.2
+ */
+export function useAdminDashboardSummary() {
+  return useQuery({
+    queryKey: adminKeys.dashboardSummary(),
+    queryFn: async (): Promise<DashboardSummaryResponse> => {
+      const res = await fetch(API_ROUTES.ADMIN.DASHBOARD_SUMMARY)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || '대시보드 요약 데이터 조회 실패')
+      }
+      return res.json()
+    },
+  })
+}
 
 /**
  * 관리자 제보 목록 조회 훅
@@ -179,6 +200,14 @@ export function useAdminContentImages(search: string, page: number) {
 }
 
 // ── Invalidation Hooks ──────────────────────────────────────
+
+/** 대시보드 요약 캐시 무효화 */
+export function useInvalidateAdminDashboard() {
+  const qc = useQueryClient()
+  return useCallback(() => {
+    qc.invalidateQueries({ queryKey: adminKeys.dashboard() })
+  }, [qc])
+}
 
 /** 제보 목록 캐시 무효화 */
 export function useInvalidateAdminReports() {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #361

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 관리자 대시보드의 수동 fetch를 대체할 `useAdminDashboardSummary` React Query 훅 추가 및 `adminKeys` 팩토리 패턴 확장

---

## 📋 변경 사항

- [x] `adminKeys`에 `dashboard()`, `dashboardSummary()` 키 추가
- [x] `useAdminDashboardSummary` 훅 구현 (`/api/admin/dashboard/summary` 호출)
- [x] `useInvalidateAdminDashboard` 캐시 무효화 훅 추가
- [x] 기존 서브 페이지 훅(`useAdminReports`, `useAdminSupplements`, `useAdminStatusReports`) adminKeys 패턴 준수 점검 완료

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 5.1, 5.2, 5.4, 5.5
- 이 훅은 Task 12.1에서 `src/app/admin/page.tsx`에 적용될 예정
