### PR TITLE
[Test] Task 1.2 - isKoreanCoordinates 좌표 경계 분류 PBT 작성

### DIFF
--- a/src/lib/__tests__/directions.test.ts
+++ b/src/lib/__tests__/directions.test.ts
@@ -1,0 +1,55 @@
+/**
+ * isKoreanCoordinates Property-Based Tests
+ *
+ * Feature: navigation-google-maps-default
+ * Property 1: Boundary classification biconditional
+ *
+ * Validates: Requirements 1.2, 1.3, 4.4
+ */
+import * as fc from 'fast-check'
+import { isKoreanCoordinates } from '@/lib/directions'
+
+const KOREA_LAT_MIN = 33.0
+const KOREA_LAT_MAX = 38.7
+const KOREA_LNG_MIN = 124.5
+const KOREA_LNG_MAX = 132.0
+
+describe('Feature: navigation-google-maps-default', () => {
+  describe('Property 1: Boundary classification biconditional', () => {
+    /**
+     * **Validates: Requirements 1.2, 1.3, 4.4**
+     *
+     * For any coordinate pair (lat, lng), isKoreanCoordinates(lat, lng)
+     * returns true iff 33.0 <= lat <= 38.7 AND 124.5 <= lng <= 132.0
+     */
+    it('should return true iff coordinates are within Korea boundary', () => {
+      fc.assert(
+        fc.property(
+          fc.double({
+            min: -90,
+            max: 90,
+            noNaN: true,
+            noDefaultInfinity: true,
+          }),
+          fc.double({
+            min: -180,
+            max: 180,
+            noNaN: true,
+            noDefaultInfinity: true,
+          }),
+          (lat, lng) => {
+            const result = isKoreanCoordinates(lat, lng)
+            const expected =
+              lat >= KOREA_LAT_MIN &&
+              lat <= KOREA_LAT_MAX &&
+              lng >= KOREA_LNG_MIN &&
+              lng <= KOREA_LNG_MAX
+
+            return result === expected
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+  })
+})


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #477

---

## 📋 PR 타입

- [x] 🧪 **test**: 테스트 추가

---

## ✨ 작업 개요

> `isKoreanCoordinates` 함수의 좌표 경계 분류 정확성을 fast-check PBT로 검증하는 테스트 추가

---

## 📋 변경 사항

- [x] `src/lib/__tests__/directions.test.ts` 생성
- [x] Property 1: Boundary classification biconditional PBT 작성 (100회 반복)

---

## ✅ 체크리스트

- [x] `npx jest src/lib/__tests__/directions.test.ts --no-coverage` 통과
- [x] Requirements 1.2, 1.3, 4.4 대응

---

## 📝 추가 정보

- PBT 라이브러리: fast-check
- 랜덤 좌표 생성 범위: lat(-90~90), lng(-180~180)
- 검증 조건: `isKoreanCoordinates(lat, lng) === (33.0 <= lat <= 38.7 AND 124.5 <= lng <= 132.0)`