### PR TITLE
[Feat] Task 2.1 - DirectionsButton 국내/해외 조건 분기 추가

### DIFF
--- a/src/components/common/DirectionsButton.tsx
+++ b/src/components/common/DirectionsButton.tsx
@@ -5,6 +5,7 @@ import {
   generateDirectionsUrls,
   detectPlatform,
   openDirections,
+  isKoreanCoordinates,
   type DirectionsUrls,
 } from '@/lib/directions'
 import { AppIcon } from '@/components/common/AppIcon'
@@ -72,6 +73,8 @@ export default function DirectionsButton({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [isOpen])
 
+  const isDomestic = isKoreanCoordinates(lat, lng)
+
   const availableApps = MAP_APPS.filter(
     (app) => !app.platforms || app.platforms.includes(platform)
   )
@@ -80,6 +83,14 @@ export default function DirectionsButton({
     destination: { lat, lng },
     destinationName,
   })
+
+  const handleClick = useCallback(() => {
+    if (isDomestic) {
+      setIsOpen((prev) => !prev)
+    } else {
+      openDirections(urls.google)
+    }
+  }, [isDomestic, urls.google])
 
   const handleSelect = useCallback(
     (key: keyof DirectionsUrls) => {
@@ -92,11 +103,13 @@ export default function DirectionsButton({
   return (
     <div className="relative" ref={modalRef}>
       <button
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={handleClick}
         className={`flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 active:bg-primary-800 ${className}`}
         aria-label="길찾기"
-        aria-expanded={isOpen}
-        aria-haspopup="true"
+        {...(isDomestic && {
+          'aria-expanded': isOpen,
+          'aria-haspopup': 'true' as const,
+        })}
       >
         <svg
           className="h-4 w-4"
@@ -120,7 +133,7 @@ export default function DirectionsButton({
         길찾기
       </button>
 
-      {isOpen && (
+      {isOpen && isDomestic && (
         <div
           className="absolute bottom-full left-0 z-50 mb-2 w-48 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5"
           role="menu"


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #483

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> DirectionsButton 컴포넌트에 국내/해외 좌표 조건 분기를 추가하여, 해외 스팟은 Google Maps 바로 열기, 국내 스팟은 기존 선택 메뉴 유지

---

## 📋 변경 사항

- [x] `isKoreanCoordinates` import 추가
- [x] `isDomestic` 변수로 국내/해외 판별
- [x] `handleClick` 콜백 추가 (해외: Google Maps 직접 열기, 국내: 메뉴 토글)
- [x] `aria-haspopup`, `aria-expanded`는 국내일 때만 설정
- [x] 메뉴 드롭다운은 `isOpen && isDomestic`일 때만 표시

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 2.1, 2.3, 3.1, 3.2, 3.3 대응
- Task 2.1 구현