### PR TITLE
[UI] DirectionsButton 이모지를 브랜드 아이콘으로 교체

### DIFF
--- a/src/components/common/DirectionsButton.tsx
+++ b/src/components/common/DirectionsButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import Image from 'next/image'
 import {
   generateDirectionsUrls,
   detectPlatform,
@@ -32,8 +33,25 @@ const MAP_APPS: MapAppOption[] = [
     icon: <AppIcon name="map" size={18} />,
   },
   { key: 'apple', label: 'Apple Maps', icon: '🍎', platforms: ['ios'] },
-  { key: 'kakao', label: '카카오맵', icon: '🟡' },
-  { key: 'naver', label: '네이버 지도', icon: '🟢' },
+  {
+    key: 'kakao',
+    label: '카카오맵',
+    icon: (
+      <Image src="/icons/kakao-map.png" alt="카카오맵" width={18} height={18} />
+    ),
+  },
+  {
+    key: 'naver',
+    label: '네이버 지도',
+    icon: (
+      <Image
+        src="/icons/naver-map.png"
+        alt="네이버 지도"
+        width={18}
+        height={18}
+      />
+    ),
+  },
 ]
 
 /**


### PR DESCRIPTION
## 변경 사항

DirectionsButton 컴포넌트에서 카카오맵/네이버 지도 이모지를 실제 브랜드 아이콘 이미지로 교체

- `next/image` import 추가
- 카카오맵: `🟡` → `<Image src="/icons/kakao-map.png" />`
- 네이버: `🟢` → `<Image src="/icons/naver-map.png" />`
- 아이콘 크기 18×18 (기존 메뉴 아이콘과 일관)
- Google Maps, Apple Maps 아이콘은 기존 유지

## Requirements

- 4.1, 4.3, 5.1, 5.3, 6.3

Closes #497