### PR TITLE
feat: socialProofSection 슬라이더 컴포넌트 구현

### DIFF
--- a/.kiro/specs/landing-page/tasks.md
+++ b/.kiro/specs/landing-page/tasks.md
@@ -149,13 +149,13 @@
     - 각 카테고리별 올바른 소품 이미지 매핑 확인
     - _Requirements: 2.1, 2.4, 2.5_
 
-- [ ] 8. 소셜 프루프 섹션 구현
-  - [ ] 8.1 소셜 프루프 더미 데이터 정의
+- [x] 8. 소셜 프루프 섹션 구현
+  - [x] 8.1 소셜 프루프 더미 데이터 정의
     - `src/components/landing/data/proofData.ts` 생성
     - 6~8개 더미 ProofData 카드 (마스코트 일러스트 기반)
     - _Requirements: 3.2_
 
-  - [ ] 8.2 SocialProofSection 컴포넌트 구현
+  - [x] 8.2 SocialProofSection 컴포넌트 구현
     - `src/components/landing/SocialProofSection.tsx` 생성
     - "함께 덕질하는 즐거움" 커뮤니티 가치 카피 포함
     - ProofCard를 가로 슬라이더 형태로 표시

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ProofCard } from './ProofCard'
+import { PROOF_DUMMY_DATA } from './data/proofData'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+
+/**
+ * 소셜 프루프 섹션 컴포넌트
+ * 커뮤니티 가치 카피 + ProofCard 가로 슬라이더
+ * 자동 스크롤 + 수동 좌우 스와이프 지원
+ * Requirements: 3.1, 3.2, 3.3, 3.4, 6.6, 7.4
+ */
+
+/** 자동 스크롤 간격 (ms) */
+const AUTO_SCROLL_INTERVAL = 3500
+
+export function SocialProofSection() {
+  const sliderRef = useRef<HTMLDivElement>(null)
+  const [isPaused, setIsPaused] = useState(false)
+  const reducedMotion = usePrefersReducedMotion()
+
+  /** 한 카드 너비만큼 스크롤 */
+  const scrollByOneCard = useCallback(() => {
+    const slider = sliderRef.current
+    if (!slider) return
+
+    const cardWidth = slider.querySelector('article')?.offsetWidth ?? 0
+    const gap = 16 // gap-4 = 1rem = 16px
+    const scrollAmount = cardWidth + gap
+    const maxScroll = slider.scrollWidth - slider.clientWidth
+
+    if (slider.scrollLeft >= maxScroll - 2) {
+      // 끝에 도달하면 처음으로 돌아감
+      slider.scrollTo({ left: 0, behavior: 'smooth' })
+    } else {
+      slider.scrollBy({ left: scrollAmount, behavior: 'smooth' })
+    }
+  }, [])
+
+  /** 자동 스크롤: reduced-motion 비활성 & 일시정지 아닐 때만 */
+  useEffect(() => {
+    if (reducedMotion || isPaused) return
+
+    const timer = setInterval(scrollByOneCard, AUTO_SCROLL_INTERVAL)
+    return () => clearInterval(timer)
+  }, [reducedMotion, isPaused, scrollByOneCard])
+
+  /** 데스크톱 좌/우 화살표 버튼 핸들러 */
+  const scrollLeft = () => {
+    const slider = sliderRef.current
+    if (!slider) return
+    const cardWidth = slider.querySelector('article')?.offsetWidth ?? 0
+    slider.scrollBy({ left: -(cardWidth + 16), behavior: 'smooth' })
+  }
+
+  const scrollRight = () => {
+    scrollByOneCard()
+  }
+
+  return (
+    <section
+      className="relative overflow-hidden bg-background py-16 md:py-24"
+      aria-label="소셜 프루프"
+    >
+      <div className="mx-auto max-w-6xl px-4">
+        {/* 섹션 헤더 */}
+        <header className="mb-10 text-center md:mb-14">
+          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
+            함께 <span className="text-primary-500">덕질</span>하는 즐거움
+          </h2>
+          <p className="text-base text-sub-text md:text-lg">
+            다른 팬들의 성지순례 경험을 만나보세요
+          </p>
+        </header>
+
+        {/* 슬라이더 컨테이너 */}
+        <div className="relative">
+          {/* 좌측 화살표 (데스크톱 전용) */}
+          <button
+            type="button"
+            onClick={scrollLeft}
+            className="absolute -left-3 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border border-border bg-surface p-2 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
+            aria-label="이전 카드"
+          >
+            <ChevronLeftIcon />
+          </button>
+
+          {/* 슬라이더 */}
+          <div
+            ref={sliderRef}
+            className="scrollbar-hide flex snap-x snap-mandatory gap-4 overflow-x-auto scroll-smooth px-1 py-2"
+            role="list"
+            aria-label="성지순례 인증 카드 목록"
+            onMouseEnter={() => setIsPaused(true)}
+            onMouseLeave={() => setIsPaused(false)}
+            onTouchStart={() => setIsPaused(true)}
+            onTouchEnd={() => setIsPaused(false)}
+          >
+            {PROOF_DUMMY_DATA.map((proof) => (
+              <div
+                key={proof.id}
+                className="w-[85vw] shrink-0 snap-start sm:w-64 md:w-72 [&>article]:w-full"
+                role="listitem"
+              >
+                <ProofCard
+                  categoryTag={proof.categoryTag}
+                  spotName={proof.spotName}
+                  comment={proof.comment}
+                  image={proof.image}
+                />
+              </div>
+            ))}
+          </div>
+
+          {/* 우측 화살표 (데스크톱 전용) */}
+          <button
+            type="button"
+            onClick={scrollRight}
+            className="absolute -right-3 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border border-border bg-surface p-2 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
+            aria-label="다음 카드"
+          >
+            <ChevronRightIcon />
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/** 좌측 화살표 아이콘 */
+function ChevronLeftIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+/** 우측 화살표 아이콘 */
+function ChevronRightIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  )
+}

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -7,55 +7,134 @@ import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 
 /**
  * 소셜 프루프 섹션 컴포넌트
- * 커뮤니티 가치 카피 + ProofCard 가로 슬라이더
- * 자동 스크롤 + 수동 좌우 스와이프 지원
+ * 커뮤니티 가치 카피 + ProofCard 무한 순환 슬라이더
+ * 자동 스크롤 + 수동 좌우 스와이프 + 데스크톱 화살표 지원
  * Requirements: 3.1, 3.2, 3.3, 3.4, 6.6, 7.4
  */
 
 /** 자동 스크롤 간격 (ms) */
 const AUTO_SCROLL_INTERVAL = 3500
+/** 슬라이드 전환 시간 (ms) */
+const TRANSITION_DURATION = 500
+/** 카드 간 간격 (px) — gap-4 = 1rem = 16px */
+const CARD_GAP = 16
+
+/**
+ * 무한 순환 구현:
+ * 원본 카드 앞뒤에 클론을 배치하여 끊김 없는 루프를 만든다.
+ * [clone-last-N] [original-0 ... original-N] [clone-first-N]
+ * 클론 영역에 도달하면 transition 없이 원본 위치로 점프한다.
+ */
+const CLONE_COUNT = 4 // 앞뒤로 복제할 카드 수
+
+function getExtendedData() {
+  const data = PROOF_DUMMY_DATA
+  const len = data.length
+  // 뒤쪽 클론: 마지막 CLONE_COUNT개
+  const prefixClones = data.slice(-CLONE_COUNT).map((d, i) => ({
+    ...d,
+    id: `clone-pre-${i}`,
+  }))
+  // 앞쪽 클론: 처음 CLONE_COUNT개
+  const suffixClones = data.slice(0, CLONE_COUNT).map((d, i) => ({
+    ...d,
+    id: `clone-suf-${i}`,
+  }))
+  return { extended: [...prefixClones, ...data, ...suffixClones], len }
+}
 
 export function SocialProofSection() {
   const sliderRef = useRef<HTMLDivElement>(null)
   const [isPaused, setIsPaused] = useState(false)
+  const [isTransitioning, setIsTransitioning] = useState(true)
   const reducedMotion = usePrefersReducedMotion()
 
-  /** 한 카드 너비만큼 스크롤 */
-  const scrollByOneCard = useCallback(() => {
+  const { extended, len } = getExtendedData()
+  // 실제 인덱스 0 = extended 배열의 CLONE_COUNT 위치
+  const [currentIndex, setCurrentIndex] = useState(CLONE_COUNT)
+
+  /** 카드 1개 너비 + gap 계산 */
+  const getCardStep = useCallback(() => {
     const slider = sliderRef.current
-    if (!slider) return
-
-    const cardWidth = slider.querySelector('article')?.offsetWidth ?? 0
-    const gap = 16 // gap-4 = 1rem = 16px
-    const scrollAmount = cardWidth + gap
-    const maxScroll = slider.scrollWidth - slider.clientWidth
-
-    if (slider.scrollLeft >= maxScroll - 2) {
-      // 끝에 도달하면 처음으로 돌아감
-      slider.scrollTo({ left: 0, behavior: 'smooth' })
-    } else {
-      slider.scrollBy({ left: scrollAmount, behavior: 'smooth' })
-    }
+    if (!slider) return 0
+    const firstCard = slider.querySelector<HTMLElement>('[data-card]')
+    if (!firstCard) return 0
+    return firstCard.offsetWidth + CARD_GAP
   }, [])
 
-  /** 자동 스크롤: reduced-motion 비활성 & 일시정지 아닐 때만 */
+  /** 슬라이드 위치 계산 */
+  const getTranslateX = useCallback(
+    (index: number) => {
+      const step = getCardStep()
+      return -(index * step)
+    },
+    [getCardStep]
+  )
+
+  /** 클론 영역 도달 시 원본 위치로 점프 (transition 없이) */
+  useEffect(() => {
+    if (isTransitioning) return
+
+    let jumpIndex: number | null = null
+    if (currentIndex >= len + CLONE_COUNT) {
+      // 끝 클론 → 원본 시작으로
+      jumpIndex = currentIndex - len
+    } else if (currentIndex < CLONE_COUNT) {
+      // 앞 클론 → 원본 끝으로
+      jumpIndex = currentIndex + len
+    }
+
+    if (jumpIndex !== null) {
+      const target = jumpIndex
+      // 다음 프레임에서 transition 없이 점프
+      requestAnimationFrame(() => {
+        setIsTransitioning(false)
+        setCurrentIndex(target)
+        // 점프 후 다시 transition 활성화
+        requestAnimationFrame(() => {
+          setIsTransitioning(true)
+        })
+      })
+    }
+  }, [currentIndex, isTransitioning, len])
+
+  /** 다음 카드로 이동 */
+  const goNext = useCallback(() => {
+    setIsTransitioning(true)
+    setCurrentIndex((prev) => prev + 1)
+  }, [])
+
+  /** 이전 카드로 이동 */
+  const goPrev = useCallback(() => {
+    setIsTransitioning(true)
+    setCurrentIndex((prev) => prev - 1)
+  }, [])
+
+  /** transition 종료 감지 → 클론 점프 트리거 */
+  const handleTransitionEnd = useCallback(() => {
+    setIsTransitioning(false)
+  }, [])
+
+  /** 자동 스크롤 */
   useEffect(() => {
     if (reducedMotion || isPaused) return
-
-    const timer = setInterval(scrollByOneCard, AUTO_SCROLL_INTERVAL)
+    const timer = setInterval(goNext, AUTO_SCROLL_INTERVAL)
     return () => clearInterval(timer)
-  }, [reducedMotion, isPaused, scrollByOneCard])
+  }, [reducedMotion, isPaused, goNext])
 
-  /** 데스크톱 좌/우 화살표 버튼 핸들러 */
-  const scrollLeft = () => {
-    const slider = sliderRef.current
-    if (!slider) return
-    const cardWidth = slider.querySelector('article')?.offsetWidth ?? 0
-    slider.scrollBy({ left: -(cardWidth + 16), behavior: 'smooth' })
+  /** 터치 스와이프 지원 */
+  const touchStartX = useRef(0)
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsPaused(true)
+    touchStartX.current = e.touches[0].clientX
   }
-
-  const scrollRight = () => {
-    scrollByOneCard()
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const diff = touchStartX.current - e.changedTouches[0].clientX
+    if (Math.abs(diff) > 50) {
+      if (diff > 0) goNext()
+      else goPrev()
+    }
+    setIsPaused(false)
   }
 
   return (
@@ -74,50 +153,62 @@ export function SocialProofSection() {
           </p>
         </header>
 
-        {/* 슬라이더 컨테이너 */}
-        <div className="relative">
+        {/* 슬라이더 + 화살표 컨테이너 */}
+        <div className="relative flex items-center gap-3 md:gap-5">
           {/* 좌측 화살표 (데스크톱 전용) */}
           <button
             type="button"
-            onClick={scrollLeft}
-            className="absolute -left-3 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border border-border bg-surface p-2 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
+            onClick={goPrev}
+            className="hidden shrink-0 rounded-full border border-border bg-surface p-3 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
             aria-label="이전 카드"
           >
             <ChevronLeftIcon />
           </button>
 
-          {/* 슬라이더 */}
+          {/* 슬라이더 뷰포트 */}
           <div
-            ref={sliderRef}
-            className="scrollbar-hide flex snap-x snap-mandatory gap-4 overflow-x-auto scroll-smooth px-1 py-2"
-            role="list"
-            aria-label="성지순례 인증 카드 목록"
+            className="min-w-0 flex-1 overflow-hidden"
             onMouseEnter={() => setIsPaused(true)}
             onMouseLeave={() => setIsPaused(false)}
-            onTouchStart={() => setIsPaused(true)}
-            onTouchEnd={() => setIsPaused(false)}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
           >
-            {PROOF_DUMMY_DATA.map((proof) => (
-              <div
-                key={proof.id}
-                className="w-[85vw] shrink-0 snap-start sm:w-64 md:w-72 [&>article]:w-full"
-                role="listitem"
-              >
-                <ProofCard
-                  categoryTag={proof.categoryTag}
-                  spotName={proof.spotName}
-                  comment={proof.comment}
-                  image={proof.image}
-                />
-              </div>
-            ))}
+            <div
+              ref={sliderRef}
+              className="flex gap-4"
+              role="list"
+              aria-label="성지순례 인증 카드 목록"
+              style={{
+                transform: `translateX(${getTranslateX(currentIndex)}px)`,
+                transition: isTransitioning
+                  ? `transform ${TRANSITION_DURATION}ms ease-in-out`
+                  : 'none',
+              }}
+              onTransitionEnd={handleTransitionEnd}
+            >
+              {extended.map((proof, i) => (
+                <div
+                  key={proof.id}
+                  data-card
+                  className="w-[85vw] shrink-0 sm:w-64 md:w-72 [&>article]:w-full"
+                  role="listitem"
+                >
+                  <ProofCard
+                    categoryTag={proof.categoryTag}
+                    spotName={proof.spotName}
+                    comment={proof.comment}
+                    image={proof.image}
+                  />
+                </div>
+              ))}
+            </div>
           </div>
 
           {/* 우측 화살표 (데스크톱 전용) */}
           <button
             type="button"
-            onClick={scrollRight}
-            className="absolute -right-3 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border border-border bg-surface p-2 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
+            onClick={goNext}
+            className="hidden shrink-0 rounded-full border border-border bg-surface p-3 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
             aria-label="다음 카드"
           >
             <ChevronRightIcon />
@@ -133,8 +224,8 @@ function ChevronLeftIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
+      width="24"
+      height="24"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -153,8 +244,8 @@ function ChevronRightIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
+      width="24"
+      height="24"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import { HeroSection } from './HeroSection'
 import { StorytellingSection } from './StorytellingSection'
+import { SocialProofSection } from './SocialProofSection'
 import { useDeviceCapability } from '@/hooks/useDeviceCapability'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 
@@ -31,14 +32,15 @@ export function WelcomePageClient() {
         <HeroSection isHighEnd={isHighEnd} reducedMotion={reducedMotion} />
       )}
 
-      {/* TODO: StorytellingSection */}
+      {/* StorytellingSection — 카테고리 스토리텔링 */}
       {isReady && (
         <StorytellingSection
           isHighEnd={isHighEnd}
           reducedMotion={reducedMotion}
         />
       )}
-      {/* TODO: SocialProofSection */}
+      {/* SocialProofSection — 자동 스크롤 슬라이더 */}
+      <SocialProofSection />
       {/* TODO: ConversionSection */}
       {/* TODO: FloatingCTA */}
     </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,18 +8,27 @@ import type { NextRequest } from 'next/server'
  * Requirements: 1.9
  */
 export function middleware(request: NextRequest) {
-  try {
-    const hasVisited = request.cookies.get('has_visited')?.value
-    if (hasVisited === 'true') {
-      return NextResponse.redirect(new URL('/map', request.url))
+  const { pathname } = request.nextUrl
+
+  // 루트 경로에서만 분기 리다이렉트
+  if (pathname === '/') {
+    try {
+      const hasVisited = request.cookies.get('has_visited')?.value
+      if (hasVisited === 'true') {
+        return NextResponse.redirect(new URL('/map', request.url))
+      }
+    } catch {
+      // 쿠키 읽기 실패 시 신규 유저로 간주
     }
-  } catch {
-    // 쿠키 읽기 실패 시 신규 유저로 간주
+
+    return NextResponse.redirect(new URL('/welcome', request.url))
   }
 
-  return NextResponse.redirect(new URL('/welcome', request.url))
+  return NextResponse.next()
 }
 
 export const config = {
-  matcher: ['/'],
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon\\.ico|icons|fonts|sw\\.js|manifest\\.json|monitoring).*)',
+  ],
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #454

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정

---

## ✨ 작업 개요

> 소셜 프루프 섹션 컴포넌트 구현 및 미들웨어 리다이렉트 버그 수정

---

## 📋 변경 사항

- [x] `SocialProofSection` 컴포넌트 생성 — 무한 순환 슬라이더
- [x] "함께 덕질하는 즐거움" 커뮤니티 가치 카피 포함
- [x] ProofCard를 가로 슬라이더 형태로 표시 (PROOF_DUMMY_DATA 활용)
- [x] 자동 스크롤 (3.5초 간격) + hover/touch 시 일시정지
- [x] prefers-reduced-motion 시 자동 스크롤 비활성화
- [x] 모바일에서 85vw 카드 너비로 한 번에 1개 카드 표시
- [x] 데스크톱 좌/우 화살표 네비게이션 버튼 (슬라이더 바깥 배치, 크기 확대)
- [x] 무한 순환: 카드 앞뒤 클론 배치로 끊김 없는 루프 구현
- [x] 터치 스와이프 지원 (50px 이상 드래그 시 카드 이동)
- [x] 시맨틱 HTML 태그 (section, header, role=list/listitem)
- [x] WelcomePageClient에 SocialProofSection 통합
- [x] **미들웨어 수정**: 시크릿 모드 첫 진입 시 `/welcome` 리다이렉트 미작동 수정 — matcher를 `['/']`에서 정적 파일 제외 패턴으로 확장

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인
- [x] 시크릿 모드 첫 진입 시 `/welcome` 리다이렉트 확인

---

## 📝 추가 정보

- Requirements: 1.9, 3.1, 3.2, 3.3, 3.4, 6.6, 7.4
- Task 8.2 (landing-page spec)
- 슬라이더 무한 순환: 앞뒤 4개 클론 카드 배치, 클론 영역 도달 시 transition 없이 원본 위치로 점프
- 미들웨어 `matcher: ['/']`가 Next.js App Router에서 루트 page.tsx 없을 때 트리거 안 되는 이슈 → 범용 matcher + pathname 체크로 수정