### PR TITLE
[UI] bg-white 다크 모드 일괄 적용

### DIFF
--- a/src/app/admin/content-images/page.tsx
+++ b/src/app/admin/content-images/page.tsx
@@ -247,7 +247,7 @@ export default function AdminContentImagesPage() {
             {contents.map((content) => (
               <div
                 key={content.id}
-                className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                className="rounded-lg border border-gray-200 bg-surface p-4 shadow-sm"
               >
                 <div className="flex items-start gap-3">
                   <div className="flex-shrink-0">
@@ -336,7 +336,7 @@ export default function AdminContentImagesPage() {
 
       {showUploadModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+          <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
             <h2 className="mb-4 text-xl font-bold text-gray-800">
               {selectedContent ? '이미지 업로드' : '새 콘텐츠 추가'}
             </h2>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -36,7 +36,7 @@ export default function AdminDashboardPage() {
   return (
     <div className="min-h-screen bg-neutral-50">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-6 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-6 py-4">
         <h1 className="text-xl font-bold text-neutral-800">관리자 대시보드</h1>
         <p className="mt-0.5 text-sm text-neutral-500">
           모든 관리 기능의 현황을 확인하고 빠르게 이동할 수 있습니다
@@ -58,7 +58,7 @@ export default function AdminDashboardPage() {
             {[...Array(4)].map((_, i) => (
               <div
                 key={i}
-                className="h-40 animate-pulse rounded-xl border border-neutral-200 bg-white"
+                className="h-40 animate-pulse rounded-xl border border-neutral-200 bg-surface"
               />
             ))}
           </div>

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -40,7 +40,7 @@ export default function AdminReportsPage() {
 
   return (
     <div className="min-h-screen bg-neutral-50">
-      <div className="border-b border-neutral-200 bg-white px-6 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-6 py-4">
         <h1 className="text-xl font-bold text-neutral-800">제보 관리</h1>
         <p className="mt-0.5 text-sm text-neutral-500">
           유저 제보를 검토하고 승인/반려할 수 있습니다
@@ -48,7 +48,7 @@ export default function AdminReportsPage() {
       </div>
 
       <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
-        <div className="w-96 flex-shrink-0 border-r border-neutral-200 bg-white">
+        <div className="w-96 flex-shrink-0 border-r border-neutral-200 bg-surface">
           <AdminReportList
             onSelectReport={handleSelectReport}
             selectedReportId={selectedReport?.id}

--- a/src/app/admin/status-reports/page.tsx
+++ b/src/app/admin/status-reports/page.tsx
@@ -42,7 +42,7 @@ export default function AdminStatusReportsPage() {
 
   return (
     <div className="min-h-screen bg-neutral-50">
-      <div className="border-b border-neutral-200 bg-white px-6 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-6 py-4">
         <h1 className="text-xl font-bold text-neutral-800">상태 신고 검토</h1>
         <p className="mt-0.5 text-sm text-neutral-500">
           사용자가 신고한 스팟 상태를 검토하고 확인 처리할 수 있습니다
@@ -50,7 +50,7 @@ export default function AdminStatusReportsPage() {
       </div>
 
       <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
-        <div className="w-96 flex-shrink-0 border-r border-neutral-200 bg-white">
+        <div className="w-96 flex-shrink-0 border-r border-neutral-200 bg-surface">
           <AdminStatusReportList
             onSelectReport={handleSelectReport}
             selectedReportId={selectedReport?.id}

--- a/src/app/admin/supplements/page.tsx
+++ b/src/app/admin/supplements/page.tsx
@@ -41,7 +41,7 @@ export default function AdminSupplementsPage() {
 
   return (
     <div className="min-h-screen bg-neutral-50">
-      <div className="border-b border-neutral-200 bg-white px-6 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-6 py-4">
         <h1 className="text-xl font-bold text-neutral-800">정보 보완 검토</h1>
         <p className="mt-0.5 text-sm text-neutral-500">
           사용자가 제출한 정보 보완을 검토하고 승인/반려할 수 있습니다
@@ -49,7 +49,7 @@ export default function AdminSupplementsPage() {
       </div>
 
       <div className="flex h-[calc(100vh-theme(spacing.14)-73px)]">
-        <div className="w-96 flex-shrink-0 border-r border-neutral-200 bg-white">
+        <div className="w-96 flex-shrink-0 border-r border-neutral-200 bg-surface">
           <AdminSupplementList
             onSelectSupplement={handleSelectSupplement}
             selectedSupplementId={selectedSupplement?.id}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -50,7 +50,7 @@ function SignInForm() {
         <button
           onClick={() => loginWithProvider('google')}
           disabled={isLoading}
-          className="flex w-full items-center justify-center gap-3 rounded-lg bg-white px-4 py-3 text-gray-700 transition hover:bg-gray-100 disabled:opacity-50"
+          className="flex w-full items-center justify-center gap-3 rounded-lg bg-surface px-4 py-3 text-gray-700 transition hover:bg-gray-100 disabled:opacity-50"
         >
           <svg className="h-5 w-5" viewBox="0 0 24 24">
             <path

--- a/src/app/community/[id]/edit/page.tsx
+++ b/src/app/community/[id]/edit/page.tsx
@@ -125,7 +125,7 @@ export default function EditPostPage() {
   if (isLoading) {
     return (
       <main className="bg-navy-50 min-h-screen">
-        <div className="border-navy-200 border-b bg-white px-4 py-4">
+        <div className="border-navy-200 border-b bg-surface px-4 py-4">
           <div className="mx-auto max-w-4xl">
             <h1 className="text-navy-800 text-xl font-bold">게시글 수정</h1>
             <p className="text-navy-500 text-sm">로딩 중...</p>
@@ -144,14 +144,14 @@ export default function EditPostPage() {
   if (error || !post) {
     return (
       <main className="bg-navy-50 min-h-screen">
-        <div className="border-navy-200 border-b bg-white px-4 py-4">
+        <div className="border-navy-200 border-b bg-surface px-4 py-4">
           <div className="mx-auto max-w-4xl">
             <h1 className="text-navy-800 text-xl font-bold">게시글 수정</h1>
             <p className="text-navy-500 text-sm">오류 발생</p>
           </div>
         </div>
         <div className="mx-auto max-w-4xl px-4 py-6">
-          <div className="rounded-lg bg-white p-6 text-center shadow-sm">
+          <div className="rounded-lg bg-surface p-6 text-center shadow-sm">
             <p className="text-navy-600">게시글을 찾을 수 없습니다.</p>
             <Link
               href="/community"
@@ -169,14 +169,14 @@ export default function EditPostPage() {
   if (!canEdit()) {
     return (
       <main className="bg-navy-50 min-h-screen">
-        <div className="border-navy-200 border-b bg-white px-4 py-4">
+        <div className="border-navy-200 border-b bg-surface px-4 py-4">
           <div className="mx-auto max-w-4xl">
             <h1 className="text-navy-800 text-xl font-bold">게시글 수정</h1>
             <p className="text-navy-500 text-sm">권한 없음</p>
           </div>
         </div>
         <div className="mx-auto max-w-4xl px-4 py-6">
-          <div className="rounded-lg bg-white p-6 text-center shadow-sm">
+          <div className="rounded-lg bg-surface p-6 text-center shadow-sm">
             <p className="text-navy-600">본인의 게시글만 수정할 수 있습니다.</p>
             <Link
               href={`/community/${postId}`}
@@ -193,7 +193,7 @@ export default function EditPostPage() {
   return (
     <main className="bg-navy-50 min-h-screen">
       {/* 페이지 타이틀 */}
-      <div className="border-navy-200 border-b bg-white px-4 py-4">
+      <div className="border-navy-200 border-b bg-surface px-4 py-4">
         <div className="mx-auto max-w-4xl">
           <h1 className="text-navy-800 text-xl font-bold">게시글 수정</h1>
           <p className="text-navy-500 text-sm">
@@ -206,7 +206,7 @@ export default function EditPostPage() {
 
       {/* 메인 콘텐츠 */}
       <div className="mx-auto max-w-4xl px-4 py-6">
-        <div className="rounded-lg bg-white p-6 shadow-sm">
+        <div className="rounded-lg bg-surface p-6 shadow-sm">
           {/* 비회원 게시글 안내 */}
           {post.isGuest && (
             <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4">

--- a/src/app/community/media/[title]/page.tsx
+++ b/src/app/community/media/[title]/page.tsx
@@ -105,7 +105,7 @@ export default function MediaPilgrimagePage({ params }: PageProps) {
   return (
     <main className="bg-navy-50 min-h-screen">
       {/* 페이지 타이틀 */}
-      <div className="border-navy-200 border-b bg-white px-4 py-4">
+      <div className="border-navy-200 border-b bg-surface px-4 py-4">
         <div className="mx-auto max-w-4xl">
           <div className="flex items-center gap-2">
             <Link
@@ -177,7 +177,7 @@ export default function MediaPilgrimagePage({ params }: PageProps) {
         {/* 통계 카드 */}
         {data && (
           <div className="mb-6 grid grid-cols-2 gap-4">
-            <div className="rounded-lg bg-white p-4 shadow-sm">
+            <div className="rounded-lg bg-surface p-4 shadow-sm">
               <div className="flex items-center gap-3">
                 <div className="bg-navy-100 flex h-10 w-10 items-center justify-center rounded-full">
                   <svg
@@ -202,7 +202,7 @@ export default function MediaPilgrimagePage({ params }: PageProps) {
                 </div>
               </div>
             </div>
-            <div className="rounded-lg bg-white p-4 shadow-sm">
+            <div className="rounded-lg bg-surface p-4 shadow-sm">
               <div className="flex items-center gap-3">
                 <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100">
                   <svg
@@ -237,7 +237,7 @@ export default function MediaPilgrimagePage({ params }: PageProps) {
         )}
 
         {/* 성지 목록 */}
-        <div className="rounded-lg bg-white shadow-sm">
+        <div className="rounded-lg bg-surface shadow-sm">
           <div className="border-navy-100 border-b px-4 py-3">
             <div className="flex items-center gap-2">
               <svg

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -142,7 +142,7 @@ function WriteForm() {
   }
 
   return (
-    <div className="rounded-lg bg-white p-6 shadow-sm">
+    <div className="rounded-lg bg-surface p-6 shadow-sm">
       {/* 에러 메시지 표시 */}
       {errors.length > 0 && (
         <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4">
@@ -510,7 +510,7 @@ function WriteForm() {
  */
 function WriteFormSkeleton() {
   return (
-    <div className="rounded-lg bg-white p-6 shadow-sm">
+    <div className="rounded-lg bg-surface p-6 shadow-sm">
       <div className="animate-pulse space-y-6">
         <div className="h-16 w-full rounded-lg bg-neutral-200"></div>
         <div>
@@ -550,7 +550,7 @@ export default function WritePage() {
   return (
     <main className="min-h-screen bg-primary-50">
       {/* 페이지 타이틀 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-4xl">
           <h1 className="text-xl font-bold text-primary">게시글 작성</h1>
           <p className="text-sm text-secondary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,7 +91,7 @@ function HomeContent() {
 
       {/* 필터 영역 (상단 통합 바) */}
       <div className="absolute left-0 right-0 top-0 z-[1000]">
-        <div className="flex items-center border-b border-neutral-200 bg-white/95 px-4 py-3 shadow-sm backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/95">
+        <div className="flex items-center border-b border-neutral-200 bg-surface/95 px-4 py-3 shadow-sm backdrop-blur-sm dark:bg-neutral-900/95">
           <ContentSearchFilter />
           <div className="mx-2 h-8 w-px flex-shrink-0 bg-neutral-300 dark:bg-neutral-700" />
           <div className="min-w-0 flex-1">
@@ -107,7 +107,7 @@ function HomeContent() {
       </div>
 
       {/* 데스크톱용 플로팅 정보 패널 */}
-      <div className="absolute bottom-4 left-4 hidden rounded-lg bg-white/90 p-4 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90 md:block">
+      <div className="absolute bottom-4 left-4 hidden rounded-lg bg-surface/90 p-4 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90 md:block">
         <div className="flex items-center space-x-3">
           <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-primary text-white">
             <AppIcon name="location" size="lg" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,7 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
  */
 export default function Home() {
   return (
-    <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-neutral-100 dark:bg-neutral-900">
+    <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
       <HomeContent />
     </main>
   )
@@ -91,29 +91,29 @@ function HomeContent() {
 
       {/* 필터 영역 (상단 통합 바) */}
       <div className="absolute left-0 right-0 top-0 z-[1000]">
-        <div className="flex items-center border-b border-neutral-200 bg-surface/95 px-4 py-3 shadow-sm backdrop-blur-sm dark:bg-neutral-900/95">
+        <div className="flex items-center border-b border-neutral-200 bg-surface/95 px-4 py-3 shadow-sm backdrop-blur-sm">
           <ContentSearchFilter />
-          <div className="mx-2 h-8 w-px flex-shrink-0 bg-neutral-300 dark:bg-neutral-700" />
+          <div className="mx-2 h-8 w-px flex-shrink-0 bg-neutral-300" />
           <div className="min-w-0 flex-1">
             <CategoryFilter />
           </div>
         </div>
         {/* 필터 변경 시 얇은 로딩 프로그레스 바 */}
         {(isFetching || isPlaceholderData) && (
-          <div className="h-0.5 w-full overflow-hidden bg-neutral-200 dark:bg-neutral-700">
+          <div className="h-0.5 w-full overflow-hidden bg-neutral-200">
             <div className="animate-loading-bar h-full w-1/3 bg-primary" />
           </div>
         )}
       </div>
 
       {/* 데스크톱용 플로팅 정보 패널 */}
-      <div className="absolute bottom-4 left-4 hidden rounded-lg bg-surface/90 p-4 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90 md:block">
+      <div className="absolute bottom-4 left-4 hidden rounded-lg bg-surface/90 p-4 shadow-lg backdrop-blur-sm md:block">
         <div className="flex items-center space-x-3">
           <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-primary text-white">
             <AppIcon name="location" size="lg" />
           </div>
           <div>
-            <p className="text-sm font-semibold text-primary dark:text-primary-400">
+            <p className="text-sm font-semibold text-primary">
               {spotCount}개의 특별한 여행지
             </p>
             <p className="text-xs text-secondary dark:text-neutral-400">

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -72,7 +72,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
     <div className="min-h-screen bg-gray-50">
       <div className="mx-auto max-w-4xl px-4 py-8">
         {/* 프로필 헤더 */}
-        <div className="mb-8 rounded-xl bg-white p-6 shadow-sm">
+        <div className="mb-8 rounded-xl bg-surface p-6 shadow-sm">
           <div className="flex items-center gap-4">
             {userInfo.image ? (
               <Image
@@ -123,7 +123,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
             className={`rounded-lg px-4 py-2 font-medium ${
               activeTab === 'checkins'
                 ? 'bg-blue-600 text-white'
-                : 'bg-white text-gray-600 hover:bg-gray-50'
+                : 'bg-surface text-gray-600 hover:bg-gray-50'
             }`}
           >
             인증 갤러리
@@ -133,7 +133,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
             className={`rounded-lg px-4 py-2 font-medium ${
               activeTab === 'badges'
                 ? 'bg-blue-600 text-white'
-                : 'bg-white text-gray-600 hover:bg-gray-50'
+                : 'bg-surface text-gray-600 hover:bg-gray-50'
             }`}
           >
             트로피 룸
@@ -143,7 +143,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
             className={`rounded-lg px-4 py-2 font-medium ${
               activeTab === 'progress'
                 ? 'bg-blue-600 text-white'
-                : 'bg-white text-gray-600 hover:bg-gray-50'
+                : 'bg-surface text-gray-600 hover:bg-gray-50'
             }`}
           >
             진행 현황
@@ -153,7 +153,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
             className={`rounded-lg px-4 py-2 font-medium ${
               activeTab === 'reports'
                 ? 'bg-primary text-white'
-                : 'bg-white text-neutral-600 hover:bg-neutral-50'
+                : 'bg-surface text-neutral-600 hover:bg-neutral-50'
             }`}
           >
             제보한 스팟
@@ -161,7 +161,7 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
         </div>
 
         {/* 탭 콘텐츠 */}
-        <div className="rounded-xl bg-white p-6 shadow-sm">
+        <div className="rounded-xl bg-surface p-6 shadow-sm">
           {activeTab === 'checkins' && (
             <CheckInGallery userId={userId} limit={12} />
           )}

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function ReportDetailPage() {
   if (error) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-neutral-50">
-        <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 text-center shadow-md">
+        <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 text-center shadow-md">
           <p className="text-lg">😥</p>
           <p className="mt-2 text-sm text-secondary">{error.message}</p>
           <Link
@@ -57,7 +57,7 @@ export default function ReportDetailPage() {
   if (!report) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-neutral-50">
-        <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 text-center shadow-md">
+        <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 text-center shadow-md">
           <p className="text-lg">📭</p>
           <p className="mt-2 text-sm text-secondary">제보를 찾을 수 없습니다</p>
           <Link
@@ -74,7 +74,7 @@ export default function ReportDetailPage() {
   return (
     <div className="min-h-screen bg-neutral-50">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-lg">
           <Link
             href="/reports"
@@ -152,7 +152,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
         )}
 
       {/* 장소 정보 */}
-      <div className="rounded-lg bg-white p-4 shadow-sm">
+      <div className="rounded-lg bg-surface p-4 shadow-sm">
         <div className="flex items-start justify-between">
           <div>
             <h2 className="text-lg font-bold text-primary">{report.name}</h2>
@@ -180,7 +180,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
 
       {/* 작품 정보 */}
       {report.relatedContent && report.relatedContent.length > 0 && (
-        <div className="rounded-lg bg-white p-4 shadow-sm">
+        <div className="rounded-lg bg-surface p-4 shadow-sm">
           <h3 className="text-sm font-semibold text-secondary">관련 작품</h3>
           <div className="mt-2 flex flex-wrap gap-2">
             {report.relatedContent.map((content, i) => (
@@ -197,7 +197,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
 
       {/* 증거 사진 쌍 */}
       {report.evidencePairs.length > 0 && (
-        <div className="rounded-lg bg-white p-4 shadow-sm">
+        <div className="rounded-lg bg-surface p-4 shadow-sm">
           <h3 className="text-sm font-semibold text-secondary">증거 사진</h3>
           <div className="mt-3 space-y-3">
             {report.evidencePairs.map((pair, i) => (
@@ -243,7 +243,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
       )}
 
       {/* 제출 정보 */}
-      <div className="rounded-lg bg-white p-4 shadow-sm">
+      <div className="rounded-lg bg-surface p-4 shadow-sm">
         <div className="flex items-center justify-between text-xs text-muted">
           <span>
             제보일: {new Date(report.createdAt).toLocaleDateString('ko-KR')}
@@ -270,7 +270,7 @@ function ReportDetailContent({ report }: { report: SpotReport }) {
 /** 검토 히스토리 타임라인 */
 function ReviewHistoryTimeline({ history }: { history: ReviewHistory[] }) {
   return (
-    <div className="rounded-lg bg-white p-4 shadow-sm">
+    <div className="rounded-lg bg-surface p-4 shadow-sm">
       <h3 className="text-sm font-semibold text-secondary">검토 이력</h3>
       <div className="mt-3 space-y-3">
         {history.map((entry, i) => (
@@ -387,7 +387,7 @@ function RevisionForm({ report }: { report: SpotReport }) {
 function ReportDetailSkeleton() {
   return (
     <div className="min-h-screen bg-neutral-50">
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-lg">
           <div className="h-4 w-24 animate-pulse rounded bg-surface" />
           <div className="mt-3 h-6 w-40 animate-pulse rounded bg-surface" />

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -18,7 +18,7 @@ export default function NewReportPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-neutral-50">
-        <div className="border-b border-neutral-200 bg-white px-4 py-4">
+        <div className="border-b border-neutral-200 bg-surface px-4 py-4">
           <div className="mx-auto max-w-lg">
             <div className="h-6 w-32 animate-pulse rounded bg-surface" />
           </div>
@@ -52,7 +52,7 @@ export default function NewReportPage() {
   return (
     <div className="min-h-screen bg-neutral-50">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-lg">
           <Link
             href="/reports"

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -17,7 +17,7 @@ export default function MyReportsPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-neutral-50">
-        <div className="border-b border-neutral-200 bg-white px-4 py-4">
+        <div className="border-b border-neutral-200 bg-surface px-4 py-4">
           <div className="mx-auto max-w-lg">
             <div className="h-6 w-32 animate-pulse rounded bg-surface" />
           </div>
@@ -50,7 +50,7 @@ export default function MyReportsPage() {
   return (
     <div className="min-h-screen bg-neutral-50">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-lg">
           <Link
             href="/"

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -20,7 +20,7 @@ function RouteListSkeleton() {
         {Array.from({ length: 6 }, (_, i) => (
           <div
             key={i}
-            className="overflow-hidden rounded-lg border border-neutral-200 bg-surface dark:bg-neutral-800"
+            className="overflow-hidden rounded-lg border border-neutral-200 bg-surface"
           >
             <SkeletonBlock className="h-40 w-full rounded-none" />
             <div className="p-4">

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -20,7 +20,7 @@ function RouteListSkeleton() {
         {Array.from({ length: 6 }, (_, i) => (
           <div
             key={i}
-            className="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800"
+            className="overflow-hidden rounded-lg border border-neutral-200 bg-surface dark:bg-neutral-800"
           >
             <SkeletonBlock className="h-40 w-full rounded-none" />
             <div className="p-4">

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -13,7 +13,7 @@ const OAUTH_PROVIDERS = [
   {
     id: 'google',
     name: 'Google',
-    color: 'bg-white text-gray-700 hover:bg-gray-100',
+    color: 'bg-surface text-gray-700 hover:bg-gray-100',
   },
   {
     id: 'kakao',

--- a/src/app/spots/[id]/edit/page.tsx
+++ b/src/app/spots/[id]/edit/page.tsx
@@ -16,7 +16,7 @@ import { UploadedImage } from '@/components/spot/ImageUpload'
 function NoPermission() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-neutral-50">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow-md">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md">
         <div className="text-center">
           <svg
             className="mx-auto mb-4 h-16 w-16 text-red-500"
@@ -119,7 +119,7 @@ export default function SpotEditPage() {
   if (authLoading || spotLoading || isLoading) {
     return (
       <main className="min-h-screen bg-primary-50">
-        <div className="border-b border-neutral-200 bg-white px-4 py-4">
+        <div className="border-b border-neutral-200 bg-surface px-4 py-4">
           <div className="mx-auto max-w-4xl">
             <Link
               href={`/spots/${spotId}`}
@@ -160,7 +160,7 @@ export default function SpotEditPage() {
   if (!isAuthenticated) {
     return (
       <main className="min-h-screen bg-primary-50">
-        <div className="border-b border-neutral-200 bg-white px-4 py-4">
+        <div className="border-b border-neutral-200 bg-surface px-4 py-4">
           <div className="mx-auto max-w-4xl">
             <h1 className="text-xl font-bold text-primary">스팟 수정</h1>
           </div>
@@ -185,7 +185,7 @@ export default function SpotEditPage() {
 
   return (
     <main className="min-h-screen bg-primary-50">
-      <div className="border-b border-neutral-200 bg-white px-4 py-4">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-4xl">
           <Link
             href={`/spots/${spotId}`}

--- a/src/components/admin/AdminDashboardCard.tsx
+++ b/src/components/admin/AdminDashboardCard.tsx
@@ -25,7 +25,7 @@ export function AdminDashboardCard({
   return (
     <Link
       href={href}
-      className="group block rounded-xl border border-neutral-200 bg-white p-6 shadow-sm transition-all hover:border-primary-300 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-800"
+      className="group block rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm transition-all hover:border-primary-300 hover:shadow-md dark:bg-neutral-800"
     >
       <div className="flex items-start justify-between">
         <span

--- a/src/components/admin/AdminDashboardCard.tsx
+++ b/src/components/admin/AdminDashboardCard.tsx
@@ -25,7 +25,7 @@ export function AdminDashboardCard({
   return (
     <Link
       href={href}
-      className="group block rounded-xl border border-neutral-200 bg-white p-6 shadow-sm transition-all hover:border-primary-300 hover:shadow-md"
+      className="group block rounded-xl border border-neutral-200 bg-white p-6 shadow-sm transition-all hover:border-primary-300 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-800"
     >
       <div className="flex items-start justify-between">
         <span

--- a/src/components/admin/AdminDashboardCard.tsx
+++ b/src/components/admin/AdminDashboardCard.tsx
@@ -25,7 +25,7 @@ export function AdminDashboardCard({
   return (
     <Link
       href={href}
-      className="group block rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm transition-all hover:border-primary-300 hover:shadow-md dark:bg-neutral-800"
+      className="group block rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm transition-all hover:border-primary-300 hover:shadow-md"
     >
       <div className="flex items-start justify-between">
         <span

--- a/src/components/admin/AdminReportReview.tsx
+++ b/src/components/admin/AdminReportReview.tsx
@@ -82,7 +82,7 @@ export function AdminReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -129,7 +129,7 @@ export function AdminReportReview({
 
         {/* 작품 정보 */}
         {report.relatedContent && report.relatedContent.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               작품 정보
             </h3>
@@ -158,7 +158,7 @@ export function AdminReportReview({
 
         {/* 증거 사진 쌍 */}
         {report.evidencePairs && report.evidencePairs.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               증거 사진 ({report.evidencePairs.length}쌍)
             </h3>
@@ -207,7 +207,7 @@ export function AdminReportReview({
 
         {/* 검토 히스토리 */}
         {report.reviewHistory && report.reviewHistory.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토 히스토리
             </h3>
@@ -250,7 +250,7 @@ export function AdminReportReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토
             </h3>

--- a/src/components/admin/AdminReportReview.tsx
+++ b/src/components/admin/AdminReportReview.tsx
@@ -82,7 +82,7 @@ export function AdminReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -129,7 +129,7 @@ export function AdminReportReview({
 
         {/* 작품 정보 */}
         {report.relatedContent && report.relatedContent.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               작품 정보
             </h3>
@@ -158,7 +158,7 @@ export function AdminReportReview({
 
         {/* 증거 사진 쌍 */}
         {report.evidencePairs && report.evidencePairs.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               증거 사진 ({report.evidencePairs.length}쌍)
             </h3>
@@ -207,7 +207,7 @@ export function AdminReportReview({
 
         {/* 검토 히스토리 */}
         {report.reviewHistory && report.reviewHistory.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토 히스토리
             </h3>
@@ -250,7 +250,7 @@ export function AdminReportReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토
             </h3>

--- a/src/components/admin/AdminReportReview.tsx
+++ b/src/components/admin/AdminReportReview.tsx
@@ -82,7 +82,7 @@ export function AdminReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4">
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -129,7 +129,7 @@ export function AdminReportReview({
 
         {/* 작품 정보 */}
         {report.relatedContent && report.relatedContent.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               작품 정보
             </h3>
@@ -158,7 +158,7 @@ export function AdminReportReview({
 
         {/* 증거 사진 쌍 */}
         {report.evidencePairs && report.evidencePairs.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               증거 사진 ({report.evidencePairs.length}쌍)
             </h3>
@@ -207,7 +207,7 @@ export function AdminReportReview({
 
         {/* 검토 히스토리 */}
         {report.reviewHistory && report.reviewHistory.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토 히스토리
             </h3>
@@ -250,7 +250,7 @@ export function AdminReportReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토
             </h3>

--- a/src/components/admin/AdminStatusReportReview.tsx
+++ b/src/components/admin/AdminStatusReportReview.tsx
@@ -117,7 +117,7 @@ export function AdminStatusReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -148,7 +148,7 @@ export function AdminStatusReportReview({
         </section>
 
         {/* 설명 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             신고 내용
           </h3>
@@ -159,7 +159,7 @@ export function AdminStatusReportReview({
 
         {/* 증거 사진 */}
         {report.photoUrl && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               증거 사진
             </h3>
@@ -185,7 +185,7 @@ export function AdminStatusReportReview({
         {isPending && (
           <section className="space-y-4">
             {/* 확인 처리 */}
-            <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+            <div className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
               <h3 className="mb-3 text-sm font-semibold text-neutral-700">
                 확인 처리
               </h3>
@@ -199,7 +199,7 @@ export function AdminStatusReportReview({
             </div>
 
             {/* 스팟 상태 수동 변경 */}
-            <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+            <div className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
               <h3 className="mb-3 text-sm font-semibold text-neutral-700">
                 스팟 상태 수동 변경
               </h3>

--- a/src/components/admin/AdminStatusReportReview.tsx
+++ b/src/components/admin/AdminStatusReportReview.tsx
@@ -117,7 +117,7 @@ export function AdminStatusReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4">
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -148,7 +148,7 @@ export function AdminStatusReportReview({
         </section>
 
         {/* 설명 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4">
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             신고 내용
           </h3>
@@ -159,7 +159,7 @@ export function AdminStatusReportReview({
 
         {/* 증거 사진 */}
         {report.photoUrl && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               증거 사진
             </h3>
@@ -185,7 +185,7 @@ export function AdminStatusReportReview({
         {isPending && (
           <section className="space-y-4">
             {/* 확인 처리 */}
-            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
               <h3 className="mb-3 text-sm font-semibold text-neutral-700">
                 확인 처리
               </h3>
@@ -199,7 +199,7 @@ export function AdminStatusReportReview({
             </div>
 
             {/* 스팟 상태 수동 변경 */}
-            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
               <h3 className="mb-3 text-sm font-semibold text-neutral-700">
                 스팟 상태 수동 변경
               </h3>

--- a/src/components/admin/AdminStatusReportReview.tsx
+++ b/src/components/admin/AdminStatusReportReview.tsx
@@ -117,7 +117,7 @@ export function AdminStatusReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -148,7 +148,7 @@ export function AdminStatusReportReview({
         </section>
 
         {/* 설명 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             신고 내용
           </h3>
@@ -159,7 +159,7 @@ export function AdminStatusReportReview({
 
         {/* 증거 사진 */}
         {report.photoUrl && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               증거 사진
             </h3>
@@ -185,7 +185,7 @@ export function AdminStatusReportReview({
         {isPending && (
           <section className="space-y-4">
             {/* 확인 처리 */}
-            <div className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+            <div className="rounded-lg border border-neutral-200 bg-surface p-4">
               <h3 className="mb-3 text-sm font-semibold text-neutral-700">
                 확인 처리
               </h3>
@@ -199,7 +199,7 @@ export function AdminStatusReportReview({
             </div>
 
             {/* 스팟 상태 수동 변경 */}
-            <div className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+            <div className="rounded-lg border border-neutral-200 bg-surface p-4">
               <h3 className="mb-3 text-sm font-semibold text-neutral-700">
                 스팟 상태 수동 변경
               </h3>

--- a/src/components/admin/AdminSupplementReview.tsx
+++ b/src/components/admin/AdminSupplementReview.tsx
@@ -114,7 +114,7 @@ export function AdminSupplementReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -145,7 +145,7 @@ export function AdminSupplementReview({
         </section>
 
         {/* 보완 내용 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             보완 내용
           </h3>
@@ -156,7 +156,7 @@ export function AdminSupplementReview({
 
         {/* 씬 정보 (scene_info 타입) */}
         {supplement.type === 'scene_info' && supplement.sceneInfo && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               씬 정보
             </h3>
@@ -195,7 +195,7 @@ export function AdminSupplementReview({
 
         {/* 사진 (photo 타입) */}
         {supplement.photos && supplement.photos.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               첨부 사진 ({supplement.photos.length}장)
             </h3>
@@ -230,7 +230,7 @@ export function AdminSupplementReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토
             </h3>

--- a/src/components/admin/AdminSupplementReview.tsx
+++ b/src/components/admin/AdminSupplementReview.tsx
@@ -114,7 +114,7 @@ export function AdminSupplementReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -145,7 +145,7 @@ export function AdminSupplementReview({
         </section>
 
         {/* 보완 내용 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             보완 내용
           </h3>
@@ -156,7 +156,7 @@ export function AdminSupplementReview({
 
         {/* 씬 정보 (scene_info 타입) */}
         {supplement.type === 'scene_info' && supplement.sceneInfo && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               씬 정보
             </h3>
@@ -195,7 +195,7 @@ export function AdminSupplementReview({
 
         {/* 사진 (photo 타입) */}
         {supplement.photos && supplement.photos.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               첨부 사진 ({supplement.photos.length}장)
             </h3>
@@ -230,7 +230,7 @@ export function AdminSupplementReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4 dark:bg-neutral-800">
+          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토
             </h3>

--- a/src/components/admin/AdminSupplementReview.tsx
+++ b/src/components/admin/AdminSupplementReview.tsx
@@ -114,7 +114,7 @@ export function AdminSupplementReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4">
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             기본 정보
           </h3>
@@ -145,7 +145,7 @@ export function AdminSupplementReview({
         </section>
 
         {/* 보완 내용 */}
-        <section className="rounded-lg border border-neutral-200 bg-white p-4">
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
           <h3 className="mb-3 text-sm font-semibold text-neutral-700">
             보완 내용
           </h3>
@@ -156,7 +156,7 @@ export function AdminSupplementReview({
 
         {/* 씬 정보 (scene_info 타입) */}
         {supplement.type === 'scene_info' && supplement.sceneInfo && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               씬 정보
             </h3>
@@ -195,7 +195,7 @@ export function AdminSupplementReview({
 
         {/* 사진 (photo 타입) */}
         {supplement.photos && supplement.photos.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               첨부 사진 ({supplement.photos.length}장)
             </h3>
@@ -230,7 +230,7 @@ export function AdminSupplementReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-white p-4">
+          <section className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
             <h3 className="mb-3 text-sm font-semibold text-neutral-700">
               검토
             </h3>

--- a/src/components/admin/ReportSummaryCard.tsx
+++ b/src/components/admin/ReportSummaryCard.tsx
@@ -32,7 +32,7 @@ export const ReportSummaryCard = React.memo(function ReportSummaryCard({
       className={`w-full rounded-lg border p-3 text-left transition-colors ${
         isSelected
           ? 'border-neutral-400 bg-primary-50'
-          : 'border-neutral-200 bg-white hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+          : 'border-neutral-200 bg-surface hover:bg-neutral-50 dark:bg-neutral-800'
       }`}
     >
       <div className="flex gap-3">

--- a/src/components/admin/ReportSummaryCard.tsx
+++ b/src/components/admin/ReportSummaryCard.tsx
@@ -32,7 +32,7 @@ export const ReportSummaryCard = React.memo(function ReportSummaryCard({
       className={`w-full rounded-lg border p-3 text-left transition-colors ${
         isSelected
           ? 'border-neutral-400 bg-primary-50'
-          : 'border-neutral-200 bg-white hover:bg-neutral-50'
+          : 'border-neutral-200 bg-white hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
       }`}
     >
       <div className="flex gap-3">

--- a/src/components/admin/ReportSummaryCard.tsx
+++ b/src/components/admin/ReportSummaryCard.tsx
@@ -32,7 +32,7 @@ export const ReportSummaryCard = React.memo(function ReportSummaryCard({
       className={`w-full rounded-lg border p-3 text-left transition-colors ${
         isSelected
           ? 'border-neutral-400 bg-primary-50'
-          : 'border-neutral-200 bg-surface hover:bg-neutral-50 dark:bg-neutral-800'
+          : 'border-neutral-200 bg-surface hover:bg-neutral-50'
       }`}
     >
       <div className="flex gap-3">

--- a/src/components/admin/StatusReportSummaryCard.tsx
+++ b/src/components/admin/StatusReportSummaryCard.tsx
@@ -60,7 +60,7 @@ export const StatusReportSummaryCard = React.memo(
         className={`w-full rounded-lg border p-3 text-left transition-colors ${
           isSelected
             ? 'border-neutral-400 bg-primary-50'
-            : 'border-neutral-200 bg-surface hover:bg-neutral-50 dark:bg-neutral-800'
+            : 'border-neutral-200 bg-surface hover:bg-neutral-50'
         }`}
       >
         <div className="flex items-start justify-between gap-2">

--- a/src/components/admin/StatusReportSummaryCard.tsx
+++ b/src/components/admin/StatusReportSummaryCard.tsx
@@ -60,7 +60,7 @@ export const StatusReportSummaryCard = React.memo(
         className={`w-full rounded-lg border p-3 text-left transition-colors ${
           isSelected
             ? 'border-neutral-400 bg-primary-50'
-            : 'border-neutral-200 bg-white hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+            : 'border-neutral-200 bg-surface hover:bg-neutral-50 dark:bg-neutral-800'
         }`}
       >
         <div className="flex items-start justify-between gap-2">

--- a/src/components/admin/StatusReportSummaryCard.tsx
+++ b/src/components/admin/StatusReportSummaryCard.tsx
@@ -60,7 +60,7 @@ export const StatusReportSummaryCard = React.memo(
         className={`w-full rounded-lg border p-3 text-left transition-colors ${
           isSelected
             ? 'border-neutral-400 bg-primary-50'
-            : 'border-neutral-200 bg-white hover:bg-neutral-50'
+            : 'border-neutral-200 bg-white hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
         }`}
       >
         <div className="flex items-start justify-between gap-2">

--- a/src/components/admin/SupplementSummaryCard.tsx
+++ b/src/components/admin/SupplementSummaryCard.tsx
@@ -63,7 +63,7 @@ export const SupplementSummaryCard = React.memo(function SupplementSummaryCard({
       className={`w-full rounded-lg border p-3 text-left transition-colors ${
         isSelected
           ? 'border-neutral-400 bg-primary-50'
-          : 'border-neutral-200 bg-surface hover:bg-neutral-50 dark:bg-neutral-800'
+          : 'border-neutral-200 bg-surface hover:bg-neutral-50'
       }`}
     >
       <div className="flex items-start justify-between gap-2">

--- a/src/components/admin/SupplementSummaryCard.tsx
+++ b/src/components/admin/SupplementSummaryCard.tsx
@@ -63,7 +63,7 @@ export const SupplementSummaryCard = React.memo(function SupplementSummaryCard({
       className={`w-full rounded-lg border p-3 text-left transition-colors ${
         isSelected
           ? 'border-neutral-400 bg-primary-50'
-          : 'border-neutral-200 bg-white hover:bg-neutral-50'
+          : 'border-neutral-200 bg-white hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
       }`}
     >
       <div className="flex items-start justify-between gap-2">

--- a/src/components/admin/SupplementSummaryCard.tsx
+++ b/src/components/admin/SupplementSummaryCard.tsx
@@ -63,7 +63,7 @@ export const SupplementSummaryCard = React.memo(function SupplementSummaryCard({
       className={`w-full rounded-lg border p-3 text-left transition-colors ${
         isSelected
           ? 'border-neutral-400 bg-primary-50'
-          : 'border-neutral-200 bg-white hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+          : 'border-neutral-200 bg-surface hover:bg-neutral-50 dark:bg-neutral-800'
       }`}
     >
       <div className="flex items-start justify-between gap-2">

--- a/src/components/checkin/BadgeEarnedModal.tsx
+++ b/src/components/checkin/BadgeEarnedModal.tsx
@@ -39,7 +39,7 @@ export function BadgeEarnedModal({ badges, onClose }: BadgeEarnedModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
       <div className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 p-1">
-        <div className="rounded-xl bg-white p-6 text-center dark:bg-neutral-800">
+        <div className="rounded-xl bg-surface p-6 text-center dark:bg-neutral-800">
           {/* 축하 텍스트 */}
           <div className="mb-4">
             <span className="text-4xl">🎉</span>
@@ -108,7 +108,7 @@ export function BadgeEarnedModal({ badges, onClose }: BadgeEarnedModalProps) {
           {[...Array(20)].map((_, i) => (
             <div
               key={i}
-              className="absolute h-1 w-1 animate-ping rounded-full bg-white"
+              className="absolute h-1 w-1 animate-ping rounded-full bg-surface"
               style={{
                 left: `${Math.random() * 100}%`,
                 top: `${Math.random() * 100}%`,

--- a/src/components/checkin/BadgeEarnedModal.tsx
+++ b/src/components/checkin/BadgeEarnedModal.tsx
@@ -39,7 +39,7 @@ export function BadgeEarnedModal({ badges, onClose }: BadgeEarnedModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
       <div className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 p-1">
-        <div className="rounded-xl bg-white p-6 text-center">
+        <div className="rounded-xl bg-white p-6 text-center dark:bg-neutral-800">
           {/* 축하 텍스트 */}
           <div className="mb-4">
             <span className="text-4xl">🎉</span>

--- a/src/components/checkin/BadgeEarnedModal.tsx
+++ b/src/components/checkin/BadgeEarnedModal.tsx
@@ -39,7 +39,7 @@ export function BadgeEarnedModal({ badges, onClose }: BadgeEarnedModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
       <div className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 p-1">
-        <div className="rounded-xl bg-surface p-6 text-center dark:bg-neutral-800">
+        <div className="rounded-xl bg-surface p-6 text-center">
           {/* 축하 텍스트 */}
           <div className="mb-4">
             <span className="text-4xl">🎉</span>

--- a/src/components/checkin/CheckInDetailModal.tsx
+++ b/src/components/checkin/CheckInDetailModal.tsx
@@ -31,7 +31,7 @@ export function CheckInDetailModal({
       onClick={onClose}
     >
       <div
-        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white"
+        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white dark:bg-neutral-800"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}

--- a/src/components/checkin/CheckInDetailModal.tsx
+++ b/src/components/checkin/CheckInDetailModal.tsx
@@ -31,7 +31,7 @@ export function CheckInDetailModal({
       onClick={onClose}
     >
       <div
-        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white dark:bg-neutral-800"
+        className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-surface"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}

--- a/src/components/checkin/CheckInModal.tsx
+++ b/src/components/checkin/CheckInModal.tsx
@@ -138,7 +138,7 @@ export function CheckInModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white dark:bg-neutral-800">
+      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-surface">
         {/* 헤더 */}
         <div className="flex items-center justify-between border-b p-4">
           <h2 className="text-lg font-bold">순례 인증</h2>

--- a/src/components/checkin/CheckInModal.tsx
+++ b/src/components/checkin/CheckInModal.tsx
@@ -138,7 +138,7 @@ export function CheckInModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white">
+      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white dark:bg-neutral-800">
         {/* 헤더 */}
         <div className="flex items-center justify-between border-b p-4">
           <h2 className="text-lg font-bold">순례 인증</h2>

--- a/src/components/checkin/ComparisonViewer.tsx
+++ b/src/components/checkin/ComparisonViewer.tsx
@@ -163,10 +163,10 @@ export function ComparisonViewer({
 
         {/* 슬라이더 핸들 */}
         <div
-          className="absolute bottom-0 top-0 w-1 bg-white shadow-lg"
+          className="absolute bottom-0 top-0 w-1 bg-surface shadow-lg"
           style={{ left: `${sliderPosition}%`, transform: 'translateX(-50%)' }}
         >
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white p-2 shadow-lg">
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-surface p-2 shadow-lg">
             <svg
               className="h-4 w-4 text-gray-600"
               fill="none"

--- a/src/components/checkin/QuickCheckIn.tsx
+++ b/src/components/checkin/QuickCheckIn.tsx
@@ -147,7 +147,7 @@ export function QuickCheckIn({
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 sm:items-center">
-      <div className="w-full max-w-lg rounded-t-2xl bg-white dark:bg-neutral-800 sm:rounded-2xl">
+      <div className="w-full max-w-lg rounded-t-2xl bg-surface sm:rounded-2xl">
         {/* 헤더 */}
         <div className="flex items-center justify-between border-b p-4">
           <div>

--- a/src/components/checkin/QuickCheckIn.tsx
+++ b/src/components/checkin/QuickCheckIn.tsx
@@ -147,7 +147,7 @@ export function QuickCheckIn({
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 sm:items-center">
-      <div className="w-full max-w-lg rounded-t-2xl bg-white sm:rounded-2xl">
+      <div className="w-full max-w-lg rounded-t-2xl bg-white dark:bg-neutral-800 sm:rounded-2xl">
         {/* 헤더 */}
         <div className="flex items-center justify-between border-b p-4">
           <div>

--- a/src/components/common/DirectionsButton.tsx
+++ b/src/components/common/DirectionsButton.tsx
@@ -122,7 +122,7 @@ export default function DirectionsButton({
 
       {isOpen && (
         <div
-          className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black/5"
+          className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black/5 dark:bg-neutral-800"
           role="menu"
           aria-label="지도 앱 선택"
         >

--- a/src/components/common/DirectionsButton.tsx
+++ b/src/components/common/DirectionsButton.tsx
@@ -122,7 +122,7 @@ export default function DirectionsButton({
 
       {isOpen && (
         <div
-          className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5 dark:bg-neutral-800"
+          className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5"
           role="menu"
           aria-label="지도 앱 선택"
         >

--- a/src/components/common/DirectionsButton.tsx
+++ b/src/components/common/DirectionsButton.tsx
@@ -122,7 +122,7 @@ export default function DirectionsButton({
 
       {isOpen && (
         <div
-          className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black/5 dark:bg-neutral-800"
+          className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5 dark:bg-neutral-800"
           role="menu"
           aria-label="지도 앱 선택"
         >

--- a/src/components/common/EmptyFilterOverlay.tsx
+++ b/src/components/common/EmptyFilterOverlay.tsx
@@ -7,8 +7,8 @@ import { FilterIcon } from '@/components/icons'
 export function EmptyFilterOverlay() {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface dark:bg-neutral-700">
+      <div className="backdrop-blur-sm/95 pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
           <FilterIcon size="lg" className="text-muted" />
         </div>
         <p className="text-lg font-semibold text-primary-800 dark:text-primary-300">

--- a/src/components/common/EmptyFilterOverlay.tsx
+++ b/src/components/common/EmptyFilterOverlay.tsx
@@ -7,7 +7,7 @@ import { FilterIcon } from '@/components/icons'
 export function EmptyFilterOverlay() {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="pointer-events-auto rounded-xl bg-white/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
+      <div className="pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
         <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface dark:bg-neutral-700">
           <FilterIcon size="lg" className="text-muted" />
         </div>

--- a/src/components/common/EmptySearchOverlay.tsx
+++ b/src/components/common/EmptySearchOverlay.tsx
@@ -11,8 +11,8 @@ interface EmptySearchOverlayProps {
 export function EmptySearchOverlay({ searchQuery }: EmptySearchOverlayProps) {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface dark:bg-neutral-700">
+      <div className="backdrop-blur-sm/95 pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
           <SearchIcon size="lg" className="text-muted" />
         </div>
         <p className="text-lg font-semibold text-primary-800 dark:text-primary-300">

--- a/src/components/common/EmptySearchOverlay.tsx
+++ b/src/components/common/EmptySearchOverlay.tsx
@@ -11,7 +11,7 @@ interface EmptySearchOverlayProps {
 export function EmptySearchOverlay({ searchQuery }: EmptySearchOverlayProps) {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="pointer-events-auto rounded-xl bg-white/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
+      <div className="pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl backdrop-blur-sm dark:bg-neutral-800/95">
         <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface dark:bg-neutral-700">
           <SearchIcon size="lg" className="text-muted" />
         </div>

--- a/src/components/common/LoginRequiredModal.tsx
+++ b/src/components/common/LoginRequiredModal.tsx
@@ -22,7 +22,7 @@ export function LoginRequiredModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-900">
+      <div className="mx-4 w-full max-w-sm rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-900">
         <div className="mb-4 flex justify-center">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
             <svg

--- a/src/components/common/LoginRequiredModal.tsx
+++ b/src/components/common/LoginRequiredModal.tsx
@@ -22,7 +22,7 @@ export function LoginRequiredModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="mx-4 w-full max-w-sm rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-900">
+      <div className="mx-4 w-full max-w-sm rounded-lg bg-surface p-6 shadow-xl">
         <div className="mb-4 flex justify-center">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
             <svg

--- a/src/components/common/SkeletonUI.tsx
+++ b/src/components/common/SkeletonUI.tsx
@@ -18,7 +18,7 @@ interface SkeletonBaseProps {
 export function SkeletonBlock({ className = '' }: SkeletonBaseProps) {
   return (
     <div
-      className={`animate-pulse rounded bg-neutral-200 dark:bg-neutral-700 ${className}`}
+      className={`animate-pulse rounded bg-neutral-200 ${className}`}
       role="status"
       aria-label="로딩 중"
     />
@@ -31,7 +31,7 @@ export function SkeletonBlock({ className = '' }: SkeletonBaseProps) {
  */
 export function SpotCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg bg-surface shadow-sm dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-sm">
       {/* 이미지 영역 */}
       <SkeletonBlock className="h-48 w-full rounded-none" />
       <div className="p-4">
@@ -52,7 +52,7 @@ export function SpotCardSkeleton() {
  */
 export function GalleryCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg bg-surface shadow-sm dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-sm">
       <SkeletonBlock className="h-48 w-full rounded-none" />
       <div className="p-3">
         <SkeletonBlock className="mb-2 h-4 w-3/4" />
@@ -83,7 +83,7 @@ export function GalleryGridSkeleton({ count = 8 }: { count?: number }) {
 export function MapSkeleton() {
   return (
     <div
-      className="flex h-full w-full items-center justify-center bg-neutral-100 dark:bg-neutral-800"
+      className="flex h-full w-full items-center justify-center bg-neutral-100"
       role="status"
       aria-label="지도 로딩 중"
     >
@@ -101,9 +101,9 @@ export function MapSkeleton() {
  */
 export function SpotDetailSkeleton() {
   return (
-    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
+    <div className="min-h-screen bg-neutral-50">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-surface px-4 py-4 dark:bg-neutral-800">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4">
         <div className="mx-auto max-w-7xl">
           <SkeletonBlock className="h-5 w-32" />
           <SkeletonBlock className="mt-2 h-6 w-40" />
@@ -113,7 +113,7 @@ export function SpotDetailSkeleton() {
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="space-y-8">
           {/* 스팟 정보 카드 */}
-          <div className="rounded-lg bg-surface p-6 shadow-md dark:bg-neutral-800">
+          <div className="rounded-lg bg-surface p-6 shadow-md">
             <SkeletonBlock className="mb-4 h-8 w-64" />
             <SkeletonBlock className="mb-4 h-4 w-48" />
             <div className="space-y-2">
@@ -123,7 +123,7 @@ export function SpotDetailSkeleton() {
           </div>
 
           {/* 사진 그리드 */}
-          <div className="rounded-lg bg-surface p-6 shadow-md dark:bg-neutral-800">
+          <div className="rounded-lg bg-surface p-6 shadow-md">
             <SkeletonBlock className="mb-4 h-6 w-16" />
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3].map((i) => (
@@ -143,9 +143,9 @@ export function SpotDetailSkeleton() {
  */
 export function GalleryPageSkeleton() {
   return (
-    <main className="min-h-screen bg-primary-50 dark:bg-neutral-900">
+    <main className="min-h-screen bg-primary-50">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-surface px-4 py-6 dark:bg-neutral-800">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-6">
         <div className="mx-auto max-w-6xl">
           <SkeletonBlock className="h-8 w-32" />
           <SkeletonBlock className="mt-2 h-4 w-48" />
@@ -157,7 +157,7 @@ export function GalleryPageSkeleton() {
       </div>
 
       {/* 탭 */}
-      <div className="border-b border-neutral-200 bg-surface px-4 py-3 dark:bg-neutral-800">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-3">
         <div className="mx-auto flex max-w-6xl gap-2">
           <SkeletonBlock className="h-10 w-28" />
           <SkeletonBlock className="h-10 w-28" />

--- a/src/components/common/SkeletonUI.tsx
+++ b/src/components/common/SkeletonUI.tsx
@@ -31,7 +31,7 @@ export function SkeletonBlock({ className = '' }: SkeletonBaseProps) {
  */
 export function SpotCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-sm dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-sm dark:bg-neutral-800">
       {/* 이미지 영역 */}
       <SkeletonBlock className="h-48 w-full rounded-none" />
       <div className="p-4">
@@ -52,7 +52,7 @@ export function SpotCardSkeleton() {
  */
 export function GalleryCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-sm dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-sm dark:bg-neutral-800">
       <SkeletonBlock className="h-48 w-full rounded-none" />
       <div className="p-3">
         <SkeletonBlock className="mb-2 h-4 w-3/4" />
@@ -89,9 +89,7 @@ export function MapSkeleton() {
     >
       <div className="text-center">
         <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-neutral-300 border-t-primary dark:border-neutral-600 dark:border-t-primary-400" />
-        <p className="mt-4 text-neutral-500 dark:text-neutral-300">
-          지도 로딩 중...
-        </p>
+        <p className="mt-4 text-neutral-500">지도 로딩 중...</p>
       </div>
     </div>
   )
@@ -105,7 +103,7 @@ export function SpotDetailSkeleton() {
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-4 dark:bg-neutral-800">
         <div className="mx-auto max-w-7xl">
           <SkeletonBlock className="h-5 w-32" />
           <SkeletonBlock className="mt-2 h-6 w-40" />
@@ -115,7 +113,7 @@ export function SpotDetailSkeleton() {
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="space-y-8">
           {/* 스팟 정보 카드 */}
-          <div className="rounded-lg bg-white p-6 shadow-md dark:bg-neutral-800">
+          <div className="rounded-lg bg-surface p-6 shadow-md dark:bg-neutral-800">
             <SkeletonBlock className="mb-4 h-8 w-64" />
             <SkeletonBlock className="mb-4 h-4 w-48" />
             <div className="space-y-2">
@@ -125,7 +123,7 @@ export function SpotDetailSkeleton() {
           </div>
 
           {/* 사진 그리드 */}
-          <div className="rounded-lg bg-white p-6 shadow-md dark:bg-neutral-800">
+          <div className="rounded-lg bg-surface p-6 shadow-md dark:bg-neutral-800">
             <SkeletonBlock className="mb-4 h-6 w-16" />
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3].map((i) => (
@@ -147,7 +145,7 @@ export function GalleryPageSkeleton() {
   return (
     <main className="min-h-screen bg-primary-50 dark:bg-neutral-900">
       {/* 헤더 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-6 dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-6 dark:bg-neutral-800">
         <div className="mx-auto max-w-6xl">
           <SkeletonBlock className="h-8 w-32" />
           <SkeletonBlock className="mt-2 h-4 w-48" />
@@ -159,7 +157,7 @@ export function GalleryPageSkeleton() {
       </div>
 
       {/* 탭 */}
-      <div className="border-b border-neutral-200 bg-white px-4 py-3 dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="border-b border-neutral-200 bg-surface px-4 py-3 dark:bg-neutral-800">
         <div className="mx-auto flex max-w-6xl gap-2">
           <SkeletonBlock className="h-10 w-28" />
           <SkeletonBlock className="h-10 w-28" />

--- a/src/components/common/SpotErrorDisplay.tsx
+++ b/src/components/common/SpotErrorDisplay.tsx
@@ -11,7 +11,7 @@ interface SpotErrorDisplayProps {
  */
 export function SpotErrorDisplay({ error, onRetry }: SpotErrorDisplayProps) {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-neutral-100 dark:bg-neutral-800">
+    <div className="flex h-full w-full items-center justify-center bg-neutral-100">
       <div className="text-center">
         <div className="mx-auto h-12 w-12 rounded-full bg-danger-surface p-3 dark:bg-red-900/30">
           <AlertTriangleIcon size={24} color="#dc2626" />

--- a/src/components/common/SpotLoadingSkeleton.tsx
+++ b/src/components/common/SpotLoadingSkeleton.tsx
@@ -6,7 +6,7 @@ import { SpinnerIcon } from '@/components/icons'
  */
 export function SpotLoadingSkeleton() {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-neutral-100 dark:bg-neutral-800">
+    <div className="flex h-full w-full items-center justify-center bg-neutral-100">
       <div className="text-center">
         <SpinnerIcon
           size="lg"

--- a/src/components/common/SpotLoadingSkeleton.tsx
+++ b/src/components/common/SpotLoadingSkeleton.tsx
@@ -12,9 +12,7 @@ export function SpotLoadingSkeleton() {
           size="lg"
           className="mx-auto animate-spin text-neutral-400 dark:text-neutral-200"
         />
-        <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-300">
-          스팟 데이터 로딩 중...
-        </p>
+        <p className="mt-2 text-sm text-neutral-500">스팟 데이터 로딩 중...</p>
       </div>
     </div>
   )

--- a/src/components/community/CommentSection.tsx
+++ b/src/components/community/CommentSection.tsx
@@ -313,7 +313,9 @@ export default function CommentSection({
   }
 
   return (
-    <div className={`rounded-lg bg-white p-6 shadow-sm ${className}`}>
+    <div
+      className={`rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800 ${className}`}
+    >
       {/* 섹션 헤더 */}
       <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-primary-800">
         <svg
@@ -393,7 +395,7 @@ export default function CommentSection({
             className="absolute inset-0 bg-black/50"
             onClick={() => setDeleteTarget(null)}
           />
-          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
             <h3 className="mb-2 text-lg font-semibold text-primary-800">
               댓글 삭제
             </h3>

--- a/src/components/community/CommentSection.tsx
+++ b/src/components/community/CommentSection.tsx
@@ -314,7 +314,7 @@ export default function CommentSection({
 
   return (
     <div
-      className={`rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800 ${className}`}
+      className={`rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800 ${className}`}
     >
       {/* 섹션 헤더 */}
       <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-primary-800">
@@ -395,7 +395,7 @@ export default function CommentSection({
             className="absolute inset-0 bg-black/50"
             onClick={() => setDeleteTarget(null)}
           />
-          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
+          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
             <h3 className="mb-2 text-lg font-semibold text-primary-800">
               댓글 삭제
             </h3>

--- a/src/components/community/CommentSection.tsx
+++ b/src/components/community/CommentSection.tsx
@@ -313,9 +313,7 @@ export default function CommentSection({
   }
 
   return (
-    <div
-      className={`rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800 ${className}`}
-    >
+    <div className={`rounded-lg bg-surface p-6 shadow-sm ${className}`}>
       {/* 섹션 헤더 */}
       <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-primary-800">
         <svg
@@ -395,7 +393,7 @@ export default function CommentSection({
             className="absolute inset-0 bg-black/50"
             onClick={() => setDeleteTarget(null)}
           />
-          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
+          <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-surface p-6 shadow-xl">
             <h3 className="mb-2 text-lg font-semibold text-primary-800">
               댓글 삭제
             </h3>

--- a/src/components/community/PasswordModal.tsx
+++ b/src/components/community/PasswordModal.tsx
@@ -75,7 +75,7 @@ export default function PasswordModal({
       />
 
       {/* 모달 콘텐츠 */}
-      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
+      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
         {/* 헤더 */}
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-surface">

--- a/src/components/community/PasswordModal.tsx
+++ b/src/components/community/PasswordModal.tsx
@@ -75,7 +75,7 @@ export default function PasswordModal({
       />
 
       {/* 모달 콘텐츠 */}
-      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
+      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
         {/* 헤더 */}
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-surface">

--- a/src/components/community/PasswordModal.tsx
+++ b/src/components/community/PasswordModal.tsx
@@ -75,7 +75,7 @@ export default function PasswordModal({
       />
 
       {/* 모달 콘텐츠 */}
-      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
         {/* 헤더 */}
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-surface">

--- a/src/components/community/PostDetail.tsx
+++ b/src/components/community/PostDetail.tsx
@@ -89,7 +89,7 @@ function DeleteConfirmModal({
       />
 
       {/* 모달 콘텐츠 */}
-      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100">
             <svg
@@ -261,7 +261,7 @@ function PostContent({ post }: PostContentProps) {
 
   return (
     <>
-      <article className="rounded-lg bg-white p-6 shadow-sm">
+      <article className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
         {/* 게시글 헤더 */}
         <header className="mb-6 border-b border-neutral-100 pb-4">
           <h1 className="mb-4 text-2xl font-bold text-primary-800">
@@ -471,7 +471,9 @@ export default function PostDetail({
 
   if (isLoading) {
     return (
-      <div className={`rounded-lg bg-white p-6 shadow-sm ${className}`}>
+      <div
+        className={`rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800 ${className}`}
+      >
         <PostDetailSkeleton />
       </div>
     )
@@ -479,7 +481,9 @@ export default function PostDetail({
 
   if (error) {
     return (
-      <div className={`rounded-lg bg-white shadow-sm ${className}`}>
+      <div
+        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+      >
         <PostDetailError error={error} onRetry={() => refetch()} />
       </div>
     )
@@ -487,7 +491,9 @@ export default function PostDetail({
 
   if (!post) {
     return (
-      <div className={`rounded-lg bg-white p-6 shadow-sm ${className}`}>
+      <div
+        className={`rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800 ${className}`}
+      >
         <p className="text-center text-secondary">게시글을 찾을 수 없습니다</p>
       </div>
     )

--- a/src/components/community/PostDetail.tsx
+++ b/src/components/community/PostDetail.tsx
@@ -89,7 +89,7 @@ function DeleteConfirmModal({
       />
 
       {/* 모달 콘텐츠 */}
-      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
+      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100">
             <svg
@@ -261,7 +261,7 @@ function PostContent({ post }: PostContentProps) {
 
   return (
     <>
-      <article className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
+      <article className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
         {/* 게시글 헤더 */}
         <header className="mb-6 border-b border-neutral-100 pb-4">
           <h1 className="mb-4 text-2xl font-bold text-primary-800">
@@ -472,7 +472,7 @@ export default function PostDetail({
   if (isLoading) {
     return (
       <div
-        className={`rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800 ${className}`}
+        className={`rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800 ${className}`}
       >
         <PostDetailSkeleton />
       </div>
@@ -482,7 +482,7 @@ export default function PostDetail({
   if (error) {
     return (
       <div
-        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
       >
         <PostDetailError error={error} onRetry={() => refetch()} />
       </div>
@@ -492,7 +492,7 @@ export default function PostDetail({
   if (!post) {
     return (
       <div
-        className={`rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800 ${className}`}
+        className={`rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800 ${className}`}
       >
         <p className="text-center text-secondary">게시글을 찾을 수 없습니다</p>
       </div>

--- a/src/components/community/PostDetail.tsx
+++ b/src/components/community/PostDetail.tsx
@@ -89,7 +89,7 @@ function DeleteConfirmModal({
       />
 
       {/* 모달 콘텐츠 */}
-      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
+      <div className="relative z-10 mx-4 w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100">
             <svg
@@ -261,7 +261,7 @@ function PostContent({ post }: PostContentProps) {
 
   return (
     <>
-      <article className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
+      <article className="rounded-lg bg-surface p-6 shadow-sm">
         {/* 게시글 헤더 */}
         <header className="mb-6 border-b border-neutral-100 pb-4">
           <h1 className="mb-4 text-2xl font-bold text-primary-800">
@@ -471,9 +471,7 @@ export default function PostDetail({
 
   if (isLoading) {
     return (
-      <div
-        className={`rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800 ${className}`}
-      >
+      <div className={`rounded-lg bg-surface p-6 shadow-sm ${className}`}>
         <PostDetailSkeleton />
       </div>
     )
@@ -481,9 +479,7 @@ export default function PostDetail({
 
   if (error) {
     return (
-      <div
-        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
-      >
+      <div className={`rounded-lg bg-surface shadow-sm ${className}`}>
         <PostDetailError error={error} onRetry={() => refetch()} />
       </div>
     )
@@ -491,9 +487,7 @@ export default function PostDetail({
 
   if (!post) {
     return (
-      <div
-        className={`rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800 ${className}`}
-      >
+      <div className={`rounded-lg bg-surface p-6 shadow-sm ${className}`}>
         <p className="text-center text-secondary">게시글을 찾을 수 없습니다</p>
       </div>
     )

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -16,7 +16,7 @@ export default function PostDetailClient() {
   return (
     <main className="min-h-screen bg-primary-50">
       {/* 페이지 타이틀 */}
-      <div className="border-b border-border bg-surface px-4 py-4 dark:bg-neutral-800">
+      <div className="border-b border-border bg-surface px-4 py-4">
         <div className="mx-auto max-w-4xl">
           <div className="flex items-center gap-2">
             <Link

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -16,7 +16,7 @@ export default function PostDetailClient() {
   return (
     <main className="min-h-screen bg-primary-50">
       {/* 페이지 타이틀 */}
-      <div className="border-b border-border bg-white px-4 py-4">
+      <div className="border-b border-border bg-white px-4 py-4 dark:bg-neutral-800">
         <div className="mx-auto max-w-4xl">
           <div className="flex items-center gap-2">
             <Link

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -16,7 +16,7 @@ export default function PostDetailClient() {
   return (
     <main className="min-h-screen bg-primary-50">
       {/* 페이지 타이틀 */}
-      <div className="border-b border-border bg-white px-4 py-4 dark:bg-neutral-800">
+      <div className="border-b border-border bg-surface px-4 py-4 dark:bg-neutral-800">
         <div className="mx-auto max-w-4xl">
           <div className="flex items-center gap-2">
             <Link

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -254,7 +254,9 @@ export default function PostList({
   // 로딩 상태
   if (isLoading) {
     return (
-      <div className={`rounded-lg bg-white shadow-sm ${className}`}>
+      <div
+        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+      >
         <PostListSkeleton />
       </div>
     )
@@ -263,7 +265,9 @@ export default function PostList({
   // 에러 상태
   if (error) {
     return (
-      <div className={`rounded-lg bg-white shadow-sm ${className}`}>
+      <div
+        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+      >
         <PostListError error={error} onRetry={() => refetch()} />
       </div>
     )
@@ -272,7 +276,9 @@ export default function PostList({
   // 빈 목록
   if (!posts || posts.length === 0) {
     return (
-      <div className={`rounded-lg bg-white shadow-sm ${className}`}>
+      <div
+        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+      >
         <PostListEmpty />
       </div>
     )
@@ -280,7 +286,7 @@ export default function PostList({
 
   return (
     <div
-      className={`overflow-hidden rounded-lg bg-white shadow-sm ${className}`}
+      className={`overflow-hidden rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
     >
       {/* 게시글 목록 */}
       <div className="divide-y divide-neutral-100">

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -254,9 +254,7 @@ export default function PostList({
   // 로딩 상태
   if (isLoading) {
     return (
-      <div
-        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
-      >
+      <div className={`rounded-lg bg-surface shadow-sm ${className}`}>
         <PostListSkeleton />
       </div>
     )
@@ -265,9 +263,7 @@ export default function PostList({
   // 에러 상태
   if (error) {
     return (
-      <div
-        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
-      >
+      <div className={`rounded-lg bg-surface shadow-sm ${className}`}>
         <PostListError error={error} onRetry={() => refetch()} />
       </div>
     )
@@ -276,9 +272,7 @@ export default function PostList({
   // 빈 목록
   if (!posts || posts.length === 0) {
     return (
-      <div
-        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
-      >
+      <div className={`rounded-lg bg-surface shadow-sm ${className}`}>
         <PostListEmpty />
       </div>
     )
@@ -286,7 +280,7 @@ export default function PostList({
 
   return (
     <div
-      className={`overflow-hidden rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
+      className={`overflow-hidden rounded-lg bg-surface shadow-sm ${className}`}
     >
       {/* 게시글 목록 */}
       <div className="divide-y divide-neutral-100">

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -255,7 +255,7 @@ export default function PostList({
   if (isLoading) {
     return (
       <div
-        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
       >
         <PostListSkeleton />
       </div>
@@ -266,7 +266,7 @@ export default function PostList({
   if (error) {
     return (
       <div
-        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
       >
         <PostListError error={error} onRetry={() => refetch()} />
       </div>
@@ -277,7 +277,7 @@ export default function PostList({
   if (!posts || posts.length === 0) {
     return (
       <div
-        className={`rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+        className={`rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
       >
         <PostListEmpty />
       </div>
@@ -286,7 +286,7 @@ export default function PostList({
 
   return (
     <div
-      className={`overflow-hidden rounded-lg bg-white shadow-sm dark:bg-neutral-800 ${className}`}
+      className={`overflow-hidden rounded-lg bg-surface shadow-sm dark:bg-neutral-800 ${className}`}
     >
       {/* 게시글 목록 */}
       <div className="divide-y divide-neutral-100">

--- a/src/components/gallery/ComparisonCard.tsx
+++ b/src/components/gallery/ComparisonCard.tsx
@@ -151,7 +151,7 @@ export const ComparisonCard = memo(function ComparisonCard({
             </div>
           )}
           <span
-            className="text-sm font-medium text-neutral-900"
+            className="text-sm font-medium text-neutral-900 dark:text-neutral-100"
             data-testid="user-nickname"
           >
             {checkIn.userName}

--- a/src/components/gallery/ComparisonCard.tsx
+++ b/src/components/gallery/ComparisonCard.tsx
@@ -93,7 +93,7 @@ export const ComparisonCard = memo(function ComparisonCard({
             </div>
 
             {/* 중앙 구분선 */}
-            <div className="absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-white shadow-sm" />
+            <div className="absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-surface shadow-sm" />
           </div>
         ) : (
           /* 단일 이미지 모드 */
@@ -151,7 +151,7 @@ export const ComparisonCard = memo(function ComparisonCard({
             </div>
           )}
           <span
-            className="text-sm font-medium text-neutral-900 dark:text-neutral-100"
+            className="text-sm font-medium text-neutral-900"
             data-testid="user-nickname"
           >
             {checkIn.userName}

--- a/src/components/gallery/ContentGrid.tsx
+++ b/src/components/gallery/ContentGrid.tsx
@@ -65,7 +65,7 @@ function ContentCard({ content, onClick }: ContentCardProps) {
     <button
       type="button"
       onClick={onClick}
-      className="group relative flex flex-col overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:bg-neutral-800"
+      className="group relative flex flex-col overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
       aria-label={`${content.title} 작품 보기`}
     >
       {/* 포스터 이미지 영역 */}

--- a/src/components/gallery/ContentGrid.tsx
+++ b/src/components/gallery/ContentGrid.tsx
@@ -65,7 +65,7 @@ function ContentCard({ content, onClick }: ContentCardProps) {
     <button
       type="button"
       onClick={onClick}
-      className="group relative flex flex-col overflow-hidden rounded-xl bg-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      className="group relative flex flex-col overflow-hidden rounded-xl bg-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:bg-neutral-800"
       aria-label={`${content.title} 작품 보기`}
     >
       {/* 포스터 이미지 영역 */}
@@ -92,7 +92,7 @@ function ContentCard({ content, onClick }: ContentCardProps) {
       {/* 작품 정보 영역 */}
       <div className="flex flex-1 flex-col p-3">
         {/* 작품 제목 */}
-        <h3 className="mb-2 line-clamp-2 text-left text-sm font-semibold text-neutral-900">
+        <h3 className="mb-2 line-clamp-2 text-left text-sm font-semibold text-neutral-900 dark:text-neutral-100">
           {content.title}
         </h3>
 

--- a/src/components/gallery/ContentGrid.tsx
+++ b/src/components/gallery/ContentGrid.tsx
@@ -65,7 +65,7 @@ function ContentCard({ content, onClick }: ContentCardProps) {
     <button
       type="button"
       onClick={onClick}
-      className="group relative flex flex-col overflow-hidden rounded-xl bg-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:bg-neutral-800"
+      className="group relative flex flex-col overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:bg-neutral-800"
       aria-label={`${content.title} 작품 보기`}
     >
       {/* 포스터 이미지 영역 */}
@@ -92,7 +92,7 @@ function ContentCard({ content, onClick }: ContentCardProps) {
       {/* 작품 정보 영역 */}
       <div className="flex flex-1 flex-col p-3">
         {/* 작품 제목 */}
-        <h3 className="mb-2 line-clamp-2 text-left text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+        <h3 className="mb-2 line-clamp-2 text-left text-sm font-semibold text-neutral-900">
           {content.title}
         </h3>
 

--- a/src/components/gallery/ContentTab.tsx
+++ b/src/components/gallery/ContentTab.tsx
@@ -29,7 +29,7 @@ function LoadingSkeleton() {
     <>
       {[1, 2, 3, 4].map((i) => (
         <MasonryItem key={`skeleton-${i}`}>
-          <div className="animate-pulse rounded-xl bg-white shadow-md dark:bg-neutral-800">
+          <div className="animate-pulse rounded-xl bg-surface shadow-md dark:bg-neutral-800">
             <div className="aspect-[4/5] rounded-t-xl bg-border" />
             <div className="p-3">
               <div className="mb-2 flex items-center gap-2">
@@ -85,7 +85,7 @@ function ContentGridSkeleton() {
       {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
         <div
           key={i}
-          className="animate-pulse rounded-xl bg-white shadow-md dark:bg-neutral-800"
+          className="animate-pulse rounded-xl bg-surface shadow-md dark:bg-neutral-800"
         >
           <div className="aspect-[3/4] rounded-t-xl bg-border" />
           <div className="p-3">

--- a/src/components/gallery/ContentTab.tsx
+++ b/src/components/gallery/ContentTab.tsx
@@ -29,7 +29,7 @@ function LoadingSkeleton() {
     <>
       {[1, 2, 3, 4].map((i) => (
         <MasonryItem key={`skeleton-${i}`}>
-          <div className="animate-pulse rounded-xl bg-white shadow-md">
+          <div className="animate-pulse rounded-xl bg-white shadow-md dark:bg-neutral-800">
             <div className="aspect-[4/5] rounded-t-xl bg-border" />
             <div className="p-3">
               <div className="mb-2 flex items-center gap-2">
@@ -83,7 +83,10 @@ function ContentGridSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
       {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-        <div key={i} className="animate-pulse rounded-xl bg-white shadow-md">
+        <div
+          key={i}
+          className="animate-pulse rounded-xl bg-white shadow-md dark:bg-neutral-800"
+        >
           <div className="aspect-[3/4] rounded-t-xl bg-border" />
           <div className="p-3">
             <div className="mb-2 h-4 w-3/4 rounded bg-border" />

--- a/src/components/gallery/ContentTab.tsx
+++ b/src/components/gallery/ContentTab.tsx
@@ -29,7 +29,7 @@ function LoadingSkeleton() {
     <>
       {[1, 2, 3, 4].map((i) => (
         <MasonryItem key={`skeleton-${i}`}>
-          <div className="animate-pulse rounded-xl bg-surface shadow-md dark:bg-neutral-800">
+          <div className="animate-pulse rounded-xl bg-surface shadow-md">
             <div className="aspect-[4/5] rounded-t-xl bg-border" />
             <div className="p-3">
               <div className="mb-2 flex items-center gap-2">
@@ -83,10 +83,7 @@ function ContentGridSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
       {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-        <div
-          key={i}
-          className="animate-pulse rounded-xl bg-surface shadow-md dark:bg-neutral-800"
-        >
+        <div key={i} className="animate-pulse rounded-xl bg-surface shadow-md">
           <div className="aspect-[3/4] rounded-t-xl bg-border" />
           <div className="p-3">
             <div className="mb-2 h-4 w-3/4 rounded bg-border" />

--- a/src/components/gallery/GalleryContent.tsx
+++ b/src/components/gallery/GalleryContent.tsx
@@ -36,7 +36,7 @@ function ContentSkeleton() {
         {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
           <div
             key={i}
-            className="animate-pulse rounded-lg bg-white shadow-sm dark:bg-neutral-800"
+            className="animate-pulse rounded-lg bg-surface shadow-sm dark:bg-neutral-800"
           >
             <div className="h-48 rounded-t-lg bg-border" />
             <div className="p-3">

--- a/src/components/gallery/GalleryContent.tsx
+++ b/src/components/gallery/GalleryContent.tsx
@@ -36,7 +36,7 @@ function ContentSkeleton() {
         {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
           <div
             key={i}
-            className="animate-pulse rounded-lg bg-surface shadow-sm dark:bg-neutral-800"
+            className="animate-pulse rounded-lg bg-surface shadow-sm"
           >
             <div className="h-48 rounded-t-lg bg-border" />
             <div className="p-3">

--- a/src/components/gallery/GalleryContent.tsx
+++ b/src/components/gallery/GalleryContent.tsx
@@ -34,7 +34,10 @@ function ContentSkeleton() {
     <div className="mx-auto max-w-6xl px-4 py-6">
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
         {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-          <div key={i} className="animate-pulse rounded-lg bg-white shadow-sm">
+          <div
+            key={i}
+            className="animate-pulse rounded-lg bg-white shadow-sm dark:bg-neutral-800"
+          >
             <div className="h-48 rounded-t-lg bg-border" />
             <div className="p-3">
               <div className="mb-2 h-4 w-3/4 rounded bg-border" />

--- a/src/components/gallery/HallOfFameTab.tsx
+++ b/src/components/gallery/HallOfFameTab.tsx
@@ -30,7 +30,7 @@ function LoadingSkeleton() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="flex items-center gap-4 rounded-xl border border-neutral-100 bg-white p-3"
+              className="flex items-center gap-4 rounded-xl border border-neutral-100 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-800"
             >
               <div className="h-10 w-10 animate-pulse rounded-full bg-border" />
               <div className="h-14 w-14 animate-pulse rounded-lg bg-border" />
@@ -48,7 +48,7 @@ function LoadingSkeleton() {
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl bg-white shadow-md"
+              className="animate-pulse rounded-xl bg-white shadow-md dark:bg-neutral-800"
             >
               <div className="aspect-square w-full rounded-t-xl bg-border" />
             </div>

--- a/src/components/gallery/HallOfFameTab.tsx
+++ b/src/components/gallery/HallOfFameTab.tsx
@@ -30,7 +30,7 @@ function LoadingSkeleton() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="flex items-center gap-4 rounded-xl border border-neutral-100 bg-surface p-3 dark:bg-neutral-800"
+              className="flex items-center gap-4 rounded-xl border border-neutral-100 bg-surface p-3"
             >
               <div className="h-10 w-10 animate-pulse rounded-full bg-border" />
               <div className="h-14 w-14 animate-pulse rounded-lg bg-border" />
@@ -48,7 +48,7 @@ function LoadingSkeleton() {
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl bg-surface shadow-md dark:bg-neutral-800"
+              className="animate-pulse rounded-xl bg-surface shadow-md"
             >
               <div className="aspect-square w-full rounded-t-xl bg-border" />
             </div>

--- a/src/components/gallery/HallOfFameTab.tsx
+++ b/src/components/gallery/HallOfFameTab.tsx
@@ -30,7 +30,7 @@ function LoadingSkeleton() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="flex items-center gap-4 rounded-xl border border-neutral-100 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-800"
+              className="flex items-center gap-4 rounded-xl border border-neutral-100 bg-surface p-3 dark:bg-neutral-800"
             >
               <div className="h-10 w-10 animate-pulse rounded-full bg-border" />
               <div className="h-14 w-14 animate-pulse rounded-lg bg-border" />
@@ -48,7 +48,7 @@ function LoadingSkeleton() {
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-xl bg-white shadow-md dark:bg-neutral-800"
+              className="animate-pulse rounded-xl bg-surface shadow-md dark:bg-neutral-800"
             >
               <div className="aspect-square w-full rounded-t-xl bg-border" />
             </div>

--- a/src/components/gallery/RankingList.tsx
+++ b/src/components/gallery/RankingList.tsx
@@ -59,7 +59,7 @@ function getRankStyle(rank: number): string {
     case 3:
       return 'bg-gradient-to-r from-orange-50 to-amber-50 border-orange-200'
     default:
-      return 'bg-white border-neutral-100'
+      return 'bg-white dark:bg-neutral-800 border-neutral-100 dark:border-neutral-700'
   }
 }
 
@@ -94,7 +94,7 @@ export function RankingList({
     <div className="space-y-8">
       {/* 이번 주 인기 스팟 섹션 */}
       <section>
-        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900">
+        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900 dark:text-neutral-100">
           <AppIcon name="popular" size={24} />
           <span>이번 주 인기 스팟</span>
         </h2>
@@ -159,7 +159,7 @@ export function RankingList({
                   {/* 스팟 정보 */}
                   <div className="min-w-0 flex-1">
                     <p
-                      className="truncate font-medium text-neutral-900"
+                      className="truncate font-medium text-neutral-900 dark:text-neutral-100"
                       data-testid="spot-name"
                     >
                       {item.spotName}
@@ -181,7 +181,7 @@ export function RankingList({
 
       {/* 인기 인증샷 섹션 */}
       <section>
-        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900">
+        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900 dark:text-neutral-100">
           <span>❤️</span>
           <span>인기 인증샷</span>
         </h2>
@@ -202,7 +202,7 @@ export function RankingList({
               return (
                 <div
                   key={item.checkInId}
-                  className={`group relative overflow-hidden rounded-xl bg-white shadow-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg ${onCheckInClick ? 'cursor-pointer' : ''} `}
+                  className={`group relative overflow-hidden rounded-xl bg-white shadow-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg dark:bg-neutral-800 ${onCheckInClick ? 'cursor-pointer' : ''} `}
                   onClick={() => onCheckInClick?.(item.checkInId)}
                   role={onCheckInClick ? 'button' : undefined}
                   tabIndex={onCheckInClick ? 0 : undefined}
@@ -235,7 +235,7 @@ export function RankingList({
 
                     {/* 순위 뱃지 */}
                     <div
-                      className={`absolute left-2 top-2 flex h-7 w-7 items-center justify-center rounded-full ${rank <= 3 ? 'bg-white/90 shadow-md' : 'bg-black/50'} `}
+                      className={`absolute left-2 top-2 flex h-7 w-7 items-center justify-center rounded-full ${rank <= 3 ? 'bg-white/90 shadow-md dark:bg-neutral-800/90' : 'bg-black/50'} `}
                     >
                       {medal ? (
                         <span className="text-base">{medal}</span>

--- a/src/components/gallery/RankingList.tsx
+++ b/src/components/gallery/RankingList.tsx
@@ -202,7 +202,7 @@ export function RankingList({
               return (
                 <div
                   key={item.checkInId}
-                  className={`group relative overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg dark:bg-neutral-800 ${onCheckInClick ? 'cursor-pointer' : ''} `}
+                  className={`group relative overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg ${onCheckInClick ? 'cursor-pointer' : ''} `}
                   onClick={() => onCheckInClick?.(item.checkInId)}
                   role={onCheckInClick ? 'button' : undefined}
                   tabIndex={onCheckInClick ? 0 : undefined}
@@ -235,7 +235,7 @@ export function RankingList({
 
                     {/* 순위 뱃지 */}
                     <div
-                      className={`absolute left-2 top-2 flex h-7 w-7 items-center justify-center rounded-full ${rank <= 3 ? 'bg-surface/90 shadow-md dark:bg-neutral-800/90' : 'bg-black/50'} `}
+                      className={`absolute left-2 top-2 flex h-7 w-7 items-center justify-center rounded-full ${rank <= 3 ? 'shadow-md/90 bg-surface/90' : 'bg-black/50'} `}
                     >
                       {medal ? (
                         <span className="text-base">{medal}</span>

--- a/src/components/gallery/RankingList.tsx
+++ b/src/components/gallery/RankingList.tsx
@@ -59,7 +59,7 @@ function getRankStyle(rank: number): string {
     case 3:
       return 'bg-gradient-to-r from-orange-50 to-amber-50 border-orange-200'
     default:
-      return 'bg-white dark:bg-neutral-800 border-neutral-100 dark:border-neutral-700'
+      return 'bg-surface border-neutral-100'
   }
 }
 
@@ -94,7 +94,7 @@ export function RankingList({
     <div className="space-y-8">
       {/* 이번 주 인기 스팟 섹션 */}
       <section>
-        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900 dark:text-neutral-100">
+        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900">
           <AppIcon name="popular" size={24} />
           <span>이번 주 인기 스팟</span>
         </h2>
@@ -159,7 +159,7 @@ export function RankingList({
                   {/* 스팟 정보 */}
                   <div className="min-w-0 flex-1">
                     <p
-                      className="truncate font-medium text-neutral-900 dark:text-neutral-100"
+                      className="truncate font-medium text-neutral-900"
                       data-testid="spot-name"
                     >
                       {item.spotName}
@@ -181,7 +181,7 @@ export function RankingList({
 
       {/* 인기 인증샷 섹션 */}
       <section>
-        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900 dark:text-neutral-100">
+        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-neutral-900">
           <span>❤️</span>
           <span>인기 인증샷</span>
         </h2>
@@ -202,7 +202,7 @@ export function RankingList({
               return (
                 <div
                   key={item.checkInId}
-                  className={`group relative overflow-hidden rounded-xl bg-white shadow-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg dark:bg-neutral-800 ${onCheckInClick ? 'cursor-pointer' : ''} `}
+                  className={`group relative overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg dark:bg-neutral-800 ${onCheckInClick ? 'cursor-pointer' : ''} `}
                   onClick={() => onCheckInClick?.(item.checkInId)}
                   role={onCheckInClick ? 'button' : undefined}
                   tabIndex={onCheckInClick ? 0 : undefined}
@@ -235,7 +235,7 @@ export function RankingList({
 
                     {/* 순위 뱃지 */}
                     <div
-                      className={`absolute left-2 top-2 flex h-7 w-7 items-center justify-center rounded-full ${rank <= 3 ? 'bg-white/90 shadow-md dark:bg-neutral-800/90' : 'bg-black/50'} `}
+                      className={`absolute left-2 top-2 flex h-7 w-7 items-center justify-center rounded-full ${rank <= 3 ? 'bg-surface/90 shadow-md dark:bg-neutral-800/90' : 'bg-black/50'} `}
                     >
                       {medal ? (
                         <span className="text-base">{medal}</span>

--- a/src/components/gallery/SpotSearchModal.tsx
+++ b/src/components/gallery/SpotSearchModal.tsx
@@ -154,7 +154,7 @@ export function SpotSearchModal({
       aria-labelledby="spot-search-title"
     >
       <div
-        className="max-h-[80vh] w-full max-w-md overflow-hidden rounded-xl bg-white dark:bg-neutral-800"
+        className="max-h-[80vh] w-full max-w-md overflow-hidden rounded-xl bg-surface"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}
@@ -164,7 +164,7 @@ export function SpotSearchModal({
           </h2>
           <button
             onClick={onClose}
-            className="rounded-full p-1 hover:bg-neutral-100 dark:hover:bg-neutral-700"
+            className="rounded-full p-1 hover:bg-neutral-100"
             aria-label="닫기"
           >
             <svg
@@ -273,7 +273,7 @@ export function SpotSearchModal({
                   <button
                     onClick={() => handleSelectSpot(spot.id)}
                     disabled={isLoading && selectedSpotId === spot.id}
-                    className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:hover:bg-neutral-700"
+                    className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-neutral-50 disabled:opacity-50"
                   >
                     {/* 썸네일 */}
                     <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg bg-neutral-100">
@@ -312,7 +312,7 @@ export function SpotSearchModal({
 
                     {/* 스팟 정보 */}
                     <div className="min-w-0 flex-1">
-                      <p className="truncate font-medium text-neutral-900 dark:text-neutral-100">
+                      <p className="truncate font-medium text-neutral-900">
                         {spot.name}
                       </p>
                       {spot.category &&

--- a/src/components/gallery/SpotSearchModal.tsx
+++ b/src/components/gallery/SpotSearchModal.tsx
@@ -154,7 +154,7 @@ export function SpotSearchModal({
       aria-labelledby="spot-search-title"
     >
       <div
-        className="max-h-[80vh] w-full max-w-md overflow-hidden rounded-xl bg-white"
+        className="max-h-[80vh] w-full max-w-md overflow-hidden rounded-xl bg-white dark:bg-neutral-800"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}
@@ -164,7 +164,7 @@ export function SpotSearchModal({
           </h2>
           <button
             onClick={onClose}
-            className="rounded-full p-1 hover:bg-neutral-100"
+            className="rounded-full p-1 hover:bg-neutral-100 dark:hover:bg-neutral-700"
             aria-label="닫기"
           >
             <svg
@@ -273,7 +273,7 @@ export function SpotSearchModal({
                   <button
                     onClick={() => handleSelectSpot(spot.id)}
                     disabled={isLoading && selectedSpotId === spot.id}
-                    className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-neutral-50 disabled:opacity-50"
+                    className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:hover:bg-neutral-700"
                   >
                     {/* 썸네일 */}
                     <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg bg-neutral-100">
@@ -312,7 +312,7 @@ export function SpotSearchModal({
 
                     {/* 스팟 정보 */}
                     <div className="min-w-0 flex-1">
-                      <p className="truncate font-medium text-neutral-900">
+                      <p className="truncate font-medium text-neutral-900 dark:text-neutral-100">
                         {spot.name}
                       </p>
                       {spot.category &&

--- a/src/components/map/AutocompleteDropdown.tsx
+++ b/src/components/map/AutocompleteDropdown.tsx
@@ -106,7 +106,7 @@ export default function AutocompleteDropdown({
     <div
       id={id}
       ref={dropdownRef}
-      className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
+      className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-lg border border-neutral-200 bg-surface shadow-lg dark:bg-neutral-800"
       role="listbox"
       aria-label="자동완성 제안 목록"
     >
@@ -137,7 +137,7 @@ export default function AutocompleteDropdown({
               tabIndex={0}
               onClick={() => handleItemClick(item)}
               onKeyDown={(e) => handleKeyDown(e, item)}
-              className="flex cursor-pointer items-center justify-between px-4 py-2.5 transition-colors hover:bg-neutral-50 focus:bg-neutral-50 focus:outline-none dark:hover:bg-neutral-700 dark:focus:bg-neutral-700"
+              className="flex cursor-pointer items-center justify-between px-4 py-2.5 transition-colors hover:bg-neutral-50 focus:bg-neutral-50 focus:outline-none dark:focus:bg-neutral-700"
               aria-selected="false"
             >
               <div className="flex items-center gap-2">
@@ -148,7 +148,7 @@ export default function AutocompleteDropdown({
                   className="flex-shrink-0"
                 />
                 {/* 콘텐츠명 */}
-                <span className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                <span className="text-sm font-medium text-neutral-900">
                   {item.name}
                 </span>
               </div>

--- a/src/components/map/AutocompleteDropdown.tsx
+++ b/src/components/map/AutocompleteDropdown.tsx
@@ -106,7 +106,7 @@ export default function AutocompleteDropdown({
     <div
       id={id}
       ref={dropdownRef}
-      className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-lg border border-neutral-200 bg-surface shadow-lg dark:bg-neutral-800"
+      className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-lg border border-neutral-200 bg-surface shadow-lg"
       role="listbox"
       aria-label="자동완성 제안 목록"
     >

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -51,7 +51,7 @@ export default function CategoryFilter() {
         className={`h-9 flex-shrink-0 rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
           isAllSelected
             ? 'border-primary bg-primary text-white shadow-md'
-            : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-500'
+            : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:bg-neutral-800/90 dark:text-neutral-500'
         }`}
       >
         전체
@@ -69,7 +69,7 @@ export default function CategoryFilter() {
             className={`flex h-9 flex-shrink-0 items-center gap-1.5 overflow-hidden rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
               isSelected
                 ? 'border-transparent shadow-md'
-                : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-500'
+                : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:bg-neutral-800/90 dark:text-neutral-500'
             }`}
             style={{
               backgroundColor: isSelected ? config.bgColor : undefined,

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -51,7 +51,7 @@ export default function CategoryFilter() {
         className={`h-9 flex-shrink-0 rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
           isAllSelected
             ? 'border-primary bg-primary text-white shadow-md'
-            : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:bg-neutral-800/90 dark:text-neutral-500'
+            : 'line-through/90 border-neutral-300 bg-neutral-200/90 text-neutral-500 dark:text-neutral-500'
         }`}
       >
         전체
@@ -69,7 +69,7 @@ export default function CategoryFilter() {
             className={`flex h-9 flex-shrink-0 items-center gap-1.5 overflow-hidden rounded-full border px-4 text-sm font-bold shadow-sm transition-all ${
               isSelected
                 ? 'border-transparent shadow-md'
-                : 'border-neutral-300 bg-neutral-200/90 text-neutral-500 line-through dark:bg-neutral-800/90 dark:text-neutral-500'
+                : 'line-through/90 border-neutral-300 bg-neutral-200/90 text-neutral-500 dark:text-neutral-500'
             }`}
             style={{
               backgroundColor: isSelected ? config.bgColor : undefined,

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -115,16 +115,14 @@ export default function ContentSearchFilter({
     >
       <div
         className={`flex items-center rounded-full transition-all duration-200 ${
-          isFocused
-            ? 'bg-surface ring-2 ring-primary/50 dark:bg-neutral-800'
-            : 'bg-transparent'
+          isFocused ? 'bg-surface ring-2 ring-primary/50' : 'bg-transparent'
         }`}
       >
         <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
           <svg
             className={`h-4 w-4 transition-colors ${
               isFocused
-                ? 'text-primary dark:text-primary-400'
+                ? 'text-primary'
                 : 'text-neutral-400 dark:text-neutral-500'
             }`}
             fill="none"

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -116,7 +116,7 @@ export default function ContentSearchFilter({
       <div
         className={`flex items-center rounded-full transition-all duration-200 ${
           isFocused
-            ? 'bg-white ring-2 ring-primary/50 dark:bg-neutral-800'
+            ? 'bg-surface ring-2 ring-primary/50 dark:bg-neutral-800'
             : 'bg-transparent'
         }`}
       >
@@ -149,7 +149,7 @@ export default function ContentSearchFilter({
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full rounded-full bg-transparent py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-400 focus:outline-none dark:text-neutral-100 dark:placeholder-neutral-500"
+          className="w-full rounded-full bg-transparent py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-400 focus:outline-none dark:placeholder-neutral-500"
           role="combobox"
           aria-label="콘텐츠 검색"
           aria-expanded={isDropdownOpen}

--- a/src/components/map/SearchInput.tsx
+++ b/src/components/map/SearchInput.tsx
@@ -94,7 +94,7 @@ export default function SearchInput({
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full rounded-full border border-neutral-200 bg-surface/90 py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 shadow-sm transition-all focus:border-primary focus:bg-surface focus:outline-none focus:ring-1 focus:ring-primary dark:bg-neutral-800/90 dark:text-white dark:placeholder-neutral-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+        className="w-full rounded-full border border-neutral-200 bg-surface/90 py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 shadow-sm transition-all focus:border-primary focus:bg-surface focus:outline-none focus:ring-1 focus:ring-primary/90 dark:text-white dark:placeholder-neutral-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
         aria-label="콘텐츠 검색"
       />
 

--- a/src/components/map/SearchInput.tsx
+++ b/src/components/map/SearchInput.tsx
@@ -94,7 +94,7 @@ export default function SearchInput({
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full rounded-full border border-neutral-200 bg-white/90 py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 shadow-sm transition-all focus:border-primary focus:bg-white focus:outline-none focus:ring-1 focus:ring-primary dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-white dark:placeholder-neutral-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+        className="w-full rounded-full border border-neutral-200 bg-surface/90 py-2 pl-10 pr-10 text-sm text-neutral-900 placeholder-neutral-500 shadow-sm transition-all focus:border-primary focus:bg-surface focus:outline-none focus:ring-1 focus:ring-primary dark:bg-neutral-800/90 dark:text-white dark:placeholder-neutral-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
         aria-label="콘텐츠 검색"
       />
 

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -255,7 +255,7 @@ export default function SpotDetailMap({
               <Popup>
                 <div className="p-2">
                   <div className="mb-1 flex items-center justify-between">
-                    <h4 className="font-semibold text-neutral-900 dark:text-neutral-100">
+                    <h4 className="font-semibold text-neutral-900">
                       {facility.name}
                     </h4>
                     <span className="rounded bg-surface px-2 py-1 text-xs text-primary-800">
@@ -277,19 +277,17 @@ export default function SpotDetailMap({
 
       {/* 범례 */}
       {facilities.length > 0 && (
-        <div className="absolute bottom-4 left-4 z-[1000] rounded-lg bg-white/90 p-3 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90">
-          <h4 className="mb-2 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-            범례
-          </h4>
+        <div className="absolute bottom-4 left-4 z-[1000] rounded-lg bg-surface/90 p-3 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90">
+          <h4 className="mb-2 text-sm font-semibold text-neutral-900">범례</h4>
           <div className="space-y-1">
-            <div className="flex items-center text-xs text-neutral-700 dark:text-neutral-300">
+            <div className="flex items-center text-xs text-neutral-700">
               <div className="mr-2 h-3 w-3 rounded-full bg-red-500"></div>
               <span>특별한 여행지</span>
             </div>
             {Array.from(new Set(facilities.map((f) => f.type))).map((type) => (
               <div
                 key={type}
-                className="flex items-center text-xs text-neutral-700 dark:text-neutral-300"
+                className="flex items-center text-xs text-neutral-700"
               >
                 <div
                   className={`mr-2 h-3 w-3 rounded-full ${getFacilityColor(type)}`}

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -277,7 +277,7 @@ export default function SpotDetailMap({
 
       {/* 범례 */}
       {facilities.length > 0 && (
-        <div className="absolute bottom-4 left-4 z-[1000] rounded-lg bg-surface/90 p-3 shadow-lg backdrop-blur-sm dark:bg-neutral-900/90">
+        <div className="absolute bottom-4 left-4 z-[1000] rounded-lg bg-surface/90 p-3 shadow-lg backdrop-blur-sm">
           <h4 className="mb-2 text-sm font-semibold text-neutral-900">범례</h4>
           <div className="space-y-1">
             <div className="flex items-center text-xs text-neutral-700">

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -255,7 +255,7 @@ export default function SpotDetailMap({
               <Popup>
                 <div className="p-2">
                   <div className="mb-1 flex items-center justify-between">
-                    <h4 className="font-semibold text-neutral-900">
+                    <h4 className="font-semibold text-neutral-900 dark:text-neutral-100">
                       {facility.name}
                     </h4>
                     <span className="rounded bg-surface px-2 py-1 text-xs text-primary-800">

--- a/src/components/mobile/GpsErrorFallback.tsx
+++ b/src/components/mobile/GpsErrorFallback.tsx
@@ -55,7 +55,7 @@ export default function GpsErrorFallback({
 
   return (
     <div
-      className="absolute bottom-20 left-4 right-4 z-[1001] rounded-xl bg-surface p-4 shadow-xl dark:bg-neutral-800 md:bottom-4 md:left-auto md:right-16 md:w-80"
+      className="absolute bottom-20 left-4 right-4 z-[1001] rounded-xl bg-surface p-4 shadow-xl md:bottom-4 md:left-auto md:right-16 md:w-80"
       role="alert"
     >
       <div className="flex items-start gap-3">

--- a/src/components/mobile/GpsErrorFallback.tsx
+++ b/src/components/mobile/GpsErrorFallback.tsx
@@ -55,7 +55,7 @@ export default function GpsErrorFallback({
 
   return (
     <div
-      className="absolute bottom-20 left-4 right-4 z-[1001] rounded-xl bg-white p-4 shadow-xl md:bottom-4 md:left-auto md:right-16 md:w-80"
+      className="absolute bottom-20 left-4 right-4 z-[1001] rounded-xl bg-white p-4 shadow-xl dark:bg-neutral-800 md:bottom-4 md:left-auto md:right-16 md:w-80"
       role="alert"
     >
       <div className="flex items-start gap-3">

--- a/src/components/mobile/GpsErrorFallback.tsx
+++ b/src/components/mobile/GpsErrorFallback.tsx
@@ -55,7 +55,7 @@ export default function GpsErrorFallback({
 
   return (
     <div
-      className="absolute bottom-20 left-4 right-4 z-[1001] rounded-xl bg-white p-4 shadow-xl dark:bg-neutral-800 md:bottom-4 md:left-auto md:right-16 md:w-80"
+      className="absolute bottom-20 left-4 right-4 z-[1001] rounded-xl bg-surface p-4 shadow-xl dark:bg-neutral-800 md:bottom-4 md:left-auto md:right-16 md:w-80"
       role="alert"
     >
       <div className="flex items-start gap-3">

--- a/src/components/mobile/LocationButton.tsx
+++ b/src/components/mobile/LocationButton.tsx
@@ -63,7 +63,7 @@ export default function LocationButton({
     <button
       onClick={handleClick}
       disabled={isLoading}
-      className={`flex h-10 w-10 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-70 dark:bg-neutral-800 dark:focus:ring-offset-neutral-900 ${className}`}
+      className={`flex h-10 w-10 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-70 dark:focus:ring-offset-neutral-900 ${className}`}
       aria-label="현재 위치로 이동"
       title="현재 위치로 이동"
     >
@@ -71,7 +71,7 @@ export default function LocationButton({
         <div className="h-5 w-5 animate-spin rounded-full border-2 border-border border-t-primary dark:border-neutral-600 dark:border-t-primary-400" />
       ) : (
         <svg
-          className="h-5 w-5 text-primary dark:text-primary-400"
+          className="h-5 w-5 text-primary"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/src/components/mobile/LocationButton.tsx
+++ b/src/components/mobile/LocationButton.tsx
@@ -63,7 +63,7 @@ export default function LocationButton({
     <button
       onClick={handleClick}
       disabled={isLoading}
-      className={`flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-70 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:focus:ring-offset-neutral-900 ${className}`}
+      className={`flex h-10 w-10 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-70 dark:bg-neutral-800 dark:focus:ring-offset-neutral-900 ${className}`}
       aria-label="현재 위치로 이동"
       title="현재 위치로 이동"
     >

--- a/src/components/mobile/ViewfinderOverlay.tsx
+++ b/src/components/mobile/ViewfinderOverlay.tsx
@@ -289,7 +289,7 @@ export function ViewfinderOverlay({
             className="h-18 w-18 flex items-center justify-center rounded-full border-4 border-white bg-white/20 transition-transform active:scale-95 disabled:opacity-50"
             aria-label="사진 촬영"
           >
-            <div className="h-14 w-14 rounded-full bg-white" />
+            <div className="h-14 w-14 rounded-full bg-surface" />
           </button>
         </div>
       </div>

--- a/src/components/profile/ContentProgressCard.tsx
+++ b/src/components/profile/ContentProgressCard.tsx
@@ -29,7 +29,7 @@ export function ContentProgressCard({
 
   return (
     <div
-      className={`rounded-xl border border-neutral-100 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-800 ${className}`}
+      className={`rounded-xl border border-neutral-100 bg-surface p-4 shadow-sm dark:bg-neutral-800 ${className}`}
     >
       <div className="mb-3 flex items-center justify-between">
         <h3 className="font-bold text-neutral-800">{progress.contentName}</h3>

--- a/src/components/profile/ContentProgressCard.tsx
+++ b/src/components/profile/ContentProgressCard.tsx
@@ -29,7 +29,7 @@ export function ContentProgressCard({
 
   return (
     <div
-      className={`rounded-xl border border-neutral-100 bg-white p-4 shadow-sm ${className}`}
+      className={`rounded-xl border border-neutral-100 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-800 ${className}`}
     >
       <div className="mb-3 flex items-center justify-between">
         <h3 className="font-bold text-neutral-800">{progress.contentName}</h3>

--- a/src/components/profile/ContentProgressCard.tsx
+++ b/src/components/profile/ContentProgressCard.tsx
@@ -29,7 +29,7 @@ export function ContentProgressCard({
 
   return (
     <div
-      className={`rounded-xl border border-neutral-100 bg-surface p-4 shadow-sm dark:bg-neutral-800 ${className}`}
+      className={`rounded-xl border border-neutral-100 bg-surface p-4 shadow-sm ${className}`}
     >
       <div className="mb-3 flex items-center justify-between">
         <h3 className="font-bold text-neutral-800">{progress.contentName}</h3>

--- a/src/components/report/MyReportList.tsx
+++ b/src/components/report/MyReportList.tsx
@@ -92,7 +92,7 @@ function ReportCard({ report }: { report: SpotReport }) {
   return (
     <Link
       href={`/reports/${report.id}`}
-      className="flex gap-3 rounded-lg border border-border bg-white p-3 transition-colors hover:bg-surface/50"
+      className="flex gap-3 rounded-lg border border-border bg-white p-3 transition-colors hover:bg-surface/50 dark:bg-neutral-800"
     >
       {/* 썸네일 */}
       {thumbnail ? (

--- a/src/components/report/MyReportList.tsx
+++ b/src/components/report/MyReportList.tsx
@@ -92,7 +92,7 @@ function ReportCard({ report }: { report: SpotReport }) {
   return (
     <Link
       href={`/reports/${report.id}`}
-      className="flex gap-3 rounded-lg border border-border bg-surface p-3 transition-colors hover:bg-surface/50 dark:bg-neutral-800"
+      className="flex gap-3 rounded-lg border border-border bg-surface p-3 transition-colors hover:bg-surface/50"
     >
       {/* 썸네일 */}
       {thumbnail ? (

--- a/src/components/report/MyReportList.tsx
+++ b/src/components/report/MyReportList.tsx
@@ -92,7 +92,7 @@ function ReportCard({ report }: { report: SpotReport }) {
   return (
     <Link
       href={`/reports/${report.id}`}
-      className="flex gap-3 rounded-lg border border-border bg-white p-3 transition-colors hover:bg-surface/50 dark:bg-neutral-800"
+      className="flex gap-3 rounded-lg border border-border bg-surface p-3 transition-colors hover:bg-surface/50 dark:bg-neutral-800"
     >
       {/* 썸네일 */}
       {thumbnail ? (

--- a/src/components/report/NearbySpotWarning.tsx
+++ b/src/components/report/NearbySpotWarning.tsx
@@ -64,7 +64,7 @@ export function NearbySpotWarning({
             key={item.id}
             type="button"
             onClick={() => item.type === 'spot' && onSelectSpot(item.id)}
-            className="flex w-full items-center gap-3 rounded-md bg-white p-2 text-left transition-colors hover:bg-amber-100"
+            className="flex w-full items-center gap-3 rounded-md bg-white p-2 text-left transition-colors hover:bg-amber-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
           >
             {item.thumbnailUrl ? (
               <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded">
@@ -102,7 +102,7 @@ export function NearbySpotWarning({
         <button
           type="button"
           onClick={onContinue}
-          className="flex-1 rounded-lg border border-amber-300 bg-white py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100"
+          className="flex-1 rounded-lg border border-amber-300 bg-white py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
         >
           계속 진행
         </button>

--- a/src/components/report/NearbySpotWarning.tsx
+++ b/src/components/report/NearbySpotWarning.tsx
@@ -64,7 +64,7 @@ export function NearbySpotWarning({
             key={item.id}
             type="button"
             onClick={() => item.type === 'spot' && onSelectSpot(item.id)}
-            className="flex w-full items-center gap-3 rounded-md bg-surface p-2 text-left transition-colors hover:bg-amber-100 dark:bg-neutral-800"
+            className="flex w-full items-center gap-3 rounded-md bg-surface p-2 text-left transition-colors hover:bg-amber-100"
           >
             {item.thumbnailUrl ? (
               <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded">
@@ -102,7 +102,7 @@ export function NearbySpotWarning({
         <button
           type="button"
           onClick={onContinue}
-          className="flex-1 rounded-lg border border-amber-300 bg-surface py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:bg-neutral-800"
+          className="flex-1 rounded-lg border border-amber-300 bg-surface py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100"
         >
           계속 진행
         </button>

--- a/src/components/report/NearbySpotWarning.tsx
+++ b/src/components/report/NearbySpotWarning.tsx
@@ -64,7 +64,7 @@ export function NearbySpotWarning({
             key={item.id}
             type="button"
             onClick={() => item.type === 'spot' && onSelectSpot(item.id)}
-            className="flex w-full items-center gap-3 rounded-md bg-white p-2 text-left transition-colors hover:bg-amber-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+            className="flex w-full items-center gap-3 rounded-md bg-surface p-2 text-left transition-colors hover:bg-amber-100 dark:bg-neutral-800"
           >
             {item.thumbnailUrl ? (
               <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded">
@@ -102,7 +102,7 @@ export function NearbySpotWarning({
         <button
           type="button"
           onClick={onContinue}
-          className="flex-1 rounded-lg border border-amber-300 bg-white py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+          className="flex-1 rounded-lg border border-amber-300 bg-surface py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-100 dark:bg-neutral-800"
         >
           계속 진행
         </button>

--- a/src/components/route/CompletionEffect.tsx
+++ b/src/components/route/CompletionEffect.tsx
@@ -65,7 +65,7 @@ export function CompletionEffect({
       </div>
 
       {/* 축하 카드 */}
-      <div className="relative z-10 mx-4 w-full max-w-sm animate-[scaleIn_0.4s_ease-out] rounded-2xl bg-white p-8 text-center shadow-2xl dark:bg-neutral-800">
+      <div className="relative z-10 mx-4 w-full max-w-sm animate-[scaleIn_0.4s_ease-out] rounded-2xl bg-surface p-8 text-center shadow-2xl dark:bg-neutral-800">
         <div className="mb-4 text-6xl">🏆</div>
         <h2 className="text-text-primary mb-2 text-2xl font-bold">
           완주 축하!

--- a/src/components/route/CompletionEffect.tsx
+++ b/src/components/route/CompletionEffect.tsx
@@ -65,7 +65,7 @@ export function CompletionEffect({
       </div>
 
       {/* 축하 카드 */}
-      <div className="relative z-10 mx-4 w-full max-w-sm animate-[scaleIn_0.4s_ease-out] rounded-2xl bg-white p-8 text-center shadow-2xl">
+      <div className="relative z-10 mx-4 w-full max-w-sm animate-[scaleIn_0.4s_ease-out] rounded-2xl bg-white p-8 text-center shadow-2xl dark:bg-neutral-800">
         <div className="mb-4 text-6xl">🏆</div>
         <h2 className="text-text-primary mb-2 text-2xl font-bold">
           완주 축하!

--- a/src/components/route/CompletionEffect.tsx
+++ b/src/components/route/CompletionEffect.tsx
@@ -65,7 +65,7 @@ export function CompletionEffect({
       </div>
 
       {/* 축하 카드 */}
-      <div className="relative z-10 mx-4 w-full max-w-sm animate-[scaleIn_0.4s_ease-out] rounded-2xl bg-surface p-8 text-center shadow-2xl dark:bg-neutral-800">
+      <div className="relative z-10 mx-4 w-full max-w-sm animate-[scaleIn_0.4s_ease-out] rounded-2xl bg-surface p-8 text-center shadow-2xl">
         <div className="mb-4 text-6xl">🏆</div>
         <h2 className="text-text-primary mb-2 text-2xl font-bold">
           완주 축하!

--- a/src/components/route/NavigationPanel.tsx
+++ b/src/components/route/NavigationPanel.tsx
@@ -107,7 +107,7 @@ export function NavigationPanel({
   }, [currentPosition, currentSpot.coordinates, distanceToNext])
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface pb-safe-bottom shadow-[0_-4px_20px_rgba(0,0,0,0.1)] dark:border-neutral-700">
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface pb-safe-bottom shadow-[0_-4px_20px_rgba(0,0,0,0.1)]">
       {/* 진행률 바 */}
       <div className="h-1.5 w-full bg-neutral-200">
         <div
@@ -217,7 +217,7 @@ export function NavigationPanel({
               )}
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:border-neutral-700 dark:bg-neutral-800"
+                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:bg-neutral-800"
               >
                 종료
               </button>
@@ -234,7 +234,7 @@ export function NavigationPanel({
               )}
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:border-neutral-700 dark:bg-neutral-800"
+                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:bg-neutral-800"
               >
                 종료
               </button>
@@ -249,7 +249,7 @@ export function NavigationPanel({
               </button>
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:border-neutral-700 dark:bg-neutral-800"
+                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:bg-neutral-800"
               >
                 종료
               </button>

--- a/src/components/route/NavigationPanel.tsx
+++ b/src/components/route/NavigationPanel.tsx
@@ -217,7 +217,7 @@ export function NavigationPanel({
               )}
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:bg-neutral-800"
+                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface"
               >
                 종료
               </button>
@@ -234,7 +234,7 @@ export function NavigationPanel({
               )}
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:bg-neutral-800"
+                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface"
               >
                 종료
               </button>
@@ -249,7 +249,7 @@ export function NavigationPanel({
               </button>
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:bg-neutral-800"
+                className="text-text-secondary rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm transition-colors hover:bg-accent-surface"
               >
                 종료
               </button>

--- a/src/components/route/NavigationPanel.tsx
+++ b/src/components/route/NavigationPanel.tsx
@@ -107,7 +107,7 @@ export function NavigationPanel({
   }, [currentPosition, currentSpot.coordinates, distanceToNext])
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface pb-safe-bottom shadow-[0_-4px_20px_rgba(0,0,0,0.1)]">
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface pb-safe-bottom shadow-[0_-4px_20px_rgba(0,0,0,0.1)] dark:border-neutral-700">
       {/* 진행률 바 */}
       <div className="h-1.5 w-full bg-neutral-200">
         <div
@@ -217,7 +217,7 @@ export function NavigationPanel({
               )}
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface"
+                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:border-neutral-700 dark:bg-neutral-800"
               >
                 종료
               </button>
@@ -234,7 +234,7 @@ export function NavigationPanel({
               )}
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface"
+                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:border-neutral-700 dark:bg-neutral-800"
               >
                 종료
               </button>
@@ -249,7 +249,7 @@ export function NavigationPanel({
               </button>
               <button
                 onClick={onEndRoute}
-                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface"
+                className="text-text-secondary rounded-lg border-2 border-border bg-white px-4 py-3 text-sm transition-colors hover:bg-accent-surface dark:border-neutral-700 dark:bg-neutral-800"
               >
                 종료
               </button>

--- a/src/components/route/RecommendedRoutes.tsx
+++ b/src/components/route/RecommendedRoutes.tsx
@@ -18,7 +18,7 @@ function RecommendedSkeleton() {
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
-          className="w-72 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-surface dark:bg-neutral-800"
+          className="w-72 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-surface"
         >
           <SkeletonBlock className="h-32 w-full rounded-none" />
           <div className="p-3">

--- a/src/components/route/RecommendedRoutes.tsx
+++ b/src/components/route/RecommendedRoutes.tsx
@@ -18,7 +18,7 @@ function RecommendedSkeleton() {
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
-          className="w-72 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-white"
+          className="w-72 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-white dark:border-neutral-700 dark:bg-neutral-800"
         >
           <SkeletonBlock className="h-32 w-full rounded-none" />
           <div className="p-3">

--- a/src/components/route/RecommendedRoutes.tsx
+++ b/src/components/route/RecommendedRoutes.tsx
@@ -18,7 +18,7 @@ function RecommendedSkeleton() {
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
-          className="w-72 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-white dark:border-neutral-700 dark:bg-neutral-800"
+          className="w-72 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-surface dark:bg-neutral-800"
         >
           <SkeletonBlock className="h-32 w-full rounded-none" />
           <div className="p-3">

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -126,7 +126,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
   return (
     <div className="space-y-6">
       {/* 코스 기본 정보 */}
-      <div className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
+      <div className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
         <div className="mb-4 flex items-start justify-between">
           <div>
             <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -203,7 +203,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         )}
 
         {/* 작성자 정보 */}
-        <div className="mt-4 border-t border-border pt-4 text-sm text-muted dark:border-neutral-700">
+        <div className="mt-4 border-t border-border pt-4 text-sm text-muted">
           코스 제작: {route.authorName}
         </div>
       </div>
@@ -224,7 +224,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
             className={`flex items-center justify-center gap-2 rounded-lg border-2 px-6 py-3 text-sm font-semibold transition-colors ${
               isBookmarked
                 ? 'border-amber-400 bg-amber-50 text-amber-700'
-                : 'border-border bg-white text-primary hover:bg-primary-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+                : 'border-border bg-surface text-primary hover:bg-primary-50 dark:bg-neutral-800'
             }`}
           >
             <AppIcon
@@ -237,7 +237,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
           {user && route.authorId === user.id && (
             <button
               onClick={() => router.push(`/routes/${route.id}/edit`)}
-              className="rounded-lg border-2 border-border bg-white px-4 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+              className="rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:bg-neutral-800"
             >
               ✏️ 수정
             </button>
@@ -254,7 +254,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       )}
 
       {/* 코스 지도 */}
-      <div className="rounded-lg bg-white p-4 shadow-sm dark:bg-neutral-800">
+      <div className="rounded-lg bg-surface p-4 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 지도
         </h2>
@@ -268,8 +268,8 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       </div>
 
       {/* 스팟 순서 목록 */}
-      <div className="rounded-lg bg-white p-4 shadow-sm dark:bg-neutral-900">
-        <h2 className="text-text-primary mb-3 text-lg font-semibold dark:text-neutral-100">
+      <div className="rounded-lg bg-surface p-4 shadow-sm dark:bg-neutral-900">
+        <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 순서 ({availableSpots.length}곳)
         </h2>
         <ol className="space-y-0">

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -126,7 +126,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
   return (
     <div className="space-y-6">
       {/* 코스 기본 정보 */}
-      <div className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
+      <div className="rounded-lg bg-surface p-6 shadow-sm">
         <div className="mb-4 flex items-start justify-between">
           <div>
             <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -224,7 +224,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
             className={`flex items-center justify-center gap-2 rounded-lg border-2 px-6 py-3 text-sm font-semibold transition-colors ${
               isBookmarked
                 ? 'border-amber-400 bg-amber-50 text-amber-700'
-                : 'border-border bg-surface text-primary hover:bg-primary-50 dark:bg-neutral-800'
+                : 'border-border bg-surface text-primary hover:bg-primary-50'
             }`}
           >
             <AppIcon
@@ -237,7 +237,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
           {user && route.authorId === user.id && (
             <button
               onClick={() => router.push(`/routes/${route.id}/edit`)}
-              className="rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:bg-neutral-800"
+              className="rounded-lg border-2 border-border bg-surface px-4 py-3 text-sm text-primary transition-colors hover:bg-primary-50"
             >
               ✏️ 수정
             </button>
@@ -254,7 +254,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       )}
 
       {/* 코스 지도 */}
-      <div className="rounded-lg bg-surface p-4 shadow-sm dark:bg-neutral-800">
+      <div className="rounded-lg bg-surface p-4 shadow-sm">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 지도
         </h2>
@@ -268,7 +268,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       </div>
 
       {/* 스팟 순서 목록 */}
-      <div className="rounded-lg bg-surface p-4 shadow-sm dark:bg-neutral-900">
+      <div className="rounded-lg bg-surface p-4 shadow-sm">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 순서 ({availableSpots.length}곳)
         </h2>

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -126,7 +126,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
   return (
     <div className="space-y-6">
       {/* 코스 기본 정보 */}
-      <div className="rounded-lg bg-white p-6 shadow-sm">
+      <div className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
         <div className="mb-4 flex items-start justify-between">
           <div>
             <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -203,7 +203,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         )}
 
         {/* 작성자 정보 */}
-        <div className="mt-4 border-t border-border pt-4 text-sm text-muted">
+        <div className="mt-4 border-t border-border pt-4 text-sm text-muted dark:border-neutral-700">
           코스 제작: {route.authorName}
         </div>
       </div>
@@ -224,7 +224,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
             className={`flex items-center justify-center gap-2 rounded-lg border-2 px-6 py-3 text-sm font-semibold transition-colors ${
               isBookmarked
                 ? 'border-amber-400 bg-amber-50 text-amber-700'
-                : 'border-border bg-white text-primary hover:bg-primary-50'
+                : 'border-border bg-white text-primary hover:bg-primary-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
             }`}
           >
             <AppIcon
@@ -237,7 +237,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
           {user && route.authorId === user.id && (
             <button
               onClick={() => router.push(`/routes/${route.id}/edit`)}
-              className="rounded-lg border-2 border-border bg-white px-4 py-3 text-sm text-primary transition-colors hover:bg-primary-50"
+              className="rounded-lg border-2 border-border bg-white px-4 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
             >
               ✏️ 수정
             </button>
@@ -254,7 +254,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       )}
 
       {/* 코스 지도 */}
-      <div className="rounded-lg bg-white p-4 shadow-sm">
+      <div className="rounded-lg bg-white p-4 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 지도
         </h2>

--- a/src/components/route/RouteFilterBar.tsx
+++ b/src/components/route/RouteFilterBar.tsx
@@ -73,7 +73,7 @@ export function RouteFilterBar({
       {/* 정렬 + 텍스트 필터 */}
       <div className="flex flex-wrap items-center gap-2">
         {/* 정렬 */}
-        <div className="flex rounded-lg border border-border bg-white dark:bg-neutral-800">
+        <div className="flex rounded-lg border border-border bg-surface">
           {SORT_OPTIONS.map((opt) => (
             <button
               key={opt.value}
@@ -81,7 +81,7 @@ export function RouteFilterBar({
               className={`px-3 py-1.5 text-sm transition-colors ${
                 filters.sort === opt.value
                   ? 'bg-primary text-white'
-                  : 'text-primary hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-neutral-700'
+                  : 'text-primary hover:bg-primary-50 dark:text-primary-400'
               } ${opt.value === 'popular' ? 'rounded-l-lg' : ''} ${opt.value === 'duration' ? 'rounded-r-lg' : ''}`}
             >
               {opt.label}
@@ -95,7 +95,7 @@ export function RouteFilterBar({
           placeholder="작품명 검색"
           value={filters.contentName}
           onChange={(e) => updateFilter({ contentName: e.target.value })}
-          className="text-text-primary rounded-lg border border-border bg-white px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:bg-neutral-800 dark:text-white dark:focus:border-primary-500"
+          className="text-text-primary rounded-lg border border-border bg-surface px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:bg-neutral-800 dark:text-white dark:focus:border-primary-500"
         />
 
         {/* 지역 필터 */}
@@ -104,7 +104,7 @@ export function RouteFilterBar({
           placeholder="지역 검색"
           value={filters.regionTag}
           onChange={(e) => updateFilter({ regionTag: e.target.value })}
-          className="text-text-primary rounded-lg border border-border bg-white px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:bg-neutral-800 dark:text-white dark:focus:border-primary-500"
+          className="text-text-primary rounded-lg border border-border bg-surface px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:bg-neutral-800 dark:text-white dark:focus:border-primary-500"
         />
       </div>
 
@@ -117,7 +117,7 @@ export function RouteFilterBar({
             className={`rounded-full px-3 py-1 text-xs transition-colors ${
               activeDurationIdx === idx
                 ? 'bg-primary text-white'
-                : 'bg-primary-50 text-primary hover:bg-primary-100 dark:bg-neutral-800 dark:text-primary-400 dark:hover:bg-neutral-700'
+                : 'bg-primary-50 text-primary hover:bg-primary-100 dark:bg-neutral-800 dark:text-primary-400'
             }`}
           >
             {preset.label}

--- a/src/components/route/RouteFilterBar.tsx
+++ b/src/components/route/RouteFilterBar.tsx
@@ -81,7 +81,7 @@ export function RouteFilterBar({
               className={`px-3 py-1.5 text-sm transition-colors ${
                 filters.sort === opt.value
                   ? 'bg-primary text-white'
-                  : 'text-primary hover:bg-primary-50 dark:text-primary-400'
+                  : 'text-primary hover:bg-primary-50'
               } ${opt.value === 'popular' ? 'rounded-l-lg' : ''} ${opt.value === 'duration' ? 'rounded-r-lg' : ''}`}
             >
               {opt.label}
@@ -95,7 +95,7 @@ export function RouteFilterBar({
           placeholder="작품명 검색"
           value={filters.contentName}
           onChange={(e) => updateFilter({ contentName: e.target.value })}
-          className="text-text-primary rounded-lg border border-border bg-surface px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:bg-neutral-800 dark:text-white dark:focus:border-primary-500"
+          className="text-text-primary rounded-lg border border-border bg-surface px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:text-white dark:focus:border-primary-500"
         />
 
         {/* 지역 필터 */}
@@ -104,7 +104,7 @@ export function RouteFilterBar({
           placeholder="지역 검색"
           value={filters.regionTag}
           onChange={(e) => updateFilter({ regionTag: e.target.value })}
-          className="text-text-primary rounded-lg border border-border bg-surface px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:bg-neutral-800 dark:text-white dark:focus:border-primary-500"
+          className="text-text-primary rounded-lg border border-border bg-surface px-3 py-1.5 text-sm placeholder-muted outline-none focus:border-primary-400 dark:text-white dark:focus:border-primary-500"
         />
       </div>
 
@@ -117,7 +117,7 @@ export function RouteFilterBar({
             className={`rounded-full px-3 py-1 text-xs transition-colors ${
               activeDurationIdx === idx
                 ? 'bg-primary text-white'
-                : 'bg-primary-50 text-primary hover:bg-primary-100 dark:bg-neutral-800 dark:text-primary-400'
+                : 'bg-primary-50 text-primary hover:bg-primary-100'
             }`}
           >
             {preset.label}

--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -495,7 +495,7 @@ export function RouteFormContent({
       )}
 
       {/* Step 1: 기본 정보 (코스명 + 설명만) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm">
+      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           기본 정보
         </h2>
@@ -532,7 +532,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 2: 스팟 관리 (핵심) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm">
+      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           스팟 목록 <span className="text-red-500">*</span>
           <span className="ml-2 text-sm font-normal text-muted">
@@ -553,7 +553,7 @@ export function RouteFormContent({
 
           {/* 검색 결과 드롭다운 */}
           {searchQuery && hasSearched && (
-            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border bg-white shadow-lg">
+            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
               {searchResults.length === 0 ? (
                 <div className="px-4 py-4 text-center text-sm text-muted">
                   &ldquo;{searchQuery}&rdquo;에 대한 검색 결과가 없습니다
@@ -567,7 +567,7 @@ export function RouteFormContent({
                       type="button"
                       onClick={() => handleAddSpot(result.id)}
                       disabled={alreadyAdded}
-                      className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-primary-50 disabled:opacity-40"
+                      className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-primary-50 disabled:opacity-40 dark:hover:bg-neutral-700"
                     >
                       <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded bg-surface">
                         {result.thumbnailUrl ? (
@@ -617,7 +617,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 3: 시작 지점 (선택) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm">
+      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-1 text-lg font-semibold">
           시작 지점
           <span className="ml-2 text-sm font-normal text-muted">(선택)</span>
@@ -685,13 +685,13 @@ export function RouteFormContent({
             {hasGeoSearched &&
               geocodeResults.length > 0 &&
               !startPointCoords && (
-                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-white shadow-lg">
+                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
                   {geocodeResults.map((result, idx) => (
                     <button
                       key={idx}
                       type="button"
                       onClick={() => handleSelectGeoResult(result)}
-                      className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-primary-50"
+                      className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-primary-50 dark:hover:bg-neutral-700"
                     >
                       <OptimizedImage
                         src={getPlaceIconPath(result.type, result.placeClass)}
@@ -838,7 +838,7 @@ export function RouteFormContent({
                   className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
                     regionTags.includes(tag)
                       ? 'border-primary bg-primary text-white'
-                      : 'border-border bg-white text-primary hover:border-neutral-300 hover:bg-primary-50'
+                      : 'border-border bg-white text-primary hover:border-neutral-300 hover:bg-primary-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
                   }`}
                 >
                   {tag}

--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -495,7 +495,7 @@ export function RouteFormContent({
       )}
 
       {/* Step 1: 기본 정보 (코스명 + 설명만) */}
-      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
+      <section className="rounded-lg bg-surface p-6 shadow-sm">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           기본 정보
         </h2>
@@ -532,7 +532,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 2: 스팟 관리 (핵심) */}
-      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
+      <section className="rounded-lg bg-surface p-6 shadow-sm">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           스팟 목록 <span className="text-red-500">*</span>
           <span className="ml-2 text-sm font-normal text-muted">
@@ -553,7 +553,7 @@ export function RouteFormContent({
 
           {/* 검색 결과 드롭다운 */}
           {searchQuery && hasSearched && (
-            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
+            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg">
               {searchResults.length === 0 ? (
                 <div className="px-4 py-4 text-center text-sm text-muted">
                   &ldquo;{searchQuery}&rdquo;에 대한 검색 결과가 없습니다
@@ -617,7 +617,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 3: 시작 지점 (선택) */}
-      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
+      <section className="rounded-lg bg-surface p-6 shadow-sm">
         <h2 className="text-text-primary mb-1 text-lg font-semibold">
           시작 지점
           <span className="ml-2 text-sm font-normal text-muted">(선택)</span>
@@ -685,7 +685,7 @@ export function RouteFormContent({
             {hasGeoSearched &&
               geocodeResults.length > 0 &&
               !startPointCoords && (
-                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
+                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg">
                   {geocodeResults.map((result, idx) => (
                     <button
                       key={idx}
@@ -745,7 +745,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 4: 코스 디테일 (태그 + 소요시간 + 난이도 + 공개설정) */}
-      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-900">
+      <section className="rounded-lg bg-surface p-6 shadow-sm">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           코스 디테일
         </h2>
@@ -765,12 +765,12 @@ export function RouteFormContent({
                 value={contentInput}
                 onChange={handleContentInputChange}
                 placeholder="작품명 검색"
-                className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none dark:bg-neutral-800"
+                className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none"
               />
               {contentInput &&
                 hasContentSearched &&
                 contentSuggestions.length > 0 && (
-                  <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
+                  <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg">
                     {contentSuggestions.map((suggestion) => {
                       const alreadyAdded =
                         relatedContentNames.includes(suggestion)
@@ -838,7 +838,7 @@ export function RouteFormContent({
                   className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
                     regionTags.includes(tag)
                       ? 'border-primary bg-primary text-white'
-                      : 'border-border bg-surface text-primary hover:border-neutral-300 hover:bg-primary-50 dark:bg-neutral-800'
+                      : 'border-border bg-surface text-primary hover:border-neutral-300 hover:bg-primary-50'
                   }`}
                 >
                   {tag}
@@ -927,7 +927,7 @@ export function RouteFormContent({
 
       {/* 미리보기 */}
       {showPreview && spots.length >= 2 && (
-        <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-900">
+        <section className="rounded-lg bg-surface p-6 shadow-sm">
           <h2 className="text-text-primary mb-3 text-lg font-semibold">
             코스 미리보기
           </h2>
@@ -951,7 +951,7 @@ export function RouteFormContent({
         <button
           type="button"
           onClick={() => router.back()}
-          className="rounded-lg border border-border bg-surface px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-primary-400 dark:hover:bg-neutral-800"
+          className="rounded-lg border border-border bg-surface px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50"
         >
           취소
         </button>
@@ -959,7 +959,7 @@ export function RouteFormContent({
           <button
             type="button"
             onClick={() => setShowPreview(!showPreview)}
-            className="rounded-lg border border-border bg-surface px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-primary-400 dark:hover:bg-neutral-800"
+            className="rounded-lg border border-border bg-surface px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50"
           >
             {showPreview ? '미리보기 닫기' : '🗺️ 미리보기'}
           </button>

--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -495,7 +495,7 @@ export function RouteFormContent({
       )}
 
       {/* Step 1: 기본 정보 (코스명 + 설명만) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
+      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           기본 정보
         </h2>
@@ -532,7 +532,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 2: 스팟 관리 (핵심) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
+      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           스팟 목록 <span className="text-red-500">*</span>
           <span className="ml-2 text-sm font-normal text-muted">
@@ -553,7 +553,7 @@ export function RouteFormContent({
 
           {/* 검색 결과 드롭다운 */}
           {searchQuery && hasSearched && (
-            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+            <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
               {searchResults.length === 0 ? (
                 <div className="px-4 py-4 text-center text-sm text-muted">
                   &ldquo;{searchQuery}&rdquo;에 대한 검색 결과가 없습니다
@@ -567,7 +567,7 @@ export function RouteFormContent({
                       type="button"
                       onClick={() => handleAddSpot(result.id)}
                       disabled={alreadyAdded}
-                      className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-primary-50 disabled:opacity-40 dark:hover:bg-neutral-700"
+                      className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-primary-50 disabled:opacity-40"
                     >
                       <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded bg-surface">
                         {result.thumbnailUrl ? (
@@ -617,7 +617,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 3: 시작 지점 (선택) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-800">
+      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-800">
         <h2 className="text-text-primary mb-1 text-lg font-semibold">
           시작 지점
           <span className="ml-2 text-sm font-normal text-muted">(선택)</span>
@@ -685,13 +685,13 @@ export function RouteFormContent({
             {hasGeoSearched &&
               geocodeResults.length > 0 &&
               !startPointCoords && (
-                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+                <div className="mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
                   {geocodeResults.map((result, idx) => (
                     <button
                       key={idx}
                       type="button"
                       onClick={() => handleSelectGeoResult(result)}
-                      className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-primary-50 dark:hover:bg-neutral-700"
+                      className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-primary-50"
                     >
                       <OptimizedImage
                         src={getPlaceIconPath(result.type, result.placeClass)}
@@ -745,7 +745,7 @@ export function RouteFormContent({
       </section>
 
       {/* Step 4: 코스 디테일 (태그 + 소요시간 + 난이도 + 공개설정) */}
-      <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-900">
+      <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-900">
         <h2 className="text-text-primary mb-4 text-lg font-semibold">
           코스 디테일
         </h2>
@@ -765,12 +765,12 @@ export function RouteFormContent({
                 value={contentInput}
                 onChange={handleContentInputChange}
                 placeholder="작품명 검색"
-                className="w-full rounded-lg border border-border bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none dark:bg-neutral-800"
               />
               {contentInput &&
                 hasContentSearched &&
                 contentSuggestions.length > 0 && (
-                  <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+                  <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
                     {contentSuggestions.map((suggestion) => {
                       const alreadyAdded =
                         relatedContentNames.includes(suggestion)
@@ -780,7 +780,7 @@ export function RouteFormContent({
                           type="button"
                           onClick={() => handleSelectContent(suggestion)}
                           disabled={alreadyAdded}
-                          className="text-text-primary flex w-full items-center px-4 py-2 text-left text-sm transition-colors hover:bg-primary-50 disabled:opacity-40 dark:hover:bg-neutral-700"
+                          className="text-text-primary flex w-full items-center px-4 py-2 text-left text-sm transition-colors hover:bg-primary-50 disabled:opacity-40"
                         >
                           <span className="truncate">{suggestion}</span>
                           {alreadyAdded && (
@@ -838,7 +838,7 @@ export function RouteFormContent({
                   className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
                     regionTags.includes(tag)
                       ? 'border-primary bg-primary text-white'
-                      : 'border-border bg-white text-primary hover:border-neutral-300 hover:bg-primary-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+                      : 'border-border bg-surface text-primary hover:border-neutral-300 hover:bg-primary-50 dark:bg-neutral-800'
                   }`}
                 >
                   {tag}
@@ -913,7 +913,7 @@ export function RouteFormContent({
               aria-checked={isPublic}
             >
               <span
-                className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                className={`absolute top-0.5 h-5 w-5 rounded-full bg-surface shadow transition-transform ${
                   isPublic ? 'left-[22px]' : 'left-0.5'
                 }`}
               />
@@ -927,7 +927,7 @@ export function RouteFormContent({
 
       {/* 미리보기 */}
       {showPreview && spots.length >= 2 && (
-        <section className="rounded-lg bg-white p-6 shadow-sm dark:bg-neutral-900">
+        <section className="rounded-lg bg-surface p-6 shadow-sm dark:bg-neutral-900">
           <h2 className="text-text-primary mb-3 text-lg font-semibold">
             코스 미리보기
           </h2>
@@ -951,7 +951,7 @@ export function RouteFormContent({
         <button
           type="button"
           onClick={() => router.back()}
-          className="rounded-lg border border-border bg-white px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-primary-400 dark:hover:bg-neutral-800"
+          className="rounded-lg border border-border bg-surface px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-primary-400 dark:hover:bg-neutral-800"
         >
           취소
         </button>
@@ -959,7 +959,7 @@ export function RouteFormContent({
           <button
             type="button"
             onClick={() => setShowPreview(!showPreview)}
-            className="rounded-lg border border-border bg-white px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-primary-400 dark:hover:bg-neutral-800"
+            className="rounded-lg border border-border bg-surface px-6 py-3 text-sm text-primary transition-colors hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-primary-400 dark:hover:bg-neutral-800"
           >
             {showPreview ? '미리보기 닫기' : '🗺️ 미리보기'}
           </button>

--- a/src/components/route/RouteListContent.tsx
+++ b/src/components/route/RouteListContent.tsx
@@ -13,7 +13,7 @@ import type { Route } from '@/types/route'
 
 function RouteCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-surface shadow-sm dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg border border-border bg-surface shadow-sm">
       <SkeletonBlock className="h-40 w-full rounded-none" />
       <div className="p-4">
         <SkeletonBlock className="mb-2 h-5 w-3/4" />

--- a/src/components/route/RouteListContent.tsx
+++ b/src/components/route/RouteListContent.tsx
@@ -13,7 +13,7 @@ import type { Route } from '@/types/route'
 
 function RouteCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg border border-border bg-surface shadow-sm dark:bg-neutral-800">
       <SkeletonBlock className="h-40 w-full rounded-none" />
       <div className="p-4">
         <SkeletonBlock className="mb-2 h-5 w-3/4" />

--- a/src/components/route/RouteListContent.tsx
+++ b/src/components/route/RouteListContent.tsx
@@ -13,7 +13,7 @@ import type { Route } from '@/types/route'
 
 function RouteCardSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-white shadow-sm">
+    <div className="overflow-hidden rounded-lg border border-border bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-800">
       <SkeletonBlock className="h-40 w-full rounded-none" />
       <div className="p-4">
         <SkeletonBlock className="mb-2 h-5 w-3/4" />

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -214,7 +214,7 @@ export default function RouteMap({
         center={defaultCenter}
         zoom={13}
         style={{ height: '100%', width: '100%' }}
-        className="overflow-hidden rounded-lg border-2 border-border dark:border-neutral-700"
+        className="overflow-hidden rounded-lg border-2 border-border"
         ref={mapRef}
         zoomControl={true}
         scrollWheelZoom={true}
@@ -368,7 +368,7 @@ export default function RouteMap({
       </MapContainer>
 
       {/* 범례 */}
-      <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm dark:bg-neutral-800/90">
+      <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-surface/90 px-3 py-2 shadow-md backdrop-blur-sm dark:bg-neutral-800/90">
         <div className="flex flex-wrap items-center gap-3 text-xs">
           {startPoint && (
             <div className="flex items-center gap-1">

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -214,7 +214,7 @@ export default function RouteMap({
         center={defaultCenter}
         zoom={13}
         style={{ height: '100%', width: '100%' }}
-        className="overflow-hidden rounded-lg border-2 border-border"
+        className="overflow-hidden rounded-lg border-2 border-border dark:border-neutral-700"
         ref={mapRef}
         zoomControl={true}
         scrollWheelZoom={true}
@@ -368,7 +368,7 @@ export default function RouteMap({
       </MapContainer>
 
       {/* 범례 */}
-      <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm">
+      <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm dark:bg-neutral-800/90">
         <div className="flex flex-wrap items-center gap-3 text-xs">
           {startPoint && (
             <div className="flex items-center gap-1">

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -368,7 +368,7 @@ export default function RouteMap({
       </MapContainer>
 
       {/* 범례 */}
-      <div className="absolute bottom-3 left-3 z-[1000] rounded-lg bg-surface/90 px-3 py-2 shadow-md backdrop-blur-sm dark:bg-neutral-800/90">
+      <div className="backdrop-blur-sm/90 absolute bottom-3 left-3 z-[1000] rounded-lg bg-surface/90 px-3 py-2 shadow-md">
         <div className="flex flex-wrap items-center gap-3 text-xs">
           {startPoint && (
             <div className="flex items-center gap-1">

--- a/src/components/route/SpotOrderList.tsx
+++ b/src/components/route/SpotOrderList.tsx
@@ -222,7 +222,7 @@ export function SpotOrderList({
                 ? 'border-primary-400 bg-primary-50 opacity-50'
                 : dragOverIndex === idx
                   ? 'border-primary bg-primary-50'
-                  : 'border-border bg-white hover:border-neutral-300'
+                  : 'border-border bg-white hover:border-neutral-300 dark:border-neutral-700 dark:bg-neutral-800'
             } cursor-grab active:cursor-grabbing`}
           >
             {/* 드래그 핸들 + 순서 번호 */}

--- a/src/components/route/SpotOrderList.tsx
+++ b/src/components/route/SpotOrderList.tsx
@@ -108,7 +108,7 @@ export function SpotOrderList({
 
   if (spots.length === 0) {
     return (
-      <div className="rounded-lg border-2 border-dashed border-border p-8 text-center dark:border-neutral-800">
+      <div className="rounded-lg border-2 border-dashed border-border p-8 text-center">
         <p className="text-sm text-muted">
           스팟을 검색하여 코스에 추가해주세요
         </p>
@@ -222,7 +222,7 @@ export function SpotOrderList({
                 ? 'border-primary-400 bg-primary-50 opacity-50'
                 : dragOverIndex === idx
                   ? 'border-primary bg-primary-50'
-                  : 'border-border bg-surface hover:border-neutral-300 dark:bg-neutral-800'
+                  : 'border-border bg-surface hover:border-neutral-300'
             } cursor-grab active:cursor-grabbing`}
           >
             {/* 드래그 핸들 + 순서 번호 */}

--- a/src/components/route/SpotOrderList.tsx
+++ b/src/components/route/SpotOrderList.tsx
@@ -222,7 +222,7 @@ export function SpotOrderList({
                 ? 'border-primary-400 bg-primary-50 opacity-50'
                 : dragOverIndex === idx
                   ? 'border-primary bg-primary-50'
-                  : 'border-border bg-white hover:border-neutral-300 dark:border-neutral-700 dark:bg-neutral-800'
+                  : 'border-border bg-surface hover:border-neutral-300 dark:bg-neutral-800'
             } cursor-grab active:cursor-grabbing`}
           >
             {/* 드래그 핸들 + 순서 번호 */}

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -206,7 +206,7 @@ export function AddressSearch({
 
       {/* 검색 결과 드롭다운 */}
       {isOpen && results.length > 0 && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-surface shadow-lg">
           {results.map((result, index) => (
             <button
               key={index}
@@ -250,7 +250,7 @@ export function AddressSearch({
 
       {/* 검색 결과 없음 */}
       {isOpen && results.length === 0 && !isLoading && query.length >= 2 && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-surface p-4 text-center shadow-lg dark:bg-neutral-800">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-surface p-4 text-center shadow-lg">
           <p className="text-sm text-muted">검색 결과가 없습니다</p>
         </div>
       )}

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -206,7 +206,7 @@ export function AddressSearch({
 
       {/* 검색 결과 드롭다운 */}
       {isOpen && results.length > 0 && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-white shadow-lg">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-white shadow-lg dark:bg-neutral-800">
           {results.map((result, index) => (
             <button
               key={index}
@@ -250,7 +250,7 @@ export function AddressSearch({
 
       {/* 검색 결과 없음 */}
       {isOpen && results.length === 0 && !isLoading && query.length >= 2 && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-white p-4 text-center shadow-lg">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-white p-4 text-center shadow-lg dark:bg-neutral-800">
           <p className="text-sm text-muted">검색 결과가 없습니다</p>
         </div>
       )}

--- a/src/components/spot/AddressSearch.tsx
+++ b/src/components/spot/AddressSearch.tsx
@@ -206,7 +206,7 @@ export function AddressSearch({
 
       {/* 검색 결과 드롭다운 */}
       {isOpen && results.length > 0 && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-white shadow-lg dark:bg-neutral-800">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-auto rounded-lg border border-border bg-surface shadow-lg dark:bg-neutral-800">
           {results.map((result, index) => (
             <button
               key={index}
@@ -250,7 +250,7 @@ export function AddressSearch({
 
       {/* 검색 결과 없음 */}
       {isOpen && results.length === 0 && !isLoading && query.length >= 2 && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-white p-4 text-center shadow-lg dark:bg-neutral-800">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-border bg-surface p-4 text-center shadow-lg dark:bg-neutral-800">
           <p className="text-sm text-muted">검색 결과가 없습니다</p>
         </div>
       )}

--- a/src/components/spot/EventInfoSection.tsx
+++ b/src/components/spot/EventInfoSection.tsx
@@ -55,7 +55,7 @@ export function EventInfoSection({
   const emptyMessage = emptyMessages[category] || emptyMessages.sports
 
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-md dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-md dark:bg-neutral-800">
       <div className="p-6">
         {/* 헤더 */}
         <div className="mb-4 flex items-center gap-2">

--- a/src/components/spot/EventInfoSection.tsx
+++ b/src/components/spot/EventInfoSection.tsx
@@ -55,7 +55,7 @@ export function EventInfoSection({
   const emptyMessage = emptyMessages[category] || emptyMessages.sports
 
   return (
-    <div className="overflow-hidden rounded-lg bg-surface shadow-md dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-md">
       <div className="p-6">
         {/* 헤더 */}
         <div className="mb-4 flex items-center gap-2">

--- a/src/components/spot/EventInfoSection.tsx
+++ b/src/components/spot/EventInfoSection.tsx
@@ -55,7 +55,7 @@ export function EventInfoSection({
   const emptyMessage = emptyMessages[category] || emptyMessages.sports
 
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-md">
+    <div className="overflow-hidden rounded-lg bg-white shadow-md dark:bg-neutral-800">
       <div className="p-6">
         {/* 헤더 */}
         <div className="mb-4 flex items-center gap-2">

--- a/src/components/spot/ExternalLinkCard.tsx
+++ b/src/components/spot/ExternalLinkCard.tsx
@@ -38,7 +38,7 @@ export const ExternalLinkCard = memo(function ExternalLinkCard({
     <button
       type="button"
       onClick={handleClick}
-      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-white p-4 text-left transition-all hover:border-primary-300 hover:shadow-md"
+      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-white p-4 text-left transition-all hover:border-primary-300 hover:shadow-md dark:bg-neutral-800"
       style={{
         borderLeftWidth: '4px',
         borderLeftColor: config.color,

--- a/src/components/spot/ExternalLinkCard.tsx
+++ b/src/components/spot/ExternalLinkCard.tsx
@@ -38,7 +38,7 @@ export const ExternalLinkCard = memo(function ExternalLinkCard({
     <button
       type="button"
       onClick={handleClick}
-      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-white p-4 text-left transition-all hover:border-primary-300 hover:shadow-md dark:bg-neutral-800"
+      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-surface p-4 text-left transition-all hover:border-primary-300 hover:shadow-md dark:bg-neutral-800"
       style={{
         borderLeftWidth: '4px',
         borderLeftColor: config.color,

--- a/src/components/spot/ExternalLinkCard.tsx
+++ b/src/components/spot/ExternalLinkCard.tsx
@@ -38,7 +38,7 @@ export const ExternalLinkCard = memo(function ExternalLinkCard({
     <button
       type="button"
       onClick={handleClick}
-      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-surface p-4 text-left transition-all hover:border-primary-300 hover:shadow-md dark:bg-neutral-800"
+      className="group flex w-full items-center gap-3 rounded-lg border border-border bg-surface p-4 text-left transition-all hover:border-primary-300 hover:shadow-md"
       style={{
         borderLeftWidth: '4px',
         borderLeftColor: config.color,

--- a/src/components/spot/ExternalLinkForm.tsx
+++ b/src/components/spot/ExternalLinkForm.tsx
@@ -110,7 +110,7 @@ function AddLinkForm({
             value={type}
             onChange={(e) => setType(e.target.value as ExternalLinkType)}
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
+            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {(Object.keys(LINK_TYPE_CONFIG) as ExternalLinkType[]).map(
               (key) => (
@@ -133,7 +133,7 @@ function AddLinkForm({
             onChange={(e) => setLabel(e.target.value)}
             placeholder="예: FC 바르셀로나 공식 사이트"
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
+            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
             maxLength={100}
           />
         </div>
@@ -147,7 +147,7 @@ function AddLinkForm({
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
+            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
           />
           <p className="mt-1 text-xs text-muted">https:// 로 시작해야 합니다</p>
         </div>
@@ -184,7 +184,7 @@ function LinkItem({
   const config = LINK_TYPE_CONFIG[link.type]
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-surface p-3 dark:bg-neutral-800">
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-surface p-3">
       {/* 아이콘 */}
       <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-base">
         <span

--- a/src/components/spot/ExternalLinkForm.tsx
+++ b/src/components/spot/ExternalLinkForm.tsx
@@ -110,7 +110,7 @@ function AddLinkForm({
             value={type}
             onChange={(e) => setType(e.target.value as ExternalLinkType)}
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
           >
             {(Object.keys(LINK_TYPE_CONFIG) as ExternalLinkType[]).map(
               (key) => (
@@ -133,7 +133,7 @@ function AddLinkForm({
             onChange={(e) => setLabel(e.target.value)}
             placeholder="예: FC 바르셀로나 공식 사이트"
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
             maxLength={100}
           />
         </div>
@@ -147,7 +147,7 @@ function AddLinkForm({
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
           />
           <p className="mt-1 text-xs text-muted">https:// 로 시작해야 합니다</p>
         </div>
@@ -184,7 +184,7 @@ function LinkItem({
   const config = LINK_TYPE_CONFIG[link.type]
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-white p-3">
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-white p-3 dark:bg-neutral-800">
       {/* 아이콘 */}
       <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-base">
         <span

--- a/src/components/spot/ExternalLinkForm.tsx
+++ b/src/components/spot/ExternalLinkForm.tsx
@@ -110,7 +110,7 @@ function AddLinkForm({
             value={type}
             onChange={(e) => setType(e.target.value as ExternalLinkType)}
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
+            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
           >
             {(Object.keys(LINK_TYPE_CONFIG) as ExternalLinkType[]).map(
               (key) => (
@@ -133,7 +133,7 @@ function AddLinkForm({
             onChange={(e) => setLabel(e.target.value)}
             placeholder="예: FC 바르셀로나 공식 사이트"
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
+            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
             maxLength={100}
           />
         </div>
@@ -147,7 +147,7 @@ function AddLinkForm({
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
             disabled={disabled}
-            className="text-text-primary w-full rounded-lg border border-border bg-white px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
+            className="text-text-primary w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm placeholder-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-800"
           />
           <p className="mt-1 text-xs text-muted">https:// 로 시작해야 합니다</p>
         </div>
@@ -184,7 +184,7 @@ function LinkItem({
   const config = LINK_TYPE_CONFIG[link.type]
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-white p-3 dark:bg-neutral-800">
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-surface p-3 dark:bg-neutral-800">
       {/* 아이콘 */}
       <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-base">
         <span

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -91,7 +91,7 @@ function CoinLockerDetail({ details }: { details: CoinLockerDetails }) {
             {details.sizes.map((size) => (
               <div
                 key={size}
-                className="rounded-md border border-purple-200 bg-white px-2 py-1 text-xs dark:bg-neutral-800"
+                className="rounded-md border border-purple-200 bg-surface px-2 py-1 text-xs dark:bg-neutral-800"
               >
                 <span className="font-medium text-purple-700">
                   {LOCKER_SIZE_LABEL[size]}
@@ -314,11 +314,11 @@ export default memo(function FacilityCard({
   const displayFacility = isOtaku ? { ...facility, ...voteData } : facility
 
   return (
-    <div className="rounded-lg border border-neutral-200 p-4 transition-all hover:border-neutral-300 hover:shadow-md dark:border-neutral-700">
+    <div className="rounded-lg border border-neutral-200 p-4 transition-all hover:border-neutral-300 hover:shadow-md">
       <div className="flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <div className="mb-2 flex items-center space-x-2">
-            <h4 className="truncate font-semibold text-neutral-900 dark:text-neutral-100">
+            <h4 className="truncate font-semibold text-neutral-900">
               {facility.name}
             </h4>
             <span

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -91,7 +91,7 @@ function CoinLockerDetail({ details }: { details: CoinLockerDetails }) {
             {details.sizes.map((size) => (
               <div
                 key={size}
-                className="rounded-md border border-purple-200 bg-surface px-2 py-1 text-xs dark:bg-neutral-800"
+                className="rounded-md border border-purple-200 bg-surface px-2 py-1 text-xs"
               >
                 <span className="font-medium text-purple-700">
                   {LOCKER_SIZE_LABEL[size]}

--- a/src/components/spot/FacilityCard.tsx
+++ b/src/components/spot/FacilityCard.tsx
@@ -91,7 +91,7 @@ function CoinLockerDetail({ details }: { details: CoinLockerDetails }) {
             {details.sizes.map((size) => (
               <div
                 key={size}
-                className="rounded-md border border-purple-200 bg-white px-2 py-1 text-xs"
+                className="rounded-md border border-purple-200 bg-white px-2 py-1 text-xs dark:bg-neutral-800"
               >
                 <span className="font-medium text-purple-700">
                   {LOCKER_SIZE_LABEL[size]}
@@ -314,11 +314,11 @@ export default memo(function FacilityCard({
   const displayFacility = isOtaku ? { ...facility, ...voteData } : facility
 
   return (
-    <div className="rounded-lg border border-neutral-200 p-4 transition-all hover:border-neutral-300 hover:shadow-md">
+    <div className="rounded-lg border border-neutral-200 p-4 transition-all hover:border-neutral-300 hover:shadow-md dark:border-neutral-700">
       <div className="flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <div className="mb-2 flex items-center space-x-2">
-            <h4 className="truncate font-semibold text-neutral-900">
+            <h4 className="truncate font-semibold text-neutral-900 dark:text-neutral-100">
               {facility.name}
             </h4>
             <span

--- a/src/components/spot/FacilityFilter.tsx
+++ b/src/components/spot/FacilityFilter.tsx
@@ -42,7 +42,7 @@ export default function FacilityFilter({
         className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
           isAllSelected
             ? 'border-primary-300 bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300'
-            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400'
+            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400'
         }`}
         aria-pressed={isAllSelected}
       >
@@ -61,7 +61,7 @@ export default function FacilityFilter({
             className={`inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
               isSelected
                 ? color + ' dark:bg-opacity-20'
-                : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400'
+                : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400'
             }`}
             aria-pressed={isSelected}
           >

--- a/src/components/spot/FacilityFilter.tsx
+++ b/src/components/spot/FacilityFilter.tsx
@@ -42,7 +42,7 @@ export default function FacilityFilter({
         className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
           isAllSelected
             ? 'border-primary-300 bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300'
-            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700'
+            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400'
         }`}
         aria-pressed={isAllSelected}
       >
@@ -61,7 +61,7 @@ export default function FacilityFilter({
             className={`inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
               isSelected
                 ? color + ' dark:bg-opacity-20'
-                : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700'
+                : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400'
             }`}
             aria-pressed={isSelected}
           >

--- a/src/components/spot/FacilityReportForm.tsx
+++ b/src/components/spot/FacilityReportForm.tsx
@@ -159,7 +159,7 @@ function CoinLockerFields({
               className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                 data.sizes.includes(size)
                   ? 'border-purple-400 bg-purple-100 text-purple-700'
-                  : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50'
+                  : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
               }`}
             >
               {{ small: '소형', medium: '중형', large: '대형' }[size]}
@@ -192,7 +192,7 @@ function CoinLockerFields({
                       prices: { ...data.prices, [size]: val },
                     })
                   }}
-                  className="w-20 rounded border border-neutral-200 px-2 py-1 text-xs"
+                  className="w-20 rounded border border-neutral-200 px-2 py-1 text-xs dark:border-neutral-700"
                 />
               </div>
             ))}
@@ -211,7 +211,7 @@ function CoinLockerFields({
           onChange={(e) =>
             onChange({ ...data, operatingHours: e.target.value || null })
           }
-          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm"
+          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm dark:border-neutral-700"
         />
       </div>
 
@@ -358,7 +358,7 @@ function GoodsShopFields({
               className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                 data.subtype === opt.value
                   ? 'border-pink-400 bg-pink-100 text-pink-700'
-                  : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50'
+                  : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
               }`}
             >
               {opt.label}
@@ -377,7 +377,7 @@ function GoodsShopFields({
           onChange={(e) =>
             onChange({ ...data, operatingHours: e.target.value || null })
           }
-          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm"
+          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm dark:border-neutral-700"
         />
       </div>
     </fieldset>
@@ -406,7 +406,7 @@ function TriToggle({
         className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
           value === true
             ? 'border-green-400 bg-green-100 text-green-700'
-            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50'
+            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
         }`}
       >
         {trueLabel}
@@ -417,7 +417,7 @@ function TriToggle({
         className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
           value === false
             ? 'border-red-400 bg-red-100 text-red-700'
-            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50'
+            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
         }`}
       >
         {falseLabel}
@@ -591,15 +591,15 @@ export default function FacilityReportForm({
   return (
     <>
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-        <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white shadow-2xl">
+        <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
           {/* 헤더 */}
-          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-white px-6 py-4">
-            <h2 className="text-lg font-bold text-neutral-900">
+          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-white px-6 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+            <h2 className="text-lg font-bold text-neutral-900 dark:text-neutral-100">
               편의시설 제보
             </h2>
             <button
               onClick={handleClose}
-              className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
+              className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-700"
               aria-label="닫기"
             >
               <svg
@@ -636,18 +636,18 @@ export default function FacilityReportForm({
             {/* Step 1: 장소 입력 방식 선택 */}
             {!inputMode && (
               <div className="space-y-3">
-                <p className="text-sm font-medium text-neutral-700">
+                <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                   장소를 어떻게 등록하시겠어요?
                 </p>
                 <button
                   type="button"
                   onClick={() => setInputMode('search')}
-                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50"
+                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50 dark:border-neutral-700"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">🔍</span>
                     <div>
-                      <p className="text-sm font-semibold text-neutral-900">
+                      <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
                         구글맵 장소 검색
                       </p>
                       <p className="text-xs text-neutral-500">
@@ -659,12 +659,12 @@ export default function FacilityReportForm({
                 <button
                   type="button"
                   onClick={handlePinMode}
-                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50"
+                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50 dark:border-neutral-700"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">📍</span>
                     <div>
-                      <p className="text-sm font-semibold text-neutral-900">
+                      <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
                         지도에 직접 핀 꽂기
                       </p>
                       <p className="text-xs text-neutral-500">
@@ -720,7 +720,7 @@ export default function FacilityReportForm({
                         // geo 결과는 비동기이므로 effect로 처리
                       }}
                       disabled={geo.isLoading}
-                      className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50"
+                      className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
                     >
                       {geo.isLoading ? (
                         <>
@@ -768,7 +768,7 @@ export default function FacilityReportForm({
                 {inputMode === 'pin' && (
                   <div className="space-y-3">
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-neutral-700">
+                      <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
                         이름 <span className="text-red-500">*</span>
                       </label>
                       <input
@@ -781,7 +781,7 @@ export default function FacilityReportForm({
                             name: e.target.value,
                           }))
                         }
-                        className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.name ? 'border-red-400' : 'border-neutral-200'}`}
+                        className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.name ? 'border-red-400' : 'border-neutral-200 dark:border-neutral-700'}`}
                       />
                       {errors.name && (
                         <p className="mt-1 text-xs text-red-500">
@@ -791,7 +791,7 @@ export default function FacilityReportForm({
                     </div>
 
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-neutral-700">
+                      <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
                         주소
                       </label>
                       <input
@@ -804,12 +804,12 @@ export default function FacilityReportForm({
                             address: e.target.value,
                           }))
                         }
-                        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm"
+                        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-700"
                       />
                     </div>
 
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-neutral-700">
+                      <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
                         위치 <span className="text-red-500">*</span>
                       </label>
 
@@ -829,7 +829,7 @@ export default function FacilityReportForm({
                           handleCurrentLocation()
                         }}
                         disabled={geo.isLoading}
-                        className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50"
+                        className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
                       >
                         {geo.isLoading ? (
                           <>
@@ -901,7 +901,7 @@ export default function FacilityReportForm({
 
                 {/* 카테고리 선택 */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-neutral-700">
+                  <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
                     카테고리 <span className="text-red-500">*</span>
                   </label>
                   <select
@@ -912,7 +912,7 @@ export default function FacilityReportForm({
                         type: e.target.value as FacilityType,
                       }))
                     }
-                    className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.type ? 'border-red-400' : 'border-neutral-200'}`}
+                    className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.type ? 'border-red-400' : 'border-neutral-200 dark:border-neutral-700'}`}
                   >
                     <option value="">카테고리 선택...</option>
                     <optgroup label="일반 편의시설">

--- a/src/components/spot/FacilityReportForm.tsx
+++ b/src/components/spot/FacilityReportForm.tsx
@@ -159,7 +159,7 @@ function CoinLockerFields({
               className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                 data.sizes.includes(size)
                   ? 'border-purple-400 bg-purple-100 text-purple-700'
-                  : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
+                  : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50'
               }`}
             >
               {{ small: '소형', medium: '중형', large: '대형' }[size]}
@@ -358,7 +358,7 @@ function GoodsShopFields({
               className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                 data.subtype === opt.value
                   ? 'border-pink-400 bg-pink-100 text-pink-700'
-                  : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
+                  : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50'
               }`}
             >
               {opt.label}
@@ -406,7 +406,7 @@ function TriToggle({
         className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
           value === true
             ? 'border-green-400 bg-green-100 text-green-700'
-            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
+            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50'
         }`}
       >
         {trueLabel}
@@ -417,7 +417,7 @@ function TriToggle({
         className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
           value === false
             ? 'border-red-400 bg-red-100 text-red-700'
-            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
+            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50'
         }`}
       >
         {falseLabel}
@@ -591,9 +591,9 @@ export default function FacilityReportForm({
   return (
     <>
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-        <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-surface shadow-2xl dark:bg-neutral-800">
+        <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-surface shadow-2xl">
           {/* 헤더 */}
-          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-surface px-6 py-4 dark:bg-neutral-800">
+          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-surface px-6 py-4">
             <h2 className="text-lg font-bold text-neutral-900">
               편의시설 제보
             </h2>

--- a/src/components/spot/FacilityReportForm.tsx
+++ b/src/components/spot/FacilityReportForm.tsx
@@ -159,7 +159,7 @@ function CoinLockerFields({
               className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                 data.sizes.includes(size)
                   ? 'border-purple-400 bg-purple-100 text-purple-700'
-                  : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+                  : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
               }`}
             >
               {{ small: '소형', medium: '중형', large: '대형' }[size]}
@@ -192,7 +192,7 @@ function CoinLockerFields({
                       prices: { ...data.prices, [size]: val },
                     })
                   }}
-                  className="w-20 rounded border border-neutral-200 px-2 py-1 text-xs dark:border-neutral-700"
+                  className="w-20 rounded border border-neutral-200 px-2 py-1 text-xs"
                 />
               </div>
             ))}
@@ -211,7 +211,7 @@ function CoinLockerFields({
           onChange={(e) =>
             onChange({ ...data, operatingHours: e.target.value || null })
           }
-          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm dark:border-neutral-700"
+          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm"
         />
       </div>
 
@@ -358,7 +358,7 @@ function GoodsShopFields({
               className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                 data.subtype === opt.value
                   ? 'border-pink-400 bg-pink-100 text-pink-700'
-                  : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+                  : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
               }`}
             >
               {opt.label}
@@ -377,7 +377,7 @@ function GoodsShopFields({
           onChange={(e) =>
             onChange({ ...data, operatingHours: e.target.value || null })
           }
-          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm dark:border-neutral-700"
+          className="w-full rounded border border-neutral-200 px-3 py-1.5 text-sm"
         />
       </div>
     </fieldset>
@@ -406,7 +406,7 @@ function TriToggle({
         className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
           value === true
             ? 'border-green-400 bg-green-100 text-green-700'
-            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
         }`}
       >
         {trueLabel}
@@ -417,7 +417,7 @@ function TriToggle({
         className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
           value === false
             ? 'border-red-400 bg-red-100 text-red-700'
-            : 'border-neutral-200 bg-white text-neutral-500 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700'
+            : 'border-neutral-200 bg-surface text-neutral-500 hover:bg-neutral-50 dark:bg-neutral-800'
         }`}
       >
         {falseLabel}
@@ -591,15 +591,15 @@ export default function FacilityReportForm({
   return (
     <>
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-        <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+        <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-xl bg-surface shadow-2xl dark:bg-neutral-800">
           {/* 헤더 */}
-          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-white px-6 py-4 dark:border-neutral-700 dark:bg-neutral-800">
-            <h2 className="text-lg font-bold text-neutral-900 dark:text-neutral-100">
+          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-surface px-6 py-4 dark:bg-neutral-800">
+            <h2 className="text-lg font-bold text-neutral-900">
               편의시설 제보
             </h2>
             <button
               onClick={handleClose}
-              className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-700"
+              className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
               aria-label="닫기"
             >
               <svg
@@ -636,18 +636,18 @@ export default function FacilityReportForm({
             {/* Step 1: 장소 입력 방식 선택 */}
             {!inputMode && (
               <div className="space-y-3">
-                <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                <p className="text-sm font-medium text-neutral-700">
                   장소를 어떻게 등록하시겠어요?
                 </p>
                 <button
                   type="button"
                   onClick={() => setInputMode('search')}
-                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50 dark:border-neutral-700"
+                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">🔍</span>
                     <div>
-                      <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                      <p className="text-sm font-semibold text-neutral-900">
                         구글맵 장소 검색
                       </p>
                       <p className="text-xs text-neutral-500">
@@ -659,12 +659,12 @@ export default function FacilityReportForm({
                 <button
                   type="button"
                   onClick={handlePinMode}
-                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50 dark:border-neutral-700"
+                  className="w-full rounded-lg border-2 border-neutral-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50/50"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">📍</span>
                     <div>
-                      <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                      <p className="text-sm font-semibold text-neutral-900">
                         지도에 직접 핀 꽂기
                       </p>
                       <p className="text-xs text-neutral-500">
@@ -720,7 +720,7 @@ export default function FacilityReportForm({
                         // geo 결과는 비동기이므로 effect로 처리
                       }}
                       disabled={geo.isLoading}
-                      className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+                      className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50"
                     >
                       {geo.isLoading ? (
                         <>
@@ -768,7 +768,7 @@ export default function FacilityReportForm({
                 {inputMode === 'pin' && (
                   <div className="space-y-3">
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                      <label className="mb-1 block text-sm font-medium text-neutral-700">
                         이름 <span className="text-red-500">*</span>
                       </label>
                       <input
@@ -781,7 +781,7 @@ export default function FacilityReportForm({
                             name: e.target.value,
                           }))
                         }
-                        className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.name ? 'border-red-400' : 'border-neutral-200 dark:border-neutral-700'}`}
+                        className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.name ? 'border-red-400' : 'border-neutral-200'}`}
                       />
                       {errors.name && (
                         <p className="mt-1 text-xs text-red-500">
@@ -791,7 +791,7 @@ export default function FacilityReportForm({
                     </div>
 
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                      <label className="mb-1 block text-sm font-medium text-neutral-700">
                         주소
                       </label>
                       <input
@@ -804,12 +804,12 @@ export default function FacilityReportForm({
                             address: e.target.value,
                           }))
                         }
-                        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-700"
+                        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm"
                       />
                     </div>
 
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                      <label className="mb-1 block text-sm font-medium text-neutral-700">
                         위치 <span className="text-red-500">*</span>
                       </label>
 
@@ -829,7 +829,7 @@ export default function FacilityReportForm({
                           handleCurrentLocation()
                         }}
                         disabled={geo.isLoading}
-                        className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+                        className="flex w-full items-center justify-center gap-2 rounded-lg border border-neutral-200 py-2 text-sm text-neutral-600 transition-colors hover:bg-neutral-50 disabled:opacity-50"
                       >
                         {geo.isLoading ? (
                           <>
@@ -901,7 +901,7 @@ export default function FacilityReportForm({
 
                 {/* 카테고리 선택 */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  <label className="mb-1 block text-sm font-medium text-neutral-700">
                     카테고리 <span className="text-red-500">*</span>
                   </label>
                   <select
@@ -912,7 +912,7 @@ export default function FacilityReportForm({
                         type: e.target.value as FacilityType,
                       }))
                     }
-                    className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.type ? 'border-red-400' : 'border-neutral-200 dark:border-neutral-700'}`}
+                    className={`w-full rounded-lg border px-3 py-2 text-sm ${errors.type ? 'border-red-400' : 'border-neutral-200'}`}
                   >
                     <option value="">카테고리 선택...</option>
                     <optgroup label="일반 편의시설">

--- a/src/components/spot/GooglePlacesSearch.tsx
+++ b/src/components/spot/GooglePlacesSearch.tsx
@@ -199,7 +199,7 @@ export default function GooglePlacesSearch({
           type="text"
           onFocus={loadScript}
           placeholder="장소 이름으로 검색 (포커스 시 구글맵 로드)"
-          className="w-full rounded-lg border border-neutral-200 bg-surface px-3 py-2 text-sm text-neutral-400 transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
+          className="w-full rounded-lg border border-neutral-200 bg-surface px-3 py-2 text-sm text-neutral-400 transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400 dark:border-neutral-700"
           readOnly
         />
       </div>
@@ -252,7 +252,7 @@ export default function GooglePlacesSearch({
         value={query}
         onChange={(e) => handleInputChange(e.target.value)}
         placeholder="장소 이름으로 검색 (예: 아키하바라 건담 카페)"
-        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
+        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400 dark:border-neutral-700"
       />
 
       {/* 로딩 인디케이터 */}
@@ -282,7 +282,7 @@ export default function GooglePlacesSearch({
 
       {/* 자동완성 드롭다운 */}
       {suggestions.length > 0 && (
-        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-neutral-200 bg-white shadow-lg">
+        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
           {suggestions.map((suggestion, index) => {
             const prediction = suggestion.placePrediction
             return (

--- a/src/components/spot/GooglePlacesSearch.tsx
+++ b/src/components/spot/GooglePlacesSearch.tsx
@@ -199,7 +199,7 @@ export default function GooglePlacesSearch({
           type="text"
           onFocus={loadScript}
           placeholder="장소 이름으로 검색 (포커스 시 구글맵 로드)"
-          className="w-full rounded-lg border border-neutral-200 bg-surface px-3 py-2 text-sm text-neutral-400 transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400 dark:border-neutral-700"
+          className="w-full rounded-lg border border-neutral-200 bg-surface px-3 py-2 text-sm text-neutral-400 transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
           readOnly
         />
       </div>
@@ -252,7 +252,7 @@ export default function GooglePlacesSearch({
         value={query}
         onChange={(e) => handleInputChange(e.target.value)}
         placeholder="장소 이름으로 검색 (예: 아키하바라 건담 카페)"
-        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400 dark:border-neutral-700"
+        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm transition-colors focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
       />
 
       {/* 로딩 인디케이터 */}
@@ -282,7 +282,7 @@ export default function GooglePlacesSearch({
 
       {/* 자동완성 드롭다운 */}
       {suggestions.length > 0 && (
-        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-neutral-200 bg-surface shadow-lg dark:bg-neutral-800">
           {suggestions.map((suggestion, index) => {
             const prediction = suggestion.placePrediction
             return (

--- a/src/components/spot/GooglePlacesSearch.tsx
+++ b/src/components/spot/GooglePlacesSearch.tsx
@@ -282,7 +282,7 @@ export default function GooglePlacesSearch({
 
       {/* 자동완성 드롭다운 */}
       {suggestions.length > 0 && (
-        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-neutral-200 bg-surface shadow-lg dark:bg-neutral-800">
+        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-neutral-200 bg-surface shadow-lg">
           {suggestions.map((suggestion, index) => {
             const prediction = suggestion.placePrediction
             return (

--- a/src/components/spot/ImageUpload.tsx
+++ b/src/components/spot/ImageUpload.tsx
@@ -514,7 +514,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveLeft()
             }}
-            className="text-text-secondary rounded-full bg-white/90 p-1.5 shadow hover:bg-white"
+            className="text-text-secondary rounded-full bg-white/90 p-1.5 shadow hover:bg-white dark:bg-neutral-700/90 dark:hover:bg-neutral-700"
             title="왼쪽으로 이동"
           >
             <svg
@@ -564,7 +564,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveRight()
             }}
-            className="text-text-secondary rounded-full bg-white/90 p-1.5 shadow hover:bg-white"
+            className="text-text-secondary rounded-full bg-white/90 p-1.5 shadow hover:bg-white dark:bg-neutral-700/90 dark:hover:bg-neutral-700"
             title="오른쪽으로 이동"
           >
             <svg

--- a/src/components/spot/ImageUpload.tsx
+++ b/src/components/spot/ImageUpload.tsx
@@ -514,7 +514,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveLeft()
             }}
-            className="text-text-secondary rounded-full bg-surface/90 p-1.5 shadow hover:bg-surface dark:bg-neutral-700/90"
+            className="text-text-secondary rounded-full bg-surface/90 p-1.5 shadow hover:bg-surface"
             title="왼쪽으로 이동"
           >
             <svg
@@ -564,7 +564,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveRight()
             }}
-            className="text-text-secondary rounded-full bg-surface/90 p-1.5 shadow hover:bg-surface dark:bg-neutral-700/90"
+            className="text-text-secondary rounded-full bg-surface/90 p-1.5 shadow hover:bg-surface"
             title="오른쪽으로 이동"
           >
             <svg

--- a/src/components/spot/ImageUpload.tsx
+++ b/src/components/spot/ImageUpload.tsx
@@ -514,7 +514,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveLeft()
             }}
-            className="text-text-secondary rounded-full bg-white/90 p-1.5 shadow hover:bg-white dark:bg-neutral-700/90 dark:hover:bg-neutral-700"
+            className="text-text-secondary rounded-full bg-surface/90 p-1.5 shadow hover:bg-surface dark:bg-neutral-700/90"
             title="왼쪽으로 이동"
           >
             <svg
@@ -564,7 +564,7 @@ function ImagePreviewItem({
               e.stopPropagation()
               onMoveRight()
             }}
-            className="text-text-secondary rounded-full bg-white/90 p-1.5 shadow hover:bg-white dark:bg-neutral-700/90 dark:hover:bg-neutral-700"
+            className="text-text-secondary rounded-full bg-surface/90 p-1.5 shadow hover:bg-surface dark:bg-neutral-700/90"
             title="오른쪽으로 이동"
           >
             <svg

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -221,7 +221,7 @@ export function LocationPicker({
         <button
           type="button"
           onClick={() => mapRef.current?.zoomIn()}
-          className="flex h-8 w-8 items-center justify-center rounded bg-surface shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800"
+          className="flex h-8 w-8 items-center justify-center rounded bg-surface shadow-md transition-colors hover:bg-neutral-100"
           aria-label="확대"
         >
           <svg
@@ -241,7 +241,7 @@ export function LocationPicker({
         <button
           type="button"
           onClick={() => mapRef.current?.zoomOut()}
-          className="flex h-8 w-8 items-center justify-center rounded bg-surface shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800"
+          className="flex h-8 w-8 items-center justify-center rounded bg-surface shadow-md transition-colors hover:bg-neutral-100"
           aria-label="축소"
         >
           <svg

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -221,7 +221,7 @@ export function LocationPicker({
         <button
           type="button"
           onClick={() => mapRef.current?.zoomIn()}
-          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-neutral-100"
+          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
           aria-label="확대"
         >
           <svg
@@ -241,7 +241,7 @@ export function LocationPicker({
         <button
           type="button"
           onClick={() => mapRef.current?.zoomOut()}
-          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-neutral-100"
+          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
           aria-label="축소"
         >
           <svg

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -221,7 +221,7 @@ export function LocationPicker({
         <button
           type="button"
           onClick={() => mapRef.current?.zoomIn()}
-          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+          className="flex h-8 w-8 items-center justify-center rounded bg-surface shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800"
           aria-label="확대"
         >
           <svg
@@ -241,7 +241,7 @@ export function LocationPicker({
         <button
           type="button"
           onClick={() => mapRef.current?.zoomOut()}
-          className="flex h-8 w-8 items-center justify-center rounded bg-white shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+          className="flex h-8 w-8 items-center justify-center rounded bg-surface shadow-md transition-colors hover:bg-neutral-100 dark:bg-neutral-800"
           aria-label="축소"
         >
           <svg

--- a/src/components/spot/LocationPickerMap.tsx
+++ b/src/components/spot/LocationPickerMap.tsx
@@ -66,7 +66,7 @@ export default function LocationPickerMap({
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
-      <div className="flex h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-surface shadow-2xl dark:bg-neutral-800">
+      <div className="flex h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-surface shadow-2xl">
         {/* 헤더 */}
         <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3">
           <h3 className="text-sm font-bold text-neutral-900">
@@ -94,7 +94,7 @@ export default function LocationPickerMap({
         </div>
 
         {/* 안내 */}
-        <div className="border-b border-neutral-100 bg-neutral-50 px-4 py-2 dark:bg-neutral-700">
+        <div className="border-b border-neutral-100 bg-neutral-50 px-4 py-2">
           <p className="text-xs text-neutral-500">
             지도를 클릭하여 편의시설 위치를 지정해주세요
           </p>

--- a/src/components/spot/LocationPickerMap.tsx
+++ b/src/components/spot/LocationPickerMap.tsx
@@ -66,15 +66,15 @@ export default function LocationPickerMap({
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
-      <div className="flex h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+      <div className="flex h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-surface shadow-2xl dark:bg-neutral-800">
         {/* 헤더 */}
-        <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 dark:border-neutral-700">
-          <h3 className="text-sm font-bold text-neutral-900 dark:text-neutral-100">
+        <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3">
+          <h3 className="text-sm font-bold text-neutral-900">
             📍 지도에서 위치 선택
           </h3>
           <button
             onClick={onClose}
-            className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-700"
+            className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
             aria-label="닫기"
           >
             <svg
@@ -110,7 +110,7 @@ export default function LocationPickerMap({
         </div>
 
         {/* 하단 버튼 */}
-        <div className="border-t border-neutral-200 px-4 py-3 dark:border-neutral-700">
+        <div className="border-t border-neutral-200 px-4 py-3">
           {selectedPos ? (
             <div className="mb-2 text-center text-xs text-neutral-500">
               📍 {selectedPos.lat.toFixed(6)}, {selectedPos.lng.toFixed(6)}

--- a/src/components/spot/LocationPickerMap.tsx
+++ b/src/components/spot/LocationPickerMap.tsx
@@ -66,15 +66,15 @@ export default function LocationPickerMap({
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
-      <div className="flex h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-white shadow-2xl">
+      <div className="flex h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
         {/* 헤더 */}
-        <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3">
-          <h3 className="text-sm font-bold text-neutral-900">
+        <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 dark:border-neutral-700">
+          <h3 className="text-sm font-bold text-neutral-900 dark:text-neutral-100">
             📍 지도에서 위치 선택
           </h3>
           <button
             onClick={onClose}
-            className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
+            className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-700"
             aria-label="닫기"
           >
             <svg
@@ -94,7 +94,7 @@ export default function LocationPickerMap({
         </div>
 
         {/* 안내 */}
-        <div className="border-b border-neutral-100 bg-neutral-50 px-4 py-2">
+        <div className="border-b border-neutral-100 bg-neutral-50 px-4 py-2 dark:bg-neutral-700">
           <p className="text-xs text-neutral-500">
             지도를 클릭하여 편의시설 위치를 지정해주세요
           </p>
@@ -110,7 +110,7 @@ export default function LocationPickerMap({
         </div>
 
         {/* 하단 버튼 */}
-        <div className="border-t border-neutral-200 px-4 py-3">
+        <div className="border-t border-neutral-200 px-4 py-3 dark:border-neutral-700">
           {selectedPos ? (
             <div className="mb-2 text-center text-xs text-neutral-500">
               📍 {selectedPos.lat.toFixed(6)}, {selectedPos.lng.toFixed(6)}

--- a/src/components/spot/NearbyFacilities.tsx
+++ b/src/components/spot/NearbyFacilities.tsx
@@ -244,7 +244,7 @@ export default function NearbyFacilities({
               {/* 아코디언 헤더 */}
               <button
                 onClick={() => toggleAccordion(type)}
-                className="flex w-full items-center justify-between bg-accent-surface px-4 py-3 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                className="flex w-full items-center justify-between bg-accent-surface px-4 py-3 transition-colors hover:bg-neutral-100"
               >
                 <div className="flex items-center space-x-2">
                   <span className="text-xl">{config.icon}</span>

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -57,7 +57,7 @@ export function RelatedContentItem({
         onDragOver(index)
       }}
       onDragEnd={onDragEnd}
-      className={`flex items-center justify-between rounded-lg border bg-surface p-3 transition-all dark:bg-neutral-800 ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
+      className={`flex items-center justify-between rounded-lg border bg-surface p-3 transition-all ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
     >
       {/* 드래그 핸들 */}
       <div

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -57,7 +57,7 @@ export function RelatedContentItem({
         onDragOver(index)
       }}
       onDragEnd={onDragEnd}
-      className={`flex items-center justify-between rounded-lg border bg-white p-3 transition-all ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
+      className={`flex items-center justify-between rounded-lg border bg-white p-3 transition-all dark:bg-neutral-800 ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
     >
       {/* 드래그 핸들 */}
       <div

--- a/src/components/spot/RelatedContentItem.tsx
+++ b/src/components/spot/RelatedContentItem.tsx
@@ -57,7 +57,7 @@ export function RelatedContentItem({
         onDragOver(index)
       }}
       onDragEnd={onDragEnd}
-      className={`flex items-center justify-between rounded-lg border bg-white p-3 transition-all dark:bg-neutral-800 ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
+      className={`flex items-center justify-between rounded-lg border bg-surface p-3 transition-all dark:bg-neutral-800 ${isDragging ? 'border-primary-400 opacity-50 shadow-lg' : 'border-border'} ${isDragOver ? 'border-2 border-primary bg-primary-50' : ''} `}
     >
       {/* 드래그 핸들 */}
       <div

--- a/src/components/spot/SceneImageModal.tsx
+++ b/src/components/spot/SceneImageModal.tsx
@@ -274,7 +274,7 @@ export default function SceneImageModal({
                   }}
                   className={`h-2 rounded-full transition-all ${
                     index === currentIndex
-                      ? 'w-6 bg-white'
+                      ? 'w-6 bg-surface'
                       : 'w-2 bg-white/50 hover:bg-white/70'
                   }`}
                   aria-label={`${index + 1}번째 장면으로 이동`}

--- a/src/components/spot/SpotCommunitySection.tsx
+++ b/src/components/spot/SpotCommunitySection.tsx
@@ -17,7 +17,7 @@ function PostItem({ post, onClick }: PostItemProps) {
   return (
     <article
       onClick={onClick}
-      className="cursor-pointer border-b border-neutral-100 p-4 transition-colors last:border-b-0 hover:bg-neutral-50 dark:hover:bg-neutral-700"
+      className="cursor-pointer border-b border-neutral-100 p-4 transition-colors last:border-b-0 hover:bg-neutral-50"
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
@@ -29,7 +29,7 @@ function PostItem({ post, onClick }: PostItemProps) {
     >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
-          <h4 className="mb-1 truncate text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          <h4 className="mb-1 truncate text-sm font-medium text-neutral-900">
             {post.title}
           </h4>
           <div className="flex items-center gap-2 text-xs text-neutral-500">
@@ -170,13 +170,11 @@ export default function SpotCommunitySection({
   }
 
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-md dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-md dark:bg-neutral-800">
       <div className="p-6">
         {/* 헤더 */}
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-            커뮤니티
-          </h2>
+          <h2 className="text-2xl font-bold text-neutral-900">커뮤니티</h2>
           {/* 게시글이 있을 때만 헤더에 글쓰기 버튼 표시 */}
           {posts && posts.length > 0 && (
             <Link
@@ -212,7 +210,7 @@ export default function SpotCommunitySection({
           <CommunityEmpty spotId={spotId} spotName={spotName} />
         ) : (
           <>
-            <div className="divide-y divide-neutral-100 rounded-lg border border-neutral-200 dark:border-neutral-700">
+            <div className="divide-y divide-neutral-100 rounded-lg border border-neutral-200">
               {posts.slice(0, maxPosts).map((post) => (
                 <PostItem
                   key={post.id}

--- a/src/components/spot/SpotCommunitySection.tsx
+++ b/src/components/spot/SpotCommunitySection.tsx
@@ -17,7 +17,7 @@ function PostItem({ post, onClick }: PostItemProps) {
   return (
     <article
       onClick={onClick}
-      className="cursor-pointer border-b border-neutral-100 p-4 transition-colors last:border-b-0 hover:bg-neutral-50"
+      className="cursor-pointer border-b border-neutral-100 p-4 transition-colors last:border-b-0 hover:bg-neutral-50 dark:hover:bg-neutral-700"
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
@@ -29,7 +29,7 @@ function PostItem({ post, onClick }: PostItemProps) {
     >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
-          <h4 className="mb-1 truncate text-sm font-medium text-neutral-900">
+          <h4 className="mb-1 truncate text-sm font-medium text-neutral-900 dark:text-neutral-100">
             {post.title}
           </h4>
           <div className="flex items-center gap-2 text-xs text-neutral-500">
@@ -170,11 +170,13 @@ export default function SpotCommunitySection({
   }
 
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-md">
+    <div className="overflow-hidden rounded-lg bg-white shadow-md dark:bg-neutral-800">
       <div className="p-6">
         {/* 헤더 */}
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-2xl font-bold text-neutral-900">커뮤니티</h2>
+          <h2 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+            커뮤니티
+          </h2>
           {/* 게시글이 있을 때만 헤더에 글쓰기 버튼 표시 */}
           {posts && posts.length > 0 && (
             <Link
@@ -210,7 +212,7 @@ export default function SpotCommunitySection({
           <CommunityEmpty spotId={spotId} spotName={spotName} />
         ) : (
           <>
-            <div className="divide-y divide-neutral-100 rounded-lg border border-neutral-200">
+            <div className="divide-y divide-neutral-100 rounded-lg border border-neutral-200 dark:border-neutral-700">
               {posts.slice(0, maxPosts).map((post) => (
                 <PostItem
                   key={post.id}

--- a/src/components/spot/SpotCommunitySection.tsx
+++ b/src/components/spot/SpotCommunitySection.tsx
@@ -170,7 +170,7 @@ export default function SpotCommunitySection({
   }
 
   return (
-    <div className="overflow-hidden rounded-lg bg-surface shadow-md dark:bg-neutral-800">
+    <div className="overflow-hidden rounded-lg bg-surface shadow-md">
       <div className="p-6">
         {/* 헤더 */}
         <div className="mb-4 flex items-center justify-between">

--- a/src/components/spot/SpotContentSection.tsx
+++ b/src/components/spot/SpotContentSection.tsx
@@ -65,7 +65,7 @@ export function SpotContentSection({
 
       {/* 일반 정보 섹션 (info) - other 카테고리용 */}
       {sections.includes('info') && (
-        <div className="overflow-hidden rounded-lg bg-white shadow-md dark:bg-neutral-900">
+        <div className="overflow-hidden rounded-lg bg-surface shadow-md dark:bg-neutral-900">
           <div className="p-6">
             <div className="mb-4 flex items-center gap-2">
               <AppIcon name="spot" size={28} />

--- a/src/components/spot/SpotContentSection.tsx
+++ b/src/components/spot/SpotContentSection.tsx
@@ -65,13 +65,11 @@ export function SpotContentSection({
 
       {/* 일반 정보 섹션 (info) - other 카테고리용 */}
       {sections.includes('info') && (
-        <div className="overflow-hidden rounded-lg bg-surface shadow-md dark:bg-neutral-900">
+        <div className="overflow-hidden rounded-lg bg-surface shadow-md">
           <div className="p-6">
             <div className="mb-4 flex items-center gap-2">
               <AppIcon name="spot" size={28} />
-              <h2 className="text-2xl font-bold text-primary dark:text-primary-400">
-                정보
-              </h2>
+              <h2 className="text-2xl font-bold text-primary">정보</h2>
             </div>
             <p className="text-sm text-secondary dark:text-secondary-400">
               이 장소에 대한 추가 정보가 곧 제공될 예정입니다.

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -482,7 +482,7 @@ interface SpotDetailErrorProps {
 function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow-md dark:bg-neutral-900">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md dark:bg-neutral-900">
         <div className="text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center text-red-500">
             <AlertTriangleIcon size={64} />
@@ -518,7 +518,7 @@ function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
 function SpotNotFound() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow-md dark:bg-neutral-900">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md dark:bg-neutral-900">
         <div className="text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center text-neutral-400">
             <MapPinIcon size={64} />

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -482,12 +482,12 @@ interface SpotDetailErrorProps {
 function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md dark:bg-neutral-900">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md">
         <div className="text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center text-red-500">
             <AlertTriangleIcon size={64} />
           </div>
-          <h2 className="mb-2 text-xl font-bold text-primary dark:text-primary-400">
+          <h2 className="mb-2 text-xl font-bold text-primary">
             오류가 발생했습니다
           </h2>
           <p className="mb-4 text-secondary dark:text-secondary-400">
@@ -504,7 +504,7 @@ function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
             )}
             <Link
               href="/"
-              className="inline-flex items-center rounded-md border border-border px-4 py-2 text-primary transition-colors hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-neutral-800"
+              className="inline-flex items-center rounded-md border border-border px-4 py-2 text-primary transition-colors hover:bg-primary-50"
             >
               메인으로 돌아가기
             </Link>
@@ -518,12 +518,12 @@ function SpotDetailError({ error, onRetry }: SpotDetailErrorProps) {
 function SpotNotFound() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md dark:bg-neutral-900">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-surface p-8 shadow-md">
         <div className="text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center text-neutral-400">
             <MapPinIcon size={64} />
           </div>
-          <h2 className="mb-2 text-xl font-bold text-primary dark:text-primary-400">
+          <h2 className="mb-2 text-xl font-bold text-primary">
             스팟을 찾을 수 없습니다
           </h2>
           <p className="mb-4 text-secondary dark:text-secondary-400">

--- a/src/components/spot/scene/AddSceneModal.tsx
+++ b/src/components/spot/scene/AddSceneModal.tsx
@@ -90,9 +90,9 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
-      <div className="relative z-[10000] w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
+      <div className="relative z-[10000] w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="text-lg font-bold text-neutral-900 dark:text-neutral-100">
+          <h3 className="text-lg font-bold text-neutral-900">
             작품 속 장면 추가
           </h3>
           <button
@@ -123,13 +123,13 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            <label className="mb-1 block text-sm font-medium text-neutral-700">
               이미지 <span className="text-red-500">*</span>
             </label>
             <div className="mt-1">
               {imagePreview ? (
                 <div className="relative">
-                  <div className="relative aspect-video overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-700">
+                  <div className="relative aspect-video overflow-hidden rounded-lg border border-neutral-200">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={imagePreview}
@@ -193,7 +193,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            <label className="mb-1 block text-sm font-medium text-neutral-700">
               에피소드 정보
             </label>
             <input
@@ -206,7 +206,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            <label className="mb-1 block text-sm font-medium text-neutral-700">
               설명
             </label>
             <textarea
@@ -222,7 +222,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-700"
+              className="flex-1 rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
             >
               취소
             </button>

--- a/src/components/spot/scene/AddSceneModal.tsx
+++ b/src/components/spot/scene/AddSceneModal.tsx
@@ -90,9 +90,9 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
-      <div className="relative z-[10000] w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div className="relative z-[10000] w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-800">
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="text-lg font-bold text-neutral-900">
+          <h3 className="text-lg font-bold text-neutral-900 dark:text-neutral-100">
             작품 속 장면 추가
           </h3>
           <button
@@ -123,13 +123,13 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">
+            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
               이미지 <span className="text-red-500">*</span>
             </label>
             <div className="mt-1">
               {imagePreview ? (
                 <div className="relative">
-                  <div className="relative aspect-video overflow-hidden rounded-lg border border-neutral-200">
+                  <div className="relative aspect-video overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-700">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={imagePreview}
@@ -193,7 +193,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">
+            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
               에피소드 정보
             </label>
             <input
@@ -206,7 +206,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">
+            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
               설명
             </label>
             <textarea
@@ -222,7 +222,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+              className="flex-1 rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-700"
             >
               취소
             </button>

--- a/src/components/spot/scene/AddSceneModal.tsx
+++ b/src/components/spot/scene/AddSceneModal.tsx
@@ -90,7 +90,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
-      <div className="relative z-[10000] w-full max-w-md rounded-lg bg-surface p-6 shadow-xl dark:bg-neutral-800">
+      <div className="relative z-[10000] w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
           <h3 className="text-lg font-bold text-neutral-900">
             작품 속 장면 추가

--- a/src/components/spot/scene/SceneCard.tsx
+++ b/src/components/spot/scene/SceneCard.tsx
@@ -51,7 +51,7 @@ export function SceneCard({
 
   return (
     <div
-      className="group relative aspect-[4/3] cursor-pointer overflow-hidden rounded-xl border border-neutral-200 shadow-sm transition-shadow duration-300 hover:shadow-lg"
+      className="group relative aspect-[4/3] cursor-pointer overflow-hidden rounded-xl border border-neutral-200 shadow-sm transition-shadow duration-300 hover:shadow-lg dark:border-neutral-700"
       onClick={onClick}
       role="button"
       tabIndex={0}
@@ -93,7 +93,7 @@ export function SceneCard({
         className={`absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium shadow-md transition-all ${
           liked
             ? 'bg-red-500 text-white'
-            : 'bg-white/90 text-neutral-700 hover:bg-red-500 hover:text-white'
+            : 'bg-white/90 text-neutral-700 hover:bg-red-500 hover:text-white dark:bg-neutral-700/90 dark:text-neutral-300'
         }`}
         aria-label={liked ? '좋아요 취소' : '좋아요'}
         title={liked ? '좋아요 취소' : '좋아요'}

--- a/src/components/spot/scene/SceneCard.tsx
+++ b/src/components/spot/scene/SceneCard.tsx
@@ -51,7 +51,7 @@ export function SceneCard({
 
   return (
     <div
-      className="group relative aspect-[4/3] cursor-pointer overflow-hidden rounded-xl border border-neutral-200 shadow-sm transition-shadow duration-300 hover:shadow-lg dark:border-neutral-700"
+      className="group relative aspect-[4/3] cursor-pointer overflow-hidden rounded-xl border border-neutral-200 shadow-sm transition-shadow duration-300 hover:shadow-lg"
       onClick={onClick}
       role="button"
       tabIndex={0}
@@ -93,7 +93,7 @@ export function SceneCard({
         className={`absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium shadow-md transition-all ${
           liked
             ? 'bg-red-500 text-white'
-            : 'bg-white/90 text-neutral-700 hover:bg-red-500 hover:text-white dark:bg-neutral-700/90 dark:text-neutral-300'
+            : 'bg-surface/90 text-neutral-700 hover:bg-red-500 hover:text-white dark:bg-neutral-700/90'
         }`}
         aria-label={liked ? '좋아요 취소' : '좋아요'}
         title={liked ? '좋아요 취소' : '좋아요'}

--- a/src/components/spot/scene/SceneCard.tsx
+++ b/src/components/spot/scene/SceneCard.tsx
@@ -93,7 +93,7 @@ export function SceneCard({
         className={`absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium shadow-md transition-all ${
           liked
             ? 'bg-red-500 text-white'
-            : 'bg-surface/90 text-neutral-700 hover:bg-red-500 hover:text-white dark:bg-neutral-700/90'
+            : 'bg-surface/90 text-neutral-700 hover:bg-red-500 hover:text-white'
         }`}
         aria-label={liked ? '좋아요 취소' : '좋아요'}
         title={liked ? '좋아요 취소' : '좋아요'}

--- a/src/components/spot/scene/SceneCarousel.tsx
+++ b/src/components/spot/scene/SceneCarousel.tsx
@@ -79,7 +79,7 @@ export function SceneCarousel({
         <>
           <button
             onClick={goToPrev}
-            className="absolute -left-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
+            className="absolute -left-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-surface hover:shadow-xl"
             aria-label="이전 장면"
           >
             <svg
@@ -98,7 +98,7 @@ export function SceneCarousel({
           </button>
           <button
             onClick={goToNext}
-            className="absolute -right-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
+            className="absolute -right-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-surface hover:shadow-xl"
             aria-label="다음 장면"
           >
             <svg

--- a/src/components/spot/scene/SceneCarousel.tsx
+++ b/src/components/spot/scene/SceneCarousel.tsx
@@ -79,7 +79,7 @@ export function SceneCarousel({
         <>
           <button
             onClick={goToPrev}
-            className="absolute -left-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
+            className="absolute -left-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
             aria-label="이전 장면"
           >
             <svg
@@ -98,7 +98,7 @@ export function SceneCarousel({
           </button>
           <button
             onClick={goToNext}
-            className="absolute -right-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
+            className="absolute -right-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-surface shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
             aria-label="다음 장면"
           >
             <svg

--- a/src/components/spot/scene/SceneCarousel.tsx
+++ b/src/components/spot/scene/SceneCarousel.tsx
@@ -79,7 +79,7 @@ export function SceneCarousel({
         <>
           <button
             onClick={goToPrev}
-            className="absolute -left-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-surface hover:shadow-xl"
+            className="absolute -left-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
             aria-label="이전 장면"
           >
             <svg
@@ -98,7 +98,7 @@ export function SceneCarousel({
           </button>
           <button
             onClick={goToNext}
-            className="absolute -right-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-surface hover:shadow-xl"
+            className="absolute -right-4 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg transition-all hover:bg-surface hover:shadow-xl dark:bg-neutral-800"
             aria-label="다음 장면"
           >
             <svg


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #440

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

프로젝트 전체 `bg-white` 다크 모드 일괄 적용. 52개 파일에서 `dark:bg-neutral-800` 추가, 관련 border/text/hover 다크 모드도 함께 적용.

---

## 📋 변경 사항

- [x] spot 컴포넌트 15개 파일 다크 모드 적용
- [x] route 컴포넌트 8개 파일 다크 모드 적용
- [x] gallery, community, admin, report, mobile, profile, checkin, common, map 컴포넌트 29개 파일 다크 모드 적용
- [x] `bg-white/10`, `/20`, `/30`, `/50`, `/70` 반투명 오버레이는 의도적으로 제외
- [x] 토글 스위치 인디케이터, 카메라 버튼, 캐러셀 도트 등 제외

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인