### PR TITLE
[Style] Task 7 - 버튼/폼/카드 컴포넌트 시맨틱 컬러 마이그레이션

### DIFF
--- a/.kiro/specs/20-mascot-design-system/tasks.md
+++ b/.kiro/specs/20-mascot-design-system/tasks.md
@@ -109,8 +109,8 @@
 - [x] 6. Checkpoint — 레이아웃 마이그레이션 검증
   - 모든 테스트 통과 확인, 사용자에게 질문 사항 확인
 
-- [ ] 7. 버튼/폼/카드 컴포넌트 마이그레이션
-  - [ ] 7.1 버튼 시스템 마이그레이션
+- [x] 7. 버튼/폼/카드 컴포넌트 마이그레이션
+  - [x] 7.1 버튼 시스템 마이그레이션
     - Primary 버튼: `navy-600` → `bg-primary`, 호버 시 어두운 shade
     - Secondary 버튼: Secondary 컬러 적용
     - Destructive 버튼: `danger` 시맨틱 컬러
@@ -118,14 +118,14 @@
     - 포커스 링: `navy-500` → Primary 컬러
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6_
 
-  - [ ] 7.2 폼/입력 필드 마이그레이션
+  - [x] 7.2 폼/입력 필드 마이그레이션
     - 보더: `navy-200` → `border-border`
     - 포커스: `navy-500` → Primary 컬러
     - 플레이스홀더: `text-muted`
     - 에러 상태: `danger` 시맨틱 컬러
     - _Requirements: 7.1, 7.2, 7.3, 7.4_
 
-  - [ ] 7.3 카드/배경 컴포넌트 마이그레이션
+  - [x] 7.3 카드/배경 컴포넌트 마이그레이션
     - 주 배경: `bg-background` (Pure White)
     - 카드 배경: `bg-surface` (Ghost Ivory)
     - 알림/강조 배경: `bg-accent-surface` (Soft Blush)

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -195,7 +195,7 @@ export function AddressSearch({
           type="button"
           onClick={handleSearchClick}
           disabled={isLoading}
-          className="bg-navy-600 hover:bg-navy-700 rounded-lg px-4 py-3 text-sm font-medium text-white transition-colors disabled:opacity-50"
+          className="rounded-lg bg-primary px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:opacity-50"
         >
           검색
         </button>

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -165,12 +165,12 @@ export function AddressSearch({
             onKeyDown={handleKeyDown}
             onFocus={() => results.length > 0 && setIsOpen(true)}
             placeholder="주소 또는 장소명 검색 (예: Tokyo Dome, 서울역)"
-            className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-4 py-3 pr-10 transition-colors focus:outline-none focus:ring-2"
+            className="w-full rounded-lg border border-border px-4 py-3 pr-10 text-text-primary placeholder-muted transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           {isLoading && (
             <div className="absolute right-3 top-1/2 -translate-y-1/2">
               <svg
-                className="text-navy-400 h-5 w-5 animate-spin"
+                className="h-5 w-5 animate-spin text-muted"
                 fill="none"
                 viewBox="0 0 24 24"
               >
@@ -206,17 +206,17 @@ export function AddressSearch({
 
       {/* 검색 결과 드롭다운 */}
       {isOpen && results.length > 0 && (
-        <div className="border-navy-200 absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border bg-white shadow-lg">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-white shadow-lg">
           {results.map((result, index) => (
             <button
               key={index}
               type="button"
               onClick={() => handleSelect(result)}
-              className="hover:bg-navy-50 w-full px-4 py-3 text-left transition-colors"
+              className="w-full px-4 py-3 text-left transition-colors hover:bg-primary-50"
             >
               <div className="flex items-start gap-2">
                 <svg
-                  className="text-navy-400 mt-0.5 h-4 w-4 flex-shrink-0"
+                  className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -235,11 +235,11 @@ export function AddressSearch({
                   />
                 </svg>
                 <div>
-                  <p className="text-navy-800 text-sm font-medium">
+                  <p className="text-sm font-medium text-text-primary">
                     {result.address}
                   </p>
                   {result.placeType && (
-                    <p className="text-navy-400 text-xs">{result.placeType}</p>
+                    <p className="text-xs text-muted">{result.placeType}</p>
                   )}
                 </div>
               </div>
@@ -250,12 +250,12 @@ export function AddressSearch({
 
       {/* 검색 결과 없음 */}
       {isOpen && results.length === 0 && !isLoading && query.length >= 2 && (
-        <div className="border-navy-200 absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border bg-white p-4 text-center shadow-lg">
-          <p className="text-navy-500 text-sm">검색 결과가 없습니다</p>
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-white p-4 text-center shadow-lg">
+          <p className="text-sm text-muted">검색 결과가 없습니다</p>
         </div>
       )}
 
-      <p className="text-navy-400 mt-1 text-xs">
+      <p className="mt-1 text-xs text-muted">
         전세계 주소 및 장소명 검색 가능 (Powered by OpenStreetMap)
       </p>
     </div>

--- a/src/components/spot/EventInfoSection.tsx
+++ b/src/components/spot/EventInfoSection.tsx
@@ -91,12 +91,12 @@ export function EventInfoSection({
 
         {/* 팁 메시지 */}
         {externalLinks.length > 0 && (
-          <div className="bg-navy-50 mt-6 rounded-lg p-4">
+          <div className="mt-6 rounded-lg bg-primary-50 p-4">
             <div className="flex items-start gap-2">
               <span className="text-lg">💡</span>
               <div>
-                <p className="text-navy-800 text-sm font-medium">팁</p>
-                <p className="text-navy-600 text-sm">
+                <p className="text-sm font-medium text-text-primary">팁</p>
+                <p className="text-sm text-text-secondary">
                   {category === 'sports' &&
                     '경기 당일은 혼잡할 수 있으니 미리 예매하세요!'}
                   {category === 'music' &&

--- a/src/components/spot/ExternalLinkCard.tsx
+++ b/src/components/spot/ExternalLinkCard.tsx
@@ -38,7 +38,7 @@ export const ExternalLinkCard = memo(function ExternalLinkCard({
     <button
       type="button"
       onClick={handleClick}
-      className="border-navy-200 hover:border-navy-300 group flex w-full items-center gap-3 rounded-lg border bg-white p-4 text-left transition-all hover:shadow-md"
+      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-white p-4 text-left transition-all hover:border-primary-300 hover:shadow-md"
       style={{
         borderLeftWidth: '4px',
         borderLeftColor: config.color,
@@ -55,13 +55,13 @@ export const ExternalLinkCard = memo(function ExternalLinkCard({
 
       {/* 텍스트 영역 */}
       <div className="min-w-0 flex-1">
-        <p className="text-navy-800 truncate font-medium">{link.label}</p>
-        <p className="text-navy-500 truncate text-sm">{config.label}</p>
+        <p className="truncate font-medium text-text-primary">{link.label}</p>
+        <p className="truncate text-sm text-muted">{config.label}</p>
       </div>
 
       {/* 화살표 아이콘 */}
       <svg
-        className="text-navy-400 h-5 w-5 flex-shrink-0 transition-transform group-hover:translate-x-1"
+        className="h-5 w-5 flex-shrink-0 text-muted transition-transform group-hover:translate-x-1"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"

--- a/src/components/spot/ExternalLinkForm.tsx
+++ b/src/components/spot/ExternalLinkForm.tsx
@@ -95,18 +95,22 @@ function AddLinkForm({
   }, [type, label, url, existingUrls, onAdd])
 
   return (
-    <div className="border-navy-200 bg-navy-50 rounded-lg border p-4">
-      <h4 className="text-navy-700 mb-3 text-sm font-medium">링크 추가</h4>
+    <div className="rounded-lg border border-border bg-surface p-4">
+      <h4 className="mb-3 text-sm font-medium text-text-secondary">
+        링크 추가
+      </h4>
 
       <div className="space-y-3">
         {/* 링크 타입 선택 */}
         <div>
-          <label className="text-navy-600 mb-1 block text-xs">링크 타입</label>
+          <label className="mb-1 block text-xs text-text-secondary">
+            링크 타입
+          </label>
           <select
             value={type}
             onChange={(e) => setType(e.target.value as ExternalLinkType)}
             disabled={disabled}
-            className="border-navy-200 text-navy-800 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-text-primary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {(Object.keys(LINK_TYPE_CONFIG) as ExternalLinkType[]).map(
               (key) => (
@@ -120,32 +124,32 @@ function AddLinkForm({
 
         {/* 링크 이름 */}
         <div>
-          <label className="text-navy-600 mb-1 block text-xs">링크 이름</label>
+          <label className="mb-1 block text-xs text-text-secondary">
+            링크 이름
+          </label>
           <input
             type="text"
             value={label}
             onChange={(e) => setLabel(e.target.value)}
             placeholder="예: FC 바르셀로나 공식 사이트"
             disabled={disabled}
-            className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-text-primary placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
             maxLength={100}
           />
         </div>
 
         {/* URL 입력 */}
         <div>
-          <label className="text-navy-600 mb-1 block text-xs">URL</label>
+          <label className="mb-1 block text-xs text-text-secondary">URL</label>
           <input
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
             disabled={disabled}
-            className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-text-primary placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
           />
-          <p className="text-navy-400 mt-1 text-xs">
-            https:// 로 시작해야 합니다
-          </p>
+          <p className="mt-1 text-xs text-muted">https:// 로 시작해야 합니다</p>
         </div>
 
         {/* 에러 메시지 */}
@@ -180,7 +184,7 @@ function LinkItem({
   const config = LINK_TYPE_CONFIG[link.type]
 
   return (
-    <div className="border-navy-200 flex items-center gap-3 rounded-lg border bg-white p-3">
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-white p-3">
       {/* 아이콘 */}
       <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-base">
         <span
@@ -192,10 +196,10 @@ function LinkItem({
 
       {/* 텍스트 */}
       <div className="min-w-0 flex-1">
-        <p className="text-navy-800 truncate text-sm font-medium">
+        <p className="truncate text-sm font-medium text-text-primary">
           {link.label}
         </p>
-        <p className="text-navy-500 truncate text-xs">{link.url}</p>
+        <p className="truncate text-xs text-muted">{link.url}</p>
       </div>
 
       {/* 삭제 버튼 */}
@@ -203,7 +207,7 @@ function LinkItem({
         type="button"
         onClick={onRemove}
         disabled={disabled}
-        className="text-navy-400 flex-shrink-0 rounded p-1 transition-colors hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+        className="flex-shrink-0 rounded p-1 text-muted transition-colors hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
         aria-label="링크 삭제"
       >
         <svg
@@ -280,8 +284,10 @@ export function ExternalLinkForm({
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h3 className="text-navy-800 text-lg font-semibold">{sectionTitle}</h3>
-        <span className="text-navy-500 text-sm">
+        <h3 className="text-lg font-semibold text-text-primary">
+          {sectionTitle}
+        </h3>
+        <span className="text-sm text-muted">
           {links.length}/{maxLinks}
         </span>
       </div>
@@ -308,7 +314,7 @@ export function ExternalLinkForm({
           disabled={disabled}
         />
       ) : (
-        <p className="text-navy-500 text-center text-sm">
+        <p className="text-center text-sm text-muted">
           최대 {maxLinks}개의 링크만 등록할 수 있습니다
         </p>
       )}

--- a/src/components/spot/ExternalLinkForm.tsx
+++ b/src/components/spot/ExternalLinkForm.tsx
@@ -156,7 +156,7 @@ function AddLinkForm({
           type="button"
           onClick={handleSubmit}
           disabled={disabled}
-          className="bg-navy-600 hover:bg-navy-700 w-full rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           링크 추가
         </button>
@@ -314,8 +314,8 @@ export function ExternalLinkForm({
       )}
 
       {/* 도움말 */}
-      <div className="rounded-lg bg-blue-50 p-3">
-        <p className="text-sm text-blue-700">
+      <div className="rounded-lg bg-primary-50 p-3">
+        <p className="text-sm text-primary-700">
           💡 공식 홈페이지, 티켓 예매 사이트, 일정 페이지 등 방문자에게 유용한
           링크를 추가해주세요.
         </p>

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -368,7 +368,7 @@ export default memo(function FacilityCard({
                   d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
                 />
               </svg>
-              <span className="text-navy-600 font-medium">
+              <span className="font-medium text-primary">
                 {formatDistance(facility.distance)}
               </span>
             </div>
@@ -377,7 +377,7 @@ export default memo(function FacilityCard({
 
         <button
           onClick={handleMapClick}
-          className="bg-navy-50 text-navy-600 hover:bg-navy-100 hover:text-navy-700 ml-2 flex-shrink-0 rounded-md p-2 transition-colors"
+          className="ml-2 flex-shrink-0 rounded-md bg-primary-50 p-2 text-primary transition-colors hover:bg-primary-100 hover:text-primary-600"
           title="지도에서 보기"
           aria-label={`${facility.name} 지도에서 보기`}
         >

--- a/src/components/spot/FacilityFilter.tsx
+++ b/src/components/spot/FacilityFilter.tsx
@@ -41,7 +41,7 @@ export default function FacilityFilter({
         onClick={onSelectAll}
         className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
           isAllSelected
-            ? 'border-navy-300 bg-navy-100 text-navy-800'
+            ? 'border-primary-300 bg-primary-100 text-primary-800'
             : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50'
         }`}
         aria-pressed={isAllSelected}

--- a/src/components/spot/FacilityReportForm.tsx
+++ b/src/components/spot/FacilityReportForm.tsx
@@ -640,7 +640,7 @@ export default function FacilityReportForm({
                 <button
                   type="button"
                   onClick={() => setInputMode('search')}
-                  className="hover:border-navy-300 hover:bg-navy-50/50 w-full rounded-lg border-2 border-gray-200 p-4 text-left transition-colors"
+                  className="w-full rounded-lg border-2 border-gray-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">🔍</span>
@@ -657,7 +657,7 @@ export default function FacilityReportForm({
                 <button
                   type="button"
                   onClick={handlePinMode}
-                  className="hover:border-navy-300 hover:bg-navy-50/50 w-full rounded-lg border-2 border-gray-200 p-4 text-left transition-colors"
+                  className="w-full rounded-lg border-2 border-gray-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">📍</span>
@@ -815,7 +815,7 @@ export default function FacilityReportForm({
                       <button
                         type="button"
                         onClick={() => setIsMapOpen(true)}
-                        className="border-navy-300 bg-navy-50/50 text-navy-600 hover:bg-navy-50 mb-2 flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed py-3 text-sm font-medium transition-colors"
+                        className="mb-2 flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-surface/50 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
                       >
                         📍 지도에서 위치 선택하기
                       </button>
@@ -984,7 +984,7 @@ export default function FacilityReportForm({
                 <button
                   type="submit"
                   disabled={isSubmitting || submitResult === 'success'}
-                  className="bg-navy-600 hover:bg-navy-700 w-full rounded-lg py-2.5 text-sm font-medium text-white transition-colors disabled:opacity-50"
+                  className="w-full rounded-lg bg-primary py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:opacity-50"
                 >
                   {isSubmitting ? '제보 중...' : '제보하기'}
                 </button>

--- a/src/components/spot/GooglePlacesSearch.tsx
+++ b/src/components/spot/GooglePlacesSearch.tsx
@@ -199,7 +199,7 @@ export default function GooglePlacesSearch({
           type="text"
           onFocus={loadScript}
           placeholder="장소 이름으로 검색 (포커스 시 구글맵 로드)"
-          className="focus:border-navy-400 focus:ring-navy-400 w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-400 transition-colors focus:outline-none focus:ring-1"
+          className="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-400 transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
           readOnly
         />
       </div>
@@ -252,7 +252,7 @@ export default function GooglePlacesSearch({
         value={query}
         onChange={(e) => handleInputChange(e.target.value)}
         placeholder="장소 이름으로 검색 (예: 아키하바라 건담 카페)"
-        className="focus:border-navy-400 focus:ring-navy-400 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-1"
+        className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
       />
 
       {/* 로딩 인디케이터 */}
@@ -290,7 +290,7 @@ export default function GooglePlacesSearch({
                 <button
                   type="button"
                   onClick={() => handleSelectSuggestion(suggestion)}
-                  className="hover:bg-navy-50 flex w-full items-start gap-2 px-3 py-2.5 text-left transition-colors"
+                  className="flex w-full items-start gap-2 px-3 py-2.5 text-left transition-colors hover:bg-primary-50"
                 >
                   <span className="mt-0.5 flex-shrink-0 text-gray-400">📍</span>
                   <div className="min-w-0 flex-1">

--- a/src/components/spot/ImageUpload.tsx
+++ b/src/components/spot/ImageUpload.tsx
@@ -315,7 +315,7 @@ export function ImageUpload({
           onDragLeave={handleDragLeave}
           onDragOver={handleDragOver}
           onDrop={handleDrop}
-          className={`cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors ${isDragging ? 'border-navy-500 bg-navy-50' : 'border-navy-200 bg-navy-50 hover:border-navy-400'} ${disabled ? 'cursor-not-allowed opacity-50' : ''} `}
+          className={`cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors ${isDragging ? 'border-primary bg-primary-50' : 'border-border bg-surface hover:border-primary-400'} ${disabled ? 'cursor-not-allowed opacity-50' : ''} `}
         >
           <input
             ref={fileInputRef}
@@ -327,7 +327,7 @@ export function ImageUpload({
             disabled={disabled}
           />
           <svg
-            className="text-navy-300 mx-auto mb-2 h-12 w-12"
+            className="mx-auto mb-2 h-12 w-12 text-muted"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -339,10 +339,10 @@ export function ImageUpload({
               d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
             />
           </svg>
-          <p className="text-navy-600 text-sm">
+          <p className="text-sm text-text-secondary">
             {isDragging ? '여기에 놓으세요' : '클릭하거나 드래그하여 사진 추가'}
           </p>
-          <p className="text-navy-400 mt-1 text-xs">
+          <p className="mt-1 text-xs text-muted">
             JPG, PNG, GIF, WEBP (최대 5MB) · 남은 슬롯: {remainingSlots}장
           </p>
         </div>
@@ -368,7 +368,7 @@ export function ImageUpload({
 
       {/* 최대 개수 도달 안내 */}
       {remainingSlots <= 0 && (
-        <p className="text-navy-500 text-center text-sm">
+        <p className="text-center text-sm text-muted">
           최대 {maxImages}장까지 업로드할 수 있습니다
         </p>
       )}
@@ -408,7 +408,7 @@ function ImagePreviewItem({
   const isCompleted = image.status === 'completed'
 
   return (
-    <div className="border-navy-200 bg-navy-50 group relative aspect-square overflow-hidden rounded-lg border">
+    <div className="group relative aspect-square overflow-hidden rounded-lg border border-border bg-surface">
       {/* 이미지 */}
       <Image
         src={image.url}
@@ -514,7 +514,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveLeft()
             }}
-            className="text-navy-700 rounded-full bg-white/90 p-1.5 shadow hover:bg-white"
+            className="rounded-full bg-white/90 p-1.5 text-text-secondary shadow hover:bg-white"
             title="왼쪽으로 이동"
           >
             <svg
@@ -564,7 +564,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveRight()
             }}
-            className="text-navy-700 rounded-full bg-white/90 p-1.5 shadow hover:bg-white"
+            className="rounded-full bg-white/90 p-1.5 text-text-secondary shadow hover:bg-white"
             title="오른쪽으로 이동"
           >
             <svg

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -142,7 +142,7 @@ export function LocationPicker({
   return (
     <div className="relative">
       {/* 안내 메시지 */}
-      <div className="text-navy-500 mb-2 flex items-center gap-2 text-sm">
+      <div className="mb-2 flex items-center gap-2 text-sm text-muted">
         <svg
           className="h-4 w-4"
           fill="none"
@@ -159,7 +159,7 @@ export function LocationPicker({
         <span>지도를 클릭하거나 마커를 드래그하여 위치를 선택하세요</span>
         {isLoading && (
           <svg
-            className="text-navy-400 h-4 w-4 animate-spin"
+            className="h-4 w-4 animate-spin text-muted"
             fill="none"
             viewBox="0 0 24 24"
           >
@@ -181,7 +181,7 @@ export function LocationPicker({
       </div>
 
       {/* 지도 컨테이너 */}
-      <div className="border-navy-200 h-64 w-full overflow-hidden rounded-lg border-2">
+      <div className="h-64 w-full overflow-hidden rounded-lg border-2 border-border">
         <MapContainer
           center={center}
           zoom={markerPosition ? 15 : 6}
@@ -262,8 +262,8 @@ export function LocationPicker({
 
       {/* 선택된 좌표 표시 */}
       {markerPosition && (
-        <div className="border-navy-200 bg-navy-50 mt-2 rounded-lg border p-2">
-          <p className="text-navy-600 text-xs">
+        <div className="mt-2 rounded-lg border border-border bg-surface p-2">
+          <p className="text-xs text-text-secondary">
             📍 {markerPosition.lat.toFixed(6)}, {markerPosition.lng.toFixed(6)}
           </p>
         </div>

--- a/src/components/spot/LocationPickerMap.tsx
+++ b/src/components/spot/LocationPickerMap.tsx
@@ -124,7 +124,7 @@ export default function LocationPickerMap({
             type="button"
             onClick={handleConfirm}
             disabled={!selectedPos}
-            className="bg-navy-600 hover:bg-navy-700 w-full rounded-lg py-2.5 text-sm font-medium text-white transition-colors disabled:bg-gray-300 disabled:text-gray-500"
+            className="w-full rounded-lg bg-primary py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:bg-gray-300 disabled:text-gray-500"
           >
             이 위치로 결정
           </button>

--- a/src/components/spot/NearbyFacilities.tsx
+++ b/src/components/spot/NearbyFacilities.tsx
@@ -33,7 +33,7 @@ const FACILITY_CONFIG: Record<
   convenience_store: {
     label: '편의점',
     icon: '🏪',
-    color: 'bg-blue-100 text-blue-800 border-blue-200',
+    color: 'bg-indigo-100 text-indigo-800 border-indigo-200',
   },
   cafe: {
     label: '카페',
@@ -184,7 +184,7 @@ export default function NearbyFacilities({
           <h2 className="text-2xl font-bold text-gray-900">근처 편의시설</h2>
           <button
             onClick={() => setShowReportForm(true)}
-            className="bg-navy-600 hover:bg-navy-700 rounded-lg px-3 py-1.5 text-sm font-medium text-white transition-colors"
+            className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600"
           >
             편의시설 제보
           </button>
@@ -211,7 +211,7 @@ export default function NearbyFacilities({
         </h2>
         <button
           onClick={() => setShowReportForm(true)}
-          className="bg-navy-600 hover:bg-navy-700 rounded-lg px-3 py-1.5 text-sm font-medium text-white transition-colors"
+          className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600"
         >
           편의시설 제보
         </button>
@@ -251,7 +251,7 @@ export default function NearbyFacilities({
                   <h3 className="text-lg font-semibold text-gray-900">
                     {config.label}
                   </h3>
-                  <span className="bg-navy-100 text-navy-700 rounded-full px-2 py-0.5 text-sm font-medium">
+                  <span className="rounded-full bg-primary-100 px-2 py-0.5 text-sm font-medium text-primary-700">
                     {typeFacilities.length}
                   </span>
                 </div>

--- a/src/components/spot/RelatedContentForm.tsx
+++ b/src/components/spot/RelatedContentForm.tsx
@@ -269,7 +269,7 @@ export function RelatedContentForm({
             <button
               type="button"
               onClick={handleCancel}
-              className="border-navy-300 text-navy-600 hover:bg-navy-50 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
+              className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
             >
               취소
             </button>
@@ -277,7 +277,7 @@ export function RelatedContentForm({
               type="button"
               onClick={() => handleAdd(false)}
               disabled={!newContent.name?.trim()}
-              className="bg-navy-600 hover:bg-navy-700 rounded-lg px-3 py-1.5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
             >
               추가
             </button>

--- a/src/components/spot/RelatedContentForm.tsx
+++ b/src/components/spot/RelatedContentForm.tsx
@@ -132,9 +132,8 @@ export function RelatedContentForm({
       {/* 콘텐츠 개수 표시 */}
       {value.length > 0 && (
         <div className="flex items-center justify-between">
-          <span className="text-navy-700 text-sm font-medium">
-            추가된 콘텐츠{' '}
-            <span className="text-navy-500">({value.length}개)</span>
+          <span className="text-sm font-medium text-text-secondary">
+            추가된 콘텐츠 <span className="text-muted">({value.length}개)</span>
           </span>
           {isMaxReached && (
             <span className="text-xs text-amber-600">
@@ -165,11 +164,11 @@ export function RelatedContentForm({
 
       {/* 콘텐츠 추가 폼 */}
       {isAdding ? (
-        <div className="border-navy-200 bg-navy-50 rounded-lg border p-4">
+        <div className="rounded-lg border border-border bg-surface p-4">
           <div className="space-y-3">
             {/* 콘텐츠 타입 */}
             <div>
-              <label className="text-navy-700 mb-1 block text-sm font-medium">
+              <label className="mb-1 block text-sm font-medium text-text-secondary">
                 콘텐츠 타입
               </label>
               <select
@@ -180,7 +179,7 @@ export function RelatedContentForm({
                     type: e.target.value as ContentType,
                   })
                 }
-                className="border-navy-200 text-navy-800 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                className="w-full rounded-lg border border-border px-3 py-2 text-sm text-text-primary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               >
                 {(Object.keys(CONTENT_TYPE_LABELS) as ContentType[]).map(
                   (type) => (
@@ -194,7 +193,7 @@ export function RelatedContentForm({
 
             {/* 콘텐츠 이름 */}
             <div>
-              <label className="text-navy-700 mb-1 block text-sm font-medium">
+              <label className="mb-1 block text-sm font-medium text-text-secondary">
                 이름 <span className="text-red-500">*</span>
               </label>
               <input
@@ -205,14 +204,14 @@ export function RelatedContentForm({
                   setDuplicateWarning(null)
                 }}
                 placeholder="작품명, 팀명, 아티스트명 등"
-                className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                className="w-full rounded-lg border border-border px-3 py-2 text-sm text-text-primary placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
             </div>
 
             {/* 연도 */}
             <div>
-              <label className="text-navy-700 mb-1 block text-sm font-medium">
-                연도 <span className="text-navy-400 text-xs">(선택)</span>
+              <label className="mb-1 block text-sm font-medium text-text-secondary">
+                연도 <span className="text-xs text-muted">(선택)</span>
               </label>
               <input
                 type="number"
@@ -226,14 +225,14 @@ export function RelatedContentForm({
                 placeholder="2024"
                 min={1900}
                 max={2100}
-                className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                className="w-full rounded-lg border border-border px-3 py-2 text-sm text-text-primary placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
             </div>
 
             {/* 추가 정보 */}
             <div>
-              <label className="text-navy-700 mb-1 block text-sm font-medium">
-                추가 정보 <span className="text-navy-400 text-xs">(선택)</span>
+              <label className="mb-1 block text-sm font-medium text-text-secondary">
+                추가 정보 <span className="text-xs text-muted">(선택)</span>
               </label>
               <input
                 type="text"
@@ -245,7 +244,7 @@ export function RelatedContentForm({
                   })
                 }
                 placeholder="에피소드, 시즌, 앨범명 등"
-                className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                className="w-full rounded-lg border border-border px-3 py-2 text-sm text-text-primary placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
             </div>
           </div>
@@ -288,7 +287,7 @@ export function RelatedContentForm({
           <button
             type="button"
             onClick={() => setIsAdding(true)}
-            className="border-navy-200 bg-navy-50 text-navy-600 hover:border-navy-300 hover:bg-navy-100 flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-3 text-sm font-medium transition-colors"
+            className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-surface px-4 py-3 text-sm font-medium text-primary transition-colors hover:border-primary-300 hover:bg-primary-100"
           >
             <svg
               className="h-4 w-4"
@@ -310,7 +309,7 @@ export function RelatedContentForm({
 
       {/* 빈 상태 안내 메시지 */}
       {value.length === 0 && !isAdding && (
-        <p className="text-navy-400 text-center text-xs">
+        <p className="text-center text-xs text-muted">
           이 스팟과 관련된 작품, 팀, 아티스트 등을 추가할 수 있습니다
         </p>
       )}

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -57,11 +57,11 @@ export function RelatedContentItem({
         onDragOver(index)
       }}
       onDragEnd={onDragEnd}
-      className={`flex items-center justify-between rounded-lg border bg-white p-3 transition-all ${isDragging ? 'border-navy-400 opacity-50 shadow-lg' : 'border-navy-200'} ${isDragOver ? 'border-navy-500 bg-navy-50 border-2' : ''} `}
+      className={`flex items-center justify-between rounded-lg border bg-white p-3 transition-all ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
     >
       {/* 드래그 핸들 */}
       <div
-        className="text-navy-400 hover:text-navy-600 mr-2 cursor-grab active:cursor-grabbing"
+        className="mr-2 cursor-grab text-muted hover:text-text-secondary active:cursor-grabbing"
         aria-label="드래그하여 순서 변경"
       >
         <svg
@@ -83,7 +83,7 @@ export function RelatedContentItem({
       <div className="flex flex-1 items-center gap-3">
         {/* 대표 이미지가 있으면 원형 뱃지로 표시, 없으면 기본 아이콘 */}
         {content.imageUrl ? (
-          <div className="border-navy-200 relative h-8 w-8 flex-shrink-0 overflow-hidden rounded-full border-2">
+          <div className="relative h-8 w-8 flex-shrink-0 overflow-hidden rounded-full border-2 border-border">
             <Image
               src={content.imageUrl}
               alt={content.name}
@@ -96,8 +96,10 @@ export function RelatedContentItem({
           <ContentTypeIcon type={content.type} size="lg" />
         )}
         <div className="min-w-0 flex-1">
-          <p className="text-navy-800 truncate font-medium">{content.name}</p>
-          <p className="text-navy-500 truncate text-xs">
+          <p className="truncate font-medium text-text-primary">
+            {content.name}
+          </p>
+          <p className="truncate text-xs text-muted">
             {typeLabel}
             {content.year && ` · ${content.year}년`}
             {content.additionalInfo && ` · ${content.additionalInfo}`}
@@ -109,7 +111,7 @@ export function RelatedContentItem({
       <button
         type="button"
         onClick={onRemove}
-        className="text-navy-400 ml-2 rounded p-1 transition-colors hover:bg-red-50 hover:text-red-500"
+        className="ml-2 rounded p-1 text-muted transition-colors hover:bg-red-50 hover:text-red-500"
         aria-label={`${content.name} 삭제`}
       >
         <svg

--- a/src/components/spot/RelatedContentSection.tsx
+++ b/src/components/spot/RelatedContentSection.tsx
@@ -66,7 +66,7 @@ export function RelatedContentSection({
             <button
               type="button"
               onClick={() => setIsExpanded(!isExpanded)}
-              className="border-navy-300 text-navy-600 hover:bg-navy-50 inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
             >
               {isExpanded ? (
                 <>
@@ -156,7 +156,7 @@ function RelatedContentCard({ content }: RelatedContentCardProps) {
       )}
       <Link
         href={`/community/media/${encodeURIComponent(content.name)}`}
-        className="text-navy-600 hover:text-navy-800 mt-3 inline-flex items-center gap-1 text-sm transition-colors"
+        className="mt-3 inline-flex items-center gap-1 text-sm text-primary transition-colors hover:text-primary-700"
       >
         <span>커뮤니티 보기</span>
         <svg

--- a/src/components/spot/SceneGallery.tsx
+++ b/src/components/spot/SceneGallery.tsx
@@ -112,7 +112,7 @@ export default function SceneGallery({
           </div>
           <button
             onClick={() => setShowAddModal(true)}
-            className="bg-navy-600 hover:bg-navy-700 flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-white transition-colors"
+            className="flex items-center gap-1 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600"
           >
             <svg
               className="h-4 w-4"

--- a/src/components/spot/SpotCommunitySection.tsx
+++ b/src/components/spot/SpotCommunitySection.tsx
@@ -121,7 +121,7 @@ function CommunityEmpty({
       <p className="mb-4 text-sm text-gray-500">첫 번째 후기를 남겨보세요!</p>
       <Link
         href={`/community/write?spotId=${spotId}&spotName=${encodeURIComponent(spotName)}`}
-        className="bg-navy-600 hover:bg-navy-700 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
+        className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600"
       >
         <svg
           className="h-4 w-4"
@@ -177,7 +177,7 @@ export default function SpotCommunitySection({
           {posts && posts.length > 0 && (
             <Link
               href={`/community/write?spotId=${spotId}&spotName=${encodeURIComponent(spotName)}`}
-              className="bg-navy-600 hover:bg-navy-700 flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-white transition-colors"
+              className="flex items-center gap-1 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600"
             >
               <svg
                 className="h-4 w-4"
@@ -223,7 +223,7 @@ export default function SpotCommunitySection({
               <div className="mt-4 text-center">
                 <Link
                   href={`/community?spotId=${spotId}`}
-                  className="text-navy-600 hover:text-navy-700 text-sm hover:underline"
+                  className="text-sm text-primary hover:text-primary-600 hover:underline"
                 >
                   게시글 {posts.length}개 전체보기 →
                 </Link>

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -53,7 +53,7 @@ const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
   loading: () => (
     <div className="flex h-64 items-center justify-center rounded-lg bg-gray-100">
       <div className="text-center text-gray-500">
-        <div className="border-navy-600 mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"></div>
+        <div className="mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
         <p>지도를 불러오는 중...</p>
       </div>
     </div>
@@ -135,20 +135,20 @@ function SpotDetailPage({ spot, spotId, facilities }: SpotDetailPageProps) {
   const router = useRouter()
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-background">
       {/* 페이지 타이틀 */}
-      <div className="border-b border-slate-200 bg-white px-4 py-4">
+      <div className="border-b border-border bg-surface px-4 py-4">
         <div className="mx-auto max-w-7xl">
           <div className="flex items-center justify-between">
             <div>
               <Link
                 href="/"
-                className="text-navy-500 hover:text-navy-700 flex items-center gap-2"
+                className="flex items-center gap-2 text-primary hover:text-primary-600"
               >
                 <ArrowLeftIcon size="md" />
                 <span>지도로 돌아가기</span>
               </Link>
-              <h1 className="text-navy-800 mt-2 text-xl font-bold">
+              <h1 className="mt-2 text-xl font-bold text-text-primary">
                 특별한 여행지
               </h1>
             </div>
@@ -159,7 +159,7 @@ function SpotDetailPage({ spot, spotId, facilities }: SpotDetailPageProps) {
                 {hasEditPermission && (
                   <Link
                     href={`/spots/${spotId}/edit`}
-                    className="border-navy-300 text-navy-600 hover:bg-navy-50 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
                   >
                     수정
                   </Link>
@@ -279,11 +279,11 @@ function SpotDetailContent({
 
           {/* 최초 제보자 표시 */}
           {spot.firstReporterId && spot.firstReporterName && (
-            <p className="text-navy-500 mb-2 text-sm md:mb-3">
+            <p className="mb-2 text-sm text-muted md:mb-3">
               📍 최초 제보:{' '}
               <Link
                 href={`/profile/${spot.firstReporterId}`}
-                className="text-navy-600 font-medium hover:underline"
+                className="font-medium text-primary hover:underline"
               >
                 @{spot.firstReporterName}
               </Link>
@@ -395,14 +395,14 @@ function SpotDetailContent({
             </h2>
             <button
               onClick={handleSupplementClick}
-              className="bg-navy-600 hover:bg-navy-700 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600"
             >
               {showSupplementForm ? '닫기' : '정보 수정 제안'}
             </button>
           </div>
 
           {showSupplementForm && (
-            <div className="border-navy-100 mb-4 rounded-lg border p-4">
+            <div className="mb-4 rounded-lg border border-primary-100 p-4">
               <SupplementForm
                 spotId={spot.id}
                 onSuccess={handleSupplementSuccess}
@@ -479,7 +479,7 @@ interface SpotDetailErrorProps {
 
 function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-50">
+    <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow-md">
         <div className="text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center text-red-500">
@@ -493,14 +493,14 @@ function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
             {onRetry && (
               <button
                 onClick={onRetry}
-                className="bg-navy-600 hover:bg-navy-700 inline-flex items-center rounded-md px-4 py-2 text-white transition-colors"
+                className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primary-600"
               >
                 다시 시도
               </button>
             )}
             <Link
               href="/"
-              className="border-navy-300 text-navy-600 hover:bg-navy-50 inline-flex items-center rounded-md border px-4 py-2 transition-colors"
+              className="inline-flex items-center rounded-md border border-border px-4 py-2 text-primary transition-colors hover:bg-primary-50"
             >
               메인으로 돌아가기
             </Link>
@@ -513,7 +513,7 @@ function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
 
 function SpotNotFound() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-50">
+    <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow-md">
         <div className="text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center text-gray-400">
@@ -527,7 +527,7 @@ function SpotNotFound() {
           </p>
           <Link
             href="/"
-            className="bg-navy-600 hover:bg-navy-700 inline-flex items-center rounded-md px-4 py-2 text-white transition-colors"
+            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primary-600"
           >
             메인으로 돌아가기
           </Link>

--- a/src/components/spot/SpotForm.tsx
+++ b/src/components/spot/SpotForm.tsx
@@ -28,7 +28,7 @@ const LocationPicker = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="bg-navy-100 h-64 w-full animate-pulse rounded-lg" />
+      <div className="h-64 w-full animate-pulse rounded-lg bg-neutral-100" />
     ),
   }
 )
@@ -102,15 +102,15 @@ export function SpotForm({
 
       <form onSubmit={onSubmit} className="space-y-6">
         {/* 기본 정보 섹션 */}
-        <div className="border-navy-100 border-b pb-6">
-          <h2 className="text-navy-800 mb-4 text-lg font-semibold">
+        <div className="border-b border-border pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-text-primary">
             기본 정보
           </h2>
 
           <div className="mb-4">
             <label
               htmlFor="name"
-              className="text-navy-700 mb-2 block text-sm font-medium"
+              className="mb-2 block text-sm font-medium text-text-secondary"
             >
               스팟 이름 <span className="text-red-500">*</span>
             </label>
@@ -121,10 +121,10 @@ export function SpotForm({
               value={formData.name}
               onChange={handleChange}
               placeholder="스팟 이름을 입력하세요"
-              className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-4 py-3 transition-colors focus:outline-none focus:ring-2"
+              className="w-full rounded-lg border border-border px-4 py-3 text-text-primary placeholder-muted transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               maxLength={100}
             />
-            <p className="text-navy-400 mt-1 text-right text-xs">
+            <p className="mt-1 text-right text-xs text-muted">
               {formData.name.length}/100
             </p>
           </div>
@@ -132,7 +132,7 @@ export function SpotForm({
           <div className="mb-4">
             <label
               htmlFor="category"
-              className="text-navy-700 mb-2 block text-sm font-medium"
+              className="mb-2 block text-sm font-medium text-text-secondary"
             >
               카테고리 <span className="text-red-500">*</span>
             </label>
@@ -141,7 +141,7 @@ export function SpotForm({
               name="category"
               value={formData.category}
               onChange={handleChange}
-              className="border-navy-200 text-navy-800 focus:border-navy-500 focus:ring-navy-500/20 w-full rounded-lg border px-4 py-3 transition-colors focus:outline-none focus:ring-2"
+              className="w-full rounded-lg border border-border px-4 py-3 text-text-primary transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
             >
               <option value="">카테고리를 선택하세요</option>
               {(Object.keys(CATEGORY_CONFIG) as SpotCategory[]).map((key) => (
@@ -155,7 +155,7 @@ export function SpotForm({
           <div>
             <label
               htmlFor="description"
-              className="text-navy-700 mb-2 block text-sm font-medium"
+              className="mb-2 block text-sm font-medium text-text-secondary"
             >
               설명 <span className="text-red-500">*</span>
             </label>
@@ -166,23 +166,23 @@ export function SpotForm({
               onChange={handleChange}
               placeholder="스팟에 대한 설명을 입력하세요"
               rows={4}
-              className="border-navy-200 text-navy-800 placeholder-navy-400 focus:border-navy-500 focus:ring-navy-500/20 w-full resize-none rounded-lg border px-4 py-3 transition-colors focus:outline-none focus:ring-2"
+              className="w-full resize-none rounded-lg border border-border px-4 py-3 text-text-primary placeholder-muted transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               maxLength={2000}
             />
-            <p className="text-navy-400 mt-1 text-right text-xs">
+            <p className="mt-1 text-right text-xs text-muted">
               {formData.description.length}/2000
             </p>
           </div>
         </div>
 
         {/* 위치 정보 섹션 */}
-        <div className="border-navy-100 border-b pb-6">
-          <h2 className="text-navy-800 mb-4 text-lg font-semibold">
+        <div className="border-b border-border pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-text-primary">
             위치 정보
           </h2>
 
           <div className="mb-4">
-            <label className="text-navy-700 mb-2 block text-sm font-medium">
+            <label className="mb-2 block text-sm font-medium text-text-secondary">
               주소 <span className="text-red-500">*</span>
             </label>
             <AddressSearch
@@ -213,10 +213,10 @@ export function SpotForm({
         />
 
         {/* 관련 콘텐츠 섹션 */}
-        <div className="border-navy-100 border-b pb-6">
-          <h2 className="text-navy-800 mb-4 text-lg font-semibold">
+        <div className="border-b border-border pb-6">
+          <h2 className="mb-4 text-lg font-semibold text-text-primary">
             관련 콘텐츠{' '}
-            <span className="text-navy-400 text-xs font-normal">(선택)</span>
+            <span className="text-xs font-normal text-muted">(선택)</span>
           </h2>
           <RelatedContentForm
             value={formData.relatedContent}
@@ -229,7 +229,7 @@ export function SpotForm({
         {/* 외부 링크 섹션 */}
         {formData.category &&
           ['sports', 'music', 'game'].includes(formData.category) && (
-            <div className="border-navy-100 border-b pb-6">
+            <div className="border-b border-border pb-6">
               <ExternalLinkForm
                 links={formData.externalLinks}
                 onChange={(links) => {

--- a/src/components/spot/SpotForm.tsx
+++ b/src/components/spot/SpotForm.tsx
@@ -267,14 +267,14 @@ export function SpotForm({
             <button
               type="button"
               onClick={onCancel}
-              className="border-navy-300 text-navy-600 hover:bg-navy-50 rounded-lg border px-6 py-2.5 text-sm font-medium transition-colors"
+              className="rounded-lg border border-border px-6 py-2.5 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
             >
               취소
             </button>
             <button
               type="submit"
               disabled={isSubmitting || isDeleting}
-              className="bg-navy-600 hover:bg-navy-700 rounded-lg px-6 py-2.5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isSubmitting ? (
                 <span className="flex items-center gap-2">

--- a/src/components/spot/form/PhotoUploadSection.tsx
+++ b/src/components/spot/form/PhotoUploadSection.tsx
@@ -12,12 +12,10 @@ export function PhotoUploadSection({
   disabled,
 }: PhotoUploadSectionProps) {
   return (
-    <div className="border-navy-100 border-b pb-6">
-      <h2 className="text-navy-800 mb-4 text-lg font-semibold">
+    <div className="border-b border-border pb-6">
+      <h2 className="mb-4 text-lg font-semibold text-text-primary">
         사진{' '}
-        <span className="text-navy-400 text-xs font-normal">
-          (선택, 최대 5장)
-        </span>
+        <span className="text-xs font-normal text-muted">(선택, 최대 5장)</span>
       </h2>
       <ImageUpload
         images={images}

--- a/src/components/spot/scene/AddSceneModal.tsx
+++ b/src/components/spot/scene/AddSceneModal.tsx
@@ -159,7 +159,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
                   </button>
                 </div>
               ) : (
-                <label className="hover:border-navy-400 flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 p-6 transition-colors hover:bg-gray-100">
+                <label className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 p-6 transition-colors hover:border-primary-400 hover:bg-gray-100">
                   <svg
                     className="mb-2 h-10 w-10 text-gray-400"
                     fill="none"
@@ -199,7 +199,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
               value={episodeInfo}
               onChange={(e) => setEpisodeInfo(e.target.value)}
               placeholder="1화, OVA, 극장판 등"
-              className="focus:border-navy-500 focus:ring-navy-500 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-1"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
 
@@ -212,7 +212,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
               onChange={(e) => setDescription(e.target.value)}
               placeholder="장면에 대한 간단한 설명"
               rows={2}
-              className="focus:border-navy-500 focus:ring-navy-500 w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-1"
+              className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
 
@@ -227,7 +227,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
             <button
               type="submit"
               disabled={isSubmitting}
-              className="bg-navy-600 hover:bg-navy-700 flex-1 rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+              className="flex-1 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
             >
               {isSubmitting ? '업로드 중...' : '추가하기'}
             </button>

--- a/src/components/spot/scene/SceneCarousel.tsx
+++ b/src/components/spot/scene/SceneCarousel.tsx
@@ -126,7 +126,7 @@ export function SceneCarousel({
               onClick={() => goToSlide(index)}
               className={`h-2.5 rounded-full transition-all ${
                 index === currentIndex
-                  ? 'bg-navy-600 w-8'
+                  ? 'w-8 bg-primary'
                   : 'w-2.5 bg-gray-300 hover:bg-gray-400'
               }`}
               aria-label={`${index + 1}번째 슬라이드로 이동`}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #407

---

## 📋 PR 타입

- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정

---

## ✨ 작업 개요

> 버튼, 폼/입력 필드, 카드/배경 컴포넌트의 레거시 navy/slate/blue 컬러를 시맨틱 디자인 토큰으로 마이그레이션

---

## 📋 변경 사항

- [x] Primary 버튼: `navy-600` → `bg-primary`, 호버 `hover:bg-primary-600`
- [x] Secondary/outline 버튼: `border-navy-300 text-navy-600` → `border-border text-primary`
- [x] 포커스 링: `focus:ring-navy-500` → `focus:ring-primary`
- [x] 입력 필드 보더: `border-navy-200` → `border-border`
- [x] 입력 필드 포커스: `focus:border-navy-500` → `focus:border-primary`
- [x] 플레이스홀더: `placeholder-navy-400` → `placeholder-muted`
- [x] 텍스트: `text-navy-800` → `text-text-primary`, `text-navy-700` → `text-text-secondary`
- [x] 카드 배경/보더: `bg-navy-50` → `bg-surface`, `border-navy-200` → `border-border`
- [x] 페이지 배경: `bg-slate-50` → `bg-background`
- [x] 로딩 스피너: `border-navy-600` → `border-primary`
- [x] 도움말 배경: `bg-blue-50` → `bg-primary-50`

### Requirements 대응
- 5.1~5.6: 버튼 시스템 디자인 개편
- 7.1~7.4: 폼/입력 필드 디자인 개편
- 8.1~8.5: 카드/배경 디자인 개편

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인
