### PR TITLE
[fix] 순례 갤러리 → 순례 인증 명칭 변경 및 피드 그리드 공통 컴포넌트 추출

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -205,7 +205,7 @@ function GalleryHeaderPlaceholder() {
   return (
     <div className="border-b border-neutral-200 bg-surface px-4 py-6">
       <div className="mx-auto max-w-6xl">
-        <h1 className="text-2xl font-bold text-main-text">순례 갤러리</h1>
+        <h1 className="text-2xl font-bold text-main-text">순례 인증</h1>
         <p className="mt-1 text-sm text-sub-text">오타쿠들의 발자취</p>
         {/* 통계 영역 - Task 2.1에서 실제 데이터로 교체 */}
         <div className="mt-4 flex gap-6">

--- a/src/components/gallery/ContentTab.tsx
+++ b/src/components/gallery/ContentTab.tsx
@@ -4,8 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback } from 'react'
 import { CheckIn } from '@/types'
 import { ContentGrid, ContentSummary } from './ContentGrid'
-import { MasonryGrid, MasonryItem } from './MasonryGrid'
-import { ComparisonCard } from './ComparisonCard'
+import { FeedGrid } from './FeedGrid'
 import { useCheckInFeed } from '@/hooks/useCheckInFeed'
 import { useContentList as useContentListQuery } from '@/hooks/useGalleryQueries'
 
@@ -24,37 +23,18 @@ export interface ContentTabProps {
   onCheckInClick?: (checkIn: CheckIn) => void
 }
 
-function LoadingSkeleton() {
+function ContentGridSkeleton() {
   return (
-    <>
-      {[1, 2, 3, 4].map((i) => (
-        <MasonryItem key={`skeleton-${i}`}>
-          <div className="animate-pulse rounded-xl bg-surface shadow-md">
-            <div className="aspect-[4/5] rounded-t-xl bg-border" />
-            <div className="p-3">
-              <div className="mb-2 flex items-center gap-2">
-                <div className="h-6 w-6 rounded-full bg-border" />
-                <div className="h-4 w-20 rounded bg-border" />
-              </div>
-              <div className="h-4 w-32 rounded bg-surface" />
-            </div>
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+      {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+        <div key={i} className="animate-pulse rounded-xl bg-surface shadow-md">
+          <div className="aspect-[3/4] rounded-t-xl bg-border" />
+          <div className="p-3">
+            <div className="mb-2 h-4 w-3/4 rounded bg-border" />
+            <div className="h-3 w-1/2 rounded bg-surface" />
           </div>
-        </MasonryItem>
+        </div>
       ))}
-    </>
-  )
-}
-
-function EmptyFilteredState({ contentName }: { contentName: string }) {
-  return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
-      <div className="mb-4 text-5xl">📸</div>
-      <p className="text-text-secondary text-lg font-medium">
-        &apos;{contentName}&apos; 관련 인증샷이 없어요
-      </p>
-      <p className="mt-2 text-sm text-secondary">
-        첫 번째 순례 인증샷을 올려보세요!
-      </p>
     </div>
   )
 }
@@ -75,22 +55,6 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
       >
         다시 시도
       </button>
-    </div>
-  )
-}
-
-function ContentGridSkeleton() {
-  return (
-    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
-      {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-        <div key={i} className="animate-pulse rounded-xl bg-surface shadow-md">
-          <div className="aspect-[3/4] rounded-t-xl bg-border" />
-          <div className="p-3">
-            <div className="mb-2 h-4 w-3/4 rounded bg-border" />
-            <div className="h-3 w-1/2 rounded bg-surface" />
-          </div>
-        </div>
-      ))}
     </div>
   )
 }
@@ -163,7 +127,7 @@ export function ContentTab({
     loadMoreRef,
   } = useCheckInFeed({
     contentName: selectedContent,
-    itemsPerPage: 20,
+    itemsPerPage: 21,
     sortBy: 'latest',
     enabled: !!selectedContent,
   })
@@ -185,68 +149,23 @@ export function ContentTab({
     router.push(`/gallery?${params.toString()}`)
   }, [router, searchParams])
 
-  // 작품이 선택된 경우: 필터링된 체크인 피드 표시
+  // 작품이 선택된 경우: FeedGrid로 필터링된 체크인 피드 표시
   if (selectedContent) {
-    if (checkInsError && checkIns.length === 0) {
-      return (
-        <div className="mx-auto max-w-6xl px-4 py-6">
-          <FilteredFeedHeader
-            contentName={selectedContent}
-            onBack={handleBack}
-          />
-          <ErrorState onRetry={refreshCheckIns} />
-        </div>
-      )
-    }
-
-    if (!isLoadingCheckIns && checkIns.length === 0) {
-      return (
-        <div className="mx-auto max-w-6xl px-4 py-6">
-          <FilteredFeedHeader
-            contentName={selectedContent}
-            onBack={handleBack}
-          />
-          <EmptyFilteredState contentName={selectedContent} />
-        </div>
-      )
-    }
-
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">
         <FilteredFeedHeader contentName={selectedContent} onBack={handleBack} />
-        <MasonryGrid>
-          {checkIns.map((checkIn) => (
-            <MasonryItem key={checkIn.id}>
-              <ComparisonCard
-                checkIn={checkIn}
-                spot={
-                  checkIn.spot || {
-                    id: checkIn.spotId,
-                    name: '알 수 없는 스팟',
-                  }
-                }
-                badges={checkIn.badges}
-                onClick={() => onCheckInClick?.(checkIn)}
-              />
-            </MasonryItem>
-          ))}
-          {isLoadingCheckIns && <LoadingSkeleton />}
-        </MasonryGrid>
-        <div
-          ref={loadMoreRef}
-          className="flex h-20 items-center justify-center"
-          aria-hidden="true"
-        >
-          {isLoadingMore && (
-            <div className="flex items-center gap-2 text-secondary">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-300 border-t-primary-500" />
-              <span className="text-sm">더 불러오는 중...</span>
-            </div>
-          )}
-          {!hasMore && checkIns.length > 0 && (
-            <p className="text-sm text-muted">모든 인증샷을 불러왔습니다</p>
-          )}
-        </div>
+        <FeedGrid
+          checkIns={checkIns}
+          isLoading={isLoadingCheckIns}
+          isLoadingMore={isLoadingMore}
+          error={checkInsError ? new Error(checkInsError) : null}
+          hasMore={hasMore}
+          onRetry={refreshCheckIns}
+          loadMoreRef={loadMoreRef as React.RefObject<HTMLDivElement>}
+          onCheckInClick={onCheckInClick}
+          emptyMessage={`'${selectedContent}' 관련 인증샷이 없어요`}
+          emptySubMessage="첫 번째 순례 인증샷을 올려보세요!"
+        />
       </div>
     )
   }

--- a/src/components/gallery/FeedGrid.tsx
+++ b/src/components/gallery/FeedGrid.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { CheckIn } from '@/types'
+
+/**
+ * FeedGrid 공통 컴포넌트
+ * FeedTab과 ContentTab에서 공유하는 3열 정사각형 그리드
+ *
+ * - 3열 정사각형 그리드 (grid-cols-3 gap-0.5)
+ * - FeedGridItem: aspect-square + object-cover + 호버 오버레이
+ * - 로딩 스켈레톤, 빈 상태, 에러 상태 포함
+ * - 무한 스크롤 트리거 영역
+ */
+
+export interface FeedGridProps {
+  checkIns: (CheckIn & { spot?: { id: string; name: string } })[]
+  isLoading: boolean
+  isLoadingMore: boolean
+  error: Error | null
+  hasMore: boolean
+  onRetry: () => void
+  loadMoreRef: React.RefObject<HTMLDivElement>
+  onCheckInClick?: (checkIn: CheckIn) => void
+  emptyMessage?: string
+  emptySubMessage?: string
+}
+
+/** 그리드 아이템 (정사각형 + 호버 오버레이) */
+function FeedGridItem({
+  checkIn,
+  spotName,
+  isPriority,
+  onClick,
+}: {
+  checkIn: CheckIn & { spot?: { id: string; name: string } }
+  spotName: string
+  isPriority: boolean
+  onClick?: () => void
+}) {
+  const [imageError, setImageError] = useState(false)
+
+  return (
+    <button
+      type="button"
+      className="group relative aspect-square w-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary-400"
+      onClick={onClick}
+      aria-label={`${checkIn.userName}님의 ${spotName} 인증샷`}
+    >
+      <Image
+        src={imageError ? '/images/placeholder-spot.jpg' : checkIn.photoUrl}
+        alt={`${checkIn.userName}의 인증샷`}
+        fill
+        className="object-cover"
+        sizes="(max-width: 896px) 33vw, 299px"
+        priority={isPriority}
+        onError={() => setImageError(true)}
+      />
+      {/* 호버 오버레이 */}
+      <div className="absolute inset-0 flex items-center justify-center bg-black/30 opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="flex gap-4 text-sm font-semibold text-white">
+          <span>❤️ {checkIn.likeCount ?? 0}</span>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+/** 로딩 스켈레톤 (3열 정사각형 그리드) */
+function LoadingSkeleton() {
+  return (
+    <>
+      {Array.from({ length: 9 }, (_, i) => (
+        <div
+          key={`skeleton-${i}`}
+          className="aspect-square animate-pulse bg-border"
+        />
+      ))}
+    </>
+  )
+}
+
+/** 빈 상태 컴포넌트 */
+function EmptyState({
+  message,
+  subMessage,
+}: {
+  message: string
+  subMessage: string
+}) {
+  return (
+    <div className="col-span-3 flex flex-col items-center justify-center py-16 text-center">
+      <div className="mb-4 text-5xl">📸</div>
+      <p className="text-text-secondary text-lg font-medium">{message}</p>
+      <p className="mt-2 text-sm text-secondary">{subMessage}</p>
+    </div>
+  )
+}
+
+/** 에러 상태 컴포넌트 */
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="col-span-3 flex flex-col items-center justify-center py-16 text-center">
+      <div className="mb-4 text-5xl">😢</div>
+      <p className="text-text-secondary text-lg font-medium">
+        데이터를 불러올 수 없습니다
+      </p>
+      <p className="mt-2 text-sm text-secondary">
+        네트워크 연결을 확인해주세요
+      </p>
+      <button
+        onClick={onRetry}
+        className="mt-4 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600"
+      >
+        다시 시도
+      </button>
+    </div>
+  )
+}
+
+export function FeedGrid({
+  checkIns,
+  isLoading,
+  isLoadingMore,
+  error,
+  hasMore,
+  onRetry,
+  loadMoreRef,
+  onCheckInClick,
+  emptyMessage = '아직 인증샷이 없어요',
+  emptySubMessage = '첫 번째 순례 인증샷을 올려보세요!',
+}: FeedGridProps) {
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-0.5">
+        {/* 에러 상태 */}
+        {error && checkIns.length === 0 && <ErrorState onRetry={onRetry} />}
+
+        {/* 빈 상태 */}
+        {!isLoading && checkIns.length === 0 && !error && (
+          <EmptyState message={emptyMessage} subMessage={emptySubMessage} />
+        )}
+
+        {/* 체크인 그리드 */}
+        {checkIns.map((checkIn, index) => (
+          <FeedGridItem
+            key={checkIn.id}
+            checkIn={checkIn}
+            spotName={checkIn.spot?.name ?? '알 수 없는 스팟'}
+            isPriority={index < 6}
+            onClick={() => onCheckInClick?.(checkIn)}
+          />
+        ))}
+
+        {/* 초기 로딩 스켈레톤 */}
+        {isLoading && <LoadingSkeleton />}
+      </div>
+
+      {/* 무한 스크롤 트리거 영역 */}
+      <div
+        ref={loadMoreRef}
+        className="flex h-20 items-center justify-center"
+        aria-hidden="true"
+      >
+        {isLoadingMore && (
+          <div className="flex items-center gap-2 text-secondary">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-300 border-t-primary-500" />
+            <span className="text-sm">더 불러오는 중...</span>
+          </div>
+        )}
+        {!hasMore && checkIns.length > 0 && (
+          <p className="text-sm text-muted">모든 인증샷을 불러왔습니다</p>
+        )}
+      </div>
+    </>
+  )
+}
+
+export default FeedGrid

--- a/src/components/gallery/FeedTab.tsx
+++ b/src/components/gallery/FeedTab.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import Image from 'next/image'
 import { CheckIn } from '@/types'
 import { useCheckInFeed } from '@/hooks/useCheckInFeed'
+import { FeedGrid } from './FeedGrid'
 
 /**
  * FeedTab 컴포넌트
@@ -58,96 +58,6 @@ function SearchBar({
   )
 }
 
-/** 로딩 스켈레톤 (3열 정사각형 그리드) */
-function LoadingSkeleton() {
-  return (
-    <>
-      {Array.from({ length: 9 }, (_, i) => (
-        <div
-          key={`skeleton-${i}`}
-          className="aspect-square animate-pulse bg-border"
-        />
-      ))}
-    </>
-  )
-}
-
-/** 빈 상태 컴포넌트 */
-function EmptyState() {
-  return (
-    <div className="col-span-3 flex flex-col items-center justify-center py-16 text-center">
-      <div className="mb-4 text-5xl">📸</div>
-      <p className="text-text-secondary text-lg font-medium">
-        아직 인증샷이 없어요
-      </p>
-      <p className="mt-2 text-sm text-secondary">
-        첫 번째 순례 인증샷을 올려보세요!
-      </p>
-    </div>
-  )
-}
-
-/** 에러 상태 컴포넌트 */
-function ErrorState({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div className="col-span-3 flex flex-col items-center justify-center py-16 text-center">
-      <div className="mb-4 text-5xl">😢</div>
-      <p className="text-text-secondary text-lg font-medium">
-        데이터를 불러올 수 없습니다
-      </p>
-      <p className="mt-2 text-sm text-secondary">
-        네트워크 연결을 확인해주세요
-      </p>
-      <button
-        onClick={onRetry}
-        className="mt-4 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600"
-      >
-        다시 시도
-      </button>
-    </div>
-  )
-}
-
-/** 그리드 아이템 (정사각형 + 호버 오버레이) */
-function FeedGridItem({
-  checkIn,
-  spotName,
-  isPriority,
-  onClick,
-}: {
-  checkIn: CheckIn & { spot?: { id: string; name: string } }
-  spotName: string
-  isPriority: boolean
-  onClick?: () => void
-}) {
-  const [imageError, setImageError] = useState(false)
-
-  return (
-    <button
-      type="button"
-      className="group relative aspect-square w-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary-400"
-      onClick={onClick}
-      aria-label={`${checkIn.userName}님의 ${spotName} 인증샷`}
-    >
-      <Image
-        src={imageError ? '/images/placeholder-spot.jpg' : checkIn.photoUrl}
-        alt={`${checkIn.userName}의 인증샷`}
-        fill
-        className="object-cover"
-        sizes="(max-width: 896px) 33vw, 299px"
-        priority={isPriority}
-        onError={() => setImageError(true)}
-      />
-      {/* 호버 오버레이 */}
-      <div className="absolute inset-0 flex items-center justify-center bg-black/30 opacity-0 transition-opacity group-hover:opacity-100">
-        <div className="flex gap-4 text-sm font-semibold text-white">
-          <span>❤️ {checkIn.likeCount ?? 0}</span>
-        </div>
-      </div>
-    </button>
-  )
-}
-
 export function FeedTab({ onCheckInClick }: FeedTabProps) {
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -178,44 +88,16 @@ export function FeedTab({ onCheckInClick }: FeedTabProps) {
       <SearchBar value={searchQuery} onChange={setSearchQuery} />
 
       <div className="mx-auto max-w-4xl px-0.5 py-2">
-        <div className="grid grid-cols-3 gap-0.5">
-          {/* 에러 상태 */}
-          {error && filtered.length === 0 && <ErrorState onRetry={refresh} />}
-
-          {/* 빈 상태 */}
-          {!isLoading && filtered.length === 0 && !error && <EmptyState />}
-
-          {/* 체크인 그리드 */}
-          {filtered.map((checkIn, index) => (
-            <FeedGridItem
-              key={checkIn.id}
-              checkIn={checkIn}
-              spotName={checkIn.spot?.name ?? '알 수 없는 스팟'}
-              isPriority={index < 6}
-              onClick={() => onCheckInClick?.(checkIn)}
-            />
-          ))}
-
-          {/* 초기 로딩 스켈레톤 */}
-          {isLoading && <LoadingSkeleton />}
-        </div>
-
-        {/* 무한 스크롤 트리거 영역 */}
-        <div
-          ref={loadMoreRef}
-          className="flex h-20 items-center justify-center"
-          aria-hidden="true"
-        >
-          {isLoadingMore && (
-            <div className="flex items-center gap-2 text-secondary">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-300 border-t-primary-500" />
-              <span className="text-sm">더 불러오는 중...</span>
-            </div>
-          )}
-          {!hasMore && checkIns.length > 0 && (
-            <p className="text-sm text-muted">모든 인증샷을 불러왔습니다</p>
-          )}
-        </div>
+        <FeedGrid
+          checkIns={filtered}
+          isLoading={isLoading}
+          isLoadingMore={isLoadingMore}
+          error={error ? new Error(error) : null}
+          hasMore={hasMore}
+          onRetry={refresh}
+          loadMoreRef={loadMoreRef as React.RefObject<HTMLDivElement>}
+          onCheckInClick={onCheckInClick}
+        />
       </div>
     </div>
   )

--- a/src/components/gallery/GalleryHeader.tsx
+++ b/src/components/gallery/GalleryHeader.tsx
@@ -7,7 +7,7 @@ import { AppIcon } from '@/components/common/AppIcon'
  * 순례 갤러리 페이지의 헤더 영역을 담당합니다.
  *
  * Requirements:
- * - 5.1: "순례 갤러리" 페이지 제목 표시
+ * - 5.1: "순례 인증" 페이지 제목 표시
  * - 5.2: "오타쿠들의 발자취" 부제목 표시
  * - 5.3: 총 인증 수, 오늘 인증 수 통계 표시
  */
@@ -25,7 +25,7 @@ export function GalleryHeader({
     <header className="border-b border-border bg-surface px-4 py-6">
       <div className="mx-auto max-w-6xl">
         {/* 페이지 제목 - Requirements 5.1 */}
-        <h1 className="text-2xl font-bold text-main-text">순례 갤러리</h1>
+        <h1 className="text-2xl font-bold text-main-text">순례 인증</h1>
 
         {/* 부제목 - Requirements 5.2 */}
         <p className="mt-1 text-sm text-sub-text">오타쿠들의 발자취</p>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -34,7 +34,7 @@ export function Header() {
             href="/gallery"
             className="text-text-secondary text-sm transition hover:text-secondary-400"
           >
-            순례 갤러리
+            순례 인증
           </Link>
           <Link
             href="/routes"
@@ -167,7 +167,7 @@ export function Header() {
               className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
             >
               <AppIcon name="gallery" size="sm" />
-              순례 갤러리
+              순례 인증
             </Link>
             <Link
               href="/routes"


### PR DESCRIPTION
## 개요

UX 품질 개선 체크포인트 후 발견된 3가지 수정사항을 핫픽스로 처리합니다.

Closes #533

## 변경 사항

### 1. "순례 갤러리" → "순례 인증" 명칭 변경
- `Header.tsx` 데스크톱/모바일 네비게이션 메뉴 텍스트
- `GalleryHeader.tsx` h1 텍스트
- `gallery/page.tsx` GalleryHeaderPlaceholder h1 텍스트

### 2. FeedGrid 공통 컴포넌트 추출
- `FeedGrid.tsx` 신규 생성: FeedGridItem, 3열 그리드, 로딩/빈/에러 상태, 무한 스크롤 트리거
- `FeedTab.tsx` 리팩토링: 인라인 그리드를 FeedGrid로 교체 (SearchBar는 FeedTab 전용 유지)

### 3. ContentTab 작품별 피드에 FeedGrid 적용
- MasonryGrid + ComparisonCard (aspect-[4/5]) → FeedGrid (3열 aspect-square)
- 이미지가 적을 때 과도하게 큰 사이즈 문제 해결

## 테스트
- `npm run type-check` 통과