### PR TITLE
[UI] 필터 바 다크 모드 수정 및 검색 입력창 UX 개선

### DIFF
--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -20,7 +20,7 @@ function RouteListSkeleton() {
         {Array.from({ length: 6 }, (_, i) => (
           <div
             key={i}
-            className="overflow-hidden rounded-lg border border-neutral-200 bg-white"
+            className="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800"
           >
             <SkeletonBlock className="h-40 w-full rounded-none" />
             <div className="p-4">

--- a/src/components/common/EmptyFilterOverlay.tsx
+++ b/src/components/common/EmptyFilterOverlay.tsx
@@ -7,17 +7,17 @@ import { FilterIcon } from '@/components/icons'
 export function EmptyFilterOverlay() {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="pointer-events-auto rounded-xl bg-white/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
+      <div className="pointer-events-auto rounded-xl bg-white/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface dark:bg-neutral-700">
           <FilterIcon size="lg" className="text-muted" />
         </div>
-        <p className="text-lg font-semibold text-primary-800">
+        <p className="text-lg font-semibold text-primary-800 dark:text-primary-300">
           카테고리를 선택해주세요
         </p>
-        <p className="mt-2 text-sm text-secondary">
+        <p className="mt-2 text-sm text-secondary dark:text-neutral-400">
           표시할 스팟 카테고리가 선택되지 않았습니다
         </p>
-        <p className="mt-1 text-xs text-muted">
+        <p className="mt-1 text-xs text-muted dark:text-neutral-500">
           필터에서 원하는 카테고리를 선택하세요
         </p>
       </div>

--- a/src/components/common/EmptySearchOverlay.tsx
+++ b/src/components/common/EmptySearchOverlay.tsx
@@ -11,17 +11,17 @@ interface EmptySearchOverlayProps {
 export function EmptySearchOverlay({ searchQuery }: EmptySearchOverlayProps) {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="pointer-events-auto rounded-xl bg-white/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
+      <div className="pointer-events-auto rounded-xl bg-white/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface dark:bg-neutral-700">
           <SearchIcon size="lg" className="text-muted" />
         </div>
-        <p className="text-lg font-semibold text-primary-800">
+        <p className="text-lg font-semibold text-primary-800 dark:text-primary-300">
           검색 결과가 없습니다
         </p>
-        <p className="mt-2 text-sm text-secondary">
+        <p className="mt-2 text-sm text-secondary dark:text-neutral-400">
           &quot;{searchQuery}&quot;에 해당하는 스팟을 찾을 수 없습니다
         </p>
-        <p className="mt-1 text-xs text-muted">
+        <p className="mt-1 text-xs text-muted dark:text-neutral-500">
           다른 검색어를 입력하거나 필터를 조정해 보세요
         </p>
       </div>

--- a/src/components/common/SkeletonUI.tsx
+++ b/src/components/common/SkeletonUI.tsx
@@ -18,7 +18,7 @@ interface SkeletonBaseProps {
 export function SkeletonBlock({ className = '' }: SkeletonBaseProps) {
   return (
     <div
-      className={`animate-pulse rounded bg-neutral-200 ${className}`}
+      className={`animate-pulse rounded bg-neutral-200 dark:bg-neutral-700 ${className}`}
       role="status"
       aria-label="로딩 중"
     />
@@ -31,7 +31,7 @@ export function SkeletonBlock({ className = '' }: SkeletonBaseProps) {
  */
 export function SpotCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-sm">
+    <div className="overflow-hidden rounded-lg bg-white shadow-sm dark:bg-neutral-800">
       {/* 이미지 영역 */}
       <SkeletonBlock className="h-48 w-full rounded-none" />
       <div className="p-4">
@@ -52,7 +52,7 @@ export function SpotCardSkeleton() {
  */
 export function GalleryCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-sm">
+    <div className="overflow-hidden rounded-lg bg-white shadow-sm dark:bg-neutral-800">
       <SkeletonBlock className="h-48 w-full rounded-none" />
       <div className="p-3">
         <SkeletonBlock className="mb-2 h-4 w-3/4" />
@@ -83,13 +83,15 @@ export function GalleryGridSkeleton({ count = 8 }: { count?: number }) {
 export function MapSkeleton() {
   return (
     <div
-      className="flex h-full w-full items-center justify-center bg-neutral-800"
+      className="flex h-full w-full items-center justify-center bg-neutral-100 dark:bg-neutral-800"
       role="status"
       aria-label="지도 로딩 중"
     >
       <div className="text-center">
-        <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-neutral-400 border-t-white" />
-        <p className="mt-4 text-neutral-200">지도 로딩 중...</p>
+        <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-neutral-300 border-t-primary dark:border-neutral-600 dark:border-t-primary-400" />
+        <p className="mt-4 text-neutral-500 dark:text-neutral-300">
+          지도 로딩 중...
+        </p>
       </div>
     </div>
   )

--- a/src/components/common/SkeletonUI.tsx
+++ b/src/components/common/SkeletonUI.tsx
@@ -103,36 +103,33 @@ export function MapSkeleton() {
  */
 export function SpotDetailSkeleton() {
   return (
-    <div className="min-h-screen bg-neutral-50">
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-white px-4 py-4 dark:border-neutral-700 dark:bg-neutral-800">
         <div className="mx-auto max-w-7xl">
-          <SkeletonBlock className="h-5 w-32 bg-neutral-200" />
-          <SkeletonBlock className="mt-2 h-6 w-40 bg-neutral-200" />
+          <SkeletonBlock className="h-5 w-32" />
+          <SkeletonBlock className="mt-2 h-6 w-40" />
         </div>
       </div>
 
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="space-y-8">
           {/* 스팟 정보 카드 */}
-          <div className="rounded-lg bg-white p-6 shadow-md">
-            <SkeletonBlock className="mb-4 h-8 w-64 bg-neutral-200" />
-            <SkeletonBlock className="mb-4 h-4 w-48 bg-neutral-200" />
+          <div className="rounded-lg bg-white p-6 shadow-md dark:bg-neutral-800">
+            <SkeletonBlock className="mb-4 h-8 w-64" />
+            <SkeletonBlock className="mb-4 h-4 w-48" />
             <div className="space-y-2">
-              <SkeletonBlock className="h-4 w-full bg-neutral-200" />
-              <SkeletonBlock className="h-4 w-3/4 bg-neutral-200" />
+              <SkeletonBlock className="h-4 w-full" />
+              <SkeletonBlock className="h-4 w-3/4" />
             </div>
           </div>
 
           {/* 사진 그리드 */}
-          <div className="rounded-lg bg-white p-6 shadow-md">
-            <SkeletonBlock className="mb-4 h-6 w-16 bg-neutral-200" />
+          <div className="rounded-lg bg-white p-6 shadow-md dark:bg-neutral-800">
+            <SkeletonBlock className="mb-4 h-6 w-16" />
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3].map((i) => (
-                <SkeletonBlock
-                  key={i}
-                  className="aspect-video bg-neutral-200"
-                />
+                <SkeletonBlock key={i} className="aspect-video" />
               ))}
             </div>
           </div>
@@ -148,21 +145,21 @@ export function SpotDetailSkeleton() {
  */
 export function GalleryPageSkeleton() {
   return (
-    <main className="min-h-screen bg-primary-50">
+    <main className="min-h-screen bg-primary-50 dark:bg-neutral-900">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-6">
+      <div className="border-b border-neutral-200 bg-white px-4 py-6 dark:border-neutral-700 dark:bg-neutral-800">
         <div className="mx-auto max-w-6xl">
           <SkeletonBlock className="h-8 w-32" />
-          <SkeletonBlock className="mt-2 h-4 w-48 bg-surface" />
+          <SkeletonBlock className="mt-2 h-4 w-48" />
           <div className="mt-4 flex gap-4">
-            <SkeletonBlock className="h-6 w-24 bg-surface" />
-            <SkeletonBlock className="h-6 w-24 bg-surface" />
+            <SkeletonBlock className="h-6 w-24" />
+            <SkeletonBlock className="h-6 w-24" />
           </div>
         </div>
       </div>
 
       {/* 탭 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-3">
+      <div className="border-b border-neutral-200 bg-white px-4 py-3 dark:border-neutral-700 dark:bg-neutral-800">
         <div className="mx-auto flex max-w-6xl gap-2">
           <SkeletonBlock className="h-10 w-28" />
           <SkeletonBlock className="h-10 w-28" />

--- a/src/components/common/SpotErrorDisplay.tsx
+++ b/src/components/common/SpotErrorDisplay.tsx
@@ -11,15 +11,17 @@ interface SpotErrorDisplayProps {
  */
 export function SpotErrorDisplay({ error, onRetry }: SpotErrorDisplayProps) {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-primary-800">
+    <div className="flex h-full w-full items-center justify-center bg-neutral-100 dark:bg-neutral-800">
       <div className="text-center">
-        <div className="mx-auto h-12 w-12 rounded-full bg-danger-surface p-3">
+        <div className="mx-auto h-12 w-12 rounded-full bg-danger-surface p-3 dark:bg-red-900/30">
           <AlertTriangleIcon size={24} color="#dc2626" />
         </div>
-        <p className="mt-4 text-neutral-200">
+        <p className="mt-4 text-neutral-700 dark:text-neutral-200">
           스팟 데이터를 불러올 수 없습니다
         </p>
-        <p className="mt-1 text-xs text-muted">{error.message}</p>
+        <p className="mt-1 text-xs text-muted dark:text-neutral-500">
+          {error.message}
+        </p>
         <button
           onClick={onRetry}
           className="mt-3 rounded bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-primary-400"

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -25,6 +25,7 @@ export default function ContentSearchFilter({
   )
   const [inputValue, setInputValue] = useState(searchQuery)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
   const { suggestions, isLoading } = useAutocomplete(inputValue)
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -51,7 +52,6 @@ export default function ContentSearchFilter({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
       setInputValue(value)
-      // 입력 시에는 자동완성만 열고, 실제 검색은 하지 않음
       setIsDropdownOpen(value.length >= 2)
     },
     []
@@ -77,10 +77,15 @@ export default function ContentSearchFilter({
   }, [])
 
   const handleFocus = useCallback(() => {
+    setIsFocused(true)
     if (inputValue.length >= 2) {
       setIsDropdownOpen(true)
     }
   }, [inputValue.length])
+
+  const handleBlur = useCallback(() => {
+    setIsFocused(false)
+  }, [])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -92,7 +97,6 @@ export default function ContentSearchFilter({
           handleClear()
         }
       } else if (e.key === 'Enter') {
-        // Enter 키 입력 시에만 검색 적용
         if (inputValue.trim()) {
           setSearchQuery(inputValue.trim())
         }
@@ -103,60 +107,78 @@ export default function ContentSearchFilter({
   )
 
   return (
-    <div ref={containerRef} className={`relative w-48 md:w-56 ${className}`}>
-      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-        <svg
-          className="h-4 w-4 text-neutral-400 dark:text-neutral-500"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          />
-        </svg>
-      </div>
-      <input
-        ref={inputRef}
-        type="text"
-        value={inputValue}
-        onChange={handleInputChange}
-        onFocus={handleFocus}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        className="w-full rounded-full bg-transparent py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 transition-all focus:outline-none dark:text-white dark:placeholder-neutral-400"
-        role="combobox"
-        aria-label="콘텐츠 검색"
-        aria-expanded={isDropdownOpen}
-        aria-controls={dropdownId}
-        aria-haspopup="listbox"
-        aria-autocomplete="list"
-      />
-      <button
-        type="button"
-        onClick={handleClear}
-        className="absolute inset-y-0 right-0 flex items-center pr-3 text-neutral-400 transition-colors hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300"
-        aria-label="검색어 초기화"
+    <div
+      ref={containerRef}
+      className={`relative flex-shrink-0 transition-all duration-300 ease-in-out ${
+        isFocused ? 'w-72' : 'w-48 md:w-56'
+      } ${className}`}
+    >
+      <div
+        className={`flex items-center rounded-full transition-all duration-200 ${
+          isFocused
+            ? 'bg-white ring-2 ring-primary/50 dark:bg-neutral-800'
+            : 'bg-transparent'
+        }`}
       >
-        <svg
-          className="h-4 w-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+          <svg
+            className={`h-4 w-4 transition-colors ${
+              isFocused
+                ? 'text-primary dark:text-primary-400'
+                : 'text-neutral-400 dark:text-neutral-500'
+            }`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={handleInputChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="w-full rounded-full bg-transparent py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-400 focus:outline-none dark:text-neutral-100 dark:placeholder-neutral-500"
+          role="combobox"
+          aria-label="콘텐츠 검색"
+          aria-expanded={isDropdownOpen}
+          aria-controls={dropdownId}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+        />
+        <button
+          type="button"
+          onClick={handleClear}
+          className="absolute inset-y-0 right-0 flex items-center pr-3 text-neutral-400 transition-colors hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300"
+          aria-label="검색어 초기화"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M6 18L18 6M6 6l12 12"
-          />
-        </svg>
-      </button>
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
       <AutocompleteDropdown
         id={dropdownId}
         items={suggestions}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #438

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

필터 바 다크 모드 전면 수정 및 검색 입력창 포커스 UX 개선 (확장 애니메이션 + 테두리 유지).

---

## 📋 변경 사항

- [x] ContentSearchFilter: 포커스 시 w-48 → w-72 부드러운 확장 애니메이션 (duration-300)
- [x] ContentSearchFilter: 포커스 중 ring-2 ring-primary/50 테두리 유지
- [x] ContentSearchFilter: 포커스 시 돋보기 아이콘 primary 색상 전환
- [x] EmptyFilterOverlay: 다크 모드 배경/텍스트 추가
- [x] EmptySearchOverlay: 다크 모드 배경/텍스트 추가
- [x] SpotErrorDisplay: bg-primary-800 → bg-neutral-100/dark:bg-neutral-800 수정
- [x] SkeletonUI: SkeletonBlock, MapSkeleton, SpotCardSkeleton, GalleryCardSkeleton 다크 모드 추가

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인