### PR TITLE
[Feat] Task 4 - pwaStore 및 설치 이벤트 리스너 구현

### DIFF
--- a/.kiro/specs/21-pwa-setup/tasks.md
+++ b/.kiro/specs/21-pwa-setup/tasks.md
@@ -57,8 +57,8 @@
   - `npm run type-check` 및 `npm run build` 실행하여 Serwist 통합, 타입 선언, 레거시 파일 삭제 후 빌드가 정상 동작하는지 확인
   - Ensure all tests pass, ask the user if questions arise.
 
-- [x] 4. pwaStore 및 설치 이벤트 리스너 구현
-  - [ ] 4.1 pwaStore Zustand 스토어 생성
+- [-] 4. pwaStore 및 설치 이벤트 리스너 구현
+  - [x] 4.1 pwaStore Zustand 스토어 생성
     - `src/stores/pwaStore.ts` 파일 생성
     - `PwaState` 인터페이스 구현: deferredPrompt, isInstallable, isInstalled, isDismissed
     - `setDeferredPrompt`, `triggerInstall`, `dismiss`, `setInstalled`, `reset` 액션 구현
@@ -78,7 +78,7 @@
     - `'dismissed'` 결과 시 `isInstalled === false`, `deferredPrompt === null` 검증
     - **Validates: Requirements 5.6**
 
-  - [ ] 4.4 InstallPromptListener 컴포넌트 생성
+  - [x] 4.4 InstallPromptListener 컴포넌트 생성
     - `src/components/pwa/InstallPromptListener.tsx` 생성 ('use client')
     - `beforeinstallprompt` 이벤트 리스너 등록 → `preventDefault()` 호출 → `pwaStore.setDeferredPrompt()` 저장
     - `appinstalled` 이벤트 리스너 등록 → `pwaStore.setInstalled()` 호출

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import 'leaflet/dist/leaflet.css'
 import './globals.css'
 import { Providers } from '@/lib/providers'
 import { Header } from '@/components/layout'
-import { SerwistRegistration } from '@/components/pwa'
+import { SerwistRegistration, InstallPromptListener } from '@/components/pwa'
 import JsonLd from '@/components/seo/JsonLd'
 import GoogleAnalytics from '@/components/seo/GoogleAnalytics'
 import { generateWebSiteJsonLd } from '@/lib/seo/json-ld'
@@ -73,6 +73,7 @@ export default function RootLayout({
         <Providers>
           <Header />
           <main className="pt-14">{children}</main>
+          <InstallPromptListener />
           <SerwistRegistration />
         </Providers>
       </body>

--- a/src/components/pwa/InstallPromptListener.tsx
+++ b/src/components/pwa/InstallPromptListener.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePwaStore } from '@/stores/pwaStore'
+
+/**
+ * beforeinstallprompt / appinstalled 이벤트를 감지하여 pwaStore에 연결하는 리스너.
+ * standalone 모드 감지도 포함.
+ * layout.tsx의 Providers 내부에 주입한다.
+ */
+export function InstallPromptListener() {
+  useEffect(() => {
+    const { setDeferredPrompt, setInstalled } = usePwaStore.getState()
+
+    // standalone 모드 감지 (이미 설치된 상태)
+    const standaloneQuery = window.matchMedia('(display-mode: standalone)')
+    if (standaloneQuery.matches) {
+      setInstalled()
+    }
+    const handleStandaloneChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setInstalled()
+    }
+    standaloneQuery.addEventListener('change', handleStandaloneChange)
+
+    // beforeinstallprompt 이벤트 감지
+    const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault()
+      setDeferredPrompt(e)
+    }
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+
+    // appinstalled 이벤트 감지
+    const handleAppInstalled = () => {
+      setInstalled()
+    }
+    window.addEventListener('appinstalled', handleAppInstalled)
+
+    return () => {
+      standaloneQuery.removeEventListener('change', handleStandaloneChange)
+      window.removeEventListener(
+        'beforeinstallprompt',
+        handleBeforeInstallPrompt
+      )
+      window.removeEventListener('appinstalled', handleAppInstalled)
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -1,1 +1,2 @@
 export { SerwistRegistration } from './SerwistRegistration'
+export { InstallPromptListener } from './InstallPromptListener'

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -74,3 +74,11 @@ export {
   useBottomSheetSpotId,
 } from './bottomSheetStore'
 export type { BottomSheetHeight } from './bottomSheetStore'
+
+// PWA Store - PWA 설치 상태 관리
+export {
+  usePwaStore,
+  useIsInstallable,
+  useIsInstalled,
+  useIsDismissed,
+} from './pwaStore'

--- a/src/stores/pwaStore.ts
+++ b/src/stores/pwaStore.ts
@@ -1,0 +1,91 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+interface PwaState {
+  /** 지연된 설치 프롬프트 이벤트 */
+  deferredPrompt: BeforeInstallPromptEvent | null
+  /** 설치 가능 여부 (beforeinstallprompt 수신 시 true) */
+  isInstallable: boolean
+  /** 설치 완료 여부 (appinstalled 이벤트 또는 standalone 모드) */
+  isInstalled: boolean
+  /** 사용자가 바텀 시트를 닫았는지 (세션 단위) */
+  isDismissed: boolean
+}
+
+interface PwaStore extends PwaState {
+  setDeferredPrompt: (event: BeforeInstallPromptEvent) => void
+  triggerInstall: () => Promise<'accepted' | 'dismissed'>
+  dismiss: () => void
+  setInstalled: () => void
+  reset: () => void
+}
+
+export const usePwaStore = create<PwaStore>()(
+  devtools(
+    (set, get) => ({
+      deferredPrompt: null,
+      isInstallable: false,
+      isInstalled: false,
+      isDismissed: false,
+
+      setDeferredPrompt: (event) =>
+        set(
+          { deferredPrompt: event, isInstallable: true },
+          false,
+          'pwaStore/setDeferredPrompt'
+        ),
+
+      triggerInstall: async () => {
+        const { deferredPrompt } = get()
+        if (!deferredPrompt) return 'dismissed'
+
+        await deferredPrompt.prompt()
+        const { outcome } = await deferredPrompt.userChoice
+
+        if (outcome === 'accepted') {
+          set(
+            { isInstalled: true, deferredPrompt: null, isInstallable: false },
+            false,
+            'pwaStore/triggerInstall:accepted'
+          )
+        } else {
+          set(
+            { deferredPrompt: null, isInstallable: false },
+            false,
+            'pwaStore/triggerInstall:dismissed'
+          )
+        }
+
+        return outcome
+      },
+
+      dismiss: () => set({ isDismissed: true }, false, 'pwaStore/dismiss'),
+
+      setInstalled: () =>
+        set(
+          { isInstalled: true, isInstallable: false, deferredPrompt: null },
+          false,
+          'pwaStore/setInstalled'
+        ),
+
+      reset: () =>
+        set(
+          {
+            deferredPrompt: null,
+            isInstallable: false,
+            isInstalled: false,
+            isDismissed: false,
+          },
+          false,
+          'pwaStore/reset'
+        ),
+    }),
+    { name: 'pwa-store' }
+  )
+)
+
+// Selectors
+export const useIsInstallable = () =>
+  usePwaStore((state) => state.isInstallable)
+export const useIsInstalled = () => usePwaStore((state) => state.isInstalled)
+export const useIsDismissed = () => usePwaStore((state) => state.isDismissed)

--- a/src/types/pwa.d.ts
+++ b/src/types/pwa.d.ts
@@ -7,19 +7,20 @@
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent
  */
-interface BeforeInstallPromptEvent extends Event {
-  readonly platforms: string[]
-  readonly userChoice: Promise<{
-    outcome: 'accepted' | 'dismissed'
-    platform?: string
-  }>
-  prompt(): Promise<void>
-}
+
+export {}
 
 declare global {
+  interface BeforeInstallPromptEvent extends Event {
+    readonly platforms: string[]
+    readonly userChoice: Promise<{
+      outcome: 'accepted' | 'dismissed'
+      platform?: string
+    }>
+    prompt(): Promise<void>
+  }
+
   interface WindowEventMap {
     beforeinstallprompt: BeforeInstallPromptEvent
   }
 }
-
-export {}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #422

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

PWA 커스텀 앱 설치 UX를 위한 Zustand 스토어(pwaStore)와 브라우저 이벤트 리스너(InstallPromptListener) 구현

---

## 📋 변경 사항

- [x] `src/stores/pwaStore.ts` — Zustand 스토어 생성 (PwaState, setDeferredPrompt, triggerInstall, dismiss, setInstalled, reset 액션)
- [x] `src/stores/index.ts` — pwaStore export 추가
- [x] `src/types/pwa.d.ts` — BeforeInstallPromptEvent 타입을 global scope로 수정
- [x] `src/components/pwa/InstallPromptListener.tsx` — beforeinstallprompt, appinstalled 이벤트 리스너 및 standalone 모드 감지
- [x] `src/components/pwa/index.ts` — InstallPromptListener export 추가
- [x] `src/app/layout.tsx` — Providers 내부에 InstallPromptListener 주입

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] Requirements 5.1, 5.2, 5.6, 5.8 대응

---
<img width="678" height="718" alt="image" src="https://github.com/user-attachments/assets/bffc685f-8c24-4058-bcec-51c7577d055f" />

## 📝 추가 정보

- pwa.d.ts의 BeforeInstallPromptEvent를 `declare global` 블록 안으로 이동하여 모듈 파일에서도 글로벌 타입으로 인식되도록 수정
- optional 태스크(4.2 PBT, 4.3 PBT)는 MVP 우선으로 건너뜀