### PR TITLE
[Feat] 랜딩 페이지 라우트 구조 변경 및 미들웨어 설정

### DIFF
--- a/src/app/(landing)/welcome/page.tsx
+++ b/src/app/(landing)/welcome/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+import { WelcomePageClient } from '@/components/landing/WelcomePageClient'
+
+export const metadata: Metadata = {
+  title: '환영합니다',
+  description:
+    '관광지가 아닌 성지를 탐험하세요. 애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+  openGraph: {
+    title: 'Not a Trip - 관광지가 아닌 성지를 탐험하세요',
+    description:
+      '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+  },
+}
+
+export default function WelcomePage() {
+  return <WelcomePageClient />
+}

--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -19,25 +19,25 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
 })
 
 /**
- * 메인 페이지 컴포넌트
+ * 지도 메인 페이지 컴포넌트 (/map)
  * Requirements 1.1, 1.4, 2.1, 2.2를 만족하는 지도 기반 메인 페이지
  * - useQuery로 필터 변경 시 지도 유지 (번쩍임 방지)
  * - 카테고리 필터링 지원
  * - filterStore 전역 상태 사용
  */
-export default function Home() {
+export default function MapPage() {
   return (
     <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
-      <HomeContent />
+      <MapContent />
     </main>
   )
 }
 
 /**
- * 메인 페이지 내부 콘텐츠 컴포넌트
+ * 지도 페이지 내부 콘텐츠 컴포넌트
  * useQuery를 사용하여 필터 변경 시 지도가 유지되고 로딩 인디케이터만 표시
  */
-function HomeContent() {
+function MapContent() {
   const selectedCategories = useSelectedCategories()
   const searchQuery = useSearchQuery()
   const isNoCategorySelected = selectedCategories.length === 0

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useCallback, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+/**
+ * 랜딩 페이지 클라이언트 컴포넌트 (스켈레톤)
+ * 추후 HeroSection, StorytellingSection, SocialProofSection,
+ * ConversionSection, FloatingCTA 등을 통합할 예정
+ * Requirements: 1.8, 1.9
+ */
+export function WelcomePageClient() {
+  const router = useRouter()
+
+  /** 페이지 이탈 시에도 has_visited 쿠키 설정 */
+  useEffect(() => {
+    const handleBeforeUnload = () => setHasVisitedCookie()
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [])
+
+  /** CTA 클릭 시 has_visited 쿠키 설정 후 /map으로 이동 */
+  const handleExplore = useCallback(() => {
+    setHasVisitedCookie()
+    router.push('/map')
+  }, [router])
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* TODO: HeroSection */}
+      {/* TODO: StorytellingSection */}
+      {/* TODO: SocialProofSection */}
+      {/* TODO: ConversionSection */}
+      {/* TODO: FloatingCTA */}
+
+      {/* 임시 CTA — 추후 HeroSection으로 대체 */}
+      <section className="flex min-h-screen flex-col items-center justify-center px-4">
+        <h1 className="mb-4 text-3xl font-bold text-main-text">
+          관광지가 아닌 성지를 탐험하세요
+        </h1>
+        <p className="mb-8 text-center text-sub-text">
+          애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등
+          <br />
+          팬들만 아는 특별한 여행지를 발견하세요.
+        </p>
+        <button
+          onClick={handleExplore}
+          className="rounded-lg bg-primary px-6 py-3 text-white transition-colors hover:bg-primary-600"
+        >
+          지도 탐색하기
+        </button>
+      </section>
+    </div>
+  )
+}
+
+/**
+ * has_visited 쿠키를 설정하여 다음 방문 시 /map으로 리다이렉트
+ * 만료: 365일
+ */
+function setHasVisitedCookie() {
+  const maxAge = 365 * 24 * 60 * 60 // 365일 (초)
+  document.cookie = `has_visited=true; path=/; max-age=${maxAge}; SameSite=Lax`
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+/**
+ * 루트(/) 경로 접속 시 쿠키 기반 분기 리다이렉트
+ * - has_visited=true → /map (기존 사용자)
+ * - has_visited 없음 또는 읽기 실패 → /welcome (신규 사용자)
+ * Requirements: 1.9
+ */
+export function middleware(request: NextRequest) {
+  try {
+    const hasVisited = request.cookies.get('has_visited')?.value
+    if (hasVisited === 'true') {
+      return NextResponse.redirect(new URL('/map', request.url))
+    }
+  } catch {
+    // 쿠키 읽기 실패 시 신규 유저로 간주
+  }
+
+  return NextResponse.redirect(new URL('/welcome', request.url))
+}
+
+export const config = {
+  matcher: ['/'],
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #442

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 랜딩 페이지 구현을 위한 라우트 구조 변경. 미들웨어 기반 쿠키 분기, 지도 페이지 /map 이전, /welcome 랜딩 페이지 라우트 생성.

---

## 📋 변경 사항

- [x] `src/middleware.ts` — 루트(/) 경로에서 `has_visited` 쿠키 기반 `/map` 또는 `/welcome` 분기 리다이렉트
- [x] `src/app/page.tsx` → `src/app/(main)/map/page.tsx` — 기존 지도 페이지를 Route Group `(main)` 하위 `/map` 경로로 이전
- [x] `src/app/(landing)/welcome/page.tsx` — 서버 컴포넌트 (메타데이터 포함)
- [x] `src/components/landing/WelcomePageClient.tsx` — 클라이언트 컴포넌트 스켈레톤 (CTA 클릭/페이지 이탈 시 쿠키 설정)

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- 기존 `href="/"` 링크들은 미들웨어가 자동으로 `/map`으로 리다이렉트하므로 정상 동작
- `has_visited` 쿠키 만료: 365일
- Task 1 (1.1, 1.2, 1.3) / Requirements 1.8, 1.9 대응