### PR TITLE
[Feat] isKoreanCoordinates 좌표 경계 판별 함수 추가

### DIFF
--- a/src/lib/directions.ts
+++ b/src/lib/directions.ts
@@ -2,8 +2,29 @@
  * 길찾기 딥링크 유틸리티
  * 플랫폼별 지도 앱 딥링크 URL 생성
  *
- * @requirements 2.3
+ * @requirements 1.1, 1.2, 1.3, 1.4, 2.3
  */
+
+/** 대한민국 좌표 경계 */
+const KOREA_BOUNDARY = {
+  lat: { min: 33.0, max: 38.7 },
+  lng: { min: 124.5, max: 132.0 },
+} as const
+
+/**
+ * 좌표가 대한민국 영토 범위 내인지 판별
+ * @param lat 위도
+ * @param lng 경도
+ * @returns 국내 좌표 여부
+ */
+export function isKoreanCoordinates(lat: number, lng: number): boolean {
+  return (
+    lat >= KOREA_BOUNDARY.lat.min &&
+    lat <= KOREA_BOUNDARY.lat.max &&
+    lng >= KOREA_BOUNDARY.lng.min &&
+    lng <= KOREA_BOUNDARY.lng.max
+  )
+}
 
 export interface Coordinates {
   lat: number


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #475

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> `src/lib/directions.ts`에 `KOREA_BOUNDARY` 상수와 `isKoreanCoordinates()` 순수 함수를 추가하여 좌표 기반 국내/해외 스팟 판별 기능 구현

---

## 📋 변경 사항

- [x] `KOREA_BOUNDARY` 상수 정의 (lat: 33.0~38.7, lng: 124.5~132.0)
- [x] `isKoreanCoordinates(lat, lng): boolean` 순수 함수 export

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 1.1, 1.2, 1.3, 1.4 대응
- Task 1.1 (Spec: 25-navigation-google-maps-default)