### PR TITLE
[Feat] 오프라인 폴백 페이지 구현

### DIFF
--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Image from 'next/image'
+
+/**
+ * 오프라인 폴백 페이지
+ * Service Worker가 네비게이션 요청 실패 시 이 페이지로 폴백한다.
+ * 네트워크 복구를 자동 감지하여 새로고침을 유도한다.
+ * @requirements 4.1, 4.2, 4.3, 4.4, 4.6, 4.7
+ */
+export default function OfflinePage() {
+  const [isOnline, setIsOnline] = useState(false)
+
+  useEffect(() => {
+    // 현재 온라인 상태 확인
+    if (navigator.onLine) {
+      setIsOnline(true)
+    }
+
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  const handleRetry = () => {
+    window.location.reload()
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] flex-col items-center justify-center bg-background px-4">
+      <div className="flex max-w-sm flex-col items-center text-center">
+        {/* 마스코트 일러스트 */}
+        <Image
+          src="/icons/raw/0329/캐릭터정면1.webp"
+          alt="Not a Trip 마스코트"
+          width={180}
+          height={180}
+          className="mb-6"
+          priority
+        />
+
+        {/* 안내 문구 */}
+        <h1 className="mb-2 text-xl font-bold text-main-text">
+          네트워크가 연결되지 않았습니다
+        </h1>
+        <p className="mb-8 text-sm text-sub-text">
+          인터넷 연결을 확인한 후 다시 시도해 주세요
+        </p>
+
+        {/* 네트워크 복구 감지 시 안내 */}
+        {isOnline && (
+          <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50 px-4 py-3 text-sm text-primary-700">
+            네트워크가 복구되었습니다. 새로고침해 주세요!
+          </div>
+        )}
+
+        {/* 다시 시도 버튼 */}
+        <button
+          onClick={handleRetry}
+          className="rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary-600 active:scale-95"
+        >
+          다시 시도
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ export function Header() {
         {/* 로고 */}
         <Link href="/" className="flex items-center gap-2">
           <span className="text-text-primary flex items-center gap-1.5 text-xl font-bold">
-            <AppIcon name="logo" size="2xl" />
+            <AppIcon name="logo" size="2xl" className="max-h-8" />
             Not a Trip
           </span>
         </Link>

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -64,11 +64,12 @@ export default function CategoryFilter() {
             onClick={() => handleCategoryToggle(category)}
             className={`flex h-9 items-center gap-1.5 overflow-hidden rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
               isSelected
-                ? 'scale-105 border-transparent text-white shadow-md'
+                ? 'scale-105 border-transparent shadow-md'
                 : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-500'
             }`}
             style={{
               backgroundColor: isSelected ? config.bgColor : undefined,
+              color: isSelected ? config.fgColor : undefined,
             }}
           >
             <div className={isSelected ? '' : 'opacity-40 grayscale'}>


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #424

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> PWA 오프라인 환경에서 마스코트 일러스트와 함께 친근한 안내를 제공하는 `/offline` 폴백 페이지 구현

---

## 📋 변경 사항

- [x] `src/app/offline/page.tsx` 생성 (Next.js App Router 페이지)
- [x] "네트워크가 연결되지 않았습니다" 안내 문구 표시
- [x] 마스코트 일러스트(캐릭터정면1.webp) 표시
- [x] "다시 시도" 버튼 → `window.location.reload()` 호출
- [x] `navigator.onLine` + `online` 이벤트로 네트워크 복구 자동 감지
- [x] 네트워크 복구 시 새로고침 유도 UI 표시 (primary 컬러 배너)
- [x] Tailwind CSS 및 Semantic Color 토큰 적용

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---
<img width="1182" height="993" alt="image" src="https://github.com/user-attachments/assets/3a07247c-f9ef-4dea-883e-62e16ffe75c8" />

## 📝 추가 정보

- Requirements 4.1, 4.2, 4.3, 4.4, 4.6, 4.7 대응
- Service Worker의 네비게이션 폴백(`src/sw.ts`)이 이 페이지로 리다이렉트
- Hydration 안전: `useEffect` 내에서만 `navigator.onLine` 접근