### PR TITLE
feat: guidePanel 단일 스팟 처리 확인 및 수정

### DIFF
--- a/src/components/route/GuidePanel.tsx
+++ b/src/components/route/GuidePanel.tsx
@@ -124,6 +124,7 @@ export function GuidePanel({
             const isChecked = checkedSpotIds.includes(spot.spotId)
             const isUnavailable = spot.isAvailable === false
             const isCurrent = idx === currentSpotIndex
+            const isSingleSpot = availableSpots.length === 1
 
             return (
               <div
@@ -162,8 +163,9 @@ export function GuidePanel({
                   >
                     {spot.spotName}
                   </p>
-                  {/* 거리/시간 표시 */}
-                  {!isUnavailable &&
+                  {/* 거리/시간 표시: 단일 스팟이면 표시하지 않음 */}
+                  {!isSingleSpot &&
+                    !isUnavailable &&
                     spot.distanceFromPrev !== null &&
                     spot.distanceFromPrev > 0 && (
                       <p className="text-xs text-muted">


### PR DESCRIPTION
## 개요

GuidePanel 컴포넌트에서 단일 스팟(1개) 코스 진행 시 "다음 스팟" 거리/시간 정보가 표시되지 않도록 명시적 조건을 추가했습니다.

## 변경 내용

- `isSingleSpot` 변수를 추가하여 유효 스팟이 1개일 때 거리/시간 정보를 명시적으로 숨김
- 기존에도 첫 스팟의 `distanceFromPrev`가 `null`이라 자연스럽게 숨겨졌지만, 단일 스팟 코스에 대한 의도를 코드에 명확히 표현

## Requirements

- 1.6: 단일 스팟 시 "다음 스팟" 거리/시간 미표시, 인증 UI만 제공

Closes #546