### PR TITLE
[Feat] Task 6 - 커스텀 앱 설치 UI 구현 (InstallBottomSheet, InstallToast, layout 통합)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,12 @@ import 'leaflet/dist/leaflet.css'
 import './globals.css'
 import { Providers } from '@/lib/providers'
 import { Header } from '@/components/layout'
-import { SerwistRegistration, InstallPromptListener } from '@/components/pwa'
+import {
+  SerwistRegistration,
+  InstallPromptListener,
+  InstallBottomSheet,
+  InstallToast,
+} from '@/components/pwa'
 import JsonLd from '@/components/seo/JsonLd'
 import GoogleAnalytics from '@/components/seo/GoogleAnalytics'
 import { generateWebSiteJsonLd } from '@/lib/seo/json-ld'
@@ -74,6 +79,8 @@ export default function RootLayout({
           <Header />
           <main className="pt-14">{children}</main>
           <InstallPromptListener />
+          <InstallBottomSheet />
+          <InstallToast />
           <SerwistRegistration />
         </Providers>
       </body>

--- a/src/components/pwa/InstallBottomSheet.tsx
+++ b/src/components/pwa/InstallBottomSheet.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { usePwaStore } from '@/stores/pwaStore'
+
+/**
+ * 모바일 전용 PWA 설치 바텀 시트
+ * "Not a Trip 여권 발급받기 (앱 설치)" 문구와 설치/닫기 버튼을 제공한다.
+ * mounted 상태 패턴으로 Hydration 에러를 방지한다.
+ * @requirements 5.3, 5.4, 5.5, 5.7, 5.8, 5.9
+ */
+export function InstallBottomSheet() {
+  const [mounted, setMounted] = useState(false)
+  const isInstallable = usePwaStore((s) => s.isInstallable)
+  const isInstalled = usePwaStore((s) => s.isInstalled)
+  const isDismissed = usePwaStore((s) => s.isDismissed)
+  const triggerInstall = usePwaStore((s) => s.triggerInstall)
+  const dismiss = usePwaStore((s) => s.dismiss)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // SSR 시점에는 null 반환 → Hydration 불일치 방지
+  if (!mounted) return null
+
+  // 모바일에서만 표시 (768px 미만)
+  const isMobile = window.matchMedia('(max-width: 767px)').matches
+  if (!isMobile) return null
+
+  // standalone 모드 시 미표시
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches
+  if (isStandalone) return null
+
+  // 설치 불가, 이미 설치됨, 사용자가 닫은 경우 미표시
+  if (!isInstallable || isInstalled || isDismissed) return null
+
+  const handleInstall = async () => {
+    await triggerInstall()
+  }
+
+  return (
+    <div
+      className="animate-slide-up fixed inset-x-0 bottom-0 z-[1100] rounded-t-2xl border-t border-border bg-surface px-4 pb-safe-bottom pt-4 shadow-2xl"
+      role="dialog"
+      aria-label="앱 설치 안내"
+    >
+      {/* 드래그 핸들 (시각적 요소) */}
+      <div className="mb-3 flex justify-center">
+        <div className="h-1 w-10 rounded-full bg-muted" />
+      </div>
+
+      {/* 콘텐츠 */}
+      <div className="flex items-center gap-3">
+        {/* 아이콘 */}
+        <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-primary-100 text-2xl">
+          🛂
+        </div>
+
+        {/* 텍스트 */}
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-bold text-main-text">
+            Not a Trip 여권 발급받기
+          </p>
+          <p className="text-xs text-sub-text">
+            앱 설치로 더 빠르게 탐색하세요
+          </p>
+        </div>
+
+        {/* 닫기 버튼 */}
+        <button
+          onClick={dismiss}
+          className="flex-shrink-0 p-1 text-muted transition-colors hover:text-main-text"
+          aria-label="설치 안내 닫기"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* 설치 버튼 */}
+      <button
+        onClick={handleInstall}
+        className="mb-2 mt-3 w-full rounded-lg bg-primary py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 active:scale-[0.98]"
+      >
+        여권 발급받기 (앱 설치)
+      </button>
+    </div>
+  )
+}

--- a/src/components/pwa/InstallToast.tsx
+++ b/src/components/pwa/InstallToast.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { usePwaStore } from '@/stores/pwaStore'
+
+/**
+ * 데스크탑 전용 PWA 설치 토스트 팝업
+ * 우측 하단에 설치 안내를 표시한다.
+ * mounted 상태 패턴으로 Hydration 에러를 방지한다.
+ * @requirements 5.3, 5.8, 5.9
+ */
+export function InstallToast() {
+  const [mounted, setMounted] = useState(false)
+  const isInstallable = usePwaStore((s) => s.isInstallable)
+  const isInstalled = usePwaStore((s) => s.isInstalled)
+  const isDismissed = usePwaStore((s) => s.isDismissed)
+  const triggerInstall = usePwaStore((s) => s.triggerInstall)
+  const dismiss = usePwaStore((s) => s.dismiss)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // SSR 시점에는 null 반환 → Hydration 불일치 방지
+  if (!mounted) return null
+
+  // 데스크탑에서만 표시 (768px 이상)
+  const isDesktop = window.matchMedia('(min-width: 768px)').matches
+  if (!isDesktop) return null
+
+  // standalone 모드 시 미표시
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches
+  if (isStandalone) return null
+
+  // 설치 불가, 이미 설치됨, 사용자가 닫은 경우 미표시
+  if (!isInstallable || isInstalled || isDismissed) return null
+
+  const handleInstall = async () => {
+    await triggerInstall()
+  }
+
+  return (
+    <div
+      className="animate-slide-up fixed bottom-4 right-4 z-[1100] w-80 rounded-xl border border-border bg-surface p-4 shadow-xl"
+      role="dialog"
+      aria-label="앱 설치 안내"
+    >
+      {/* 헤더 */}
+      <div className="mb-3 flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xl">🛂</span>
+          <p className="text-sm font-bold text-main-text">
+            Not a Trip 여권 발급받기
+          </p>
+        </div>
+        <button
+          onClick={dismiss}
+          className="flex-shrink-0 p-0.5 text-muted transition-colors hover:text-main-text"
+          aria-label="설치 안내 닫기"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <p className="mb-3 text-xs text-sub-text">
+        앱을 설치하면 더 빠르고 편리하게 특별한 여행지를 탐색할 수 있어요
+      </p>
+
+      {/* 설치 버튼 */}
+      <button
+        onClick={handleInstall}
+        className="w-full rounded-lg bg-primary py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600 active:scale-[0.98]"
+      >
+        여권 발급받기 (앱 설치)
+      </button>
+    </div>
+  )
+}

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -1,2 +1,4 @@
 export { SerwistRegistration } from './SerwistRegistration'
 export { InstallPromptListener } from './InstallPromptListener'
+export { InstallBottomSheet } from './InstallBottomSheet'
+export { InstallToast } from './InstallToast'


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #426

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> PWA 커스텀 설치 UI 구현 — 모바일 바텀 시트 + 데스크탑 토스트 + layout 통합

---

## 📋 변경 사항

- [x] InstallBottomSheet 컴포넌트 구현 (모바일 768px 미만, "여권 발급받기" 테마)
- [x] InstallToast 컴포넌트 구현 (데스크탑 768px 이상, 우측 하단 토스트)
- [x] pwa/index.ts barrel export 추가
- [x] layout.tsx Providers 내부에 InstallBottomSheet, InstallToast 주입

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] Hydration 안전성 확보 (mounted 상태 패턴)
- [x] standalone 모드 시 미표시 처리
- [x] Semantic Color 토큰 적용

---
<img width="922" height="1009" alt="image" src="https://github.com/user-attachments/assets/b473a6fd-a15c-4d3f-bece-56de41666063" />

## 📝 추가 정보

- Requirements 5.3, 5.4, 5.5, 5.7, 5.8, 5.9 대응
- 두 컴포넌트 모두 mounted 상태 패턴으로 SSR 시 null 반환 → Hydration 에러 방지
- pwaStore의 isInstallable, isInstalled, isDismissed 상태에 따라 조건부 렌더링