### PR TITLE
[feat] ThemeSelector 드롭다운 메뉴 컴포넌트 구현

### DIFF
--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -1,48 +1,148 @@
 'use client'
 
 import { useTheme } from 'next-themes'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AppIcon } from './AppIcon'
+import type { AppIconType } from './AppIcon'
 
-export function ThemeToggle() {
+/** 테마 옵션 인터페이스 */
+export interface ThemeOption {
+  value: 'light' | 'dark' | 'system'
+  label: string
+  iconName: AppIconType
+}
+
+/** 테마 옵션 상수 배열 */
+export const THEME_OPTIONS: ThemeOption[] = [
+  { value: 'light', label: '라이트 모드', iconName: 'light-mode' },
+  { value: 'dark', label: '다크 모드', iconName: 'dark-mode' },
+  { value: 'system', label: '시스템 설정', iconName: 'settings' },
+]
+
+/** 테마 값에 해당하는 아이콘 이름 반환 */
+export function getIcon(theme: string | undefined): AppIconType {
+  const option = THEME_OPTIONS.find((o) => o.value === theme)
+  return option?.iconName ?? 'settings'
+}
+
+/** 테마 값에 해당하는 한글 레이블 반환 */
+export function getLabel(theme: string | undefined): string {
+  const option = THEME_OPTIONS.find((o) => o.value === theme)
+  return option?.label ?? '시스템 설정'
+}
+
+export function ThemeSelector() {
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     setMounted(true)
   }, [])
 
+  // 외부 클릭 감지 (DirectionsButton 패턴)
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  // Escape 키 감지
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen])
+
+  // 하이드레이션 안전성: 마운트 전 플레이스홀더
   if (!mounted) {
     return <div className="h-9 w-9" />
   }
 
-  const cycleTheme = () => {
-    if (theme === 'system') setTheme('light')
-    else if (theme === 'light') setTheme('dark')
-    else setTheme('system')
-  }
-
-  const getIcon = () => {
-    if (theme === 'dark') return <AppIcon name="dark-mode" size="xl" />
-    if (theme === 'light') return <AppIcon name="light-mode" size="xl" />
-    return <AppIcon name="settings" size="xl" />
-  }
-
-  const label =
-    theme === 'dark'
-      ? '다크 모드'
-      : theme === 'light'
-        ? '라이트 모드'
-        : '시스템 설정'
+  const currentTheme = theme ?? 'system'
+  const currentLabel = getLabel(currentTheme)
+  const currentIconName = getIcon(currentTheme)
 
   return (
-    <button
-      onClick={cycleTheme}
-      className="flex h-9 w-9 items-center justify-center rounded-lg text-neutral-300 transition hover:bg-neutral-700 hover:text-white"
-      aria-label={`현재: ${label}. 클릭하여 테마 변경`}
-      title={label}
-    >
-      <span className="flex items-center justify-center">{getIcon()}</span>
-    </button>
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex h-9 w-9 items-center justify-center rounded-lg text-neutral-300 transition hover:bg-neutral-700 hover:text-white"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-label={`현재: ${currentLabel}. 클릭하여 테마 선택`}
+        title={currentLabel}
+      >
+        <span className="flex items-center justify-center">
+          <AppIcon name={currentIconName} size="xl" />
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 top-full z-50 mt-1 w-44 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5"
+          role="menu"
+          aria-label="테마 선택"
+        >
+          {THEME_OPTIONS.map((option) => {
+            const isActive = currentTheme === option.value
+            return (
+              <button
+                key={option.value}
+                onClick={() => {
+                  setTheme(option.value)
+                  setIsOpen(false)
+                }}
+                className={`flex w-full items-center gap-2.5 px-3 py-2.5 text-sm transition-colors ${
+                  isActive
+                    ? 'bg-primary-50 font-medium text-primary'
+                    : 'text-text-secondary hover:bg-secondary-100'
+                }`}
+                role="menuitem"
+              >
+                <AppIcon name={option.iconName} size="sm" />
+                <span className="flex-1 text-left">{option.label}</span>
+                {isActive && (
+                  <svg
+                    className="h-4 w-4 text-primary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
   )
 }
+
+// 하위 호환을 위한 alias (Task 2에서 제거 예정)
+export const ThemeToggle = ThemeSelector

--- a/src/components/common/__tests__/ThemeSelector.test.tsx
+++ b/src/components/common/__tests__/ThemeSelector.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen, fireEvent } from '@testing-library/react'
+import fc from 'fast-check'
+import { ThemeSelector, THEME_OPTIONS, getIcon, getLabel } from '../ThemeToggle'
+
+// --- Mocks ---
+
+const mockSetTheme = jest.fn()
+let mockTheme = 'system'
+
+jest.mock('next-themes', () => ({
+  useTheme: () => ({
+    theme: mockTheme,
+    setTheme: mockSetTheme,
+  }),
+}))
+
+jest.mock('@/components/common/AppIcon', () => ({
+  AppIcon: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`} />
+  ),
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockTheme = 'system'
+})
+
+/**
+ * Feature: theme-selector-menu, Property 1: 토글 상태 반전 및 aria-expanded 동기화
+ * Validates: Requirements 1.1, 5.1
+ */
+describe('Property 1: 토글 상태 반전 및 aria-expanded 동기화', () => {
+  it('임의의 초기 상태에서 토글 후 aria-expanded가 반전된다', () => {
+    fc.assert(
+      fc.property(fc.boolean(), (initialOpen) => {
+        const { unmount } = render(<ThemeSelector />)
+        const button = screen.getByRole('button', { name: /테마 선택/ })
+
+        // 초기 상태: 닫힘 (aria-expanded="false")
+        expect(button.getAttribute('aria-expanded')).toBe('false')
+
+        if (initialOpen) {
+          // 열기: 클릭 → aria-expanded="true"
+          fireEvent.click(button)
+          expect(button.getAttribute('aria-expanded')).toBe('true')
+
+          // 닫기: 다시 클릭 → aria-expanded="false"
+          fireEvent.click(button)
+          expect(button.getAttribute('aria-expanded')).toBe('false')
+        } else {
+          // 닫힌 상태에서 클릭 → 열림
+          fireEvent.click(button)
+          expect(button.getAttribute('aria-expanded')).toBe('true')
+        }
+
+        unmount()
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+/**
+ * Feature: theme-selector-menu, Property 2: 테마-아이콘-레이블 매핑 일관성
+ * Validates: Requirements 2.3, 5.4
+ */
+describe('Property 2: 테마-아이콘-레이블 매핑 일관성', () => {
+  const expectedMapping: Record<string, { icon: string; label: string }> = {
+    light: { icon: 'light-mode', label: '라이트 모드' },
+    dark: { icon: 'dark-mode', label: '다크 모드' },
+    system: { icon: 'settings', label: '시스템 설정' },
+  }
+
+  it('임의의 테마 값에 대해 getIcon/getLabel이 올바른 매핑을 반환한다', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('light', 'dark', 'system'), (themeValue) => {
+        const expected = expectedMapping[themeValue]
+
+        // getIcon 매핑 검증
+        expect(getIcon(themeValue)).toBe(expected.icon)
+
+        // getLabel 매핑 검증
+        expect(getLabel(themeValue)).toBe(expected.label)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  it('임의의 테마 값에 대해 aria-label에 해당 레이블이 포함된다', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('light', 'dark', 'system'), (themeValue) => {
+        mockTheme = themeValue
+        const { unmount } = render(<ThemeSelector />)
+        const button = screen.getByRole('button', { name: /테마 선택/ })
+
+        const expected = expectedMapping[themeValue]
+        expect(button.getAttribute('aria-label')).toContain(expected.label)
+
+        unmount()
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+/**
+ * Feature: theme-selector-menu, Property 3: 활성 테마 표시 정확성
+ * Validates: Requirements 3.1, 3.2
+ */
+describe('Property 3: 활성 테마 표시 정확성', () => {
+  it('임의의 테마 값에 대해 메뉴 열림 시 정확히 하나의 옵션만 활성 스타일 적용', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('light', 'dark', 'system'), (themeValue) => {
+        mockTheme = themeValue
+        const { unmount } = render(<ThemeSelector />)
+
+        // 메뉴 열기
+        const button = screen.getByRole('button', { name: /테마 선택/ })
+        fireEvent.click(button)
+
+        // 메뉴가 열려 있는지 확인
+        const menu = screen.getByRole('menu', { name: '테마 선택' })
+        expect(menu).toBeInTheDocument()
+
+        // 모든 menuitem 가져오기
+        const menuItems = screen.getAllByRole('menuitem')
+        expect(menuItems).toHaveLength(THEME_OPTIONS.length)
+
+        // 활성 스타일(bg-primary-50)이 적용된 항목 수 확인
+        const activeItems = menuItems.filter((item) =>
+          item.className.includes('bg-primary-50')
+        )
+        expect(activeItems).toHaveLength(1)
+
+        // 활성 항목의 텍스트가 현재 테마의 레이블과 일치
+        const expectedLabel = getLabel(themeValue)
+        expect(activeItems[0].textContent).toContain(expectedLabel)
+
+        unmount()
+      }),
+      { numRuns: 100 }
+    )
+  })
+})


### PR DESCRIPTION
## 개요

기존 `ThemeToggle` 컴포넌트의 순환 방식 테마 전환을 드롭다운 메뉴 방식의 `ThemeSelector`로 리팩토링

## 변경 사항

- `ThemeOption` 인터페이스 및 `THEME_OPTIONS` 상수 배열 정의
- `isOpen` 상태 + 드롭다운 메뉴 UI 구현
- 외부 클릭 감지 (mousedown) 및 Escape 키 닫기
- 활성 테마 시각적 표시 (체크마크 아이콘 + 배경색 하이라이트)
- 접근성 속성 (`aria-expanded`, `aria-haspopup`, `role="menu"`, `role="menuitem"`)
- 하이드레이션 안전성 유지 (`mounted` 상태)
- `getIcon`, `getLabel` 순수 함수 export
- Property-Based Test 3개 작성 (fast-check, 100회 반복)

## 관련 Requirements

1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 3.1, 3.2, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 5.4, 5.5, 6.1, 6.2

Closes #499