### PR TITLE
[fix] 테마 드롭다운 메뉴가 필터바에 가려지는 문제 수정

### DIFF
--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -98,7 +98,7 @@ export function ThemeSelector() {
 
       {isOpen && (
         <div
-          className="absolute right-0 top-full z-50 mt-1 w-44 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5"
+          className="absolute right-0 top-full z-[9999] mt-1 w-44 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5"
           role="menu"
           aria-label="테마 선택"
         >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,7 +12,7 @@ export function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   return (
-    <header className="fixed left-0 right-0 top-0 z-50 border-b border-border bg-surface/95 pt-safe-top backdrop-blur-sm">
+    <header className="fixed left-0 right-0 top-0 z-[1100] border-b border-border bg-surface/95 pt-safe-top backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
         {/* 로고 */}
         <Link href="/" className="flex items-center gap-2">


### PR DESCRIPTION
## 변경 사항

- Header z-index를 `z-50` → `z-[1100]`으로 변경 (필터바 `z-[1000]`보다 높게)
- 테마 드롭다운 메뉴 z-index를 `z-50` → `z-[9999]`로 변경

## 원인

Header에 `backdrop-blur-sm`이 적용되어 새로운 stacking context가 생성됨. 드롭다운이 Header 내부에 있어 `z-50` stacking context에 갇혀서 필터바(`z-[1000]`)를 넘을 수 없었음.

Closes #504