### PR TITLE
feat: 갤러리 피드 이미지 에러 핸들링 추가

### DIFF
--- a/src/components/gallery/FeedTab.tsx
+++ b/src/components/gallery/FeedTab.tsx
@@ -120,6 +120,8 @@ function FeedGridItem({
   isPriority: boolean
   onClick?: () => void
 }) {
+  const [imageError, setImageError] = useState(false)
+
   return (
     <button
       type="button"
@@ -128,12 +130,13 @@ function FeedGridItem({
       aria-label={`${checkIn.userName}님의 ${spotName} 인증샷`}
     >
       <Image
-        src={checkIn.photoUrl}
+        src={imageError ? '/images/placeholder-spot.jpg' : checkIn.photoUrl}
         alt={`${checkIn.userName}의 인증샷`}
         fill
         className="object-cover"
         sizes="(max-width: 896px) 33vw, 299px"
         priority={isPriority}
+        onError={() => setImageError(true)}
       />
       {/* 호버 오버레이 */}
       <div className="absolute inset-0 flex items-center justify-center bg-black/30 opacity-0 transition-opacity group-hover:opacity-100">


### PR DESCRIPTION
## 변경 사항

`FeedTab.tsx`의 `FeedGridItem` 컴포넌트에 이미지 에러 핸들링을 추가하여, 인증샷 이미지 로드 실패 시 fallback 이미지(`/images/placeholder-spot.jpg`)를 표시합니다.

- `useState(false)`로 `imageError` 상태 추가
- `Image` 컴포넌트에 `onError={() => setImageError(true)}` 핸들러 추가
- `src`를 `imageError ? '/images/placeholder-spot.jpg' : checkIn.photoUrl` 삼항 연산자로 변경
- `ComparisonCard.tsx`의 기존 패턴을 그대로 따름

## Requirements

- 1.1, 1.2, 1.3, 1.4 대응

Closes #509