### PR TITLE
[UI] Task 1 - 단순 UI 텍스트/색상 변경

### DIFF
--- a/src/components/common/EmptyFilterOverlay.tsx
+++ b/src/components/common/EmptyFilterOverlay.tsx
@@ -18,7 +18,7 @@ export function EmptyFilterOverlay() {
           표시할 스팟 카테고리가 선택되지 않았습니다
         </p>
         <p className="mt-1 text-xs text-muted">
-          아래 필터에서 원하는 카테고리를 선택하세요
+          필터에서 원하는 카테고리를 선택하세요
         </p>
       </div>
     </div>

--- a/src/components/common/SpotLoadingSkeleton.tsx
+++ b/src/components/common/SpotLoadingSkeleton.tsx
@@ -6,7 +6,7 @@ import { SpinnerIcon } from '@/components/icons'
  */
 export function SpotLoadingSkeleton() {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-primary-800">
+    <div className="flex h-full w-full items-center justify-center bg-neutral-800">
       <div className="text-center">
         <SpinnerIcon size="lg" className="mx-auto animate-spin" />
         <p className="mt-2 text-sm text-neutral-200">스팟 데이터 로딩 중...</p>

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -211,7 +211,7 @@ export default function PilgrimageMap({
 
       {/* Map attribution with navy theme */}
       <div className="absolute bottom-2 left-2 z-[1000] rounded bg-primary-800/80 px-2 py-1 text-xs text-white">
-        Anime Pilgrim
+        Not a Trip
       </div>
 
       {/* 스팟 미리보기 - 데스크탑: 툴팁, 모바일: Bottom Sheet */}

--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -3,9 +3,14 @@
 
 /* 지도 컨테이너 기본 스타일 */
 .leaflet-container {
-  background: #eeedfc; /* primary-50 */
+  background: #f4f4f5; /* neutral-100 */
   font-family: inherit;
   z-index: 0 !important;
+}
+
+/* 다크 모드 지도 컨테이너 배경 */
+.dark .leaflet-container {
+  background: #27272a; /* neutral-800 */
 }
 
 /* 지도 내부 요소들의 z-index 제한 */


### PR DESCRIPTION
## 개요

Map UI Overhaul 스펙의 Task 1: 단순 UI 텍스트/색상 변경

## 변경 사항

- SpotLoadingSkeleton 배경색 `bg-primary-800` → `bg-neutral-800`
- EmptyFilterOverlay 문구 "아래 필터에서" → "필터에서" (방향 무관)
- map.css `.leaflet-container` 배경색 `#eeedfc` → `#f4f4f5` + 다크 모드 규칙 추가
- Attribution 텍스트 "Anime Pilgrim" → "Not a Trip"

## 관련 Requirements

Requirements 1.1, 7.1, 7.2, 8.1, 8.2, 9.1, 9.2

Closes #430