### PR TITLE
feat: RouteDetailContent에서 NavigationPanel을 GuidePanel로 교체

### DIFF
--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -7,7 +7,7 @@ import dynamic from 'next/dynamic'
 import { useAuth } from '@/hooks/useAuth'
 import { useRouteNavigation } from '@/hooks/useRouteNavigation'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
-import { NavigationPanel } from '@/components/route/NavigationPanel'
+import { GuidePanel } from '@/components/route/GuidePanel'
 import { CompletionEffect } from '@/components/route/CompletionEffect'
 import { OptimizedImage } from '@/components/common'
 import type { Route, RouteDifficulty } from '@/types/route'
@@ -245,14 +245,6 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         </div>
       )}
 
-      {/* GPS 정확도 경고 */}
-      {nav.isNavigating && nav.accuracy !== null && nav.accuracy > 100 && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-          ⚠️ GPS 정확도가 낮습니다 ({Math.round(nav.accuracy)}m). 실외로
-          이동하면 정확도가 개선됩니다.
-        </div>
-      )}
-
       {/* 코스 지도 */}
       <div className="rounded-lg bg-surface p-4 shadow-sm">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
@@ -446,21 +438,18 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         onConfirm={() => router.push('/auth/signin')}
       />
 
-      {/* 따라가기 모드 하단 패널 */}
+      {/* 가이드 모드 하단 패널 */}
       {nav.isNavigating && nav.activeRoute && (
-        <NavigationPanel
-          currentSpot={nav.activeRoute.spots[nav.currentSpotIndex]}
-          currentSpotIndex={nav.currentSpotIndex}
+        <GuidePanel
           spots={nav.activeRoute.spots}
-          progress={nav.progress}
-          distanceToNext={nav.distanceToNext}
-          estimatedTimeToNext={nav.estimatedTimeToNext}
           checkedSpotIds={nav.checkedSpotIds}
+          currentSpotIndex={nav.currentSpotIndex}
+          progress={nav.progress}
           currentPosition={nav.currentPosition}
-          isCompleted={nav.isCompleted}
+          accuracy={nav.accuracy}
           onCheckIn={handleCheckIn}
-          onMoveToNext={nav.moveToNextSpot}
           onEndRoute={nav.endRoute}
+          isCompleted={nav.isCompleted}
         />
       )}
 


### PR DESCRIPTION
## 변경 사항

- `NavigationPanel` import를 `GuidePanel`로 변경
- 코스 시작 시 GuidePanel이 표시되도록 props 연결
- 기존 `nav` 훅의 상태를 GuidePanel props에 매핑
- GPS 정확도 경고를 GuidePanel 내부로 이관 (중복 제거)

## Requirements

- 3.1: 코스 시작 시 Navigation_Panel 대신 Guide_Panel 표시

Closes #517