### PR TITLE
feat: routeFormContent 최소 스팟 수 유효성 검사 1개로 변경

### DIFF
--- a/src/components/route/RouteFormContent.tsx
+++ b/src/components/route/RouteFormContent.tsx
@@ -402,7 +402,7 @@ export function RouteFormContent({
     if (!description.trim()) errs.push('설명은 필수입니다')
     if (!estimatedDuration || parseInt(estimatedDuration, 10) <= 0)
       errs.push('예상 소요시간은 필수입니다')
-    if (spots.length < 2) errs.push('코스에는 최소 2개의 스팟이 필요합니다')
+    if (spots.length < 1) errs.push('코스에는 최소 1개의 스팟이 필요합니다')
     return errs
   }, [name, description, estimatedDuration, spots])
 


### PR DESCRIPTION
## 변경 사항

- `RouteFormContent.tsx`의 스팟 유효성 검사 조건을 `spots.length < 2`에서 `spots.length < 1`로 변경
- 에러 메시지를 "코스에는 최소 1개의 스팟이 필요합니다"로 수정

## 관련 Requirements

- Requirement 1.1: 스팟 1개 이상 추가 시 코스 생성 허용
- Requirement 1.2: 스팟 0개 제출 시 에러 메시지 표시

Closes #540