### PR TITLE
[UI] 글로벌 레이아웃 시맨틱 토큰 마이그레이션

### DIFF
--- a/.kiro/specs/20-mascot-design-system/tasks.md
+++ b/.kiro/specs/20-mascot-design-system/tasks.md
@@ -61,8 +61,8 @@
 - [ ] 3. Checkpoint — 토큰 시스템 기반 검증
   - 모든 테스트 통과 확인, 빌드 정상 여부 확인, 사용자에게 질문 사항 확인
 
-- [ ] 4. 다크 모드 팔레트 대응
-  - [ ] 4.1 globals.css 다크 모드 변수 재정의
+- [x] 4. 다크 모드 팔레트 대응
+  - [x] 4.1 globals.css 다크 모드 변수 재정의
     - `@media (prefers-color-scheme: dark)` 블록에서 모든 시맨틱 컬러 변수 재정의
     - 다크 모드 배경: 어두운 Primary 계열 (기존 `#0a0a0a` 교체)
     - 다크 모드 텍스트: 밝은 Neutral 계열 (기존 `#ededed` 교체)
@@ -81,8 +81,8 @@
     - 다크 모드 카테고리 bg/fg 쌍의 대비 비율이 WCAG AA 기준(4.5:1) 이상인지 검증
     - **Validates: Requirements 9.5**
 
-- [ ] 5. 글로벌 스타일 및 레이아웃 컴포넌트 마이그레이션
-  - [ ] 5.1 globals.css 글로벌 스타일 마이그레이션
+- [x] 5. 글로벌 스타일 및 레이아웃 컴포넌트 마이그레이션
+  - [x] 5.1 globals.css 글로벌 스타일 마이그레이션
     - `body` 스타일: `var(--foreground)` → 시맨틱 토큰 참조로 교체
     - 스크롤바 트랙: `var(--navy-100)` → 시맨틱 surface 컬러
     - 스크롤바 썸: `var(--navy-400)` → 시맨틱 muted 컬러
@@ -90,7 +90,7 @@
     - 로딩 shimmer 그라데이션: `var(--navy-200/100)` → Neutral 컬러
     - _Requirements: 11.1, 11.2, 11.3, 11.4_
 
-  - [ ] 5.2 Header 컴포넌트 마이그레이션
+  - [x] 5.2 Header 컴포넌트 마이그레이션
     - 배경색: `slate-900` 계열 → `bg-surface` 시맨틱 클래스
     - 텍스트: `slate-300/white` → `text-text-secondary` / `text-text-primary`
     - 호버 상태: Secondary 컬러 적용
@@ -99,14 +99,14 @@
     - 좌측 로고 영역에 마스코트 얼굴 아이콘 배치 (에셋 미존재 시 폴백 처리)
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
 
-  - [ ] 5.3 BottomSheet/모바일 네비게이션 마이그레이션
+  - [x] 5.3 BottomSheet/모바일 네비게이션 마이그레이션
     - 배경색: `surface` 시맨틱 컬러 적용
     - 활성 아이콘: Primary 컬러
     - 비활성 아이콘: muted 컬러
     - 상단 보더: border 시맨틱 컬러
     - _Requirements: 10.1, 10.2, 10.3, 10.4_
 
-- [ ] 6. Checkpoint — 레이아웃 마이그레이션 검증
+- [x] 6. Checkpoint — 레이아웃 마이그레이션 검증
   - 모든 테스트 통과 확인, 사용자에게 질문 사항 확인
 
 - [ ] 7. 버튼/폼/카드 컴포넌트 마이그레이션
@@ -149,11 +149,39 @@
     - `:root`에서 CSS 변수 값 변경 시 해당 변수를 참조하는 Tailwind 유틸리티 클래스의 computed style이 변경된 값을 반영하는지 검증 (JSDOM 환경)
     - **Validates: Requirements 1.4, 2.6**
 
-- [ ] 9. Checkpoint — 컬러 마이그레이션 완료 검증
+- [ ] 9. 베이스 컬러 팔레트 확정 및 조정
+  - [ ] 9.1 사용자와 함께 기본 컬러 방향 확정
+    - 현재 적용된 보라 계열 Primary가 어색한 문제 해결
+    - 마스코트 캐릭터 레퍼런스 이미지 기반으로 Primary/Secondary/Neutral 기본색 후보 선정
+    - 사용자에게 후보 팔레트 제시 및 피드백 수렴
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 9.2 확정된 컬러로 globals.css 팔레트 값 교체
+    - `:root` Primary 50~900 RGB 값 교체
+    - `:root` Secondary 50~900 RGB 값 교체
+    - `:root` Neutral 50~900 RGB 값 교체
+    - 시맨틱 역할 토큰 값 재조정 (background, surface, text 등)
+    - 카테고리/콘텐츠/링크 타입 컬러 값 재조정
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
+
+  - [ ] 9.3 다크 모드 팔레트 값 재조정
+    - `@media (prefers-color-scheme: dark)` 블록의 모든 변수 값을 새 팔레트에 맞게 재조정
+    - WCAG AA 대비 기준 충족 확인
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5_
+
+  - [ ] 9.4 map.css 하드코딩 hex 값 새 팔레트에 맞게 교체
+    - Leaflet 줌 컨트롤, 팝업, 툴팁 등의 hex 값을 새 Primary 계열로 교체
+    - _Requirements: 2.1_
+
+  - [ ] 9.5 Checkpoint — 베이스 컬러 조정 검증
+    - 전체 UI 시각적 확인 (사용자 피드백)
+    - `npm run type-check` 및 `npm run build` 정상 확인
+
+- [ ] 10. Checkpoint — 컬러 마이그레이션 완료 검증
   - 모든 테스트 통과 확인, 빌드 정상 여부 확인, 사용자에게 질문 사항 확인
 
-- [ ] 10. Lottie 로딩 컴포넌트 구현
-  - [ ] 10.1 @lottiefiles/dotlottie-react 패키지 설치 및 LottieLoader 컴포넌트 생성
+- [ ] 11. Lottie 로딩 컴포넌트 구현
+  - [ ] 11.1 @lottiefiles/dotlottie-react 패키지 설치 및 LottieLoader 컴포넌트 생성
     - `npm install @lottiefiles/dotlottie-react`
     - `src/components/common/LottieLoader.tsx` 생성
     - `next/dynamic`으로 동적 임포트 (SSR 비활성화)
@@ -161,8 +189,8 @@
     - Lottie 에러 시 GIF 폴백 → CSS 스피너 최종 폴백 체인 구현
     - _Requirements: 13.3_
 
-- [ ] 11. 마스코트 에셋 기반 상태 화면 및 지도 마커 개편
-  - [ ] 11.1 상태 화면 컴포넌트 마스코트 일러스트 적용
+- [ ] 12. 마스코트 에셋 기반 상태 화면 및 지도 마커 개편
+  - [ ] 12.1 상태 화면 컴포넌트 마스코트 일러스트 적용
     - `EmptySearchOverlay`: 마스코트 일러스트 + 폴백 (기존 SearchIcon)
     - `EmptyFilterOverlay`: 마스코트 일러스트 + 폴백 (기존 FilterIcon)
     - `SpotErrorDisplay`: 마스코트 일러스트 + `accent-surface` 배경 + 폴백 (기존 AlertTriangleIcon)
@@ -171,21 +199,21 @@
     - `public/mascot/` 디렉토리 생성 및 플레이스홀더 에셋 경로 설정 (실제 에셋은 추후 추가)
     - _Requirements: 13.1, 13.2, 13.3, 13.4_
 
-  - [ ] 11.2 SpotPin 지도 마커 마스코트 테마 적용
+  - [ ] 12.2 SpotPin 지도 마커 마스코트 테마 적용
     - 마스코트 테마 커스텀 마커 에셋 적용 (에셋 미존재 시 기존 SVG divIcon 폴백)
     - 카테고리별 마커 색상을 토큰(`--category-*-bg/fg`) 참조로 변경
     - _Requirements: 12.1, 12.2, 12.4_
 
-  - [ ] 11.3 CurrentLocationMarker 마스코트 에셋 적용
+  - [ ] 12.3 CurrentLocationMarker 마스코트 에셋 적용
     - 마스코트 얼굴/SD 캐릭터 에셋 적용 (에셋 미존재 시 기존 파란 점 + 펄스 폴백)
     - _Requirements: 12.3_
 
-  - [ ]* 11.4 Property 8 속성 테스트 — 카테고리별 마커 색상 분화
+  - [ ]* 12.4 Property 8 속성 테스트 — 카테고리별 마커 색상 분화
     - **Property 8: 카테고리별 마커 색상 분화**
     - 각 SpotCategory의 SpotPin 마커가 해당 카테고리의 토큰 색상을 사용하고, 서로 다른 카테고리의 마커가 시각적으로 구분 가능한지 검증
     - **Validates: Requirements 12.2**
 
-- [ ] 12. 최종 Checkpoint — 전체 통합 검증
+- [ ] 13. 최종 Checkpoint — 전체 통합 검증
   - 모든 속성 테스트 및 단위 테스트 통과 확인
   - `npm run type-check` 및 `npm run build` 정상 확인
   - 사용자에게 질문 사항 확인

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,89 +3,89 @@
 @tailwind utilities;
 
 :root {
-  /* === Primary (Crystal Blue 계열) === */
-  --color-primary-50: 230 240 255;
-  --color-primary-100: 199 222 252;
-  --color-primary-200: 163 200 248;
-  --color-primary-300: 122 174 240;
-  --color-primary-400: 86 148 230;
-  --color-primary-500: 58 117 196;
-  --color-primary-600: 45 95 165;
-  --color-primary-700: 34 73 130;
-  --color-primary-800: 24 52 96;
-  --color-primary-900: 15 32 62;
+  /* === Primary (Indigo — 마스코트 눈 색상 기반) === */
+  --color-primary-50: 238 237 252;
+  --color-primary-100: 218 214 248;
+  --color-primary-200: 189 183 242;
+  --color-primary-300: 155 146 232;
+  --color-primary-400: 124 112 218;
+  --color-primary-500: 95 82 200;
+  --color-primary-600: 76 64 168;
+  --color-primary-700: 60 50 138;
+  --color-primary-800: 44 36 108;
+  --color-primary-900: 30 24 72;
 
-  /* === Secondary (Lavender Bloom 계열) === */
-  --color-secondary-50: 245 240 255;
-  --color-secondary-100: 232 222 252;
-  --color-secondary-200: 213 196 248;
-  --color-secondary-300: 190 166 240;
-  --color-secondary-400: 168 139 230;
-  --color-secondary-500: 142 110 204;
-  --color-secondary-600: 118 88 175;
-  --color-secondary-700: 93 68 142;
-  --color-secondary-800: 68 48 108;
-  --color-secondary-900: 44 30 72;
+  /* === Secondary (Lavender — 마스코트 꽃 장식 기반) === */
+  --color-secondary-50: 248 244 255;
+  --color-secondary-100: 238 232 252;
+  --color-secondary-200: 222 212 248;
+  --color-secondary-300: 200 186 240;
+  --color-secondary-400: 178 160 228;
+  --color-secondary-500: 155 134 212;
+  --color-secondary-600: 130 108 184;
+  --color-secondary-700: 104 84 152;
+  --color-secondary-800: 78 60 118;
+  --color-secondary-900: 52 38 82;
 
-  /* === Neutral (Ghost Ivory / Soft Blush 계열) === */
-  --color-neutral-50: 255 253 247;
-  --color-neutral-100: 252 249 242;
-  --color-neutral-200: 247 242 235;
-  --color-neutral-300: 224 218 214;
-  --color-neutral-400: 180 172 168;
-  --color-neutral-500: 140 132 128;
-  --color-neutral-600: 108 100 96;
-  --color-neutral-700: 78 72 68;
-  --color-neutral-800: 52 48 44;
-  --color-neutral-900: 28 26 24;
+  /* === Neutral (Cream / Ivory — 마스코트 머리카락/피부 톤 기반) === */
+  --color-neutral-50: 255 255 255;
+  --color-neutral-100: 250 248 245;
+  --color-neutral-200: 243 240 236;
+  --color-neutral-300: 228 224 218;
+  --color-neutral-400: 186 180 172;
+  --color-neutral-500: 148 142 134;
+  --color-neutral-600: 112 106 100;
+  --color-neutral-700: 82 78 72;
+  --color-neutral-800: 54 50 46;
+  --color-neutral-900: 32 30 28;
 
   /* === 시맨틱 역할 토큰 (직접 RGB 값 저장 — 중첩 var() 회피) === */
-  --color-background: 255 253 247;
-  --color-surface: 252 249 242;
-  --color-accent-surface: 247 242 235;
-  --color-text: 15 32 62;
-  --color-text-secondary: 34 73 130;
-  --color-muted: 180 172 168;
-  --color-border: 224 218 214;
+  --color-background: 255 255 255;
+  --color-surface: 250 248 245;
+  --color-accent-surface: 243 240 252;
+  --color-text: 30 24 72;
+  --color-text-secondary: 82 78 72;
+  --color-muted: 186 180 172;
+  --color-border: 228 224 218;
   --color-danger: 220 38 38;
   --color-danger-surface: 254 242 242;
 
   /* === 카테고리 컬러 (bg/fg 쌍) === */
-  --category-anime-bg: 232 222 252;
-  --category-anime-fg: 93 68 142;
-  --category-sports-bg: 199 236 232;
-  --category-sports-fg: 22 110 100;
-  --category-movie-drama-bg: 199 222 252;
-  --category-movie-drama-fg: 34 73 130;
-  --category-music-bg: 209 238 220;
-  --category-music-fg: 34 108 62;
-  --category-game-bg: 245 218 240;
-  --category-game-fg: 128 48 112;
-  --category-other-bg: 230 228 226;
-  --category-other-fg: 78 72 68;
+  --category-anime-bg: 238 232 252;
+  --category-anime-fg: 76 64 168;
+  --category-sports-bg: 209 240 228;
+  --category-sports-fg: 20 108 88;
+  --category-movie-drama-bg: 218 228 248;
+  --category-movie-drama-fg: 42 68 128;
+  --category-music-bg: 218 242 228;
+  --category-music-fg: 28 100 58;
+  --category-game-bg: 248 228 242;
+  --category-game-fg: 138 42 108;
+  --category-other-bg: 236 234 232;
+  --category-other-fg: 82 78 72;
 
   /* === 콘텐츠 타입 컬러 (bg/fg 쌍) === */
-  --content-anime-bg: 232 222 252;
-  --content-anime-fg: 93 68 142;
-  --content-movie-bg: 199 222 252;
-  --content-movie-fg: 34 73 130;
-  --content-drama-bg: 238 218 248;
-  --content-drama-fg: 108 48 138;
-  --content-sports-team-bg: 199 236 232;
-  --content-sports-team-fg: 22 110 100;
-  --content-artist-bg: 209 238 220;
-  --content-artist-fg: 34 108 62;
-  --content-game-bg: 245 218 240;
-  --content-game-fg: 128 48 112;
-  --content-other-bg: 230 228 226;
-  --content-other-fg: 78 72 68;
+  --content-anime-bg: 238 232 252;
+  --content-anime-fg: 76 64 168;
+  --content-movie-bg: 218 228 248;
+  --content-movie-fg: 42 68 128;
+  --content-drama-bg: 242 228 250;
+  --content-drama-fg: 108 42 138;
+  --content-sports-team-bg: 209 240 228;
+  --content-sports-team-fg: 20 108 88;
+  --content-artist-bg: 218 242 228;
+  --content-artist-fg: 28 100 58;
+  --content-game-bg: 248 228 242;
+  --content-game-fg: 138 42 108;
+  --content-other-bg: 236 234 232;
+  --content-other-fg: 82 78 72;
 
   /* === 링크 타입 컬러 === */
-  --link-official: 58 117 196;
+  --link-official: 95 82 200;
   --link-ticket: 16 185 129;
   --link-schedule: 245 158 11;
-  --link-sns: 142 110 204;
-  --link-other: 140 132 128;
+  --link-sns: 155 134 212;
+  --link-other: 148 142 134;
 
   /* === Border Radius 토큰 === */
   --radius-sm: 0.5rem;
@@ -95,89 +95,89 @@
 }
 
 .dark {
-  /* === Primary (Crystal Blue 계열 — 다크 모드 채도/밝기 조정) === */
-  --color-primary-50: 10 18 32;
-  --color-primary-100: 15 28 52;
-  --color-primary-200: 22 42 78;
-  --color-primary-300: 30 58 108;
-  --color-primary-400: 42 82 148;
-  --color-primary-500: 86 148 230;
-  --color-primary-600: 122 174 240;
-  --color-primary-700: 163 200 248;
-  --color-primary-800: 199 222 252;
-  --color-primary-900: 230 240 255;
+  /* === Primary (Indigo — 다크 모드 밝기 반전) === */
+  --color-primary-50: 14 12 28;
+  --color-primary-100: 22 18 48;
+  --color-primary-200: 34 28 72;
+  --color-primary-300: 48 40 100;
+  --color-primary-400: 68 58 138;
+  --color-primary-500: 124 112 218;
+  --color-primary-600: 155 146 232;
+  --color-primary-700: 189 183 242;
+  --color-primary-800: 218 214 248;
+  --color-primary-900: 238 237 252;
 
-  /* === Secondary (Lavender Bloom 계열 — 다크 모드 채도/밝기 조정) === */
+  /* === Secondary (Lavender — 다크 모드 밝기 반전) === */
   --color-secondary-50: 18 14 28;
   --color-secondary-100: 30 22 48;
-  --color-secondary-200: 44 32 72;
-  --color-secondary-300: 62 44 98;
-  --color-secondary-400: 82 60 128;
-  --color-secondary-500: 142 110 204;
-  --color-secondary-600: 168 139 230;
-  --color-secondary-700: 190 166 240;
-  --color-secondary-800: 213 196 248;
-  --color-secondary-900: 245 240 255;
+  --color-secondary-200: 46 34 72;
+  --color-secondary-300: 64 48 100;
+  --color-secondary-400: 88 68 138;
+  --color-secondary-500: 155 134 212;
+  --color-secondary-600: 178 160 228;
+  --color-secondary-700: 200 186 240;
+  --color-secondary-800: 222 212 248;
+  --color-secondary-900: 248 244 255;
 
   /* === Neutral (다크 모드 — 밝기 반전) === */
-  --color-neutral-50: 18 16 14;
-  --color-neutral-100: 28 26 24;
-  --color-neutral-200: 42 40 38;
-  --color-neutral-300: 58 54 52;
-  --color-neutral-400: 108 100 96;
-  --color-neutral-500: 140 132 128;
-  --color-neutral-600: 180 172 168;
-  --color-neutral-700: 210 206 202;
-  --color-neutral-800: 235 232 228;
-  --color-neutral-900: 252 249 242;
+  --color-neutral-50: 20 18 16;
+  --color-neutral-100: 30 28 26;
+  --color-neutral-200: 44 42 40;
+  --color-neutral-300: 62 58 54;
+  --color-neutral-400: 112 106 100;
+  --color-neutral-500: 148 142 134;
+  --color-neutral-600: 186 180 172;
+  --color-neutral-700: 214 210 204;
+  --color-neutral-800: 236 234 230;
+  --color-neutral-900: 250 248 245;
 
   /* === 시맨틱 역할 토큰 (다크 모드) === */
-  --color-background: 18 22 36;
-  --color-surface: 26 32 50;
-  --color-accent-surface: 34 40 60;
-  --color-text: 240 238 235;
-  --color-text-secondary: 199 222 252;
-  --color-muted: 108 100 96;
-  --color-border: 52 48 44;
+  --color-background: 20 18 28;
+  --color-surface: 28 26 38;
+  --color-accent-surface: 38 34 52;
+  --color-text: 242 240 238;
+  --color-text-secondary: 200 196 190;
+  --color-muted: 112 106 100;
+  --color-border: 54 50 46;
   --color-danger: 248 113 113;
   --color-danger-surface: 60 20 20;
 
   /* === 카테고리 컬러 (다크 모드 — WCAG AA 대비 충족) === */
-  --category-anime-bg: 58 42 82;
-  --category-anime-fg: 213 196 248;
-  --category-sports-bg: 18 62 56;
-  --category-sports-fg: 160 228 218;
-  --category-movie-drama-bg: 24 52 96;
-  --category-movie-drama-fg: 163 200 248;
-  --category-music-bg: 22 68 42;
-  --category-music-fg: 170 228 190;
-  --category-game-bg: 72 28 62;
-  --category-game-fg: 238 180 228;
-  --category-other-bg: 48 44 42;
-  --category-other-fg: 200 196 192;
+  --category-anime-bg: 48 40 72;
+  --category-anime-fg: 218 214 248;
+  --category-sports-bg: 16 58 48;
+  --category-sports-fg: 168 232 212;
+  --category-movie-drama-bg: 28 42 78;
+  --category-movie-drama-fg: 178 198 238;
+  --category-music-bg: 18 62 38;
+  --category-music-fg: 172 232 192;
+  --category-game-bg: 68 28 58;
+  --category-game-fg: 238 186 228;
+  --category-other-bg: 48 46 44;
+  --category-other-fg: 204 200 196;
 
   /* === 콘텐츠 타입 컬러 (다크 모드) === */
-  --content-anime-bg: 58 42 82;
-  --content-anime-fg: 213 196 248;
-  --content-movie-bg: 24 52 96;
-  --content-movie-fg: 163 200 248;
-  --content-drama-bg: 62 32 78;
-  --content-drama-fg: 222 180 242;
-  --content-sports-team-bg: 18 62 56;
-  --content-sports-team-fg: 160 228 218;
-  --content-artist-bg: 22 68 42;
-  --content-artist-fg: 170 228 190;
-  --content-game-bg: 72 28 62;
-  --content-game-fg: 238 180 228;
-  --content-other-bg: 48 44 42;
-  --content-other-fg: 200 196 192;
+  --content-anime-bg: 48 40 72;
+  --content-anime-fg: 218 214 248;
+  --content-movie-bg: 28 42 78;
+  --content-movie-fg: 178 198 238;
+  --content-drama-bg: 58 32 72;
+  --content-drama-fg: 228 186 242;
+  --content-sports-team-bg: 16 58 48;
+  --content-sports-team-fg: 168 232 212;
+  --content-artist-bg: 18 62 38;
+  --content-artist-fg: 172 232 192;
+  --content-game-bg: 68 28 58;
+  --content-game-fg: 238 186 228;
+  --content-other-bg: 48 46 44;
+  --content-other-fg: 204 200 196;
 
   /* === 링크 타입 컬러 (다크 모드 — 밝기 상향) === */
-  --link-official: 122 174 240;
+  --link-official: 155 146 232;
   --link-ticket: 52 211 153;
   --link-schedule: 252 211 77;
-  --link-sns: 190 166 240;
-  --link-other: 180 172 168;
+  --link-sns: 200 186 240;
+  --link-other: 186 180 172;
 }
 
 body {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { useAuth } from '@/hooks/useAuth'
 import { ThemeToggle } from '@/components/common/ThemeToggle'
 
@@ -10,36 +11,47 @@ export function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   return (
-    <header className="fixed left-0 right-0 top-0 z-50 border-b border-slate-700 bg-slate-900/95 pt-safe-top backdrop-blur-sm">
+    <header className="fixed left-0 right-0 top-0 z-50 border-b border-border bg-surface/95 pt-safe-top backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
         {/* 로고 */}
         <Link href="/" className="flex items-center gap-2">
-          <span className="text-xl font-bold text-white">✈️ Not a Trip</span>
+          <Image
+            src="/mascot/logo-face.webp"
+            alt="마스코트"
+            width={28}
+            height={28}
+            onError={(e) => {
+              e.currentTarget.style.display = 'none'
+            }}
+          />
+          <span className="text-xl font-bold text-text-primary">
+            ✈️ Not a Trip
+          </span>
         </Link>
 
         {/* 데스크톱 네비게이션 */}
         <nav className="hidden items-center gap-6 md:flex">
           <Link
             href="/"
-            className="text-sm text-slate-300 transition hover:text-white"
+            className="text-sm text-text-secondary transition hover:text-secondary-400"
           >
             홈
           </Link>
           <Link
             href="/gallery"
-            className="text-sm text-slate-300 transition hover:text-white"
+            className="text-sm text-text-secondary transition hover:text-secondary-400"
           >
             순례 갤러리
           </Link>
           <Link
             href="/routes"
-            className="text-sm text-slate-300 transition hover:text-white"
+            className="text-sm text-text-secondary transition hover:text-secondary-400"
           >
             순례 코스
           </Link>
           <Link
             href="/spots/register"
-            className="text-sm text-slate-300 transition hover:text-white"
+            className="text-sm text-text-secondary transition hover:text-secondary-400"
           >
             스팟 등록
           </Link>
@@ -62,12 +74,12 @@ export function Header() {
         {/* 인증 영역 + 모바일 메뉴 버튼 */}
         <div className="flex items-center gap-3">
           {isLoading ? (
-            <div className="h-8 w-20 animate-pulse rounded bg-slate-700" />
+            <div className="h-8 w-20 animate-pulse rounded bg-muted/30" />
           ) : isAuthenticated && user ? (
             <div className="flex items-center gap-3">
               <Link
                 href="/settings/account"
-                className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-slate-700"
+                className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-secondary-100"
               >
                 {user.image ? (
                   <img
@@ -77,17 +89,17 @@ export function Header() {
                     referrerPolicy="no-referrer"
                   />
                 ) : (
-                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-blue-600 text-xs font-bold text-white">
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-xs font-bold text-white">
                     {(user.name || user.email || '?').charAt(0).toUpperCase()}
                   </div>
                 )}
-                <span className="hidden text-sm text-slate-300 sm:block">
+                <span className="hidden text-sm text-text-secondary sm:block">
                   {user.name || user.email}
                 </span>
               </Link>
               <button
                 onClick={() => logout()}
-                className="rounded-lg bg-slate-700 px-3 py-1.5 text-sm text-white transition hover:bg-slate-600"
+                className="rounded-lg bg-neutral-300 px-3 py-1.5 text-sm text-white transition hover:bg-neutral-400"
               >
                 로그아웃
               </button>
@@ -95,7 +107,7 @@ export function Header() {
           ) : (
             <Link
               href="/auth/signin"
-              className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm text-white transition hover:bg-blue-700"
+              className="rounded-lg bg-primary px-3 py-1.5 text-sm text-white transition hover:bg-primary-600"
             >
               로그인
             </Link>
@@ -107,7 +119,7 @@ export function Header() {
           {/* 모바일 햄버거 버튼 */}
           <button
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-300 transition hover:bg-slate-700 hover:text-white md:hidden"
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary md:hidden"
             aria-label="메뉴 열기"
           >
             {isMobileMenuOpen ? (
@@ -145,40 +157,40 @@ export function Header() {
 
       {/* 모바일 드롭다운 메뉴 */}
       {isMobileMenuOpen && (
-        <nav className="border-t border-slate-700 bg-slate-900/95 backdrop-blur-sm md:hidden">
+        <nav className="border-t border-border bg-surface/95 backdrop-blur-sm md:hidden">
           <div className="space-y-1 px-4 py-3">
             <Link
               href="/"
               onClick={() => setIsMobileMenuOpen(false)}
-              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+              className="block rounded-lg px-3 py-2 text-sm text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary"
             >
               홈
             </Link>
             <Link
               href="/gallery"
               onClick={() => setIsMobileMenuOpen(false)}
-              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+              className="block rounded-lg px-3 py-2 text-sm text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary"
             >
               순례 갤러리
             </Link>
             <Link
               href="/routes"
               onClick={() => setIsMobileMenuOpen(false)}
-              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+              className="block rounded-lg px-3 py-2 text-sm text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary"
             >
               순례 코스
             </Link>
             <Link
               href="/spots/register"
               onClick={() => setIsMobileMenuOpen(false)}
-              className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+              className="block rounded-lg px-3 py-2 text-sm text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary"
             >
               스팟 등록
             </Link>
             <Link
               href="/test/error-boundary"
               onClick={() => setIsMobileMenuOpen(false)}
-              className="block rounded-lg px-3 py-2 text-sm text-yellow-400 transition hover:bg-slate-800 hover:text-yellow-300"
+              className="block rounded-lg px-3 py-2 text-sm text-yellow-400 transition hover:bg-secondary-100 hover:text-yellow-300"
             >
               🧪 테스트
             </Link>
@@ -186,7 +198,7 @@ export function Header() {
               <Link
                 href="/admin"
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="block rounded-lg px-3 py-2 text-sm text-orange-400 transition hover:bg-slate-800 hover:text-orange-300"
+                className="block rounded-lg px-3 py-2 text-sm text-orange-400 transition hover:bg-secondary-100 hover:text-orange-300"
               >
                 ⚙️ 관리자
               </Link>
@@ -195,7 +207,7 @@ export function Header() {
               <Link
                 href="/settings/account"
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="block rounded-lg px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white"
+                className="block rounded-lg px-3 py-2 text-sm text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary"
               >
                 👤 계정 설정
               </Link>

--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -1,9 +1,9 @@
-/* Leaflet map styling with navy theme */
+/* Leaflet map styling with primary theme */
 /* 주의: Leaflet 기본 CSS가 CDN에서 로드된 후 적용됨 */
 
 /* 지도 컨테이너 기본 스타일 */
 .leaflet-container {
-  background: #d9e0ed; /* navy-100 */
+  background: #eeedfc; /* primary-50 */
   font-family: inherit;
   z-index: 0 !important;
 }
@@ -46,21 +46,21 @@
   filter: brightness(0.97) contrast(1.02);
 }
 
-/* 줌 컨트롤 스타일 - navy 테마 */
+/* 줌 컨트롤 스타일 - primary 테마 */
 .leaflet-control-zoom a {
-  background-color: #345084 !important; /* navy-600 */
-  border-color: #4164a5 !important; /* navy-500 */
+  background-color: #4c40a8 !important; /* primary-600 */
+  border-color: #5f52c8 !important; /* primary-500 */
   color: white !important;
 }
 
 .leaflet-control-zoom a:hover {
-  background-color: #273c63 !important; /* navy-700 */
+  background-color: #3c328a !important; /* primary-700 */
 }
 
 /* 팝업 스타일 */
 .leaflet-popup-content-wrapper {
   background: white;
-  border: 1px solid #b3c1db; /* navy-200 */
+  border: 1px solid #bdb7f2; /* primary-200 */
   border-radius: 0.5rem;
   box-shadow:
     0 10px 15px -3px rgba(0, 0, 0, 0.1),
@@ -73,13 +73,13 @@
 
 /* Attribution 스타일 */
 .leaflet-control-attribution {
-  background: rgba(26, 40, 66, 0.8) !important; /* navy-800/80 */
+  background: rgba(30, 24, 72, 0.8) !important; /* primary-900/80 */
   color: white !important;
   font-size: 0.75rem !important;
 }
 
 .leaflet-control-attribution a {
-  color: #b3c1db !important; /* navy-200 */
+  color: #bdb7f2 !important; /* primary-200 */
 }
 
 /* SpotPin 커스텀 마커 스타일 */
@@ -153,7 +153,7 @@
 /* 스팟 팝업 스타일 */
 .spot-popup .leaflet-popup-content-wrapper {
   background: white !important;
-  border: 2px solid #8da2c9 !important; /* navy-300 */
+  border: 2px solid #5f52c8 !important; /* primary-500 */
   border-radius: 0.75rem !important;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
   max-width: 350px !important;
@@ -228,8 +228,8 @@
 
 /* Leaflet Tooltip 기본 스타일 오버라이드 */
 .leaflet-tooltip.hover-tooltip {
-  background: #1a2842; /* navy-800 */
-  border: 1px solid #345084; /* navy-600 */
+  background: #1e1848; /* primary-900 */
+  border: 1px solid #4c40a8; /* primary-600 */
   border-radius: 8px;
   padding: 0;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -261,7 +261,7 @@
   transform: translateX(-50%);
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid #1a2842; /* navy-800 */
+  border-top: 8px solid #1e1848; /* primary-900 */
 }
 
 /* 화살표 테두리 효과 */
@@ -273,7 +273,7 @@
   transform: translateX(-50%);
   border-left: 9px solid transparent;
   border-right: 9px solid transparent;
-  border-top: 9px solid #345084; /* navy-600 */
+  border-top: 9px solid #4c40a8; /* primary-600 */
   z-index: -1;
 }
 
@@ -294,7 +294,7 @@
   height: 44px;
   border-radius: 6px;
   overflow: hidden;
-  background: #273c63; /* navy-700 */
+  background: #3c328a; /* primary-700 */
 }
 
 /* 썸네일 이미지 */
@@ -349,7 +349,7 @@
 
 .hover-tooltip-category-label {
   font-size: 11px;
-  color: #b3c1db; /* navy-200 */
+  color: #bdb7f2; /* primary-200 */
 }
 
 /* 반응형 조정 */

--- a/src/components/mobile/BottomSheet.tsx
+++ b/src/components/mobile/BottomSheet.tsx
@@ -49,7 +49,7 @@ export default function BottomSheet() {
   return (
     <div
       ref={sheetRef}
-      className="fixed inset-x-0 bottom-0 z-[1000] rounded-t-2xl bg-white pb-safe-bottom pl-safe-left pr-safe-right shadow-2xl"
+      className="fixed inset-x-0 bottom-0 z-[1000] rounded-t-2xl bg-surface pb-safe-bottom pl-safe-left pr-safe-right shadow-2xl"
       style={{
         height: `${Math.max(0, displayHeight)}px`,
         transition: isDragging ? 'none' : 'height 0.3s ease-out',
@@ -62,7 +62,7 @@ export default function BottomSheet() {
         data-drag-handle
         className="flex cursor-grab items-center justify-center py-3 active:cursor-grabbing"
       >
-        <div className="h-1.5 w-10 rounded-full bg-gray-300" />
+        <div className="h-1.5 w-10 rounded-full bg-muted" />
       </div>
 
       {/* 콘텐츠 영역 */}
@@ -73,7 +73,7 @@ export default function BottomSheet() {
         {/* 로딩 상태 */}
         {isLoading && (
           <div className="flex h-20 items-center justify-center">
-            <div className="border-navy-200 border-t-navy-600 h-6 w-6 animate-spin rounded-full border-2" />
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted border-t-primary" />
           </div>
         )}
 
@@ -81,7 +81,7 @@ export default function BottomSheet() {
         {error && (
           <div className="flex h-20 flex-col items-center justify-center">
             <span className="text-2xl">😢</span>
-            <p className="text-navy-600 mt-1 text-sm">
+            <p className="mt-1 text-sm text-text-secondary">
               정보를 불러올 수 없습니다
             </p>
           </div>
@@ -103,7 +103,7 @@ export default function BottomSheet() {
                     sizes="56px"
                   />
                 ) : (
-                  <div className="bg-navy-100 flex h-full w-full items-center justify-center">
+                  <div className="flex h-full w-full items-center justify-center bg-accent-surface">
                     <span className="text-xl">🗾</span>
                   </div>
                 )}
@@ -111,10 +111,10 @@ export default function BottomSheet() {
 
               {/* 이름 + 주소 */}
               <div className="min-w-0 flex-1">
-                <h3 className="text-navy-800 truncate text-base font-bold">
+                <h3 className="truncate text-base font-bold text-text-primary">
                   {spot.name}
                 </h3>
-                <p className="text-navy-500 truncate text-sm">{spot.address}</p>
+                <p className="truncate text-sm text-muted">{spot.address}</p>
               </div>
             </div>
 
@@ -135,14 +135,14 @@ export default function BottomSheet() {
                 )}
 
                 {/* 설명 */}
-                <p className="text-navy-700 mb-4 text-sm leading-relaxed">
+                <p className="mb-4 text-sm leading-relaxed text-text-secondary">
                   {spot.description}
                 </p>
 
                 {/* 상세보기 버튼 */}
                 <button
                   onClick={handleDetailClick}
-                  className="bg-navy-600 hover:bg-navy-700 flex w-full items-center justify-center gap-1.5 rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors"
+                  className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-600"
                 >
                   <span>자세히 보기</span>
                   <svg
@@ -164,8 +164,8 @@ export default function BottomSheet() {
 
             {/* full: 주소 상세 */}
             {heightState === 'full' && (
-              <div className="bg-navy-50 mt-4 rounded-lg p-3">
-                <div className="text-navy-600 flex items-start gap-2 text-sm">
+              <div className="mt-4 rounded-lg bg-accent-surface p-3">
+                <div className="flex items-start gap-2 text-sm text-text-secondary">
                   <svg
                     className="mt-0.5 h-4 w-4 flex-shrink-0"
                     fill="none"

--- a/src/components/mobile/GpsErrorFallback.tsx
+++ b/src/components/mobile/GpsErrorFallback.tsx
@@ -63,11 +63,13 @@ export default function GpsErrorFallback({
           {config.icon}
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-navy-800 text-sm font-medium">{error.message}</p>
-          <p className="text-navy-500 mt-1 text-xs">{config.hint}</p>
+          <p className="text-sm font-medium text-primary-800">
+            {error.message}
+          </p>
+          <p className="mt-1 text-xs text-primary-500">{config.hint}</p>
 
           {/* 수동 탐색 안내 */}
-          <p className="text-navy-400 mt-2 text-xs">
+          <p className="mt-2 text-xs text-muted">
             지도를 직접 드래그하여 원하는 위치를 탐색할 수 있습니다.
           </p>
         </div>
@@ -75,7 +77,7 @@ export default function GpsErrorFallback({
         {/* 닫기 버튼 */}
         <button
           onClick={onDismiss}
-          className="text-navy-400 hover:bg-navy-100 hover:text-navy-600 flex-shrink-0 rounded-full p-1 transition-colors"
+          className="flex-shrink-0 rounded-full p-1 text-muted transition-colors hover:bg-primary-100 hover:text-primary-600"
           aria-label="닫기"
         >
           <svg

--- a/src/components/route/NavigationPanel.tsx
+++ b/src/components/route/NavigationPanel.tsx
@@ -107,9 +107,9 @@ export function NavigationPanel({
   }, [currentPosition, currentSpot.coordinates, distanceToNext])
 
   return (
-    <div className="border-navy-200 fixed inset-x-0 bottom-0 z-40 border-t bg-white pb-safe-bottom shadow-[0_-4px_20px_rgba(0,0,0,0.1)]">
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface pb-safe-bottom shadow-[0_-4px_20px_rgba(0,0,0,0.1)]">
       {/* 진행률 바 */}
-      <div className="bg-navy-100 h-1.5 w-full">
+      <div className="h-1.5 w-full bg-neutral-200">
         <div
           className="h-full bg-green-500 transition-all duration-500"
           style={{ width: `${Math.min(progress, 100)}%` }}
@@ -118,7 +118,7 @@ export function NavigationPanel({
 
       <div className="mx-auto max-w-4xl px-4 py-3">
         {/* 진행 상태 요약 */}
-        <div className="text-navy-400 mb-2 flex items-center justify-between text-xs">
+        <div className="mb-2 flex items-center justify-between text-xs text-muted">
           <span>
             {checkedCount}/{availableSpots.length}곳 인증 완료
           </span>
@@ -146,14 +146,14 @@ export function NavigationPanel({
               className={`truncate text-sm font-semibold ${
                 isCurrentUnavailable
                   ? 'text-gray-400 line-through'
-                  : 'text-navy-900'
+                  : 'text-text-primary'
               }`}
             >
               {isCurrentUnavailable ? '소실된 스팟' : currentSpot.spotName}
             </p>
             {/* 거리/시간 표시 */}
             {!isCurrentUnavailable && distanceToNext !== null && (
-              <p className="text-navy-400 text-xs">
+              <p className="text-xs text-muted">
                 {getTravelModeIcon(getTravelMode(distanceToNext))}{' '}
                 {formatDistance(distanceToNext)}
                 {estimatedTimeToNext !== null &&
@@ -210,14 +210,14 @@ export function NavigationPanel({
               {nextAvailableIndex !== null && (
                 <button
                   onClick={onMoveToNext}
-                  className="bg-navy-600 hover:bg-navy-700 flex-1 rounded-lg py-3 text-sm font-semibold text-white transition-colors"
+                  className="flex-1 rounded-lg bg-primary py-3 text-sm font-semibold text-white transition-colors hover:bg-primary-600"
                 >
                   ⏭️ 다음 스팟으로 건너뛰기
                 </button>
               )}
               <button
                 onClick={onEndRoute}
-                className="border-navy-200 text-navy-600 hover:bg-navy-50 rounded-lg border-2 bg-white px-4 py-3 text-sm transition-colors"
+                className="rounded-lg border-2 border-border bg-white px-4 py-3 text-sm text-text-secondary transition-colors hover:bg-accent-surface"
               >
                 종료
               </button>
@@ -227,14 +227,14 @@ export function NavigationPanel({
               {nextAvailableIndex !== null && (
                 <button
                   onClick={onMoveToNext}
-                  className="bg-navy-600 hover:bg-navy-700 flex-1 rounded-lg py-3 text-sm font-semibold text-white transition-colors"
+                  className="flex-1 rounded-lg bg-primary py-3 text-sm font-semibold text-white transition-colors hover:bg-primary-600"
                 >
                   ➡️ 다음 스팟으로
                 </button>
               )}
               <button
                 onClick={onEndRoute}
-                className="border-navy-200 text-navy-600 hover:bg-navy-50 rounded-lg border-2 bg-white px-4 py-3 text-sm transition-colors"
+                className="rounded-lg border-2 border-border bg-white px-4 py-3 text-sm text-text-secondary transition-colors hover:bg-accent-surface"
               >
                 종료
               </button>
@@ -249,7 +249,7 @@ export function NavigationPanel({
               </button>
               <button
                 onClick={onEndRoute}
-                className="border-navy-200 text-navy-600 hover:bg-navy-50 rounded-lg border-2 bg-white px-4 py-3 text-sm transition-colors"
+                className="rounded-lg border-2 border-border bg-white px-4 py-3 text-sm text-text-secondary transition-colors hover:bg-accent-surface"
               >
                 종료
               </button>


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #405

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> Header, BottomSheet, NavigationPanel 등 글로벌 레이아웃 컴포넌트의 레거시 컬러(navy/slate/blue)를 시맨틱 디자인 토큰으로 마이그레이션하고, 마스코트 기반 컬러 팔레트를 적용

---

## 📋 변경 사항

- [x] Header 컴포넌트: slate-900/slate-300/blue-600 → surface/text-secondary/primary 시맨틱 토큰 교체
- [x] BottomSheet 컴포넌트: 시맨틱 토큰 마이그레이션
- [x] NavigationPanel 컴포넌트: 시맨틱 토큰 마이그레이션
- [x] map.css: navy 하드코딩 hex → primary 계열 hex 교체
- [x] globals.css: 마스코트 캐릭터 기반 컬러 팔레트 값 조정 (Crystal Blue → 보라 계열)
- [x] GpsErrorFallback: UTF-8 인코딩 깨짐 복구 + navy → 시맨틱 토큰 교체

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 인코딩 깨진 파일 80+ 복구 완료
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- 이전 일괄 수정 과정에서 80개 이상 파일의 UTF-8 인코딩이 손상되어 develop에서 복원 처리함
- Requirements 4.1~4.6, 10.1~10.4, 11.1~11.4 대응
