### PR TITLE
[UI] 필터 바 통합 및 레이아웃 재구성 (Task 4~8)

### DIFF
--- a/.kiro/specs/map-ui-overhaul/tasks.md
+++ b/.kiro/specs/map-ui-overhaul/tasks.md
@@ -40,16 +40,16 @@
     - 임의의 뷰포트 크기에서 LocationButton className에 반응형 분기(`md:`, `lg:` 등) 부재 확인
     - **Validates: Requirements 6.1, 6.2**
 
-- [ ] 3. Checkpoint — 단순 변경 검증
+- [x] 3. Checkpoint — 단순 변경 검증
   - 모든 테스트 통과 확인, 빌드 정상 확인. 문제가 있으면 사용자에게 문의.
 
-- [ ] 4. CategoryFilter 가로 스크롤 전환
-  - [ ] 4.1 CategoryFilter 레이아웃 변경
+- [x] 4. CategoryFilter 가로 스크롤 전환
+  - [x] 4.1 CategoryFilter 레이아웃 변경
     - `src/components/map/CategoryFilter.tsx`에서 `flex flex-wrap` → `flex overflow-x-auto scrollbar-hide`로 변경
     - 모든 카테고리 버튼에 `flex-shrink-0` 클래스 추가
     - 이벤트 전파 차단: `onPointerDown={(e) => e.stopPropagation()}`, `onWheel={(e) => e.stopPropagation()}` 추가
     - _Requirements: 2.1, 2.2, 2.3, 2.4_
-  - [ ] 4.2 scrollbar-hide 유틸리티 CSS 추가
+  - [x] 4.2 scrollbar-hide 유틸리티 CSS 추가
     - `src/app/globals.css`에 `.scrollbar-hide` 클래스 추가 (webkit + Firefox 스크롤바 숨김)
     - _Requirements: 2.3_
   - [ ]* 4.3 Property 1 테스트: 카테고리 버튼 줄바꿈 방지
@@ -57,15 +57,15 @@
     - 임의의 카테고리 부분집합을 생성하여 렌더링 후, 모든 버튼에 `flex-shrink-0` 존재 및 부모 컨테이너에 `overflow-x-auto` 확인
     - **Validates: Requirements 2.2**
 
-- [ ] 5. ContentSearchFilter 토글 제거 및 상시 노출
-  - [ ] 5.1 ContentSearchFilter 토글 로직 제거
+- [x] 5. ContentSearchFilter 토글 제거 및 상시 노출
+  - [x] 5.1 ContentSearchFilter 토글 로직 제거
     - `src/components/map/ContentSearchFilter.tsx`에서 `isExpanded` 상태, `handleToggleExpand`, `onExpandChange` prop 제거
     - 접힌 상태의 돋보기 버튼 렌더링 분기 제거 (항상 입력 필드 렌더링)
     - 배경/테두리/그림자를 제거하여 부모 바에 위임 (통합 바 내 좌측 고정 영역)
     - 너비: `w-48 md:w-56`
     - 300ms 디바운스 유지, 컴포넌트 언마운트 시 타이머 클린업 보장
     - _Requirements: 3.2, 3.4, 3.5, 3.6_
-  - [ ] 5.2 AutocompleteDropdown 방향 변경
+  - [x] 5.2 AutocompleteDropdown 방향 변경
     - `src/components/map/AutocompleteDropdown.tsx`에서 `absolute bottom-full mb-1` → `absolute top-full mt-1`로 변경
     - _Requirements: 3.5_
   - [ ]* 5.3 Property 2 테스트: 검색 입력창 항상 노출
@@ -81,18 +81,18 @@
     - 임의의 입력 시퀀스와 타이밍을 생성하여, 300ms 디바운스 동작 및 언마운트 시 클린업 확인
     - **Validates: Requirements 3.6**
 
-- [ ] 6. Checkpoint — 개별 컴포넌트 변경 검증
+- [x] 6. Checkpoint — 개별 컴포넌트 변경 검증
   - 모든 테스트 통과 확인, 빌드 정상 확인. 문제가 있으면 사용자에게 문의.
 
-- [ ] 7. 필터 바 통합 및 레이아웃 재구성
-  - [ ] 7.1 page.tsx 필터 바를 상단 통합 바로 재구성
+- [x] 7. 필터 바 통합 및 레이아웃 재구성
+  - [x] 7.1 page.tsx 필터 바를 상단 통합 바로 재구성
     - `src/app/page.tsx`에서 하단 플로팅 영역(`absolute bottom-6 left-1/2 -translate-x-1/2`)을 상단 통합 바로 변경
     - 새 구조: `absolute top-0 left-0 right-0 z-[1000]` 컨테이너 내에 `[ContentSearchFilter | 구분선(h-8 w-px bg-neutral-300) | CategoryFilter]` 배치
     - 통합 바 스타일: `bg-white/95 backdrop-blur-sm shadow-lg dark:bg-neutral-900/95`
     - `isSearchExpanded` 상태 및 `onExpandChange` prop 전달 제거
     - 카테고리 필터 숨김 조건(`!isSearchExpanded &&`) 제거 — 항상 노출
     - _Requirements: 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 4.4_
-  - [ ] 7.2 데스크톱 정보 패널 위치 변경
+  - [x] 7.2 데스크톱 정보 패널 위치 변경
     - `src/app/page.tsx`에서 `absolute left-4 top-4` → `absolute left-4 bottom-4`로 변경
     - _Requirements: 10.1, 10.2_
   - [ ]* 7.3 Property 5 테스트: 필터 바 z-index 보장
@@ -104,7 +104,7 @@
     - 임의의 렌더링에서 EmptyFilterOverlay 텍스트에 방향 지시어("아래", "위", "왼쪽", "오른쪽") 부재 확인
     - **Validates: Requirements 7.1**
 
-- [ ] 8. 최종 Checkpoint — 전체 통합 검증
+- [x] 8. 최종 Checkpoint — 전체 통합 검증
   - 모든 테스트 통과 확인, 빌드 정상 확인, 전체 Requirements 커버리지 확인. 문제가 있으면 사용자에게 문의.
 
 ## Notes

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -347,6 +347,15 @@ button:focus-visible {
   }
 }
 
+/* Scrollbar hide utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 .leaflet-container img {
   max-width: none !important;
   max-height: none !important;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState } from 'react'
 import { AppIcon } from '@/components/common/AppIcon'
 import dynamic from 'next/dynamic'
 import { useSpotsSuspense } from '@/hooks/useSpots'
@@ -58,8 +57,6 @@ function HomeContent() {
   // filterStore에서 필터 상태 가져오기
   const selectedCategories = useSelectedCategories()
   const searchQuery = useSearchQuery()
-  const [isSearchExpanded, setIsSearchExpanded] = useState(false)
-
   // 카테고리가 전부 해제되었는지 확인
   const isNoCategorySelected = selectedCategories.length === 0
 
@@ -106,22 +103,19 @@ function HomeContent() {
       {/* 카테고리 필터 전체 해제 시 빈 상태 오버레이 */}
       {isEmptyFilterResult && !isEmptySearchResult && <EmptyFilterOverlay />}
 
-      {/* 필터 영역 (하단 중앙 플로팅 바) */}
-      <div className="absolute bottom-6 left-1/2 z-[1000] -translate-x-1/2">
-        <div className="flex items-center gap-2">
-          {/* 콘텐츠 검색 필터 (토글 버튼) */}
-          <ContentSearchFilter onExpandChange={setIsSearchExpanded} />
-          {/* 카테고리 필터 - 검색창이 열리면 숨김 */}
-          {!isSearchExpanded && (
-            <div className="rounded-2xl bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm">
-              <CategoryFilter />
-            </div>
-          )}
+      {/* 필터 영역 (상단 통합 바) — Requirements 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 4.4 */}
+      <div className="absolute left-0 right-0 top-0 z-[1000]">
+        <div className="flex items-center bg-white/95 px-4 py-2 shadow-lg backdrop-blur-sm dark:bg-neutral-900/95">
+          <ContentSearchFilter />
+          <div className="mx-2 h-8 w-px flex-shrink-0 bg-neutral-300 dark:bg-neutral-700" />
+          <div className="min-w-0 flex-1">
+            <CategoryFilter />
+          </div>
         </div>
       </div>
 
       {/* 데스크톱용 플로팅 정보 패널 */}
-      <div className="absolute left-4 top-4 hidden rounded-lg bg-white/90 p-4 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90 md:block">
+      <div className="absolute bottom-4 left-4 hidden rounded-lg bg-white/90 p-4 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90 md:block">
         <div className="flex items-center space-x-3">
           <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-primary text-white">
             <AppIcon name="location" size="lg" />

--- a/src/components/map/AutocompleteDropdown.tsx
+++ b/src/components/map/AutocompleteDropdown.tsx
@@ -106,7 +106,7 @@ export default function AutocompleteDropdown({
     <div
       id={id}
       ref={dropdownRef}
-      className="absolute bottom-full left-0 z-50 mb-1 w-full overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
+      className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
       role="listbox"
       aria-label="자동완성 제안 목록"
     >

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -40,11 +40,15 @@ export default function CategoryFilter() {
   const isAllSelected = selectedCategories.length === ALL_CATEGORIES.length
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div
+      className="scrollbar-hide flex items-center gap-2 overflow-x-auto"
+      onPointerDown={(e) => e.stopPropagation()}
+      onWheel={(e) => e.stopPropagation()}
+    >
       {/* 전체 선택 버튼 */}
       <button
         onClick={handleSelectAll}
-        className={`h-9 rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
+        className={`h-9 flex-shrink-0 rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
           isAllSelected
             ? 'scale-105 border-primary bg-primary text-white shadow-md'
             : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-500'
@@ -62,7 +66,7 @@ export default function CategoryFilter() {
           <button
             key={category}
             onClick={() => handleCategoryToggle(category)}
-            className={`flex h-9 items-center gap-1.5 overflow-hidden rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
+            className={`flex h-9 flex-shrink-0 items-center gap-1.5 overflow-hidden rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
               isSelected
                 ? 'scale-105 border-transparent shadow-md'
                 : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-500'

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -9,13 +9,11 @@ import AutocompleteDropdown from './AutocompleteDropdown'
 interface ContentSearchFilterProps {
   placeholder?: string
   className?: string
-  onExpandChange?: (expanded: boolean) => void
 }
 
 export default function ContentSearchFilter({
   placeholder = '작품명, 팀명, 아티스트명 검색...',
   className = '',
-  onExpandChange,
 }: ContentSearchFilterProps) {
   const dropdownId = useId()
   const searchQuery = useSearchQuery()
@@ -27,18 +25,13 @@ export default function ContentSearchFilter({
   )
   const [inputValue, setInputValue] = useState(searchQuery)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const [isExpanded, setIsExpanded] = useState(false)
   const { suggestions, isLoading } = useAutocomplete(inputValue)
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     setInputValue(searchQuery)
-    if (searchQuery) {
-      setIsExpanded(true)
-      onExpandChange?.(true)
-    }
-  }, [searchQuery, onExpandChange])
+  }, [searchQuery])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -46,17 +39,13 @@ export default function ContentSearchFilter({
         containerRef.current &&
         !containerRef.current.contains(event.target as Node)
       ) {
-        if (!inputValue && !searchQuery) {
-          setIsExpanded(false)
-          onExpandChange?.(false)
-        }
         setIsDropdownOpen(false)
       }
     }
 
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [inputValue, searchQuery, onExpandChange])
+  }, [])
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -72,9 +61,7 @@ export default function ContentSearchFilter({
     setInputValue('')
     clearSearchQuery()
     setIsDropdownOpen(false)
-    setIsExpanded(false)
-    onExpandChange?.(false)
-  }, [clearSearchQuery, onExpandChange])
+  }, [clearSearchQuery])
 
   const handleSelect = useCallback(
     (item: AutocompleteItem) => {
@@ -115,42 +102,8 @@ export default function ContentSearchFilter({
     [handleClear, inputValue, setSearchQuery]
   )
 
-  const handleToggleExpand = useCallback(() => {
-    const newExpanded = !isExpanded
-    setIsExpanded(newExpanded)
-    onExpandChange?.(newExpanded)
-    if (newExpanded) {
-      setTimeout(() => inputRef.current?.focus(), 100)
-    }
-  }, [isExpanded, onExpandChange])
-
-  if (!isExpanded) {
-    return (
-      <button
-        onClick={handleToggleExpand}
-        className={`flex h-10 w-10 items-center justify-center rounded-full bg-white/95 shadow-lg backdrop-blur-sm transition-all hover:bg-white dark:bg-neutral-800/95 dark:hover:bg-neutral-800 ${className}`}
-        aria-label="검색 열기"
-      >
-        <svg
-          className="h-5 w-5 text-primary dark:text-primary-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          />
-        </svg>
-      </button>
-    )
-  }
-
   return (
-    <div ref={containerRef} className={`relative ${className}`}>
+    <div ref={containerRef} className={`relative w-48 md:w-56 ${className}`}>
       <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
         <svg
           className="h-4 w-4 text-neutral-400 dark:text-neutral-500"
@@ -175,7 +128,7 @@ export default function ContentSearchFilter({
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-64 rounded-full border border-neutral-200 bg-white/95 py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 shadow-lg backdrop-blur-sm transition-all focus:border-primary focus:bg-white focus:outline-none focus:ring-1 focus:ring-primary dark:border-neutral-700 dark:bg-neutral-800/95 dark:text-white dark:placeholder-neutral-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+        className="w-full rounded-full bg-transparent py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 transition-all focus:outline-none dark:text-white dark:placeholder-neutral-400"
         role="combobox"
         aria-label="콘텐츠 검색"
         aria-expanded={isDropdownOpen}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #434

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

지도 메인 페이지의 필터 바를 하단 분리형에서 상단 통합 바로 재구성하고, 카테고리 필터를 가로 스크롤로 전환하며, 검색 입력창을 항상 노출하도록 개편.

---

## 📋 변경 사항

- [x] CategoryFilter: flex-wrap → overflow-x-auto 가로 스크롤, flex-shrink-0, 이벤트 전파 차단
- [x] globals.css: scrollbar-hide 유틸리티 CSS 추가
- [x] ContentSearchFilter: 토글 로직 제거, 항상 입력 필드 노출, 배경/테두리 제거
- [x] AutocompleteDropdown: 드롭다운 방향 하단으로 변경 (bottom-full → top-full)
- [x] page.tsx: 필터 바 상단 통합 바로 재구성, 데스크톱 정보 패널 좌측 하단으로 이동

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 2.1~2.4, 3.1~3.6, 4.1~4.4, 10.1, 10.2 대응
- 선택 사항 PBT 태스크(4.3, 5.3~5.5, 7.3~7.4)는 미포함
- 이전 PR의 Task 1~3 변경분도 포함 (동일 브랜치)