### PR TITLE
[Fix] MapContainer 재사용 에러 수정

### DIFF
--- a/.kiro/specs/18-map-ui-bugfix/tasks.md
+++ b/.kiro/specs/18-map-ui-bugfix/tasks.md
@@ -151,9 +151,9 @@
 
 ## Bug 1 Fix: MapContainer 재사용 에러 수정
 
-- [ ] 9. Fix for MapContainer 재사용 에러
+- [x] 9. Fix for MapContainer 재사용 에러
 
-  - [ ] 9.1 Implement the fix - PilgrimageMap.tsx
+  - [x] 9.1 Implement the fix - PilgrimageMap.tsx
     - MapContainer에 동적 key prop이 사용되지 않도록 보장 (spots 등 데이터 의존 key 금지)
     - spots 배열은 오직 자식 컴포넌트(SpotPin)로만 전달되어 마커 DOM만 업데이트되도록 유지
     - dynamic import의 `ssr: false` 설정과 부모 컴포넌트 리렌더링 패턴 점검
@@ -166,7 +166,7 @@
     - _Preservation: 전체 스팟 표시, 줌/드래그, GPS 위치 이동 기존 동작 유지_
     - _Requirements: 2.1, 2.2, 3.1, 3.2, 3.9_
 
-  - [ ] 9.2 Verify bug condition exploration test now passes
+  - [x] 9.2 Verify bug condition exploration test now passes
     - **Property 1: Expected Behavior** - MapContainer 안정성
     - **IMPORTANT**: Re-run the SAME test from task 1 - do NOT write a new test
     - The test from task 1 encodes the expected behavior
@@ -175,7 +175,7 @@
     - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
     - _Requirements: 2.1, 2.2_
 
-  - [ ] 9.3 Verify preservation tests still pass
+  - [x] 9.3 Verify preservation tests still pass
     - **Property 2: Preservation** - 전체 스팟 표시 및 기본 인터랙션 보존
     - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
     - Run preservation property tests from step 2

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,12 @@
 // Jest setup file for global test configuration
 import '@testing-library/jest-dom'
+
+// jsdom에 ResizeObserver가 없으므로 글로벌 mock 추가
+global.ResizeObserver = class ResizeObserver {
+  constructor(callback) {
+    this._callback = callback
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -31,6 +31,7 @@ export default function PilgrimageMap({
   onSpotSelect,
 }: PilgrimageMapProps) {
   const mapRef = useRef<LeafletMap | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
   const { center, zoom, setCenter, setZoom } = useMapStore(
     useShallow((state) => ({
       center: state.center,
@@ -72,16 +73,32 @@ export default function PilgrimageMap({
     setGpsError(null)
   }, [])
 
+  // ResizeObserver 기반 invalidateSize - setTimeout 대신 컨테이너 크기 변경 감지
+  useEffect(() => {
+    const map = mapRef.current
+    const container = containerRef.current
+    if (!map || !container) return
+
+    let rafId: number | null = null
+    const observer = new ResizeObserver(() => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        map.invalidateSize()
+      })
+    })
+    observer.observe(container)
+
+    return () => {
+      observer.disconnect()
+      if (rafId !== null) cancelAnimationFrame(rafId)
+    }
+  }, [])
+
+  // Update store when map view changes
   useEffect(() => {
     const map = mapRef.current
     if (!map) return
 
-    // 지도 크기 재계산 (중요!)
-    setTimeout(() => {
-      map.invalidateSize()
-    }, 100)
-
-    // Update store when map view changes
     const handleMoveEnd = () => {
       const newCenter = map.getCenter()
       setCenter([newCenter.lat, newCenter.lng])
@@ -101,7 +118,7 @@ export default function PilgrimageMap({
   }, [setCenter, setZoom])
 
   return (
-    <div className={`relative h-full w-full ${className}`}>
+    <div ref={containerRef} className={`relative h-full w-full ${className}`}>
       <MapContainer
         center={mapCenter}
         zoom={mapZoom}
@@ -122,10 +139,8 @@ export default function PilgrimageMap({
         ]}
         maxBoundsViscosity={1.0} // 경계 밖으로 드래그 완전 방지
         whenReady={() => {
-          // 지도가 준비되면 크기 재계산
-          setTimeout(() => {
-            mapRef.current?.invalidateSize()
-          }, 100)
+          // 지도가 준비되면 즉시 크기 재계산 (ResizeObserver가 이후 변경 감지)
+          mapRef.current?.invalidateSize()
         }}
       >
         <TileLayer


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #385

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [x] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

PilgrimageMap의 setTimeout 기반 invalidateSize를 ResizeObserver 기반으로 교체하여 MapContainer 재사용 에러 해결

---

## 📋 변경 사항

- [x] useEffect 내 `setTimeout(() => map.invalidateSize(), 100)` 제거 → ResizeObserver 기반으로 교체
- [x] whenReady 콜백 내 setTimeout 제거 → 즉시 호출로 변경
- [x] containerRef 추가 및 ResizeObserver + requestAnimationFrame debounce 적용
- [x] useEffect 클린업에서 observer.disconnect() 및 cancelAnimationFrame 호출
- [x] jest.setup.js에 ResizeObserver 글로벌 mock 추가

---

## ✅ 체크리스트

- [x] bug condition 테스트 4개 통과
- [x] preservation 테스트 6개 통과 (회귀 없음)
- [x] `npm run lint` 통과
- [x] 주요 기능 동작 확인

---
<img width="877" height="440" alt="image" src="https://github.com/user-attachments/assets/a11ec4e5-868c-4e48-a665-9e015ad6d635" />

## 📝 추가 정보 (선택)

- Requirements: 2.1, 2.2, 3.1, 3.2, 3.9
- Task 9 (9.1, 9.2, 9.3) 완료
