### PR TITLE
[enhancement] 작품별 탭을 콘텐츠별로 변경 및 ContentType 필터 추가

### DIFF
--- a/src/app/api/content-names/route.ts
+++ b/src/app/api/content-names/route.ts
@@ -9,6 +9,7 @@ interface AutocompleteItem {
   name: string
   category: SpotCategory
   count: number
+  contentType?: string
 }
 
 /**
@@ -43,9 +44,10 @@ type SearchType = 'all' | 'content' | 'spot'
  * Query params:
  *   - search: 검색어 (부분 일치, 대소문자 무시)
  *   - type: 검색 타입 (all | content | spot), 기본값 all
+ *   - contentType: ContentType 필터 (anime | movie | drama | sports_team | artist | game | other)
  *
  * Response:
- *   - items: AutocompleteItem[] (최대 10개)
+ *   - items: AutocompleteItem[] (type=content일 때 최대 50개, 그 외 최대 10개)
  *   - total: 전체 매칭 개수
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -53,6 +55,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const { searchParams } = new URL(request.url)
     const search = searchParams.get('search')?.trim() || ''
     const type = (searchParams.get('type') as SearchType) || 'all'
+    const contentType = searchParams.get('contentType')?.trim() || ''
 
     const collection = await getCollection<SpotDocument>('spots')
 
@@ -108,12 +111,22 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         })
       }
 
+      // contentType 필터 적용
+      if (contentType) {
+        contentPipeline.push({
+          $match: {
+            'relatedContent.type': contentType,
+          },
+        })
+      }
+
       contentPipeline.push(
         {
           $group: {
             _id: {
               name: '$relatedContent.name',
               category: '$category',
+              contentType: '$relatedContent.type',
             },
             count: { $sum: 1 },
           },
@@ -122,11 +135,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
           $group: {
             _id: '$_id.name',
             category: { $first: '$_id.category' },
+            contentType: { $first: '$_id.contentType' },
             count: { $sum: '$count' },
           },
         },
         { $sort: { count: -1 } },
-        { $limit: 10 }
+        { $limit: type === 'content' ? 50 : 10 }
       )
 
       const contentResults = await collection
@@ -141,14 +155,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             name,
             category: (doc.category as SpotCategory) || 'other',
             count: doc.count as number,
+            contentType: (doc.contentType as string) || undefined,
           })
         }
       })
     }
 
-    // 카운트 내림차순 정렬 후 최대 10개 제한
+    // 카운트 내림차순 정렬
     items.sort((a, b) => b.count - a.count)
-    const limitedItems = items.slice(0, 10)
+
+    // type=content일 때는 50개, 그 외 10개 제한
+    const maxItems = type === 'content' ? 50 : 10
+    const limitedItems = items.slice(0, maxItems)
 
     return NextResponse.json({
       items: limitedItems,

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -236,7 +236,7 @@ function GalleryTabsPlaceholder({
   const tabs = [
     { id: 'feed', label: '실시간 피드' },
     { id: 'hall-of-fame', label: '명예의 전당' },
-    { id: 'content', label: '작품별' },
+    { id: 'content', label: '콘텐츠별' },
   ] as const
 
   return (

--- a/src/components/gallery/ContentGrid.tsx
+++ b/src/components/gallery/ContentGrid.tsx
@@ -2,15 +2,30 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
+import { CONTENT_TYPE_CONFIG, ContentType } from '@/types/spot'
 
 /**
- * 작품 요약 정보 인터페이스
+ * ContentType → 한글 라벨 매핑
+ */
+const CONTENT_TYPE_LABELS: Record<string, string> = {
+  anime: '애니메이션',
+  movie: '영화',
+  drama: '드라마',
+  sports_team: '스포츠팀',
+  artist: '아티스트',
+  game: '게임',
+  other: '기타',
+}
+
+/**
+ * 콘텐츠 요약 정보 인터페이스
  */
 export interface ContentSummary {
   title: string
   imageUrl?: string
   checkInCount: number
   spotCount: number
+  contentType?: string
 }
 
 export interface ContentGridProps {
@@ -20,10 +35,10 @@ export interface ContentGridProps {
 
 /**
  * ContentGrid 컴포넌트
- * 작품별 탭에서 작품 포스터를 그리드 레이아웃으로 표시합니다.
+ * 콘텐츠별 탭에서 콘텐츠 포스터를 그리드 레이아웃으로 표시합니다.
  *
  * Requirements: 3.4
- * - 작품 포스터를 대형 카드로 그리드 레이아웃에 표시
+ * - 콘텐츠 포스터를 대형 카드로 그리드 레이아웃에 표시
  * - 반응형: 모바일 2열, 태블릿 3열, 데스크톱 4열
  */
 export function ContentGrid({ contents, onSelectContent }: ContentGridProps) {
@@ -31,7 +46,7 @@ export function ContentGrid({ contents, onSelectContent }: ContentGridProps) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-neutral-500">
         <span className="mb-2 text-4xl">📚</span>
-        <p>등록된 작품이 없습니다</p>
+        <p>등록된 콘텐츠가 없습니다</p>
       </div>
     )
   }
@@ -55,8 +70,32 @@ interface ContentCardProps {
 }
 
 /**
+ * ContentTypeBadge 컴포넌트
+ * 콘텐츠 타입을 작은 뱃지로 표시
+ */
+function ContentTypeBadge({ contentType }: { contentType: string }) {
+  const label = CONTENT_TYPE_LABELS[contentType] || contentType
+  const config = CONTENT_TYPE_CONFIG[contentType as ContentType]
+
+  const style = config
+    ? { backgroundColor: config.bgColor, color: config.fgColor }
+    : undefined
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium leading-tight ${
+        !config ? 'bg-neutral-100 text-neutral-600' : ''
+      }`}
+      style={style}
+    >
+      {label}
+    </span>
+  )
+}
+
+/**
  * ContentCard 컴포넌트
- * 개별 작품 포스터 카드
+ * 개별 콘텐츠 포스터 카드
  */
 function ContentCard({ content, onClick }: ContentCardProps) {
   const [imageError, setImageError] = useState(false)
@@ -66,7 +105,7 @@ function ContentCard({ content, onClick }: ContentCardProps) {
       type="button"
       onClick={onClick}
       className="group relative flex flex-col overflow-hidden rounded-xl bg-surface shadow-md transition-all duration-300 hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
-      aria-label={`${content.title} 작품 보기`}
+      aria-label={`${content.title} 콘텐츠 보기`}
     >
       {/* 포스터 이미지 영역 */}
       <div className="relative aspect-[3/4] w-full overflow-hidden bg-neutral-100">
@@ -87,11 +126,18 @@ function ContentCard({ content, onClick }: ContentCardProps) {
 
         {/* 호버 오버레이 */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        {/* ContentType 뱃지 (좌상단) */}
+        {content.contentType && (
+          <div className="absolute left-2 top-2">
+            <ContentTypeBadge contentType={content.contentType} />
+          </div>
+        )}
       </div>
 
-      {/* 작품 정보 영역 */}
+      {/* 콘텐츠 정보 영역 */}
       <div className="flex flex-1 flex-col p-3">
-        {/* 작품 제목 */}
+        {/* 콘텐츠 제목 */}
         <h3 className="mb-2 line-clamp-2 text-left text-sm font-semibold text-neutral-900">
           {content.title}
         </h3>

--- a/src/components/gallery/ContentTab.tsx
+++ b/src/components/gallery/ContentTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { CheckIn } from '@/types'
 import { ContentGrid, ContentSummary } from './ContentGrid'
 import { FeedGrid } from './FeedGrid'
@@ -9,12 +9,26 @@ import { useCheckInFeed } from '@/hooks/useCheckInFeed'
 import { useContentList as useContentListQuery } from '@/hooks/useGalleryQueries'
 
 /**
+ * ContentType 필터 칩 목록
+ */
+const CONTENT_TYPE_FILTERS = [
+  { value: 'all', label: '전체' },
+  { value: 'anime', label: '애니메이션' },
+  { value: 'movie', label: '영화' },
+  { value: 'drama', label: '드라마' },
+  { value: 'sports_team', label: '스포츠팀' },
+  { value: 'artist', label: '아티스트' },
+  { value: 'game', label: '게임' },
+  { value: 'other', label: '기타' },
+] as const
+
+/**
  * ContentTab 컴포넌트
- * 작품별 탭 - 작품 포스터 그리드와 필터링된 체크인 피드를 표시
+ * 콘텐츠별 탭 - 콘텐츠 포스터 그리드와 필터링된 체크인 피드를 표시
  *
  * Requirements:
- * - 3.4: 작품별 탭에서 작품 포스터를 대형 카드로 그리드 레이아웃에 표시
- * - 3.5: 작품 선택 시 해당 작품 체크인만 필터링
+ * - 3.4: 콘텐츠별 탭에서 콘텐츠 포스터를 대형 카드로 그리드 레이아웃에 표시
+ * - 3.5: 콘텐츠 선택 시 해당 콘텐츠 체크인만 필터링
  * - 8.3: React Query 전환
  */
 
@@ -71,7 +85,7 @@ function FilteredFeedHeader({
       <button
         onClick={onBack}
         className="flex items-center gap-1 rounded-lg bg-surface px-3 py-2 text-sm font-medium text-primary transition-colors hover:bg-border"
-        aria-label="작품 목록으로 돌아가기"
+        aria-label="콘텐츠 목록으로 돌아가기"
       >
         <svg
           className="h-4 w-4"
@@ -93,20 +107,50 @@ function FilteredFeedHeader({
   )
 }
 
+/**
+ * ContentType 필터 칩 바
+ */
+function ContentTypeFilterChips({
+  activeFilter,
+  onFilterChange,
+}: {
+  activeFilter: string
+  onFilterChange: (value: string) => void
+}) {
+  return (
+    <div className="mb-4 flex gap-2 overflow-x-auto pb-2">
+      {CONTENT_TYPE_FILTERS.map((filter) => (
+        <button
+          key={filter.value}
+          className={`flex-shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+            activeFilter === filter.value
+              ? 'bg-primary text-white'
+              : 'bg-accent-surface text-sub-text hover:bg-border'
+          }`}
+          onClick={() => onFilterChange(filter.value)}
+        >
+          {filter.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 export function ContentTab({
   selectedContent,
   onCheckInClick,
 }: ContentTabProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const [activeFilter, setActiveFilter] = useState('all')
 
-  // React Query로 작품 목록 조회
+  // React Query로 콘텐츠 목록 조회 (필터 적용)
   const {
     data: contentData,
     isLoading: isLoadingContents,
     error: contentsError,
     refetch: refreshContents,
-  } = useContentListQuery()
+  } = useContentListQuery(activeFilter)
 
   // API 응답을 ContentSummary 형식으로 변환
   const contents: ContentSummary[] = (contentData?.items ?? []).map((item) => ({
@@ -114,9 +158,10 @@ export function ContentTab({
     imageUrl: undefined,
     checkInCount: item.count,
     spotCount: 0,
+    contentType: item.contentType,
   }))
 
-  // 필터링된 체크인 피드 (작품 선택 시에만 활성화)
+  // 필터링된 체크인 피드 (콘텐츠 선택 시에만 활성화)
   const {
     checkIns,
     isLoading: isLoadingCheckIns,
@@ -149,7 +194,7 @@ export function ContentTab({
     router.push(`/gallery?${params.toString()}`)
   }, [router, searchParams])
 
-  // 작품이 선택된 경우: FeedGrid로 필터링된 체크인 피드 표시
+  // 콘텐츠가 선택된 경우: FeedGrid로 필터링된 체크인 피드 표시
   if (selectedContent) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">
@@ -170,10 +215,14 @@ export function ContentTab({
     )
   }
 
-  // 작품이 선택되지 않은 경우: 작품 목록 그리드 표시
+  // 콘텐츠가 선택되지 않은 경우: 콘텐츠 목록 그리드 표시
   if (contentsError) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">
+        <ContentTypeFilterChips
+          activeFilter={activeFilter}
+          onFilterChange={setActiveFilter}
+        />
         <ErrorState onRetry={() => refreshContents()} />
       </div>
     )
@@ -182,6 +231,10 @@ export function ContentTab({
   if (isLoadingContents) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-6">
+        <ContentTypeFilterChips
+          activeFilter={activeFilter}
+          onFilterChange={setActiveFilter}
+        />
         <ContentGridSkeleton />
       </div>
     )
@@ -189,6 +242,10 @@ export function ContentTab({
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">
+      <ContentTypeFilterChips
+        activeFilter={activeFilter}
+        onFilterChange={setActiveFilter}
+      />
       <ContentGrid contents={contents} onSelectContent={handleSelectContent} />
     </div>
   )

--- a/src/hooks/useGalleryQueries.ts
+++ b/src/hooks/useGalleryQueries.ts
@@ -36,10 +36,12 @@ interface RankingResponse {
 interface ContentNameItem {
   name: string
   count: number
+  contentType?: string
 }
 
 interface ContentNamesResponse {
   items: ContentNameItem[]
+  total: number
 }
 
 // ── Query Key Factory ───────────────────────────────────────
@@ -50,7 +52,8 @@ export const galleryKeys = {
   checkinList: (params: Record<string, unknown>) =>
     [...galleryKeys.checkins(), params] as const,
   ranking: () => [...galleryKeys.all, 'ranking'] as const,
-  contentList: () => [...galleryKeys.all, 'contentList'] as const,
+  contentList: (contentType?: string) =>
+    [...galleryKeys.all, 'contentList', contentType ?? 'all'] as const,
   checkinCount: (spotId: string) =>
     [...galleryKeys.all, 'checkinCount', spotId] as const,
 }
@@ -102,17 +105,19 @@ export function useHallOfFameRanking() {
 }
 
 /**
- * 작품 목록 조회 훅 (ContentTab용)
+ * 콘텐츠 목록 조회 훅 (ContentTab용)
  * Requirements: 8.3
  */
-export function useContentList() {
+export function useContentList(contentType?: string) {
   return useQuery({
-    queryKey: galleryKeys.contentList(),
+    queryKey: galleryKeys.contentList(contentType),
     queryFn: async (): Promise<ContentNamesResponse> => {
-      const res = await fetch(
-        buildUrl(API_ROUTES.CONTENT_NAMES, { type: 'content' })
-      )
-      if (!res.ok) throw new Error('작품 목록 조회 실패')
+      const params: Record<string, string> = { type: 'content' }
+      if (contentType && contentType !== 'all') {
+        params.contentType = contentType
+      }
+      const res = await fetch(buildUrl(API_ROUTES.CONTENT_NAMES, params))
+      if (!res.ok) throw new Error('콘텐츠 목록 조회 실패')
       return res.json()
     },
     staleTime: 5 * 60 * 1000,


### PR DESCRIPTION
## 개요

갤러리의 "작품별" 탭이 실제 콘텐츠(BTS, T1, Real Madrid 등)와 맞지 않아 "콘텐츠별"로 변경하고, ContentType 기반 필터 칩을 추가합니다.

## 변경 사항

### API (`/api/content-names/route.ts`)
- `AutocompleteItem`에 `contentType` 필드 추가
- `contentType` 쿼리 파라미터로 필터링 지원
- `type=content`일 때 limit 50으로 증가

### Gallery Page (`gallery/page.tsx`)
- 탭 라벨 "작품별" → "콘텐츠별" 변경

### Hook (`useGalleryQueries.ts`)
- `ContentNameItem`에 `contentType` 필드 추가
- `useContentList`에 `contentType` 파라미터 지원

### ContentTab (`ContentTab.tsx`)
- ContentType 필터 칩 UI 추가 (전체/애니메이션/영화/드라마/스포츠팀/아티스트/게임/기타)
- 필터 선택 시 API에 `contentType` 파라미터 전달

### ContentGrid (`ContentGrid.tsx`)
- `ContentSummary`에 `contentType` 필드 추가
- 카드 좌상단에 ContentType 뱃지 표시 (CONTENT_TYPE_CONFIG 색상 활용)

Closes #535