### PR TITLE
[refactor] ThemeSelector import 경로 업데이트

### DIFF
--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -143,6 +143,3 @@ export function ThemeSelector() {
     </div>
   )
 }
-
-// 하위 호환을 위한 alias (Task 2에서 제거 예정)
-export const ThemeToggle = ThemeSelector

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -22,4 +22,4 @@ export type { ErrorBoundaryProps } from './ErrorBoundary'
 export { AsyncBoundary } from './AsyncBoundary'
 export type { AsyncBoundaryProps } from './AsyncBoundary'
 
-export { ThemeToggle } from './ThemeToggle'
+export { ThemeSelector } from './ThemeToggle'

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useAuth } from '@/hooks/useAuth'
-import { ThemeToggle } from '@/components/common/ThemeToggle'
+import { ThemeSelector } from '@/components/common/ThemeToggle'
 import { AppIcon } from '@/components/common/AppIcon'
 
 export function Header() {
@@ -109,7 +109,7 @@ export function Header() {
           )}
 
           {/* 테마 토글 */}
-          <ThemeToggle />
+          <ThemeSelector />
 
           {/* 모바일 햄버거 버튼 */}
           <button


### PR DESCRIPTION
## 변경 사항

- `src/components/common/index.ts`에서 `ThemeToggle` export를 `ThemeSelector`로 변경
- `src/components/common/ThemeToggle.tsx`에서 하위 호환 alias 제거
- `src/components/layout/Header.tsx`에서 import 및 JSX를 `ThemeSelector`로 변경

## 관련 Spec

`.kiro/specs/27-theme-selector-menu/` Task 2

Closes #501