### PR TITLE
[Feat] Task 4 - 랜딩 페이지 정적/단순 컴포넌트 구현

### DIFF
--- a/src/components/landing/CTAButton.tsx
+++ b/src/components/landing/CTAButton.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Link from 'next/link'
+
+/**
+ * CTA(Call-To-Action) 버튼 컴포넌트
+ * next/link 기반 클라이언트 사이드 라우팅, 시맨틱 컬러 사용
+ * Requirements: 1.6, 1.7, 1.8, 7.5
+ */
+
+interface CTAButtonProps {
+  label: string
+  href: string
+  variant?: 'primary' | 'secondary'
+  size?: 'md' | 'lg'
+}
+
+const variantStyles = {
+  primary:
+    'bg-primary-500 text-white hover:bg-primary-600 focus-visible:ring-primary-500',
+  secondary:
+    'bg-secondary-100 text-secondary-700 hover:bg-secondary-200 focus-visible:ring-secondary-500',
+} as const
+
+const sizeStyles = {
+  md: 'px-6 py-3 text-base',
+  lg: 'px-8 py-4 text-lg',
+} as const
+
+export function CTAButton({
+  label,
+  href,
+  variant = 'primary',
+  size = 'md',
+}: CTAButtonProps) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center justify-center rounded-lg font-semibold transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${variantStyles[variant]} ${sizeStyles[size]} `}
+    >
+      {label}
+    </Link>
+  )
+}

--- a/src/components/landing/GlobeFallback2D.tsx
+++ b/src/components/landing/GlobeFallback2D.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+/**
+ * 2D 지구본 폴백 컴포넌트
+ * WebGL 미지원 또는 저사양 기기에서 Globe3D 대신 표시
+ * Requirements: 5.2, 5.4, 5.5, 7.2, 7.3
+ */
+
+interface GlobeFallback2DProps {
+  className?: string
+}
+
+export function GlobeFallback2D({ className = '' }: GlobeFallback2DProps) {
+  return (
+    <div
+      className={`relative flex items-center justify-center ${className}`}
+      role="img"
+      aria-label="전 세계 성지순례 포인트를 표시하는 지구본 일러스트"
+    >
+      <svg
+        viewBox="0 0 200 200"
+        className="h-48 w-48 md:h-64 md:w-64 lg:h-80 lg:w-80"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {/* 지구본 배경 원 */}
+        <circle
+          cx="100"
+          cy="100"
+          r="90"
+          className="fill-primary-100 stroke-primary-300"
+          strokeWidth="2"
+        />
+
+        {/* 경도선 */}
+        <ellipse
+          cx="100"
+          cy="100"
+          rx="90"
+          ry="90"
+          className="stroke-primary-200"
+          strokeWidth="1"
+          fill="none"
+        />
+        <ellipse
+          cx="100"
+          cy="100"
+          rx="60"
+          ry="90"
+          className="stroke-primary-200"
+          strokeWidth="1"
+          fill="none"
+        />
+        <ellipse
+          cx="100"
+          cy="100"
+          rx="30"
+          ry="90"
+          className="stroke-primary-200"
+          strokeWidth="1"
+          fill="none"
+        />
+
+        {/* 위도선 */}
+        <ellipse
+          cx="100"
+          cy="60"
+          rx="78"
+          ry="20"
+          className="stroke-primary-200"
+          strokeWidth="1"
+          fill="none"
+        />
+        <ellipse
+          cx="100"
+          cy="100"
+          rx="90"
+          ry="22"
+          className="stroke-primary-200"
+          strokeWidth="1"
+          fill="none"
+        />
+        <ellipse
+          cx="100"
+          cy="140"
+          rx="78"
+          ry="20"
+          className="stroke-primary-200"
+          strokeWidth="1"
+          fill="none"
+        />
+
+        {/* 성지순례 포인트 (도쿄, 오사카, 서울 등) */}
+        <circle cx="145" cy="72" r="4" className="fill-primary-500" />
+        <circle cx="140" cy="80" r="3" className="fill-secondary-500" />
+        <circle cx="135" cy="75" r="3.5" className="fill-primary-400" />
+        <circle cx="80" cy="90" r="3" className="fill-secondary-400" />
+        <circle cx="60" cy="70" r="3" className="fill-primary-400" />
+        <circle cx="50" cy="85" r="2.5" className="fill-secondary-500" />
+
+        {/* 포인트 간 연결선 */}
+        <line
+          x1="145"
+          y1="72"
+          x2="140"
+          y2="80"
+          className="stroke-primary-300"
+          strokeWidth="1"
+          strokeDasharray="3 2"
+        />
+        <line
+          x1="140"
+          y1="80"
+          x2="135"
+          y2="75"
+          className="stroke-primary-300"
+          strokeWidth="1"
+          strokeDasharray="3 2"
+        />
+        <line
+          x1="80"
+          y1="90"
+          x2="60"
+          y2="70"
+          className="stroke-secondary-300"
+          strokeWidth="1"
+          strokeDasharray="3 2"
+        />
+
+        {/* 글로우 효과 */}
+        <circle
+          cx="100"
+          cy="100"
+          r="90"
+          fill="none"
+          className="stroke-primary-400/30"
+          strokeWidth="4"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/src/components/landing/ProofCard.tsx
+++ b/src/components/landing/ProofCard.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Image from 'next/image'
+import { useState } from 'react'
+import { CATEGORY_CONFIG, type SpotCategory } from '@/types/spot'
+
+/**
+ * 소셜 프루프 카드 컴포넌트
+ * 카테고리 태그, 스팟 이름, 코멘트, 이미지를 표시
+ * Requirements: 3.5, 3.6
+ */
+
+interface ProofCardProps {
+  categoryTag: SpotCategory
+  spotName: string
+  comment: string
+  image?: string
+}
+
+export function ProofCard({
+  categoryTag,
+  spotName,
+  comment,
+  image,
+}: ProofCardProps) {
+  const [imageError, setImageError] = useState(false)
+  const categoryConfig = CATEGORY_CONFIG[categoryTag]
+
+  return (
+    <article className="flex w-64 shrink-0 flex-col overflow-hidden rounded-lg border border-border bg-surface md:w-72">
+      {/* 이미지 영역 */}
+      <div className="relative h-36 w-full bg-accent-surface">
+        {image && !imageError ? (
+          <Image
+            src={image}
+            alt={`${spotName} 성지순례 인증`}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 256px, 288px"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <span className="text-4xl" role="img" aria-label="성지순례 인증">
+              📍
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* 콘텐츠 영역 */}
+      <div className="flex flex-1 flex-col gap-2 p-3">
+        {/* 카테고리 태그 */}
+        <span
+          className="w-fit rounded-sm px-2 py-0.5 text-xs font-medium"
+          style={{
+            backgroundColor: categoryConfig.bgColor,
+            color: categoryConfig.fgColor,
+          }}
+        >
+          {categoryConfig.label}
+        </span>
+
+        {/* 스팟 이름 */}
+        <h3 className="text-sm font-semibold text-main-text">{spotName}</h3>
+
+        {/* 코멘트 */}
+        <p className="line-clamp-2 text-xs text-sub-text">{comment}</p>
+      </div>
+    </article>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #446

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 랜딩 페이지의 정적/단순 컴포넌트 3종(CTAButton, GlobeFallback2D, ProofCard)을 구현한다.

---

## 📋 변경 사항

- [x] CTAButton 컴포넌트 — next/link 기반, primary/secondary variant, md/lg size, 키보드 접근성
- [x] GlobeFallback2D 컴포넌트 — SVG 기반 2D 지구본 일러스트, 반응형 크기, aria-label
- [x] ProofCard 컴포넌트 — 카테고리 태그(CATEGORY_CONFIG 연동), 스팟 이름, 코멘트, 이미지 에러 폴백

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` — tsc --noEmit 통과
- [x] 시맨틱 컬러 토큰 사용 (하드코딩 없음)
- [x] 접근성: focus-visible, aria-label, alt 텍스트

---

## 📝 추가 정보

- Requirements 1.6, 1.7, 1.8, 3.5, 3.6, 5.2, 5.4, 5.5, 7.2, 7.3, 7.5 대응
- GlobeFallback2D는 이미지 에셋 대신 SVG 인라인으로 구현하여 추가 에셋 의존성 없음
- ProofCard의 카테고리 태그는 기존 CATEGORY_CONFIG의 bgColor/fgColor를 inline style로 적용