### PR TITLE
[Test] routemap spotpin tests  add

### DIFF
--- a/.kiro/specs/18-map-ui-bugfix/design.md
+++ b/.kiro/specs/18-map-ui-bugfix/design.md
@@ -1,0 +1,351 @@
+# 지도 UI 버그 수정 Design
+
+## Overview
+
+지도 UI 관련 4가지 버그를 체계적으로 수정합니다:
+1. **MapContainer 재사용 에러**: spots prop 변경 시 Leaflet 인스턴스 충돌 → MapContainer를 안정적으로 유지하고 하위 마커만 업데이트
+2. **갤러리 피드 레이아웃**: 아이템 수가 적을 때 과도한 크기 → max-width 제한 + 좌측 정렬
+3. **RouteMap 타일 깨짐**: setTimeout 기반 invalidateSize 타이밍 불일치 → ResizeObserver 기반 감지
+4. **근접 핀 이벤트 충돌**: 근접 핀 간 마우스 이동 시 이벤트 연쇄 → z-index 강화 + debounce 조정
+
+각 버그는 독립적이며, 수정 범위가 명확하게 분리되어 있어 회귀 위험이 낮습니다.
+
+## Glossary
+
+- **Bug_Condition (C)**: 각 버그가 발생하는 조건 — spots 배열 변경, 아이템 수 ≤ 3, 컨테이너 크기 미확정, 근접 핀 호버
+- **Property (P)**: 각 버그 조건에서의 기대 동작 — 에러 없는 마커 업데이트, 제한된 크기 표시, 정렬된 타일, 안정적 호버
+- **Preservation**: 기존 동작 중 변경되지 않아야 하는 것 — 전체 스팟 표시, 줌/드래그, 4개 이상 그리드, Polyline/Popup, 개별 핀 이벤트
+- **MapContainer**: react-leaflet의 지도 컨테이너 컴포넌트. 내부적으로 Leaflet Map 인스턴스를 생성하며, 리마운트 시 기존 인스턴스와 충돌
+- **invalidateSize()**: Leaflet Map의 메서드. 컨테이너 DOM 크기가 변경된 후 타일 레이아웃을 재계산
+- **ResizeObserver**: 브라우저 API. DOM 요소의 크기 변경을 비동기적으로 감지
+- **zIndexOffset**: Leaflet Marker의 속성. 마커의 z-index를 기본값 대비 오프셋으로 조정
+- **debounce**: 연속 이벤트 발생 시 마지막 이벤트 후 일정 시간 대기 후 실행하는 패턴
+
+## Bug Details
+
+### Bug Condition
+
+4가지 버그는 각각 독립적인 조건에서 발생합니다.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type UIInteraction
+  OUTPUT: { bug1: boolean, bug2: boolean, bug3: boolean, bug4: boolean }
+  
+  bug1 := input.component == "PilgrimageMap"
+          AND input.spotsArray HAS CHANGED
+          AND MapContainer ATTEMPTS RE-RENDER
+  
+  bug2 := input.component == "CheckInGallery"
+          AND input.checkinCount IN [1, 2, 3]
+          AND input.viewportWidth > singleItemMaxWidth
+  
+  bug3 := input.component == "RouteMap"
+          AND input.containerSizeNotSettled == true
+          AND invalidateSize() CALLED AT FIXED_TIMEOUT
+  
+  bug4 := input.component == "SpotPin"
+          AND input.nearbyPinCount >= 2
+          AND input.mouseMoveBetweenPins == true
+          AND debounceWindow < mouseTransitionTime
+  
+  RETURN { bug1, bug2, bug3, bug4 }
+END FUNCTION
+```
+
+### Examples
+
+**버그 1: MapContainer 재사용 에러**
+- 사용자가 카테고리 필터 "애니메이션"을 클릭 → spots 배열이 [전체 50개] → [애니메이션 15개]로 변경 → "Map container is being reused by another instance" 에러 발생
+- 기대: MapContainer는 그대로 유지, SpotPin 마커만 15개로 업데이트
+
+**버그 2: 갤러리 피드 레이아웃**
+- 스팟 상세에서 인증샷이 1개만 있을 때 → grid-cols-2에서 1개 아이템이 50% 너비를 차지하지만 max-width 제한 없음 → 큰 화면에서 과도하게 큰 이미지
+- 기대: 아이템 1개일 때 max-width 제한(예: 200px)으로 적절한 크기 유지, 좌측 정렬
+
+**버그 3: RouteMap 타일 깨짐**
+- 코스 상세 페이지 진입 → RouteMap 컨테이너가 CSS 트랜지션/레이아웃 계산 중 → setTimeout 300ms 후 invalidateSize() 호출 → 컨테이너 크기가 아직 확정되지 않은 경우 타일 어긋남
+- 기대: ResizeObserver로 컨테이너 크기 확정 시점 감지 후 invalidateSize() 호출
+
+**버그 4: 근접 핀 이벤트 충돌**
+- 도쿄 아키하바라 주변에 핀 5개가 밀집 → 핀 A에서 핀 B로 마우스 이동 → A의 mouseout(150ms) + B의 mouseover(50ms) 동시 발생 → 미리보기 깜빡임
+- 기대: z-index 간격 확대 + debounce 시간 조정으로 안정적 전환
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- 카테고리 필터 없이 전체 스팟 표시 시 모든 핀이 정상 렌더링 (3.1)
+- 지도 줌인/줌아웃, 드래그 등 기본 인터랙션 정상 동작 (3.2)
+- 갤러리 아이템 4개 이상일 때 기존 grid-cols-2/3/4 반응형 레이아웃 유지 (3.3)
+- 갤러리 이미지 클릭 시 CheckInDetailModal 정상 표시 (3.4)
+- RouteMap의 Polyline, 번호 마커, 시작 지점 마커 기존 스타일/동작 유지 (3.5)
+- RouteMap 스팟 마커 클릭 시 Popup 정상 표시 (3.6)
+- 핀이 충분히 떨어져 있을 때 개별 호버/클릭 정상 동작 (3.7)
+- 모바일 터치 시 Bottom Sheet 정상 동작 (3.8)
+- 현재 위치 버튼 클릭 시 GPS 위치 이동 정상 동작 (3.9)
+
+**Scope:**
+각 버그 수정은 해당 컴포넌트 내부로 범위가 한정됩니다. 다른 컴포넌트나 전역 상태(mapStore, uiStore, bottomSheetStore)의 동작에는 영향을 주지 않습니다.
+
+## Hypothesized Root Cause
+
+### 버그 1: MapContainer 재사용 에러
+
+**근본 원인: react-leaflet MapContainer의 불변성**
+
+react-leaflet v4의 `MapContainer`는 내부적으로 Leaflet `Map` 인스턴스를 생성하며, props 변경으로 인한 리렌더링 시 동일 DOM 노드에 새 인스턴스를 생성하려 합니다. 현재 코드에서:
+
+1. `PilgrimageMap` 컴포넌트가 `spots` prop 변경으로 리렌더링됨
+2. `MapContainer`에 `key` prop이 없어 React는 동일 컴포넌트로 인식
+3. 그러나 내부 Leaflet 인스턴스 상태와 React 상태가 불일치하면 "Map container is being reused" 에러 발생
+
+실제로 react-leaflet의 `MapContainer`는 `center`, `zoom` 등의 props가 **초기값으로만** 사용되며, 이후 변경을 반영하지 않습니다. 문제는 `spots` 변경이 부모 컴포넌트의 리렌더링을 유발하고, dynamic import된 `PilgrimageMap` 전체가 재마운트될 수 있다는 점입니다.
+
+**해결 방향**: MapContainer가 언마운트/리마운트되지 않도록 보장하고, spots 변경은 하위 SpotPin 마커들만 업데이트하도록 구조 유지.
+
+### 버그 2: 갤러리 피드 레이아웃
+
+**근본 원인: CSS Grid의 고정 컬럼 + max-width 미설정**
+
+```tsx
+<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+```
+
+- `grid-cols-2`는 아이템 수와 무관하게 2컬럼 그리드를 생성
+- 아이템 1개일 때 해당 셀이 컨테이너 너비의 50%를 차지
+- 큰 화면에서 50%가 과도하게 넓어짐
+- 개별 아이템에 `max-width` 제한이 없음
+
+### 버그 3: RouteMap 타일 깨짐
+
+**근본 원인: setTimeout 기반 타이밍의 비결정성**
+
+```tsx
+const timer = setTimeout(() => {
+  map.invalidateSize()
+  // bounds 맞추기...
+}, 300)
+```
+
+- `setTimeout(300)`은 컨테이너 DOM 크기 확정과 무관한 임의 타이밍
+- CSS 트랜지션, 레이아웃 계산, 이미지 로딩 등으로 300ms 내에 크기가 확정되지 않을 수 있음
+- `PilgrimageMap`에서도 `setTimeout(100)`으로 동일 패턴 사용 중
+
+### 버그 4: 근접 핀 이벤트 충돌
+
+**근본 원인: z-index 간격 부족 + debounce 타이밍 불균형**
+
+현재 설정:
+- `Z_INDEX = { base: 0, selected: 500, hovered: 1000 }`
+- mouseover debounce: 50ms, mouseout debounce: 150ms
+
+문제점:
+1. 근접 핀들의 z-index가 모두 `base: 0`으로 동일하여 Leaflet이 임의로 이벤트 대상을 결정
+2. 핀 A → 핀 B 이동 시: A의 mouseout(150ms 후 실행) 타이머가 B의 mouseover(50ms 후 실행)보다 늦게 완료되어 상태 충돌
+3. mouseout 핸들러가 `isPreviewHoveredRef`를 체크하지만, 핀 간 이동 시에는 프리뷰가 아닌 다른 핀 위에 있으므로 닫힘 → 다시 열림 반복
+
+## Correctness Properties
+
+Property 1: Bug Condition - MapContainer 안정성
+
+_For any_ spots 배열 변경(카테고리 필터 전환, 검색 결과 변경 등)에 대해, PilgrimageMap 컴포넌트는 MapContainer를 언마운트하지 않고 동일 Leaflet 인스턴스를 유지하며, 하위 SpotPin 마커들만 새 배열에 맞게 업데이트하여 에러 없이 동작해야 한다(SHALL).
+
+**Validates: Requirements 2.1, 2.2**
+
+Property 2: Bug Condition - 갤러리 아이템 크기 제한
+
+_For any_ 체크인 갤러리에서 아이템 수가 1~3개인 경우, 각 아이템의 렌더링 너비가 지정된 max-width를 초과하지 않으며 좌측 정렬되어야 한다(SHALL).
+
+**Validates: Requirements 2.3, 2.4**
+
+Property 3: Bug Condition - RouteMap 타일 정렬
+
+_For any_ RouteMap 컴포넌트 마운트 또는 컨테이너 크기 변경 시, ResizeObserver를 통해 컨테이너 크기 확정 시점을 감지한 후 invalidateSize()를 호출하여 타일이 정상 정렬되어야 한다(SHALL).
+
+**Validates: Requirements 2.5, 2.6**
+
+Property 4: Bug Condition - 근접 핀 호버 안정성
+
+_For any_ 근접 핀 간 마우스 이동 시, 강화된 z-index 오프셋과 조정된 debounce 타이밍으로 이벤트 연쇄가 방지되어 미리보기가 안정적으로 전환되어야 한다(SHALL).
+
+**Validates: Requirements 2.7, 2.8**
+
+Property 5: Preservation - 기존 지도/갤러리 동작 유지
+
+_For any_ 버그 조건에 해당하지 않는 입력(전체 스팟 표시, 줌/드래그, 4개 이상 갤러리, Polyline/Popup, 개별 핀 이벤트, 모바일 터치, GPS 이동)에 대해, 수정된 코드는 기존 코드와 동일한 동작을 유지해야 한다(SHALL).
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9**
+
+## Fix Implementation
+
+### Changes Required
+
+#### 버그 1: PilgrimageMap.tsx - MapContainer 안정성 확보
+
+**File**: `src/components/map/PilgrimageMap.tsx`
+
+**Specific Changes**:
+
+1. **MapContainer 리마운트 방지**: `<MapContainer>`에는 spots 등 데이터에 의존하는 동적 key prop을 절대 사용하지 않는다 (안티 패턴: `<MapContainer key={spots.length}>` 등). spots 배열은 오직 `<MapContainer>` 내부의 자식 컴포넌트(개별 `<SpotPin>`)로만 전달되어, 지도 인스턴스 자체는 유지된 채 마커 DOM만 업데이트되도록 데이터 흐름을 강제한다. dynamic import의 `ssr: false` 설정과 부모 컴포넌트의 리렌더링 패턴을 점검하여 MapContainer가 언마운트되지 않음을 보장.
+
+2. **useEffect 내 invalidateSize setTimeout 제거**: `setTimeout(() => { map.invalidateSize() }, 100)` 패턴을 ResizeObserver 기반으로 교체 (버그 3과 동일 패턴 적용).
+
+3. **whenReady 콜백 내 setTimeout 제거**: `whenReady` 콜백에서도 setTimeout 대신 즉시 또는 ResizeObserver 기반으로 변경.
+
+#### 버그 2: CheckInGallery.tsx - 레이아웃 제한
+
+**File**: `src/components/checkin/CheckInGallery.tsx`
+
+**Specific Changes**:
+
+1. **아이템 수 기반 조건부 스타일링**: 아이템 수가 1~3개일 때 그리드 아이템에 `max-w-[200px]` (또는 적절한 값) 클래스 적용.
+
+2. **좌측 정렬**: 아이템 수가 적을 때 그리드 컨테이너에 `justify-items-start` 또는 flex 기반 레이아웃으로 전환하여 좌측 정렬.
+
+3. **스켈레톤 UI 동기화**: 로딩 스켈레톤에도 동일한 max-width 제한 적용하여 레이아웃 시프트 방지.
+
+#### 버그 3: RouteMap.tsx - ResizeObserver 기반 타일 정렬
+
+**File**: `src/components/route/RouteMap.tsx`
+
+**Specific Changes**:
+
+1. **setTimeout 제거**: `setTimeout(() => { map.invalidateSize() }, 300)` 패턴 제거.
+
+2. **ResizeObserver 도입 (Debounce 적용)**: 컨테이너 div에 ref를 연결하고, ResizeObserver로 크기 변경 감지 시 `requestAnimationFrame` 또는 debounce(약 100ms)를 감싸서 `map.invalidateSize()`를 호출한다. 이는 `invalidateSize()` 자체가 지도 내부 타일 구조를 재계산하면서 미세한 픽셀 변동을 일으켜 다시 ResizeObserver를 트리거하는 무한 루프(ResizeLoop Error)를 방지하기 위함이다.
+
+3. **useEffect 클린업**: ResizeObserver의 `disconnect()`를 useEffect 클린업에서 호출하여 메모리 누수 방지.
+
+4. **bounds 맞추기 로직 통합**: invalidateSize() 호출 후 bounds 맞추기 로직을 ResizeObserver 콜백 내에서 실행.
+
+#### 버그 4: SpotPin.tsx - z-index 강화 + debounce 조정
+
+**File**: `src/components/map/SpotPin.tsx`
+
+**Specific Changes**:
+
+1. **z-index 간격 확대**: `Z_INDEX = { base: 0, selected: 500, hovered: 1000 }` → `{ base: 0, selected: 2000, hovered: 5000 }` 등으로 간격을 넓혀 근접 핀 간 z-index 충돌 최소화.
+
+2. **debounce 타이밍 조정**: mouseover debounce를 50ms → 80~100ms로 증가, mouseout debounce를 150ms → 200~250ms로 증가하여 핀 간 전환 시 안정성 확보.
+
+3. **mouseout 핸들러 개선**: mouseout 시 다른 핀 위에 있는지 확인하는 로직 추가. 다른 SpotPin의 mouseover가 이미 트리거된 경우 현재 핀의 closePreview를 스킵.
+
+4. **미리보기 모달 이벤트 통과 (Pointer Events)**: 띄워지는 미리보기(SpotPreview) DOM 요소에 `pointer-events: none` CSS 속성을 적용하여, 커서가 미리보기 모달 위에 있어도 그 아래의 핀(Marker)에 대한 hover 상태가 유지되도록 처리한다. 이는 미리보기 모달이 마우스 커서를 가려서 핀의 mouseout을 강제 유발하는 현상을 방지하기 위한 핵심 조치이다. **주의**: `pointer-events: none`이 적용되면 미리보기 내부의 버튼/링크도 클릭 불가능해지므로, 미리보기는 순수 정보 표시 전용(읽기 전용)으로 유지하고, 상세 페이지 이동 등 실제 상호작용은 핀(Marker) 자체의 클릭 이벤트에서 처리하도록 라우팅/이벤트 구조를 설계한다.
+
+## Testing Strategy
+
+### Validation Approach
+
+테스트 전략은 두 단계로 진행합니다: 먼저 수정 전 코드에서 버그를 재현하는 반례를 확인하고, 수정 후 버그가 해결되었으며 기존 동작이 보존되었는지 검증합니다.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: 수정 전 코드에서 각 버그를 재현하여 근본 원인 분석을 확인/반박합니다.
+
+**Test Plan**: 각 버그 조건을 시뮬레이션하는 테스트를 작성하고, 수정 전 코드에서 실행하여 실패를 관찰합니다.
+
+**Test Cases**:
+1. **MapContainer 재사용 테스트**: PilgrimageMap에 spots prop을 변경하며 렌더링 → 에러 발생 확인 (수정 전 코드에서 실패)
+2. **갤러리 1개 아이템 크기 테스트**: CheckInGallery에 1개 아이템 렌더링 → 렌더링된 아이템 너비가 max-width 초과 확인 (수정 전 코드에서 실패)
+3. **RouteMap 타일 정렬 테스트**: RouteMap 마운트 후 invalidateSize 호출 타이밍 확인 → setTimeout 기반임을 확인 (수정 전 코드에서 실패)
+4. **근접 핀 호버 전환 테스트**: 근접 핀 간 빠른 마우스 이동 시뮬레이션 → 이벤트 연쇄 발생 확인 (수정 전 코드에서 실패)
+
+**Expected Counterexamples**:
+- Bug 1: spots 배열 변경 시 "Map container is being reused" 에러
+- Bug 2: 1개 아이템의 렌더링 너비 > 200px
+- Bug 3: invalidateSize()가 컨테이너 크기 확정 전에 호출됨
+- Bug 4: 핀 A→B 이동 시 미리보기가 깜빡이거나 잘못된 스팟 표시
+
+### Fix Checking
+
+**Goal**: 버그 조건에 해당하는 모든 입력에 대해 수정된 함수가 기대 동작을 생성하는지 검증합니다.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE isBugCondition(input).bug1 DO
+  result := PilgrimageMap_fixed(input)
+  ASSERT NO_ERROR(result) AND markersUpdated(result, input.newSpots)
+END FOR
+
+FOR ALL input WHERE isBugCondition(input).bug2 DO
+  result := CheckInGallery_fixed(input)
+  ASSERT itemWidth(result) <= MAX_WIDTH AND alignment(result) == "left"
+END FOR
+
+FOR ALL input WHERE isBugCondition(input).bug3 DO
+  result := RouteMap_fixed(input)
+  ASSERT tilesAligned(result) AND invalidateSizeCalledAfterResize(result)
+END FOR
+
+FOR ALL input WHERE isBugCondition(input).bug4 DO
+  result := SpotPin_fixed(input)
+  ASSERT previewStable(result) AND correctSpotDisplayed(result)
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: 버그 조건에 해당하지 않는 모든 입력에 대해 수정된 함수가 기존 함수와 동일한 결과를 생성하는지 검증합니다.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE NOT isBugCondition(input).bug1 DO
+  ASSERT PilgrimageMap_original(input) = PilgrimageMap_fixed(input)
+END FOR
+
+FOR ALL input WHERE NOT isBugCondition(input).bug2 DO
+  ASSERT CheckInGallery_original(input) = CheckInGallery_fixed(input)
+END FOR
+
+FOR ALL input WHERE NOT isBugCondition(input).bug3 DO
+  ASSERT RouteMap_original(input) = RouteMap_fixed(input)
+END FOR
+
+FOR ALL input WHERE NOT isBugCondition(input).bug4 DO
+  ASSERT SpotPin_original(input) = SpotPin_fixed(input)
+END FOR
+```
+
+**Testing Approach**: Property-based testing은 preservation checking에 권장됩니다:
+- 입력 도메인 전체에 걸쳐 자동으로 많은 테스트 케이스 생성
+- 수동 단위 테스트가 놓칠 수 있는 엣지 케이스 포착
+- 모든 비버그 입력에 대해 동작이 변경되지 않았음을 강력하게 보장
+
+**Test Plan**: 수정 전 코드에서 비버그 입력에 대한 동작을 먼저 관찰한 후, 해당 동작을 캡처하는 property-based 테스트를 작성합니다.
+
+**Test Cases**:
+1. **전체 스팟 표시 보존**: 필터 없이 전체 스팟 렌더링이 수정 전후 동일한지 확인
+2. **줌/드래그 보존**: 지도 기본 인터랙션이 수정 전후 동일하게 동작하는지 확인
+3. **4개 이상 갤러리 보존**: 아이템 4개 이상일 때 기존 그리드 레이아웃이 유지되는지 확인
+4. **Polyline/Popup 보존**: RouteMap의 경로선과 팝업이 수정 전후 동일하게 렌더링되는지 확인
+5. **개별 핀 이벤트 보존**: 충분히 떨어진 핀의 호버/클릭이 수정 전후 동일하게 동작하는지 확인
+6. **모바일 터치 보존**: Bottom Sheet 동작이 수정 전후 동일한지 확인
+
+### Unit Tests
+
+- PilgrimageMap: spots prop 변경 시 MapContainer 리마운트 여부 확인
+- PilgrimageMap: 빠른 카테고리 필터 전환 시 에러 미발생 확인
+- CheckInGallery: 아이템 1개일 때 렌더링 너비 ≤ max-width 확인
+- CheckInGallery: 아이템 2~3개일 때 각 아이템 너비 ≤ max-width 확인
+- CheckInGallery: 아이템 4개 이상일 때 기존 그리드 레이아웃 유지 확인
+- RouteMap: ResizeObserver 콜백에서 invalidateSize() 호출 확인
+- RouteMap: 컴포넌트 언마운트 시 ResizeObserver disconnect 확인
+- SpotPin: z-index 오프셋 값이 기대값과 일치하는지 확인
+- SpotPin: debounce 타이밍이 조정된 값과 일치하는지 확인
+
+### Property-Based Tests
+
+- 랜덤 spots 배열(0~100개)을 생성하여 PilgrimageMap이 에러 없이 렌더링되는지 확인
+- 랜덤 체크인 수(1~20개)를 생성하여 갤러리 아이템 너비가 항상 max-width 이내인지 확인
+- 랜덤 컨테이너 크기(100px~2000px)를 생성하여 RouteMap 타일이 항상 정렬되는지 확인
+- 랜덤 핀 좌표(근접/원거리 혼합)를 생성하여 호버 이벤트가 항상 올바른 스팟을 표시하는지 확인
+
+### Integration Tests
+
+- 메인 페이지에서 카테고리 필터를 반복 전환하며 지도가 정상 동작하는지 E2E 확인
+- 스팟 상세 페이지에서 인증샷 갤러리가 다양한 아이템 수에서 올바르게 표시되는지 확인
+- 코스 상세 페이지에서 RouteMap이 다양한 화면 크기에서 타일이 정상 렌더링되는지 확인
+- 밀집 스팟 지역에서 핀 호버/클릭이 안정적으로 동작하는지 확인

--- a/.kiro/specs/18-map-ui-bugfix/tasks.md
+++ b/.kiro/specs/18-map-ui-bugfix/tasks.md
@@ -1,0 +1,296 @@
+# Implementation Plan
+
+## Bug 1: MapContainer 재사용 에러 (PilgrimageMap.tsx)
+
+- [x] 1. Write bug condition exploration test - MapContainer 안정성
+  - **Property 1: Bug Condition** - MapContainer 재사용 에러
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists
+  - **Scoped PBT Approach**: spots 배열이 변경될 때(카테고리 필터 전환) MapContainer가 에러 없이 동일 인스턴스를 유지하는지 검증
+  - Test file: `src/components/map/__tests__/PilgrimageMap.bug.test.tsx`
+  - Bug Condition: `input.component == "PilgrimageMap" AND input.spotsArray HAS CHANGED AND MapContainer ATTEMPTS RE-RENDER`
+  - PilgrimageMap에 spots prop을 [전체 50개] → [필터링 15개] → [전체 50개]로 변경하며 렌더링
+  - MapContainer가 언마운트되지 않고 동일 Leaflet 인스턴스를 유지하는지 확인
+  - SpotPin 마커들만 새 배열에 맞게 업데이트되는지 확인
+  - useEffect 내 setTimeout 기반 invalidateSize 호출 패턴이 존재하는지 확인
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples: spots 배열 변경 시 "Map container is being reused by another instance" 에러 또는 setTimeout 기반 invalidateSize 패턴 감지
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 2.1, 2.2_
+
+- [x] 2. Write preservation property tests - MapContainer 기존 동작 보존 (BEFORE implementing fix)
+  - **Property 2: Preservation** - 전체 스팟 표시 및 기본 인터랙션 보존
+  - **IMPORTANT**: Follow observation-first methodology
+  - Test file: `src/components/map/__tests__/PilgrimageMap.preservation.test.tsx`
+  - Observe: 카테고리 필터 없이 전체 스팟 표시 시 모든 핀이 정상 렌더링됨
+  - Observe: 지도 줌인/줌아웃, 드래그 등 기본 인터랙션 정상 동작
+  - Observe: 현재 위치 버튼 클릭 시 GPS 위치 이동 정상 동작
+  - Write property-based test: spots 배열이 변경되지 않는 경우(전체 표시), 모든 SpotPin이 spots.length만큼 렌더링됨
+  - Write property-based test: MapContainer의 줌/드래그 props가 유지됨 (scrollWheelZoom, doubleClickZoom, dragging, touchZoom 등)
+  - Verify test passes on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.9_
+
+
+## Bug 2: 갤러리 피드 레이아웃 (CheckInGallery.tsx)
+
+- [x] 3. Write bug condition exploration test - 갤러리 아이템 크기 제한
+  - **Property 1: Bug Condition** - 갤러리 아이템 과도한 크기
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists
+  - **Scoped PBT Approach**: 아이템 수가 1~3개일 때 각 아이템의 렌더링 너비가 max-width를 초과하는지 검증
+  - Test file: `src/components/checkin/__tests__/CheckInGallery.bug.test.tsx`
+  - Bug Condition: `input.component == "CheckInGallery" AND input.checkinCount IN [1, 2, 3] AND input.viewportWidth > singleItemMaxWidth`
+  - CheckInGallery에 1개 아이템 렌더링 → 아이템에 max-width 제한 클래스가 적용되어 있는지 확인
+  - CheckInGallery에 2~3개 아이템 렌더링 → 각 아이템에 max-width 제한이 있는지 확인
+  - 아이템 1~3개일 때 좌측 정렬(justify-items-start 또는 flex 기반)이 적용되는지 확인
+  - 스켈레톤 UI에도 동일한 max-width 제한이 적용되는지 확인
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples: 1개 아이템의 렌더링 너비 > 200px, max-width 클래스 미적용
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 2.3, 2.4_
+
+- [x] 4. Write preservation property tests - 갤러리 기존 레이아웃 보존 (BEFORE implementing fix)
+  - **Property 2: Preservation** - 4개 이상 갤러리 그리드 및 모달 동작 보존
+  - **IMPORTANT**: Follow observation-first methodology
+  - Test file: `src/components/checkin/__tests__/CheckInGallery.preservation.test.tsx`
+  - Observe: 아이템 4개 이상일 때 기존 grid-cols-2/3/4 반응형 레이아웃 유지
+  - Observe: 갤러리 이미지 클릭 시 CheckInDetailModal 정상 표시
+  - Observe: 정렬 옵션(최신순/인기순) 전환 정상 동작
+  - Write property-based test: 아이템 4~20개 범위에서 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 클래스가 유지됨
+  - Write property-based test: 아이템 클릭 시 selectedCheckIn 상태가 설정되고 CheckInDetailModal이 렌더링됨
+  - Verify test passes on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.3, 3.4_
+
+
+## Bug 3: RouteMap 타일 깨짐 (RouteMap.tsx)
+
+- [x] 5. Write bug condition exploration test - RouteMap 타일 정렬
+  - **Property 1: Bug Condition** - RouteMap 타일 깨짐
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists
+  - **Scoped PBT Approach**: RouteMap 마운트 시 invalidateSize가 ResizeObserver 기반이 아닌 setTimeout(300) 기반으로 호출되는지 검증
+  - Test file: `src/components/route/__tests__/RouteMap.bug.test.tsx`
+  - Bug Condition: `input.component == "RouteMap" AND input.containerSizeNotSettled == true AND invalidateSize() CALLED AT FIXED_TIMEOUT`
+  - RouteMap 컴포넌트 마운트 후 setTimeout(300) 패턴이 사용되는지 확인
+  - ResizeObserver가 사용되지 않고 있는지 확인
+  - invalidateSize()가 컨테이너 크기 확정과 무관하게 고정 타이밍에 호출되는지 확인
+  - useEffect 클린업에서 ResizeObserver disconnect가 없는지 확인
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples: invalidateSize()가 setTimeout(300) 기반으로 호출됨, ResizeObserver 미사용
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 2.5, 2.6_
+
+- [x] 6. Write preservation property tests - RouteMap 기존 동작 보존 (BEFORE implementing fix)
+  - **Property 2: Preservation** - Polyline, 마커, Popup 동작 보존
+  - **IMPORTANT**: Follow observation-first methodology
+  - Test file: `src/components/route/__tests__/RouteMap.preservation.test.tsx`
+  - Observe: Polyline 구간별 스타일(도보=실선, 대중교통=점선) 정상 렌더링
+  - Observe: 번호 마커(createNumberIcon) 정상 표시 및 스타일 유지
+  - Observe: 시작 지점 마커 정상 표시
+  - Observe: 스팟 마커 클릭 시 Popup 정상 표시
+  - Observe: 소실 스팟 회색 마커 + 취소선 스타일 유지
+  - Write property-based test: spots 배열(1~10개)에 대해 Marker가 spots.length만큼 렌더링됨
+  - Write property-based test: routeSegments가 올바른 isDashed 값을 가짐 (거리 기반)
+  - Write property-based test: 범례(legend) UI가 항상 렌더링됨
+  - Verify test passes on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.5, 3.6_
+
+
+## Bug 4: 근접 핀 이벤트 충돌 (SpotPin.tsx)
+
+- [x] 7. Write bug condition exploration test - 근접 핀 호버 안정성
+  - **Property 1: Bug Condition** - 근접 핀 이벤트 충돌
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists
+  - **Scoped PBT Approach**: z-index 간격과 debounce 타이밍이 근접 핀 간 이벤트 충돌을 방지하기에 충분한지 검증
+  - Test file: `src/components/map/__tests__/SpotPin.bug.test.tsx`
+  - Bug Condition: `input.component == "SpotPin" AND input.nearbyPinCount >= 2 AND input.mouseMoveBetweenPins == true AND debounceWindow < mouseTransitionTime`
+  - Z_INDEX 상수 확인: base=0, selected=500, hovered=1000 → 간격이 부족한지 검증
+  - debounce 타이밍 확인: mouseover=50ms, mouseout=150ms → 핀 간 전환 시 충돌 가능성 검증
+  - mouseout 핸들러가 다른 핀 위에 있는지 확인하는 로직이 없는지 검증
+  - SpotPreview에 pointer-events: none이 적용되지 않아 마우스 이벤트를 가로채는지 확인
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples: Z_INDEX.hovered=1000 (부족), mouseover debounce=50ms (너무 짧음), SpotPreview에 pointer-events: none 미적용
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 2.7, 2.8_
+
+- [x] 8. Write preservation property tests - 핀 기존 동작 보존 (BEFORE implementing fix)
+  - **Property 2: Preservation** - 개별 핀 이벤트 및 모바일 터치 보존
+  - **IMPORTANT**: Follow observation-first methodology
+  - Test file: `src/components/map/__tests__/SpotPin.preservation.test.tsx`
+  - Observe: 핀이 충분히 떨어져 있을 때 개별 호버/클릭 정상 동작
+  - Observe: 모바일 터치 시 Bottom Sheet 정상 동작 (touchCount 기반 로직)
+  - Observe: 핀 아이콘 생성(createImagePinIcon) 시 카테고리 색상/크기 정상 적용
+  - Observe: 선택된 핀의 시각적 피드백(선택 링, 글로우 효과) 정상 표시
+  - Write property-based test: 개별 핀 클릭 시 setSelectedSpot이 올바른 spotId로 호출됨
+  - Write property-based test: 터치 디바이스에서 mouseover/mouseout 이벤트가 무시됨
+  - Write property-based test: 핀 아이콘 크기가 상태별로 올바름 (base=48, hovered=54, selected=58)
+  - Verify test passes on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.7, 3.8_
+
+
+## Bug 1 Fix: MapContainer 재사용 에러 수정
+
+- [ ] 9. Fix for MapContainer 재사용 에러
+
+  - [ ] 9.1 Implement the fix - PilgrimageMap.tsx
+    - MapContainer에 동적 key prop이 사용되지 않도록 보장 (spots 등 데이터 의존 key 금지)
+    - spots 배열은 오직 자식 컴포넌트(SpotPin)로만 전달되어 마커 DOM만 업데이트되도록 유지
+    - dynamic import의 `ssr: false` 설정과 부모 컴포넌트 리렌더링 패턴 점검
+    - useEffect 내 `setTimeout(() => { map.invalidateSize() }, 100)` 제거 → ResizeObserver 기반으로 교체
+    - whenReady 콜백 내 `setTimeout(() => { mapRef.current?.invalidateSize() }, 100)` 제거 → 즉시 호출 또는 ResizeObserver 기반으로 변경
+    - ResizeObserver에 debounce(requestAnimationFrame 또는 100ms) 적용하여 무한 루프 방지
+    - useEffect 클린업에서 ResizeObserver disconnect() 호출
+    - _Bug_Condition: isBugCondition(input) where input.spotsArray HAS CHANGED AND MapContainer ATTEMPTS RE-RENDER_
+    - _Expected_Behavior: MapContainer는 언마운트되지 않고 동일 Leaflet 인스턴스 유지, SpotPin 마커만 업데이트_
+    - _Preservation: 전체 스팟 표시, 줌/드래그, GPS 위치 이동 기존 동작 유지_
+    - _Requirements: 2.1, 2.2, 3.1, 3.2, 3.9_
+
+  - [ ] 9.2 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - MapContainer 안정성
+    - **IMPORTANT**: Re-run the SAME test from task 1 - do NOT write a new test
+    - The test from task 1 encodes the expected behavior
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run bug condition exploration test from step 1
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.1, 2.2_
+
+  - [ ] 9.3 Verify preservation tests still pass
+    - **Property 2: Preservation** - 전체 스팟 표시 및 기본 인터랙션 보존
+    - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
+    - Run preservation property tests from step 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all tests still pass after fix (no regressions)
+
+## Bug 2 Fix: 갤러리 피드 레이아웃 수정
+
+- [ ] 10. Fix for 갤러리 피드 레이아웃
+
+  - [ ] 10.1 Implement the fix - CheckInGallery.tsx
+    - 아이템 수가 1~3개일 때 그리드 아이템에 `max-w-[200px]` (또는 적절한 값) 클래스 적용
+    - 아이템 수가 1~3개일 때 그리드 컨테이너에 `justify-items-start` 또는 flex 기반 레이아웃으로 전환하여 좌측 정렬
+    - 아이템 4개 이상일 때는 기존 `grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4` 유지
+    - 스켈레톤 UI(로딩 상태)에도 동일한 max-width 제한 적용하여 레이아웃 시프트 방지
+    - _Bug_Condition: isBugCondition(input) where input.checkinCount IN [1, 2, 3] AND viewportWidth > singleItemMaxWidth_
+    - _Expected_Behavior: itemWidth(result) <= MAX_WIDTH AND alignment(result) == "left"_
+    - _Preservation: 4개 이상 갤러리 grid-cols-2/3/4 유지, CheckInDetailModal 정상 표시_
+    - _Requirements: 2.3, 2.4, 3.3, 3.4_
+
+  - [ ] 10.2 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - 갤러리 아이템 크기 제한
+    - **IMPORTANT**: Re-run the SAME test from task 3 - do NOT write a new test
+    - The test from task 3 encodes the expected behavior
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run bug condition exploration test from step 3
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.3, 2.4_
+
+  - [ ] 10.3 Verify preservation tests still pass
+    - **Property 2: Preservation** - 4개 이상 갤러리 그리드 및 모달 동작 보존
+    - **IMPORTANT**: Re-run the SAME tests from task 4 - do NOT write new tests
+    - Run preservation property tests from step 4
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all tests still pass after fix (no regressions)
+
+## Bug 3 Fix: RouteMap 타일 깨짐 수정
+
+- [ ] 11. Fix for RouteMap 타일 깨짐
+
+  - [ ] 11.1 Implement the fix - RouteMap.tsx
+    - `setTimeout(() => { map.invalidateSize() ... }, 300)` 패턴 완전 제거
+    - 컨테이너 div에 ref를 연결하고 ResizeObserver로 크기 변경 감지
+    - ResizeObserver 콜백에 debounce(requestAnimationFrame 또는 100ms) 적용하여 무한 루프(ResizeLoop Error) 방지
+    - invalidateSize() 호출 후 bounds 맞추기 로직을 ResizeObserver 콜백 내에서 실행
+    - useEffect 클린업에서 ResizeObserver disconnect() 호출하여 메모리 누수 방지
+    - bounds가 변경될 때도 ResizeObserver 기반으로 타일 재정렬
+    - _Bug_Condition: isBugCondition(input) where containerSizeNotSettled == true AND invalidateSize() CALLED AT FIXED_TIMEOUT_
+    - _Expected_Behavior: tilesAligned(result) AND invalidateSizeCalledAfterResize(result)_
+    - _Preservation: Polyline, 번호 마커, 시작 지점 마커, Popup 기존 스타일/동작 유지_
+    - _Requirements: 2.5, 2.6, 3.5, 3.6_
+
+  - [ ] 11.2 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - RouteMap 타일 정렬
+    - **IMPORTANT**: Re-run the SAME test from task 5 - do NOT write a new test
+    - The test from task 5 encodes the expected behavior
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run bug condition exploration test from step 5
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.5, 2.6_
+
+  - [ ] 11.3 Verify preservation tests still pass
+    - **Property 2: Preservation** - Polyline, 마커, Popup 동작 보존
+    - **IMPORTANT**: Re-run the SAME tests from task 6 - do NOT write new tests
+    - Run preservation property tests from step 6
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all tests still pass after fix (no regressions)
+
+## Bug 4 Fix: 근접 핀 이벤트 충돌 수정
+
+- [ ] 12. Fix for 근접 핀 이벤트 충돌
+
+  - [ ] 12.1 Implement the fix - SpotPin.tsx z-index 강화 + debounce 조정
+    - Z_INDEX 상수 변경: `{ base: 0, selected: 500, hovered: 1000 }` → `{ base: 0, selected: 2000, hovered: 5000 }`
+    - mouseover debounce 타이밍 조정: 50ms → 80~100ms
+    - mouseout debounce 타이밍 조정: 150ms → 200~250ms
+    - mouseout 핸들러 개선: 다른 핀 위에 있는지 확인하는 로직 추가 (다른 SpotPin의 mouseover가 이미 트리거된 경우 closePreview 스킵)
+    - _Bug_Condition: isBugCondition(input) where nearbyPinCount >= 2 AND mouseMoveBetweenPins == true_
+    - _Expected_Behavior: previewStable(result) AND correctSpotDisplayed(result)_
+    - _Preservation: 개별 핀 호버/클릭, 모바일 터치 Bottom Sheet 기존 동작 유지_
+    - _Requirements: 2.7, 2.8, 3.7, 3.8_
+
+  - [ ] 12.2 Implement the fix - SpotPreview pointer-events: none 적용
+    - SpotPreview 컴포넌트(`src/components/map/SpotPreview.tsx`)의 루트 div에 `pointer-events: none` CSS 적용
+    - 이로 인해 미리보기 모달이 마우스 이벤트를 가로채지 않아 핀의 hover 상태가 유지됨
+    - SpotPreview 내부의 onMouseEnter/onMouseLeave 핸들러 제거 (pointer-events: none이므로 불필요)
+    - setPreviewHovered 관련 로직 정리 (더 이상 필요 없음)
+    - 미리보기는 순수 정보 표시 전용(읽기 전용)으로 유지
+    - 상세 페이지 이동 등 실제 상호작용은 핀(Marker) 자체의 클릭 이벤트에서 처리
+    - _Bug_Condition: SpotPreview가 마우스 이벤트를 가로채서 핀의 mouseout을 강제 유발_
+    - _Expected_Behavior: SpotPreview 위에 커서가 있어도 핀의 hover 상태 유지_
+    - _Requirements: 2.7, 2.8_
+
+  - [ ] 12.3 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - 근접 핀 호버 안정성
+    - **IMPORTANT**: Re-run the SAME test from task 7 - do NOT write a new test
+    - The test from task 7 encodes the expected behavior
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run bug condition exploration test from step 7
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.7, 2.8_
+
+  - [ ] 12.4 Verify preservation tests still pass
+    - **Property 2: Preservation** - 개별 핀 이벤트 및 모바일 터치 보존
+    - **IMPORTANT**: Re-run the SAME tests from task 8 - do NOT write new tests
+    - Run preservation property tests from step 8
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all tests still pass after fix (no regressions)
+
+## Final Checkpoint
+
+- [ ] 13. Checkpoint - 전체 테스트 통과 확인
+  - 모든 bug condition exploration 테스트 통과 확인 (tasks 1, 3, 5, 7)
+  - 모든 preservation 테스트 통과 확인 (tasks 2, 4, 6, 8)
+  - `npm run type-check` 통과 확인
+  - `npm run build` 통과 확인
+  - 4가지 버그 수정이 서로 독립적이며 회귀 없음을 확인
+  - 사용자에게 질문이 있으면 확인

--- a/src/components/map/__tests__/SpotPin.bug.test.tsx
+++ b/src/components/map/__tests__/SpotPin.bug.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Bug Condition Exploration Test - 근접 핀 호버 안정성
+ *
+ * Property 1: Bug Condition - 근접 핀 이벤트 충돌
+ * z-index 간격과 debounce 타이밍이 근접 핀 간 이벤트 충돌을
+ * 방지하기에 충분한지 검증합니다.
+ *
+ * Bug Condition:
+ *   input.component == "SpotPin"
+ *   AND input.nearbyPinCount >= 2
+ *   AND input.mouseMoveBetweenPins == true
+ *   AND debounceWindow < mouseTransitionTime
+ *
+ * EXPECTED OUTCOME: 수정 전 코드에서 테스트 FAIL (버그 존재 확인)
+ *
+ * Requirements: 2.7, 2.8
+ */
+
+// ============================================
+// Test Suite (소스코드 분석 기반)
+// ============================================
+
+describe('SpotPin Bug Condition Exploration - 근접 핀 호버 안정성', () => {
+  let sourceCode: string
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../SpotPin.tsx'),
+      'utf-8'
+    )
+  })
+
+  /**
+   * Property 1-1: Z_INDEX.hovered가 충분히 커야 한다 (5000 이상)
+   *
+   * 현재 Z_INDEX = { base: 0, selected: 500, hovered: 1000 }
+   * 근접 핀 간 z-index 충돌을 방지하려면 간격이 더 넓어야 한다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (hovered=1000, 부족)
+   */
+  test('Z_INDEX.hovered가 5000 이상이어야 한다', () => {
+    // Z_INDEX 상수에서 hovered 값 추출
+    const hoveredMatch = sourceCode.match(/hovered\s*:\s*(\d+)/)
+    expect(hoveredMatch).not.toBeNull()
+    const hoveredValue = parseInt(hoveredMatch![1], 10)
+    expect(hoveredValue).toBeGreaterThanOrEqual(5000)
+  })
+
+  /**
+   * Property 1-2: Z_INDEX.selected가 충분히 커야 한다 (2000 이상)
+   *
+   * 현재 selected: 500은 근접 핀 간 충돌 방지에 부족하다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (selected=500, 부족)
+   */
+  test('Z_INDEX.selected가 2000 이상이어야 한다', () => {
+    const selectedMatch = sourceCode.match(/selected\s*:\s*(\d+)/)
+    expect(selectedMatch).not.toBeNull()
+    const selectedValue = parseInt(selectedMatch![1], 10)
+    expect(selectedValue).toBeGreaterThanOrEqual(2000)
+  })
+
+  /**
+   * Property 1-3: mouseover debounce가 80ms 이상이어야 한다
+   *
+   * 현재 50ms는 핀 간 전환 시 너무 짧아 이벤트 연쇄가 발생한다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (50ms, 너무 짧음)
+   */
+  test('mouseover debounce 타이밍이 80ms 이상이어야 한다', () => {
+    // handleMouseOver 내 setTimeout 타이밍 추출
+    // 패턴: hoverTimeoutRef.current = setTimeout(() => { ... }, XX)
+    const mouseOverSection = sourceCode
+      .split('handleMouseOver')[1]
+      ?.split('handleMouseOut')[0]
+    expect(mouseOverSection).toBeDefined()
+
+    // 멀티라인 setTimeout 패턴 매칭: }, XX) 형태로 마지막 인자 추출
+    const timeoutMatch = mouseOverSection?.match(
+      /setTimeout\s*\([\s\S]*?,\s*(\d+)\s*\)/
+    )
+    expect(timeoutMatch).not.toBeNull()
+    const debounceMs = parseInt(timeoutMatch![1], 10)
+    expect(debounceMs).toBeGreaterThanOrEqual(80)
+  })
+
+  /**
+   * Property 1-4: mouseout debounce가 200ms 이상이어야 한다
+   *
+   * 현재 150ms는 핀 간 전환 시 안정성이 부족하다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (150ms, 부족)
+   */
+  test('mouseout debounce 타이밍이 200ms 이상이어야 한다', () => {
+    // handleMouseOut 함수 영역에서 setTimeout의 두 번째 인자 추출
+    const mouseOutSection = sourceCode.split('handleMouseOut')[1]
+    expect(mouseOutSection).toBeDefined()
+
+    const timeoutMatch = mouseOutSection?.match(
+      /setTimeout\s*\([^,]+,\s*(\d+)\s*\)/
+    )
+    expect(timeoutMatch).not.toBeNull()
+    const debounceMs = parseInt(timeoutMatch![1], 10)
+    expect(debounceMs).toBeGreaterThanOrEqual(200)
+  })
+
+  /**
+   * Property 1-5: SpotPreview에 pointer-events: none이 적용되어야 한다
+   *
+   * SpotPreview가 마우스 이벤트를 가로채서 핀의 mouseout을 강제 유발하는
+   * 현상을 방지하기 위해 pointer-events: none이 필요하다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (pointer-events: none 미적용)
+   */
+  test('SpotPreview에 pointer-events: none이 적용되어야 한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const previewSource = fs.readFileSync(
+      path.resolve(__dirname, '../SpotPreview.tsx'),
+      'utf-8'
+    )
+
+    const hasPointerEventsNone =
+      previewSource.includes('pointer-events: none') ||
+      previewSource.includes('pointer-events-none') ||
+      previewSource.includes("pointerEvents: 'none'") ||
+      previewSource.includes('pointerEvents: "none"')
+
+    expect(hasPointerEventsNone).toBe(true)
+  })
+})

--- a/src/components/map/__tests__/SpotPin.preservation.test.tsx
+++ b/src/components/map/__tests__/SpotPin.preservation.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Preservation Property Tests - 핀 기존 동작 보존
+ *
+ * Property 2: Preservation - 개별 핀 이벤트 및 모바일 터치 보존
+ * 수정 전/후 코드에서 모두 PASS해야 하며, 기존 동작이 변경되지 않았음을 보장합니다.
+ *
+ * EXPECTED OUTCOME: 수정 전 코드에서 테스트 PASS (기존 동작 보존 확인)
+ *
+ * Requirements: 3.7, 3.8
+ */
+
+import fc from 'fast-check'
+import { render, fireEvent } from '@testing-library/react'
+import { SpotPin as SpotPinType, SpotCategory } from '@/types'
+
+// ============================================
+// Mocks
+// ============================================
+
+const mockSetSelectedSpot = jest.fn()
+const mockOpenPreview = jest.fn()
+const mockClosePreview = jest.fn()
+const mockOpenBottomSheet = jest.fn()
+
+jest.mock('@/stores/mapStore', () => ({
+  useMapStore: () => ({
+    selectedSpotId: null,
+    setSelectedSpot: mockSetSelectedSpot,
+  }),
+}))
+
+jest.mock('@/stores/uiStore', () => ({
+  useUIStore: () => ({
+    openPreview: mockOpenPreview,
+    closePreview: mockClosePreview,
+    setPreviewHovered: jest.fn(),
+  }),
+  useIsPreviewHovered: () => false,
+}))
+
+jest.mock('@/stores/bottomSheetStore', () => ({
+  useBottomSheetStore: () => ({ open: mockOpenBottomSheet }),
+}))
+
+jest.mock('../map.css', () => ({}))
+jest.mock('leaflet/dist/leaflet.css', () => ({}))
+
+const mockLatLngToContainerPoint = jest.fn(() => ({ x: 100, y: 100 }))
+
+jest.mock('leaflet', () => ({
+  Icon: { Default: { imagePath: '' } },
+  divIcon: jest.fn(() => ({
+    iconSize: [48, 60],
+    iconAnchor: [24, 60],
+    popupAnchor: [0, -60],
+  })),
+}))
+
+let _capturedEventHandlers: Record<string, (...args: unknown[]) => void> = {}
+
+jest.mock('react-leaflet', () => ({
+  Marker: ({
+    position,
+    eventHandlers,
+    zIndexOffset,
+    children,
+  }: {
+    position: [number, number]
+    eventHandlers?: Record<string, () => void>
+    zIndexOffset?: number
+    children?: React.ReactNode
+  }) => {
+    _capturedEventHandlers = eventHandlers || {}
+    return (
+      <div
+        data-testid="spot-marker"
+        data-position={JSON.stringify(position)}
+        data-zindex={zIndexOffset}
+        onClick={eventHandlers?.click}
+        onMouseOver={eventHandlers?.mouseover}
+        onMouseOut={eventHandlers?.mouseout}
+      >
+        {children}
+      </div>
+    )
+  },
+  useMap: () => ({ latLngToContainerPoint: mockLatLngToContainerPoint }),
+}))
+
+// ============================================
+// Generators
+// ============================================
+
+const categories: SpotCategory[] = [
+  'animation',
+  'sports',
+  'movie_drama',
+  'music',
+  'game',
+  'other',
+]
+
+function createMockSpotPin(id: number, category?: SpotCategory): SpotPinType {
+  return {
+    id: `spot-${id}`,
+    name: `스팟 ${id}`,
+    coordinates: [35.6762 + id * 0.01, 139.6503 + id * 0.01],
+    thumbnailUrl: `https://example.com/thumb-${id}.jpg`,
+    category: category || categories[id % categories.length],
+    checkInCount: id * 3,
+  }
+}
+
+const categoryArbitrary = fc.constantFrom(...categories)
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const SpotPin = require('../SpotPin').default
+
+// ============================================
+// Test Suite
+// ============================================
+
+afterEach(() => {
+  jest.clearAllMocks()
+  _capturedEventHandlers = {}
+})
+
+describe('SpotPin Preservation - 핀 기존 동작 보존', () => {
+  /**
+   * Property 2-1: 개별 핀 클릭 시 setSelectedSpot이 올바른 spotId로 호출됨
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('핀 클릭 시 setSelectedSpot이 올바른 spotId로 호출된다', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 20 }),
+        categoryArbitrary,
+        (id, category) => {
+          const spot = createMockSpotPin(id, category)
+          const mockOnSelect = jest.fn()
+          const { container, unmount } = render(
+            <SpotPin spot={spot} onSelect={mockOnSelect} />
+          )
+
+          const marker = container.querySelector('[data-testid="spot-marker"]')
+          expect(marker).not.toBeNull()
+          fireEvent.click(marker!)
+
+          expect(mockSetSelectedSpot).toHaveBeenCalledWith(`spot-${id}`)
+          unmount()
+          jest.clearAllMocks()
+        }
+      ),
+      { numRuns: 15 }
+    )
+  })
+
+  /**
+   * Property 2-2: 핀 아이콘 크기가 상태별로 올바름 (base=48, hovered=54, selected=58)
+   *
+   * 소스코드에서 PIN_SIZES 상수가 올바른 값을 가지는지 검증한다.
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('핀 아이콘 크기 상수가 올바르다 (base=48, hovered=54, selected=58)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../SpotPin.tsx'),
+      'utf-8'
+    )
+
+    // PIN_SIZES 상수 확인
+    const baseMatch = sourceCode.match(/base\s*:\s*48/)
+    const hoveredMatch = sourceCode.match(/hovered\s*:\s*54/)
+    const selectedMatch = sourceCode.match(/selected\s*:\s*58/)
+
+    expect(baseMatch).not.toBeNull()
+    expect(hoveredMatch).not.toBeNull()
+    expect(selectedMatch).not.toBeNull()
+  })
+
+  /**
+   * Property 2-3: 마커가 올바른 좌표에 렌더링됨
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('마커가 올바른 좌표에 렌더링된다', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 20 }), (id) => {
+        const spot = createMockSpotPin(id)
+        const { container, unmount } = render(<SpotPin spot={spot} />)
+
+        const marker = container.querySelector('[data-testid="spot-marker"]')
+        expect(marker).not.toBeNull()
+        const position = JSON.parse(
+          marker!.getAttribute('data-position') || '[]'
+        )
+        expect(position).toEqual(spot.coordinates)
+
+        unmount()
+      }),
+      { numRuns: 15 }
+    )
+  })
+
+  /**
+   * Property 2-4: 터치 디바이스에서 mouseover/mouseout 이벤트가 무시됨
+   *
+   * 소스코드에서 isTouchDevice 체크가 mouseover/mouseout 핸들러에 있는지 확인
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('터치 디바이스 감지 로직이 mouseover/mouseout 핸들러에 존재한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../SpotPin.tsx'),
+      'utf-8'
+    )
+
+    // handleMouseOver에서 isTouchDevice 체크
+    const mouseOverSection = sourceCode
+      .split('handleMouseOver')[1]
+      ?.split('handleMouseOut')[0]
+    expect(mouseOverSection).toContain('isTouchDevice')
+
+    // handleMouseOut에서 isTouchDevice 체크
+    const mouseOutSection = sourceCode
+      .split('handleMouseOut')[1]
+      ?.split('return')[0]
+    expect(mouseOutSection).toContain('isTouchDevice')
+  })
+
+  /**
+   * Property 2-5: 기본 z-index offset이 0이다 (비선택, 비호버 상태)
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('기본 상태에서 z-index offset이 0이다', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 10 }), (id) => {
+        const spot = createMockSpotPin(id)
+        const { container, unmount } = render(<SpotPin spot={spot} />)
+
+        const marker = container.querySelector('[data-testid="spot-marker"]')
+        expect(marker).not.toBeNull()
+        const zIndex = marker!.getAttribute('data-zindex')
+        expect(zIndex).toBe('0')
+
+        unmount()
+      }),
+      { numRuns: 10 }
+    )
+  })
+
+  /**
+   * Property 2-6: onSelect 콜백이 소스코드에서 click 핸들러 내에 존재함
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('onSelect 콜백이 click 핸들러에서 호출되는 코드가 존재한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../SpotPin.tsx'),
+      'utf-8'
+    )
+
+    // handleClick 함수 내에서 onSelect 호출이 존재하는지 확인
+    const handleClickSection = sourceCode
+      .split('handleClick')[1]
+      ?.split('handleMouseOver')[0]
+    expect(handleClickSection).toBeDefined()
+    expect(handleClickSection).toMatch(/onSelect\?\.\(spot\.id\)/)
+  })
+})

--- a/src/components/route/__tests__/RouteMap.bug.test.tsx
+++ b/src/components/route/__tests__/RouteMap.bug.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Bug Condition Exploration Test - RouteMap 타일 정렬
+ *
+ * Property 1: Bug Condition - RouteMap 타일 깨짐
+ * RouteMap 마운트 시 invalidateSize가 ResizeObserver 기반이 아닌
+ * setTimeout(300) 기반으로 호출되는지 검증합니다.
+ *
+ * Bug Condition:
+ *   input.component == "RouteMap"
+ *   AND input.containerSizeNotSettled == true
+ *   AND invalidateSize() CALLED AT FIXED_TIMEOUT
+ *
+ * EXPECTED OUTCOME: 수정 전 코드에서 테스트 FAIL (버그 존재 확인)
+ *
+ * Requirements: 2.5, 2.6
+ */
+
+import fc from 'fast-check'
+import type { RouteSpot } from '@/types/route'
+
+// ============================================
+// Mocks
+// ============================================
+
+jest.mock('leaflet', () => ({
+  Icon: { Default: { imagePath: '' } },
+  divIcon: jest.fn(() => ({
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+    popupAnchor: [0, -16],
+  })),
+  DivIcon: jest
+    .fn()
+    .mockImplementation(() => ({
+      iconSize: [28, 28],
+      iconAnchor: [14, 14],
+      popupAnchor: [0, -16],
+    })),
+  LatLngBounds: jest
+    .fn()
+    .mockImplementation(() => ({ extend: jest.fn().mockReturnThis() })),
+}))
+
+jest.mock('react-leaflet', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react')
+  return {
+    MapContainer: React.forwardRef(function MockMapContainer(
+      {
+        children,
+        ...props
+      }: { children: React.ReactNode; [key: string]: unknown },
+      ref: React.Ref<unknown>
+    ) {
+      const mapInstance = React.useMemo(
+        () => ({
+          invalidateSize: jest.fn(),
+          setView: jest.fn(),
+          fitBounds: jest.fn(),
+          on: jest.fn(),
+          off: jest.fn(),
+        }),
+        []
+      )
+      React.useEffect(() => {
+        if (typeof ref === 'function') ref(mapInstance)
+        else if (ref && typeof ref === 'object')
+          (ref as React.MutableRefObject<unknown>).current = mapInstance
+      }, [ref, mapInstance])
+      return (
+        <div data-testid="map-container" {...props}>
+          {children}
+        </div>
+      )
+    }),
+    TileLayer: () => <div data-testid="tile-layer" />,
+    Marker: ({
+      children,
+      position,
+    }: {
+      children?: React.ReactNode
+      position: [number, number]
+    }) => (
+      <div data-testid="marker" data-position={JSON.stringify(position)}>
+        {children}
+      </div>
+    ),
+    Popup: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="popup">{children}</div>
+    ),
+    Polyline: ({ positions }: { positions: [number, number][] }) => (
+      <div data-testid="polyline" data-positions={JSON.stringify(positions)} />
+    ),
+  }
+})
+
+jest.mock('../map.css', () => ({}))
+jest.mock('leaflet/dist/leaflet.css', () => ({}))
+jest.mock('@/lib/geo-utils', () => ({
+  calculateDistance: jest.fn(() => 500),
+}))
+jest.mock('@/lib/route-utils', () => ({
+  getTravelMode: jest.fn(() => 'walking'),
+  calculateDistance: jest.fn(() => 500),
+}))
+
+// ============================================
+// Generators
+// ============================================
+
+function createMockRouteSpot(idx: number): RouteSpot {
+  return {
+    spotId: `spot-${idx}`,
+    spotName: `스팟 ${idx}`,
+    coordinates: { lat: 35.6762 + idx * 0.01, lng: 139.6503 + idx * 0.01 },
+    thumbnailUrl: `https://example.com/thumb-${idx}.jpg`,
+    distanceFromPrev: idx === 0 ? null : 500,
+    walkTimeFromPrev: idx === 0 ? null : 7,
+    isAvailable: true,
+  }
+}
+
+const spotCountArbitrary = fc.integer({ min: 2, max: 10 })
+
+// ============================================
+// Test Suite
+// ============================================
+
+describe('RouteMap Bug Condition Exploration - 타일 정렬', () => {
+  /**
+   * Property 1-1: 소스코드에 setTimeout 기반 invalidateSize 패턴이 존재하지 않아야 한다
+   *
+   * RouteMap 소스코드에서 setTimeout(...invalidateSize..., 300) 패턴이
+   * 존재하면 버그 조건이 충족됨을 의미한다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (setTimeout 패턴 존재)
+   */
+  test('소스코드에 setTimeout 기반 invalidateSize 패턴이 없어야 한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../RouteMap.tsx'),
+      'utf-8'
+    )
+
+    // setTimeout과 invalidateSize가 함께 사용되는 패턴 감지
+    const hasSetTimeoutInvalidateSize =
+      /setTimeout\s*\(\s*\(\)\s*=>\s*\{[^}]*invalidateSize/.test(sourceCode)
+
+    // 수정 후에는 setTimeout + invalidateSize 패턴이 없어야 함
+    expect(hasSetTimeoutInvalidateSize).toBe(false)
+  })
+
+  /**
+   * Property 1-2: 소스코드에 ResizeObserver가 사용되어야 한다
+   *
+   * RouteMap에서 컨테이너 크기 변경을 감지하기 위해
+   * ResizeObserver를 사용해야 한다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (ResizeObserver 미사용)
+   */
+  test('소스코드에 ResizeObserver가 사용되어야 한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../RouteMap.tsx'),
+      'utf-8'
+    )
+
+    const hasResizeObserver = /ResizeObserver/.test(sourceCode)
+    expect(hasResizeObserver).toBe(true)
+  })
+
+  /**
+   * Property 1-3: useEffect 클린업에서 ResizeObserver disconnect가 호출되어야 한다
+   *
+   * 메모리 누수 방지를 위해 useEffect 클린업에서
+   * ResizeObserver.disconnect()가 호출되어야 한다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL (disconnect 미호출)
+   */
+  test('useEffect 클린업에서 ResizeObserver disconnect가 호출되어야 한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../RouteMap.tsx'),
+      'utf-8'
+    )
+
+    const hasDisconnect = /disconnect\s*\(\s*\)/.test(sourceCode)
+    expect(hasDisconnect).toBe(true)
+  })
+
+  /**
+   * Property 1-4: 다양한 스팟 수에서 setTimeout(300) 패턴이 없어야 한다
+   *
+   * PBT로 다양한 스팟 배열에 대해 소스코드 레벨에서
+   * 고정 타이밍 패턴이 없음을 검증한다.
+   *
+   * EXPECTED: 수정 전 코드에서 FAIL
+   */
+  test('다양한 스팟 수에서 고정 타이밍(300ms) invalidateSize 패턴이 없어야 한다', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path')
+    const sourceCode = fs.readFileSync(
+      path.resolve(__dirname, '../RouteMap.tsx'),
+      'utf-8'
+    )
+
+    fc.assert(
+      fc.property(spotCountArbitrary, () => {
+        // 300ms 고정 타이밍 패턴이 없어야 함
+        const hasFixedTimeout = /setTimeout\s*\([^)]*,\s*300\s*\)/.test(
+          sourceCode
+        )
+        expect(hasFixedTimeout).toBe(false)
+      }),
+      { numRuns: 10 }
+    )
+  })
+})

--- a/src/components/route/__tests__/RouteMap.bug.test.tsx
+++ b/src/components/route/__tests__/RouteMap.bug.test.tsx
@@ -20,7 +20,6 @@
  */
 
 import fc from 'fast-check'
-import type { RouteSpot } from '@/types/route'
 
 // ============================================
 // Mocks
@@ -33,13 +32,11 @@ jest.mock('leaflet', () => ({
     iconAnchor: [14, 14],
     popupAnchor: [0, -16],
   })),
-  DivIcon: jest
-    .fn()
-    .mockImplementation(() => ({
-      iconSize: [28, 28],
-      iconAnchor: [14, 14],
-      popupAnchor: [0, -16],
-    })),
+  DivIcon: jest.fn().mockImplementation(() => ({
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+    popupAnchor: [0, -16],
+  })),
   LatLngBounds: jest
     .fn()
     .mockImplementation(() => ({ extend: jest.fn().mockReturnThis() })),
@@ -111,18 +108,6 @@ jest.mock('@/lib/route-utils', () => ({
 // ============================================
 // Generators
 // ============================================
-
-function createMockRouteSpot(idx: number): RouteSpot {
-  return {
-    spotId: `spot-${idx}`,
-    spotName: `스팟 ${idx}`,
-    coordinates: { lat: 35.6762 + idx * 0.01, lng: 139.6503 + idx * 0.01 },
-    thumbnailUrl: `https://example.com/thumb-${idx}.jpg`,
-    distanceFromPrev: idx === 0 ? null : 500,
-    walkTimeFromPrev: idx === 0 ? null : 7,
-    isAvailable: true,
-  }
-}
 
 const spotCountArbitrary = fc.integer({ min: 2, max: 10 })
 

--- a/src/components/route/__tests__/RouteMap.preservation.test.tsx
+++ b/src/components/route/__tests__/RouteMap.preservation.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Preservation Property Tests - RouteMap 기존 동작 보존
+ *
+ * Property 2: Preservation - Polyline, 마커, Popup 동작 보존
+ * 수정 전/후 코드에서 모두 PASS해야 하며, 기존 동작이 변경되지 않았음을 보장합니다.
+ *
+ * EXPECTED OUTCOME: 수정 전 코드에서 테스트 PASS (기존 동작 보존 확인)
+ *
+ * Requirements: 3.5, 3.6
+ */
+
+import fc from 'fast-check'
+import { render } from '@testing-library/react'
+import type { RouteSpot } from '@/types/route'
+
+// ============================================
+// Mocks
+// ============================================
+
+jest.mock('leaflet', () => ({
+  Icon: { Default: { imagePath: '' } },
+  divIcon: jest.fn(() => ({
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+    popupAnchor: [0, -16],
+  })),
+  DivIcon: jest.fn().mockImplementation(() => ({
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+    popupAnchor: [0, -16],
+  })),
+  LatLngBounds: jest
+    .fn()
+    .mockImplementation(() => ({ extend: jest.fn().mockReturnThis() })),
+}))
+
+jest.mock('react-leaflet', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react')
+  return {
+    MapContainer: React.forwardRef(function MockMapContainer(
+      {
+        children,
+        ...props
+      }: { children: React.ReactNode; [key: string]: unknown },
+      ref: React.Ref<unknown>
+    ) {
+      const mapInstance = React.useMemo(
+        () => ({
+          invalidateSize: jest.fn(),
+          setView: jest.fn(),
+          fitBounds: jest.fn(),
+          on: jest.fn(),
+          off: jest.fn(),
+        }),
+        []
+      )
+      React.useEffect(() => {
+        if (typeof ref === 'function') ref(mapInstance)
+        else if (ref && typeof ref === 'object')
+          (ref as React.MutableRefObject<unknown>).current = mapInstance
+      }, [ref, mapInstance])
+      return (
+        <div data-testid="map-container" {...props}>
+          {children}
+        </div>
+      )
+    }),
+    TileLayer: () => <div data-testid="tile-layer" />,
+    Marker: ({
+      children,
+      position,
+      icon,
+    }: {
+      children?: React.ReactNode
+      position: [number, number]
+      icon?: unknown
+    }) => (
+      <div
+        data-testid="marker"
+        data-position={JSON.stringify(position)}
+        data-icon={JSON.stringify(icon)}
+      >
+        {children}
+      </div>
+    ),
+    Popup: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="popup">{children}</div>
+    ),
+    Polyline: ({
+      positions,
+      pathOptions,
+    }: {
+      positions: unknown
+      pathOptions?: unknown
+    }) => (
+      <div
+        data-testid="polyline"
+        data-positions={JSON.stringify(positions)}
+        data-options={JSON.stringify(pathOptions)}
+      />
+    ),
+  }
+})
+
+jest.mock('../map.css', () => ({}))
+jest.mock('leaflet/dist/leaflet.css', () => ({}))
+jest.mock('@/lib/geo-utils', () => ({ calculateDistance: jest.fn(() => 500) }))
+jest.mock('@/lib/route-utils', () => ({
+  getTravelMode: jest.fn((d: number) => (d <= 3000 ? 'walking' : 'transit')),
+  calculateDistance: jest.fn(() => 500),
+}))
+
+// ============================================
+// Generators
+// ============================================
+
+function createMockRouteSpot(idx: number, isAvailable = true): RouteSpot {
+  return {
+    spotId: `spot-${idx}`,
+    spotName: `스팟 ${idx}`,
+    coordinates: { lat: 35.6762 + idx * 0.01, lng: 139.6503 + idx * 0.01 },
+    thumbnailUrl: `https://example.com/thumb-${idx}.jpg`,
+    distanceFromPrev: idx === 0 ? null : 500,
+    walkTimeFromPrev: idx === 0 ? null : 7,
+    isAvailable,
+  }
+}
+
+const spotCountArbitrary = fc.integer({ min: 1, max: 10 })
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const RouteMap = require('../RouteMap').default
+
+// ============================================
+// Test Suite
+// ============================================
+
+describe('RouteMap Preservation - 기존 동작 보존', () => {
+  /**
+   * Property 2-1: spots 배열에 대해 Marker가 spots.length만큼 렌더링됨
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('spots 배열에 대해 marker가 spots.length만큼 렌더링된다', () => {
+    fc.assert(
+      fc.property(spotCountArbitrary, (count) => {
+        const spots = Array.from({ length: count }, (_, i) =>
+          createMockRouteSpot(i)
+        )
+        const { container, unmount } = render(<RouteMap spots={spots} />)
+        const markers = container.querySelectorAll('[data-testid="marker"]')
+        expect(markers.length).toBe(count)
+        unmount()
+      }),
+      { numRuns: 20 }
+    )
+  })
+
+  /**
+   * Property 2-2: routeSegments가 올바른 isDashed 값을 가짐
+   * 도보 거리(<=3km)는 실선, 그 외는 점선
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('polyline 구간이 스팟 수 - 1만큼 렌더링된다', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 2, max: 10 }), (count) => {
+        const spots = Array.from({ length: count }, (_, i) =>
+          createMockRouteSpot(i)
+        )
+        const { container, unmount } = render(<RouteMap spots={spots} />)
+        const polylines = container.querySelectorAll('[data-testid="polyline"]')
+        // 최소 count-1개의 polyline (유효 스팟 간 연결)
+        expect(polylines.length).toBeGreaterThanOrEqual(count - 1)
+        unmount()
+      }),
+      { numRuns: 20 }
+    )
+  })
+
+  /**
+   * Property 2-3: 각 스팟 마커에 Popup이 포함됨
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('각 스팟 마커에 popup이 포함된다', () => {
+    fc.assert(
+      fc.property(spotCountArbitrary, (count) => {
+        const spots = Array.from({ length: count }, (_, i) =>
+          createMockRouteSpot(i)
+        )
+        const { container, unmount } = render(<RouteMap spots={spots} />)
+        const popups = container.querySelectorAll('[data-testid="popup"]')
+        expect(popups.length).toBe(count)
+        unmount()
+      }),
+      { numRuns: 20 }
+    )
+  })
+
+  /**
+   * Property 2-4: 범례(legend) UI가 항상 렌더링됨
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('범례 UI가 항상 렌더링된다', () => {
+    fc.assert(
+      fc.property(spotCountArbitrary, (count) => {
+        const spots = Array.from({ length: count }, (_, i) =>
+          createMockRouteSpot(i)
+        )
+        const { container, unmount } = render(<RouteMap spots={spots} />)
+        // 범례에 "스팟" 텍스트가 있어야 함
+        const legendText = container.textContent
+        expect(legendText).toContain('스팟')
+        expect(legendText).toContain('소실됨')
+        unmount()
+      }),
+      { numRuns: 10 }
+    )
+  })
+
+  /**
+   * Property 2-5: 시작 지점이 있을 때 시작 마커와 범례가 렌더링됨
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('시작 지점이 있을 때 시작 마커와 범례가 렌더링된다', () => {
+    const spots = Array.from({ length: 3 }, (_, i) => createMockRouteSpot(i))
+    const startPoint = {
+      name: '신주쿠역',
+      address: '도쿄 신주쿠',
+      coordinates: { lat: 35.6896, lng: 139.7006 },
+    }
+    const { container } = render(
+      <RouteMap spots={spots} startPoint={startPoint} />
+    )
+    // 시작 지점 마커 포함하여 총 4개 마커
+    const markers = container.querySelectorAll('[data-testid="marker"]')
+    expect(markers.length).toBe(4)
+    // 범례에 "시작" 텍스트
+    expect(container.textContent).toContain('시작')
+  })
+
+  /**
+   * Property 2-6: 소실 스팟이 있을 때 회색 마커 + 취소선 스타일 유지
+   * EXPECTED: 수정 전/후 모두 PASS
+   */
+  test('소실 스팟이 있을 때 popup에 소실 표시가 포함된다', () => {
+    const spots = [
+      createMockRouteSpot(0),
+      createMockRouteSpot(1, false), // 소실 스팟
+      createMockRouteSpot(2),
+    ]
+    const { container } = render(<RouteMap spots={spots} />)
+    // 소실 스팟 popup에 "소실된 스팟" 텍스트
+    expect(container.textContent).toContain('소실된 스팟')
+    // 취소선 클래스 확인
+    const lineThrough = container.querySelector('.line-through')
+    expect(lineThrough).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## [Test] Task 5~8 - RouteMap/SpotPin bug condition 및 preservation 테스트 추가

### 📋 관련 이슈
Closes #383

### 📝 변경 사항
- RouteMap bug condition 탐색 테스트 추가 (4개 테스트)
- RouteMap preservation 속성 테스트 추가 (6개 테스트)
- SpotPin bug condition 탐색 테스트 추가 (5개 테스트)
- SpotPin preservation 속성 테스트 추가 (6개 테스트)

### 🧪 테스트 결과
- Bug condition 테스트: 수정 전 코드에서 FAIL (버그 존재 확인)
- Preservation 테스트: 수정 전 코드에서 PASS (기존 동작 보존 확인)

### 📌 Requirements
- 2.5, 2.6, 2.7, 2.8, 3.5, 3.6, 3.7, 3.8
