### PR TITLE
feat: route API 최소 스팟 수 유효성 검사 1개로 변경

### DIFF
--- a/src/app/api/routes/[id]/route.ts
+++ b/src/app/api/routes/[id]/route.ts
@@ -131,9 +131,9 @@ export async function PUT(
       errors.push('유효하지 않은 난이도입니다')
     if (
       body.spots !== undefined &&
-      (!Array.isArray(body.spots) || body.spots.length < 2)
+      (!Array.isArray(body.spots) || body.spots.length < 1)
     )
-      errors.push('코스에는 최소 2개의 스팟이 필요합니다')
+      errors.push('코스에는 최소 1개의 스팟이 필요합니다')
 
     if (errors.length > 0) {
       return NextResponse.json(

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -52,8 +52,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       errors.push('예상 소요시간은 필수입니다')
     if (!body.difficulty || !VALID_DIFFICULTIES.includes(body.difficulty))
       errors.push('난이도를 선택해주세요 (easy, moderate, hard)')
-    if (!Array.isArray(body.spots) || body.spots.length < 2)
-      errors.push('코스에는 최소 2개의 스팟이 필요합니다')
+    if (!Array.isArray(body.spots) || body.spots.length < 1)
+      errors.push('코스에는 최소 1개의 스팟이 필요합니다')
 
     if (errors.length > 0) {
       return NextResponse.json(


### PR DESCRIPTION
## 변경 사항

Route API의 최소 스팟 수 유효성 검사를 2개에서 1개로 변경합니다.

- `src/app/api/routes/route.ts` (POST): `spots.length < 2` → `spots.length < 1`
- `src/app/api/routes/[id]/route.ts` (PUT): 동일한 패턴 적용
- 에러 메시지를 "코스에는 최소 1개의 스팟이 필요합니다"로 변경

## Requirements

- 1.3: Route_API가 스팟 1개 이상의 코스 생성 요청을 받으면 유효성 검사를 통과시키고 코스를 저장
- 1.4: Route_API가 스팟 0개의 코스 생성/수정 요청을 받으면 에러를 반환

Closes #542