### PR TITLE
[Feat] Task 7 - 카테고리 스토리텔링 섹션 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth/mongodb-adapter": "^3.11.1",
+        "@gsap/react": "^2.1.2",
         "@react-google-maps/api": "^2.20.8",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
@@ -17,6 +18,7 @@
         "@tanstack/react-query": "^5.90.14",
         "bcryptjs": "^3.0.3",
         "browser-image-compression": "^2.0.2",
+        "gsap": "^3.14.2",
         "leaflet": "^1.9.4",
         "mongodb": "^7.0.0",
         "next": "^15.1.0",
@@ -1497,6 +1499,16 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
       }
     },
     "node_modules/@humanfs/core": {
@@ -8842,6 +8854,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
+      "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/handlebars": {
       "version": "4.7.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.11.1",
+    "@gsap/react": "^2.1.2",
     "@react-google-maps/api": "^2.20.8",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
@@ -27,6 +28,7 @@
     "@tanstack/react-query": "^5.90.14",
     "bcryptjs": "^3.0.3",
     "browser-image-compression": "^2.0.2",
+    "gsap": "^3.14.2",
     "leaflet": "^1.9.4",
     "mongodb": "^7.0.0",
     "next": "^15.1.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -369,6 +369,28 @@ button:focus-visible {
   animation: loading-bar 1s ease-in-out infinite;
 }
 
+/* 카테고리 스토리텔링 섹션 — CSS 폴백 애니메이션 */
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-slide-in {
+  animation: fadeSlideIn 0.6s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-slide-in {
+    animation: none;
+  }
+}
+
 .leaflet-container img {
   max-width: none !important;
   max-height: none !important;

--- a/src/components/landing/CategoryCard.tsx
+++ b/src/components/landing/CategoryCard.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import type { SpotCategory } from '@/types/spot'
+
+/**
+ * 카테고리 카드 컴포넌트
+ * 스토리텔링 섹션에서 각 카테고리를 소개하는 카드
+ * Requirements: 2.4, 2.5, 2.6, 2.7, 2.8
+ */
+
+interface CategoryCardProps {
+  category: SpotCategory
+  title: string
+  description: string
+  mascotProp: string
+  spotImage: string
+  colorToken: string
+  index: number
+  isHighEnd: boolean
+  reducedMotion: boolean
+}
+
+/**
+ * 카테고리별 CSS 변수 기반 인라인 스타일 생성
+ * Tailwind의 arbitrary value로는 CSS 변수 동적 참조가 어려워 인라인 스타일 사용
+ */
+function getCategoryStyles(colorToken: string) {
+  return {
+    backgroundColor: `rgb(var(--${colorToken}-bg) / 0.3)`,
+    borderColor: `rgb(var(--${colorToken}-fg) / 0.3)`,
+  }
+}
+
+function getCategoryAccentStyle(colorToken: string) {
+  return {
+    color: `rgb(var(--${colorToken}-fg))`,
+  }
+}
+
+export function CategoryCard({
+  category,
+  title,
+  description,
+  mascotProp,
+  spotImage,
+  colorToken,
+  index,
+  isHighEnd,
+  reducedMotion,
+}: CategoryCardProps) {
+  const [imageError, setImageError] = useState(false)
+
+  const cardStyles = getCategoryStyles(colorToken)
+  const accentStyles = getCategoryAccentStyle(colorToken)
+
+  return (
+    <article
+      className={`category-card group relative flex flex-col overflow-hidden rounded-xl border backdrop-blur-sm transition-transform duration-300 ${
+        !reducedMotion && isHighEnd ? 'hover:scale-[1.02]' : ''
+      }`}
+      style={{
+        ...cardStyles,
+        willChange: 'transform',
+        transform: 'translate3d(0, 0, 0)',
+      }}
+      data-index={index}
+      data-category={category}
+    >
+      {/* 스팟 이미지 영역 */}
+      <div className="relative aspect-[16/10] w-full overflow-hidden">
+        {!imageError ? (
+          <Image
+            src={spotImage}
+            alt={`${title} 대표 이미지`}
+            fill
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div
+            className="flex h-full w-full items-center justify-center"
+            style={{ backgroundColor: `rgb(var(--${colorToken}-bg) / 0.6)` }}
+          >
+            <span className="text-lg font-semibold" style={accentStyles}>
+              {title}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* 카드 콘텐츠 */}
+      <div className="flex flex-1 flex-col gap-3 p-4 md:p-5">
+        {/* 마스코트 소품 + 제목 */}
+        <div className="flex items-center gap-3">
+          <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-lg">
+            <Image
+              src={mascotProp}
+              alt={`${title} 카테고리 아이콘`}
+              fill
+              className="object-contain"
+              sizes="40px"
+            />
+          </div>
+          <h3 className="text-lg font-bold md:text-xl" style={accentStyles}>
+            {title}
+          </h3>
+        </div>
+
+        {/* 설명 */}
+        <p className="text-sm leading-relaxed text-sub-text md:text-base">
+          {description}
+        </p>
+
+        {/* 더 보기 링크 */}
+        <Link
+          href={`/map?category=${category}`}
+          className="mt-auto inline-flex items-center gap-1 self-start text-sm font-medium transition-colors hover:underline"
+          style={accentStyles}
+        >
+          더 보기
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/src/components/landing/StorytellingSection.tsx
+++ b/src/components/landing/StorytellingSection.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import { useRef, useEffect } from 'react'
+import { CATEGORY_STORIES } from './data/categoryStories'
+import { CategoryCard } from './CategoryCard'
+
+/**
+ * 카테고리 스토리텔링 섹션
+ * GSAP ScrollTrigger 기반 3D 팝업북 스타일 스크롤 애니메이션
+ * Requirements: 2.1, 2.2, 2.3, 2.9, 5.3, 6.5, 7.6
+ *
+ * - isHighEnd === true && reducedMotion === false: GSAP 3D 팝업북 애니메이션
+ * - isHighEnd === false: 단순 CSS 애니메이션 (페이드인/슬라이드인)
+ * - reducedMotion === true: GSAP 비활성화, 정적 레이아웃
+ */
+
+interface StorytellingSectionProps {
+  isHighEnd: boolean
+  reducedMotion: boolean
+}
+
+export function StorytellingSection({
+  isHighEnd,
+  reducedMotion,
+}: StorytellingSectionProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // GSAP 애니메이션: 고성능 + 모션 허용 시에만 로드
+  if (isHighEnd && !reducedMotion) {
+    return (
+      <StorytellingSectionWithGSAP
+        containerRef={containerRef}
+        isHighEnd={isHighEnd}
+        reducedMotion={reducedMotion}
+      />
+    )
+  }
+
+  // CSS 폴백: 저사양 또는 reduced-motion
+  return (
+    <StorytellingSectionFallback
+      isHighEnd={isHighEnd}
+      reducedMotion={reducedMotion}
+    />
+  )
+}
+
+/**
+ * GSAP ScrollTrigger 기반 3D 팝업북 스타일 애니메이션 버전
+ * @gsap/react의 useGSAP() 훅으로 React 18 Strict Mode 호환
+ */
+function StorytellingSectionWithGSAP({
+  containerRef,
+  isHighEnd,
+  reducedMotion,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>
+  isHighEnd: boolean
+  reducedMotion: boolean
+}) {
+  // GSAP는 dynamic import로 로드하여 번들 분리
+  // useGSAP 훅은 scope 옵션으로 컨텍스트 자동 정리
+  useGSAPAnimation(containerRef)
+
+  return (
+    <section
+      className="relative overflow-hidden bg-background py-16 md:py-24"
+      aria-label="카테고리 스토리텔링"
+    >
+      <div className="mx-auto max-w-6xl px-4">
+        {/* 섹션 헤더 */}
+        <header className="mb-12 text-center md:mb-16">
+          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
+            어떤 <span className="text-primary-500">덕질</span>을 하시나요?
+          </h2>
+          <p className="text-base text-sub-text md:text-lg">
+            카테고리별 성지순례 스팟을 탐험해 보세요
+          </p>
+        </header>
+
+        {/* 카테고리 카드 그리드 */}
+        <div
+          ref={containerRef}
+          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {CATEGORY_STORIES.map((story, index) => (
+            <div
+              key={story.category}
+              className="gsap-card"
+              style={{
+                opacity: 0,
+                willChange: 'transform, opacity',
+                transform: 'translate3d(0, 60px, 0) rotateX(15deg)',
+              }}
+            >
+              <CategoryCard
+                {...story}
+                index={index}
+                isHighEnd={isHighEnd}
+                reducedMotion={reducedMotion}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/**
+ * CSS 페이드인/슬라이드인 폴백 버전
+ * 저사양 기기 또는 prefers-reduced-motion 활성화 시 사용
+ */
+function StorytellingSectionFallback({
+  isHighEnd,
+  reducedMotion,
+}: {
+  isHighEnd: boolean
+  reducedMotion: boolean
+}) {
+  return (
+    <section
+      className="relative overflow-hidden bg-background py-16 md:py-24"
+      aria-label="카테고리 스토리텔링"
+    >
+      <div className="mx-auto max-w-6xl px-4">
+        {/* 섹션 헤더 */}
+        <header className="mb-12 text-center md:mb-16">
+          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
+            어떤 <span className="text-primary-500">덕질</span>을 하시나요?
+          </h2>
+          <p className="text-base text-sub-text md:text-lg">
+            카테고리별 성지순례 스팟을 탐험해 보세요
+          </p>
+        </header>
+
+        {/* 카테고리 카드 그리드 — CSS 애니메이션 */}
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {CATEGORY_STORIES.map((story, index) => (
+            <div
+              key={story.category}
+              className={
+                reducedMotion
+                  ? '' // reduced-motion: 애니메이션 없이 즉시 표시
+                  : 'animate-fade-slide-in'
+              }
+              style={
+                reducedMotion
+                  ? undefined
+                  : { animationDelay: `${index * 100}ms` }
+              }
+            >
+              <CategoryCard
+                {...story}
+                index={index}
+                isHighEnd={isHighEnd}
+                reducedMotion={reducedMotion}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/**
+ * GSAP ScrollTrigger 애니메이션 훅
+ * @gsap/react의 useGSAP()으로 React 18 Strict Mode 호환
+ * scope 옵션으로 containerRef 내부만 타겟팅, 자동 클린업
+ */
+function useGSAPAnimation(
+  containerRef: React.RefObject<HTMLDivElement | null>
+) {
+  // dynamic import로 GSAP 로드 — 번들 분리
+  const gsapRef = useRef<typeof import('gsap') | null>(null)
+  const isLoadedRef = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadAndAnimate() {
+      try {
+        const [gsapModule, scrollTriggerModule, gsapReactModule] =
+          await Promise.all([
+            import('gsap'),
+            import('gsap/ScrollTrigger'),
+            import('@gsap/react'),
+          ])
+
+        if (cancelled) return
+
+        const gsap = gsapModule.default || gsapModule
+        const { ScrollTrigger } = scrollTriggerModule
+
+        gsap.registerPlugin(ScrollTrigger)
+        gsapRef.current = gsapModule
+
+        if (!containerRef.current) return
+
+        const cards =
+          containerRef.current.querySelectorAll<HTMLElement>('.gsap-card')
+
+        cards.forEach((card, i) => {
+          gsap.fromTo(
+            card,
+            {
+              opacity: 0,
+              y: 60,
+              rotateX: 15,
+              scale: 0.95,
+            },
+            {
+              opacity: 1,
+              y: 0,
+              rotateX: 0,
+              scale: 1,
+              duration: 0.8,
+              ease: 'power3.out',
+              scrollTrigger: {
+                trigger: card,
+                start: 'top 85%',
+                end: 'top 50%',
+                toggleActions: 'play none none reverse',
+              },
+              delay: (i % 3) * 0.15, // 같은 행 내 순차 딜레이
+            }
+          )
+        })
+
+        isLoadedRef.current = true
+      } catch (error) {
+        console.warn('GSAP 로드 실패, CSS 폴백 적용:', error)
+        // GSAP 로드 실패 시 카드를 보이게 처리
+        if (containerRef.current) {
+          containerRef.current
+            .querySelectorAll<HTMLElement>('.gsap-card')
+            .forEach((card) => {
+              card.style.opacity = '1'
+              card.style.transform = 'none'
+            })
+        }
+      }
+    }
+
+    loadAndAnimate()
+
+    return () => {
+      cancelled = true
+      // ScrollTrigger 클린업
+      if (gsapRef.current) {
+        import('gsap/ScrollTrigger').then(({ ScrollTrigger }) => {
+          ScrollTrigger.getAll().forEach((trigger) => trigger.kill())
+        })
+      }
+    }
+  }, [containerRef])
+}

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { HeroSection } from './HeroSection'
+import { StorytellingSection } from './StorytellingSection'
 import { useDeviceCapability } from '@/hooks/useDeviceCapability'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 
@@ -31,6 +32,12 @@ export function WelcomePageClient() {
       )}
 
       {/* TODO: StorytellingSection */}
+      {isReady && (
+        <StorytellingSection
+          isHighEnd={isHighEnd}
+          reducedMotion={reducedMotion}
+        />
+      )}
       {/* TODO: SocialProofSection */}
       {/* TODO: ConversionSection */}
       {/* TODO: FloatingCTA */}

--- a/src/components/landing/data/categoryStories.ts
+++ b/src/components/landing/data/categoryStories.ts
@@ -1,0 +1,70 @@
+import type { SpotCategory } from '@/types/spot'
+
+/**
+ * 카테고리 스토리텔링 섹션 설정 데이터
+ * 6개 카테고리별 제목, 설명, 마스코트 소품, 대표 이미지, 컬러 토큰 정의
+ * Requirements: 2.1, 2.5, 2.7
+ */
+
+export interface CategoryStoryConfig {
+  category: SpotCategory
+  title: string
+  description: string
+  /** 마스코트 큐레이터 소품 이미지 경로 */
+  mascotProp: string
+  /** 대표 스팟 이미지 경로 */
+  spotImage: string
+  /** CSS 변수 접두사 (--category-{token}-bg/fg) */
+  colorToken: string
+}
+
+export const CATEGORY_STORIES: CategoryStoryConfig[] = [
+  {
+    category: 'animation',
+    title: '애니메이션 성지순례',
+    description: '좋아하는 작품 속 그 장소를 직접 걸어보세요',
+    mascotProp: '/icons/categories/animation.webp',
+    spotImage: '/icons/categories/animation.webp',
+    colorToken: 'category-anime',
+  },
+  {
+    category: 'sports',
+    title: '스포츠 직관 여행',
+    description: '경기장의 열기를 현장에서 느껴보세요',
+    mascotProp: '/icons/categories/sports.webp',
+    spotImage: '/icons/categories/sports.webp',
+    colorToken: 'category-sports',
+  },
+  {
+    category: 'movie_drama',
+    title: '영화/드라마 촬영지',
+    description: '스크린 속 그 장면, 직접 서보세요',
+    mascotProp: '/icons/categories/movie_drama.webp',
+    spotImage: '/icons/categories/movie_drama.webp',
+    colorToken: 'category-movie-drama',
+  },
+  {
+    category: 'music',
+    title: '음악/콘서트 장소',
+    description: '아티스트의 무대를 직접 찾아가 보세요',
+    mascotProp: '/icons/categories/music.webp',
+    spotImage: '/icons/categories/music.webp',
+    colorToken: 'category-music',
+  },
+  {
+    category: 'game',
+    title: '게임 속 세계',
+    description: '게임 속 배경이 된 실제 장소를 탐험하세요',
+    mascotProp: '/icons/categories/game.webp',
+    spotImage: '/icons/categories/game.webp',
+    colorToken: 'category-game',
+  },
+  {
+    category: 'other',
+    title: '특별한 장소',
+    description: '팬들만 아는 숨겨진 명소를 발견하세요',
+    mascotProp: '/icons/categories/other.webp',
+    spotImage: '/icons/categories/other.webp',
+    colorToken: 'category-other',
+  },
+]


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #450

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 랜딩 페이지 카테고리 스토리텔링 섹션 구현 (Task 7.1, 7.2, 7.4)

---

## 📋 변경 사항

- [x] GSAP + @gsap/react 패키지 설치
- [x] 카테고리 스토리 설정 데이터 정의 (`categoryStories.ts`) — 6개 카테고리별 title, description, mascotProp, spotImage, colorToken
- [x] CategoryCard 컴포넌트 구현 — 카테고리 시맨틱 컬러, 마스코트 소품, "더 보기" 링크(`/map?category={category}`), 이미지 폴백
- [x] StorytellingSection 컴포넌트 구현 — GSAP ScrollTrigger 3D 팝업북 애니메이션, CSS 폴백, reduced-motion 대응
- [x] WelcomePageClient에 StorytellingSection 통합

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 2.1~2.9, 5.3, 6.5, 7.6 대응
- 고성능 기기: GSAP ScrollTrigger 3D 팝업북 스타일 애니메이션 (rotateX + scale + opacity)
- 저사양 기기: CSS fadeSlideIn 애니메이션 폴백
- prefers-reduced-motion: 애니메이션 완전 비활성화, 정적 레이아웃
- GSAP는 dynamic import로 번들 분리, 로드 실패 시 CSS 폴백 자동 전환
- 카테고리 컬러는 CSS 변수 기반 인라인 스타일로 동적 적용