### PR TITLE
[Feat] Task 11 - 랜딩 페이지 통합 및 반응형/접근성 마무리

### DIFF
--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -1,0 +1,13 @@
+/**
+ * 랜딩 페이지 전용 레이아웃
+ * 라이트/다크 모드 구분 없이 항상 다크 모드로 고정 렌더링
+ * Header/Footer 없이 풀스크린 랜딩 경험 제공
+ * Requirements: 6.3, 6.7
+ */
+export default function LandingLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <div className="dark">{children}</div>
+}

--- a/src/components/landing/ConversionSection.tsx
+++ b/src/components/landing/ConversionSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef } from 'react'
+import { forwardRef, useState } from 'react'
 import { usePwaStore } from '@/stores/pwaStore'
 import { CTAButton } from './CTAButton'
 
@@ -21,8 +21,16 @@ export const ConversionSection = forwardRef<
   ConversionSectionProps
 >(function ConversionSection({ isStandalone }, ref) {
   const triggerInstall = usePwaStore((s) => s.triggerInstall)
+  const isInstallable = usePwaStore((s) => s.isInstallable)
+  const [showFallbackMsg, setShowFallbackMsg] = useState(false)
 
   const handleInstall = async () => {
+    if (!isInstallable) {
+      // 설치 프롬프트 미지원 시 안내 메시지 표시
+      setShowFallbackMsg(true)
+      setTimeout(() => setShowFallbackMsg(false), 4000)
+      return
+    }
     await triggerInstall()
   }
 
@@ -60,6 +68,11 @@ export const ConversionSection = forwardRef<
             >
               🛂 여권 발급받기 (앱 설치)
             </button>
+          )}
+          {showFallbackMsg && (
+            <p className="animate-fade-slide-in text-sm text-sub-text">
+              브라우저 메뉴에서 &quot;홈 화면에 추가&quot;로 설치할 수 있어요
+            </p>
           )}
           <CTAButton
             label="지도 탐색하기"

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { forwardRef } from 'react'
 import dynamic from 'next/dynamic'
 import { CTAButton } from './CTAButton'
 import { GlobeFallback2D } from './GlobeFallback2D'
@@ -130,47 +131,50 @@ const GLOBE_DATA_POINTS: GlobeDataPoint[] = [
   },
 ]
 
-export function HeroSection({ isHighEnd, reducedMotion }: HeroSectionProps) {
-  return (
-    <section
-      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-16"
-      aria-label="히어로 섹션"
-    >
-      {/* 배경 그라데이션 */}
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-b from-primary-50/30 via-transparent to-transparent dark:from-primary-900/20"
-        aria-hidden="true"
-      />
+export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
+  function HeroSection({ isHighEnd, reducedMotion }, ref) {
+    return (
+      <section
+        ref={ref}
+        className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-16"
+        aria-label="히어로 섹션"
+      >
+        {/* 배경 그라데이션 */}
+        <div
+          className="pointer-events-none absolute inset-0 bg-gradient-to-b from-primary-50/30 via-transparent to-transparent dark:from-primary-900/20"
+          aria-hidden="true"
+        />
 
-      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col items-center gap-8 lg:flex-row lg:gap-12">
-        {/* 텍스트 + CTA 영역 */}
-        <header className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
-          <h1 className="mb-4 text-3xl font-bold leading-tight text-main-text md:text-4xl lg:text-5xl">
-            관광지가 아닌
-            <br />
-            <span className="text-primary-500">성지</span>를 탐험하세요
-          </h1>
-          <p className="mb-8 max-w-md text-base text-sub-text md:text-lg">
-            애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등
-            <br className="hidden sm:block" />
-            팬들만 아는 특별한 여행지를 발견하세요.
-          </p>
-          <CTAButton label="지도 탐색하기" href="/map" size="lg" />
-        </header>
+        <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col items-center gap-8 lg:flex-row lg:gap-12">
+          {/* 텍스트 + CTA 영역 */}
+          <header className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
+            <h1 className="mb-4 text-3xl font-bold leading-tight text-main-text md:text-4xl lg:text-5xl">
+              관광지가 아닌
+              <br />
+              <span className="text-primary-500">성지</span>를 탐험하세요
+            </h1>
+            <p className="mb-8 max-w-md text-base text-sub-text md:text-lg">
+              애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등
+              <br className="hidden sm:block" />
+              팬들만 아는 특별한 여행지를 발견하세요.
+            </p>
+            <CTAButton label="지도 탐색하기" href="/map" size="lg" />
+          </header>
 
-        {/* 지구본 비주얼 영역 */}
-        <div className="relative flex flex-1 items-center justify-center">
-          {/* 3D/2D 지구본 분기 렌더링 */}
-          {isHighEnd && !reducedMotion ? (
-            <Globe3D
-              dataPoints={GLOBE_DATA_POINTS}
-              className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]"
-            />
-          ) : (
-            <GlobeFallback2D className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]" />
-          )}
+          {/* 지구본 비주얼 영역 */}
+          <div className="relative flex flex-1 items-center justify-center">
+            {/* 3D/2D 지구본 분기 렌더링 */}
+            {isHighEnd && !reducedMotion ? (
+              <Globe3D
+                dataPoints={GLOBE_DATA_POINTS}
+                className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]"
+              />
+            ) : (
+              <GlobeFallback2D className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]" />
+            )}
+          </div>
         </div>
-      </div>
-    </section>
-  )
-}
+      </section>
+    )
+  }
+)

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -100,15 +100,17 @@ export function SocialProofSection() {
 
   /** 다음 카드로 이동 */
   const goNext = useCallback(() => {
+    if (isTransitioning) return // transition 중 클릭 무시
     setIsTransitioning(true)
     setCurrentIndex((prev) => prev + 1)
-  }, [])
+  }, [isTransitioning])
 
   /** 이전 카드로 이동 */
   const goPrev = useCallback(() => {
+    if (isTransitioning) return // transition 중 클릭 무시
     setIsTransitioning(true)
     setCurrentIndex((prev) => prev - 1)
-  }, [])
+  }, [isTransitioning])
 
   /** transition 종료 감지 → 클론 점프 트리거 */
   const handleTransitionEnd = useCallback(() => {

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -1,20 +1,43 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { HeroSection } from './HeroSection'
 import { StorytellingSection } from './StorytellingSection'
 import { SocialProofSection } from './SocialProofSection'
+import { ConversionSection } from './ConversionSection'
+import { FloatingCTA } from './FloatingCTA'
 import { useDeviceCapability } from '@/hooks/useDeviceCapability'
+import { useScrollPosition } from '@/hooks/useScrollPosition'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+import { usePwaStore } from '@/stores/pwaStore'
 
 /**
  * 랜딩 페이지 클라이언트 컴포넌트
- * 디바이스 능력 감지 후 각 섹션에 3D/2D 분기 props 전달
- * Requirements: 1.8, 1.9, 5.2, 5.3
+ * 모든 섹션을 통합하고 디바이스 능력/스크롤/모션 훅을 연결
+ * Requirements: 5.2, 5.3, 5.4, 6.1, 6.2, 6.3
  */
 export function WelcomePageClient() {
+  const router = useRouter()
   const { isHighEnd, isReady } = useDeviceCapability()
   const reducedMotion = usePrefersReducedMotion()
+
+  // 섹션 ref — useScrollPosition에 전달
+  const heroRef = useRef<HTMLElement>(null)
+  const conversionRef = useRef<HTMLElement>(null)
+
+  const { heroExited, conversionVisible } = useScrollPosition({
+    heroRef,
+    conversionRef,
+  })
+
+  // PWA standalone 모드 감지
+  const [isStandalone, setIsStandalone] = useState(false)
+  const triggerInstall = usePwaStore((s) => s.triggerInstall)
+
+  useEffect(() => {
+    setIsStandalone(window.matchMedia('(display-mode: standalone)').matches)
+  }, [])
 
   /** 페이지 이탈 시에도 has_visited 쿠키 설정 */
   useEffect(() => {
@@ -23,13 +46,27 @@ export function WelcomePageClient() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
   }, [])
 
+  // FloatingCTA 핸들러
+  const handleInstallClick = async () => {
+    await triggerInstall()
+  }
+
+  const handleExploreClick = () => {
+    setHasVisitedCookie()
+    router.push('/map')
+  }
+
   return (
     <div className="min-h-screen bg-background">
       {/* 디바이스 감지 완료 전 스켈레톤 */}
       {!isReady ? (
         <HeroSkeleton />
       ) : (
-        <HeroSection isHighEnd={isHighEnd} reducedMotion={reducedMotion} />
+        <HeroSection
+          ref={heroRef}
+          isHighEnd={isHighEnd}
+          reducedMotion={reducedMotion}
+        />
       )}
 
       {/* StorytellingSection — 카테고리 스토리텔링 */}
@@ -39,10 +76,20 @@ export function WelcomePageClient() {
           reducedMotion={reducedMotion}
         />
       )}
+
       {/* SocialProofSection — 자동 스크롤 슬라이더 */}
       <SocialProofSection />
-      {/* TODO: ConversionSection */}
-      {/* TODO: FloatingCTA */}
+
+      {/* ConversionSection — PWA 설치 유도 전환 영역 */}
+      <ConversionSection ref={conversionRef} isStandalone={isStandalone} />
+
+      {/* FloatingCTA — Hero 이탈 후 ~ Conversion 진입 전 표시 */}
+      <FloatingCTA
+        visible={heroExited && !conversionVisible}
+        isStandalone={isStandalone}
+        onInstallClick={handleInstallClick}
+        onExploreClick={handleExploreClick}
+      />
     </div>
   )
 }

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -34,6 +34,7 @@ export function WelcomePageClient() {
   // PWA standalone 모드 감지
   const [isStandalone, setIsStandalone] = useState(false)
   const triggerInstall = usePwaStore((s) => s.triggerInstall)
+  const isInstallable = usePwaStore((s) => s.isInstallable)
 
   useEffect(() => {
     setIsStandalone(window.matchMedia('(display-mode: standalone)').matches)
@@ -48,6 +49,11 @@ export function WelcomePageClient() {
 
   // FloatingCTA 핸들러
   const handleInstallClick = async () => {
+    if (!isInstallable) {
+      // 설치 프롬프트 미지원 시 ConversionSection으로 스크롤
+      conversionRef.current?.scrollIntoView({ behavior: 'smooth' })
+      return
+    }
     await triggerInstall()
   }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #458

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 랜딩 페이지의 모든 섹션을 WelcomePageClient에 통합하고, (landing) 레이아웃에 다크 모드 고정을 적용

---

## 📋 변경 사항

- [x] HeroSection에 forwardRef 지원 추가 (heroRef 전달용)
- [x] WelcomePageClient에 useScrollPosition, ConversionSection, FloatingCTA 통합
- [x] isStandalone 상태 감지 및 FloatingCTA 표시 조건 연결
- [x] (landing) Route Group layout.tsx 생성 — dark 클래스 강제 적용

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 5.2, 5.3, 5.4, 6.1, 6.2, 6.3, 6.7, 7.7 대응
- FloatingCTA 표시 조건: `heroExited && !conversionVisible`
- 다크 모드는 `(landing)/layout.tsx`에서 `dark` 클래스 래퍼로 강제 적용