### PR TITLE
[feat] 지도 스팟 마커 클릭 시 상세 페이지 이동 구현

### DIFF
--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -2,6 +2,7 @@
 
 import { AppIcon } from '@/components/common/AppIcon'
 import dynamic from 'next/dynamic'
+import { useRouter } from 'next/navigation'
 import { useSpots } from '@/hooks/useSpots'
 import CategoryFilter from '@/components/map/CategoryFilter'
 import ContentSearchFilter from '@/components/map/ContentSearchFilter'
@@ -38,6 +39,7 @@ export default function MapPage() {
  * useQuery를 사용하여 필터 변경 시 지도가 유지되고 로딩 인디케이터만 표시
  */
 function MapContent() {
+  const router = useRouter()
   const selectedCategories = useSelectedCategories()
   const searchQuery = useSearchQuery()
   const isNoCategorySelected = selectedCategories.length === 0
@@ -72,8 +74,7 @@ function MapContent() {
   const isEmptyFilterResult = isNoCategorySelected
 
   const handleSpotSelect = (spotId: string) => {
-    // eslint-disable-next-line no-console
-    console.log('Selected spot:', spotId)
+    router.push(`/spots/${spotId}`)
   }
 
   return (


### PR DESCRIPTION
## 변경 사항\n\n지도 페이지에서 스팟 마커 클릭 시 해당 스팟의 상세 페이지(`/spots/[id]`)로 이동하도록 구현\n\n### 수정 내용\n- `src/app/(main)/map/page.tsx`의 `MapContent` 컴포넌트에 `useRouter` 추가\n- `handleSpotSelect` 함수에서 `console.log`를 `router.push(`/spots/${spotId}`)` 로 교체\n\n### 관련 Requirements\n- 2.1: 스팟 마커 클릭 시 상세 페이지 이동\n- 2.2: console.log → router.push 교체\n- 2.3: spotId를 경로 파라미터로 사용\n\nCloses #511