### PR TITLE
enhancement: categoryStories description 실제 스팟 이름 포함으로 교체

### DIFF
--- a/.kiro/specs/23-landing-page-polish/tasks.md
+++ b/.kiro/specs/23-landing-page-polish/tasks.md
@@ -46,7 +46,7 @@
     - 테스트 파일: `src/components/landing/__tests__/StorytellingSection.test.tsx`, `src/components/landing/__tests__/CategoryCard.test.tsx`
     - _Requirements: 2.1, 2.2, 3.4_
 
-- [ ] 3. 체크포인트 — 코드 품질 개선 검증
+- [x] 3. 체크포인트 — 코드 품질 개선 검증
   - `npm run type-check` 및 `npm run build` 통과 확인
   - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
 
@@ -92,8 +92,8 @@
     - 테스트 파일: `src/components/landing/__tests__/data/proofData.test.ts`
     - _Requirements: 5.2, 5.3, 5.4, 5.5_
 
-- [ ] 6. 카테고리 스토리 description 실제 스팟 이름 포함으로 교체
-  - [ ] 6.1 categoryStories.ts description 교체 및 TODO 주석 추가
+- [x] 6. 카테고리 스토리 description 실제 스팟 이름 포함으로 교체
+  - [x] 6.1 categoryStories.ts description 교체 및 TODO 주석 추가
     - 웹 검색으로 각 카테고리의 대표 성지순례 명소 확인
     - 각 카테고리 description에 실제 유명 스팟 이름 1~2개 포함하는 구체적 문장으로 교체
     - title은 현재 값 유지
@@ -106,7 +106,7 @@
     - 테스트 파일: `src/components/landing/__tests__/data/categoryStories.test.ts`
     - _Requirements: 6.1, 6.3_
 
-- [ ] 7. 최종 체크포인트 — 전체 검증
+- [x] 7. 최종 체크포인트 — 전체 검증
   - `npm run type-check` 및 `npm run build` 통과 확인
   - 모든 테스트 통과 확인, 문제 발생 시 사용자에게 문의
 

--- a/src/components/landing/data/categoryStories.ts
+++ b/src/components/landing/data/categoryStories.ts
@@ -22,49 +22,55 @@ export const CATEGORY_STORIES: CategoryStoryConfig[] = [
   {
     category: 'animation',
     title: '애니메이션 성지순례',
-    description: '좋아하는 작품 속 그 장소를 직접 걸어보세요',
-    mascotProp: '/icons/categories/animation.webp',
-    spotImage: '/icons/categories/animation.webp',
+    description:
+      '슬램덩크의 가마쿠라 건널목, 스즈미야 하루히의 니시노미야를 직접 걸어보세요',
+    mascotProp: '/icons/categories/animation.webp', // TODO: 실제 마스코트 소품 이미지로 교체
+    spotImage: '/icons/categories/animation.webp', // TODO: 실제 대표 스팟 이미지로 교체
     colorToken: 'category-anime',
   },
   {
     category: 'sports',
     title: '스포츠 직관 여행',
-    description: '경기장의 열기를 현장에서 느껴보세요',
-    mascotProp: '/icons/categories/sports.webp',
-    spotImage: '/icons/categories/sports.webp',
+    description:
+      '캄프 노우의 함성, 웸블리 스타디움의 열기를 현장에서 느껴보세요',
+    mascotProp: '/icons/categories/sports.webp', // TODO: 실제 마스코트 소품 이미지로 교체
+    spotImage: '/icons/categories/sports.webp', // TODO: 실제 대표 스팟 이미지로 교체
     colorToken: 'category-sports',
   },
   {
     category: 'movie_drama',
     title: '영화/드라마 촬영지',
-    description: '스크린 속 그 장면, 직접 서보세요',
-    mascotProp: '/icons/categories/movie_drama.webp',
-    spotImage: '/icons/categories/movie_drama.webp',
+    description:
+      '해리 포터의 킹스크로스역, 도깨비의 주문진 방파제에 직접 서보세요',
+    mascotProp: '/icons/categories/movie_drama.webp', // TODO: 실제 마스코트 소품 이미지로 교체
+    spotImage: '/icons/categories/movie_drama.webp', // TODO: 실제 대표 스팟 이미지로 교체
     colorToken: 'category-movie-drama',
   },
   {
     category: 'music',
     title: '음악/콘서트 장소',
-    description: '아티스트의 무대를 직접 찾아가 보세요',
-    mascotProp: '/icons/categories/music.webp',
-    spotImage: '/icons/categories/music.webp',
+    description:
+      '비틀즈의 캐번 클럽, 런던 애비 로드 횡단보도를 직접 찾아가 보세요',
+    mascotProp: '/icons/categories/music.webp', // TODO: 실제 마스코트 소품 이미지로 교체
+    spotImage: '/icons/categories/music.webp', // TODO: 실제 대표 스팟 이미지로 교체
     colorToken: 'category-music',
   },
   {
     category: 'game',
     title: '게임 속 세계',
-    description: '게임 속 배경이 된 실제 장소를 탐험하세요',
-    mascotProp: '/icons/categories/game.webp',
-    spotImage: '/icons/categories/game.webp',
+    description:
+      '용과 같이의 가부키초, 어쌔신 크리드의 피렌체를 실제로 탐험하세요',
+    mascotProp: '/icons/categories/game.webp', // TODO: 실제 마스코트 소품 이미지로 교체
+    spotImage: '/icons/categories/game.webp', // TODO: 실제 대표 스팟 이미지로 교체
     colorToken: 'category-game',
   },
   {
     category: 'other',
     title: '특별한 장소',
-    description: '팬들만 아는 숨겨진 명소를 발견하세요',
-    mascotProp: '/icons/categories/other.webp',
-    spotImage: '/icons/categories/other.webp',
+    description:
+      '셜록 홈즈의 베이커가 221B, 엘비스의 그레이스랜드 같은 숨겨진 명소를 발견하세요',
+    mascotProp: '/icons/categories/other.webp', // TODO: 실제 마스코트 소품 이미지로 교체
+    spotImage: '/icons/categories/other.webp', // TODO: 실제 대표 스팟 이미지로 교체
     colorToken: 'category-other',
   },
 ]


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #473

---

## 📋 PR 타입

- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화

---

## ✨ 작업 개요

카테고리 스토리텔링 섹션의 일반적인 description을 웹 검색으로 검증된 실제 성지순례 스팟 이름이 포함된 구체적인 문장으로 교체

---

## 📋 변경 사항

- [x] animation: 슬램덩크의 가마쿠라 건널목, 스즈미야 하루히의 니시노미야
- [x] sports: 캄프 노우, 웸블리 스타디움
- [x] movie_drama: 해리 포터의 킹스크로스역, 도깨비의 주문진 방파제
- [x] music: 비틀즈의 캐번 클럽, 런던 애비 로드 횡단보도
- [x] game: 용과 같이의 가부키초, 어쌔신 크리드의 피렌체
- [x] other: 셜록 홈즈의 베이커가 221B, 엘비스의 그레이스랜드
- [x] mascotProp, spotImage에 TODO 주석 추가

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] title 값 변경 없음 확인
- [x] 모든 스팟 이름 웹 검색으로 팩트 체크 완료

---

## 📝 추가 정보

Requirements 6.1, 6.2, 6.3, 7.4 대응. 모든 스팟 이름은 웹 검색으로 실제 성지순례 명소임을 확인함.