### PR TITLE
[Refactor] spec 17 추가 피드백 반영 후 수정

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -27,17 +27,9 @@ export default function AdminDashboardPage() {
     )
   }
 
+  // 비관리자는 useAdminAuth가 자동 리다이렉트 — 리다이렉트 완료까지 빈 화면 유지
   if (!isAuthorized) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <h1 className="mb-2 text-2xl font-bold text-gray-800">
-            접근 권한 없음
-          </h1>
-          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
-        </div>
-      </div>
-    )
+    return null
   }
 
   return (

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -33,17 +33,9 @@ export default function AdminReportsPage() {
     )
   }
 
+  // 비관리자는 useAdminAuth가 자동 리다이렉트 — 리다이렉트 완료까지 빈 화면 유지
   if (!isAuthorized) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <h1 className="mb-2 text-2xl font-bold text-gray-800">
-            접근 권한 없음
-          </h1>
-          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
-        </div>
-      </div>
-    )
+    return null
   }
 
   return (

--- a/src/app/admin/status-reports/page.tsx
+++ b/src/app/admin/status-reports/page.tsx
@@ -35,17 +35,9 @@ export default function AdminStatusReportsPage() {
     )
   }
 
+  // 비관리자는 useAdminAuth가 자동 리다이렉트 — 리다이렉트 완료까지 빈 화면 유지
   if (!isAuthorized) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <h1 className="mb-2 text-2xl font-bold text-gray-800">
-            접근 권한 없음
-          </h1>
-          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
-        </div>
-      </div>
-    )
+    return null
   }
 
   return (

--- a/src/app/admin/supplements/page.tsx
+++ b/src/app/admin/supplements/page.tsx
@@ -34,17 +34,9 @@ export default function AdminSupplementsPage() {
     )
   }
 
+  // 비관리자는 useAdminAuth가 자동 리다이렉트 — 리다이렉트 완료까지 빈 화면 유지
   if (!isAuthorized) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <h1 className="mb-2 text-2xl font-bold text-gray-800">
-            접근 권한 없음
-          </h1>
-          <p className="text-gray-600">관리자만 접근할 수 있습니다.</p>
-        </div>
-      </div>
-    )
+    return null
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,15 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
   loading: () => <MapSkeleton />,
 })
 
+/** Home 에러 fallback — 컴포넌트 외부 정의로 참조 안정성 확보 */
+const HomeErrorFallback = ({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) => <SpotErrorDisplay error={error} onRetry={reset} />
+
 /**
  * 메인 페이지 컴포넌트
  * Requirements 1.1, 1.4, 2.1, 2.2를 만족하는 지도 기반 메인 페이지
@@ -31,9 +40,7 @@ export default function Home() {
     <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-navy-900">
       <AsyncBoundary
         pendingFallback={<SpotLoadingSkeleton />}
-        rejectedFallback={({ error, reset }) => (
-          <SpotErrorDisplay error={error} onRetry={reset} />
-        )}
+        rejectedFallback={HomeErrorFallback}
       >
         <HomeContent />
       </AsyncBoundary>

--- a/src/components/route/RouteDetailClient.tsx
+++ b/src/components/route/RouteDetailClient.tsx
@@ -78,9 +78,7 @@ export default function RouteDetailClient() {
   return (
     <AsyncBoundary
       pendingFallback={<RouteDetailSkeleton />}
-      rejectedFallback={({ error, reset }) => (
-        <RouteDetailError error={error} reset={reset} />
-      )}
+      rejectedFallback={RouteDetailError}
     >
       <RouteDetailInner routeId={routeId} />
     </AsyncBoundary>

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -65,6 +65,16 @@ const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
  * pendingFallback으로 스켈레톤, rejectedFallback으로 에러 UI 표시
  * Requirements: 2.3, 2.5, 2.6
  */
+
+/** SpotDetail 에러 fallback — 컴포넌트 외부 정의로 참조 안정성 확보 */
+const SpotDetailErrorFallback = ({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) => <SpotDetailError error={error} onRetry={reset} />
+
 export default function SpotDetailClient() {
   const params = useParams()
   const spotId = params.id as string
@@ -72,9 +82,7 @@ export default function SpotDetailClient() {
   return (
     <AsyncBoundary
       pendingFallback={<SpotDetailSkeletonUI />}
-      rejectedFallback={({ error, reset }) => (
-        <SpotDetailError error={error} onRetry={reset} />
-      )}
+      rejectedFallback={SpotDetailErrorFallback}
     >
       <SpotDetailInner spotId={spotId} />
     </AsyncBoundary>

--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -28,16 +28,16 @@ export function useAdminAuth(): UseAdminAuthReturn {
   const router = useRouter()
 
   const isLoading = status === 'loading'
-  const isAuthorized =
-    !isLoading && !!session?.user && session.user.role === 'admin'
+  const isAdmin = !!session?.user && session.user.role === 'admin'
 
-  // 비관리자 리다이렉트
+  // 비관리자 리다이렉트 — 리다이렉트 중에는 isAuthorized=false 유지
+  // 사용하는 쪽에서 !isAuthorized일 때 return null로 빈 화면 유지
   useEffect(() => {
     if (isLoading) return
-    if (!session?.user || session.user.role !== 'admin') {
+    if (!isAdmin) {
       router.push('/')
     }
-  }, [isLoading, session, router])
+  }, [isLoading, isAdmin, router])
 
-  return { isLoading, isAuthorized, session }
+  return { isLoading, isAuthorized: isAdmin, session }
 }

--- a/src/hooks/useRouteDetailViewModel.ts
+++ b/src/hooks/useRouteDetailViewModel.ts
@@ -1,19 +1,7 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { API_ROUTES } from '@/lib/api-routes'
 import { routeKeys } from '@/hooks/useRouteQueries'
 import type { Route } from '@/types/route'
-
-// ── Types ───────────────────────────────────────────────────
-
-interface UseRouteDetailViewModelProps {
-  routeId: string
-}
-
-interface UseRouteDetailViewModelReturn {
-  route: Route | null
-  isLoading: boolean
-  error: string | null
-}
 
 // ── Shared queryFn ──────────────────────────────────────────
 
@@ -31,30 +19,9 @@ function routeDetailQueryFn(routeId: string) {
 // ── Hooks ───────────────────────────────────────────────────
 
 /**
- * 코스 상세 데이터 패칭 ViewModel 훅
- * useState/useEffect 기반 수동 fetch를 React Query로 전환
- * Requirements: 7.1, 7.2
- */
-export function useRouteDetailViewModel({
-  routeId,
-}: UseRouteDetailViewModelProps): UseRouteDetailViewModelReturn {
-  const { data, isLoading, error } = useQuery({
-    queryKey: routeKeys.detail(routeId),
-    queryFn: routeDetailQueryFn(routeId),
-    enabled: !!routeId,
-  })
-
-  return {
-    route: data ?? null,
-    isLoading,
-    error: error ? error.message : null,
-  }
-}
-
-/**
  * Suspense 모드 코스 상세 훅
  * AsyncBoundary 내부에서 사용 — 로딩/에러 상태를 Suspense/ErrorBoundary로 위임
- * Requirements: 2.4, 2.5
+ * Requirements: 2.4, 2.5, 7.1, 7.2
  */
 export function useRouteDetailSuspense(routeId: string) {
   return useSuspenseQuery({


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #371

---

## 📋 PR 타입

- [x] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [x] 🐛 **fix**: 버그 수정

---

## ✨ 작업 개요

선언적 리팩토링(spec 17) 코드 리뷰 피드백 3건 반영

---

## 📋 변경 사항

- [x] useRouteDetailViewModel 미사용 일반 useQuery 훅 제거 (useRouteDetailSuspense만 유지)
- [x] useAdminAuth 비관리자 접근 시 "접근 권한 없음" UI 대신 return null로 변경 (리다이렉트 완료까지 빈 화면 유지)
- [x] AsyncBoundary rejectedFallback 인라인 화살표 함수를 외부 컴포넌트로 분리 (page.tsx, RouteDetailClient, SpotDetailClient)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] `npx tsc --noEmit` 통과
- [x] Jest 테스트 전체 통과 (10 suites / 51 tests)

---

## 📝 추가 정보

- Requirements: 2.4, 4.1, 8.3
- Spec: 17-declarative-refactoring
