### PR TITLE
feat: RouteDetailContent 단일 스팟 코스 표시 확인 및 수정

### DIFF
--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -159,10 +159,12 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
             <AppIcon name="duration" size={16} />
             {formatDuration(route.estimatedDuration)}
           </span>
-          <span className="flex items-center gap-1">
-            <AppIcon name="distance" size={16} />
-            {formatDistance(route.totalDistance)}
-          </span>
+          {route.totalDistance > 0 && (
+            <span className="flex items-center gap-1">
+              <AppIcon name="distance" size={16} />
+              {formatDistance(route.totalDistance)}
+            </span>
+          )}
           <span className="flex items-center gap-1">
             <AppIcon name="bookmark" size={16} />
             {bookmarkCount}
@@ -264,6 +266,11 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 순서 ({availableSpots.length}곳)
         </h2>
+        {availableSpots.length === 1 && (
+          <p className="mb-3 text-center text-xs text-primary">
+            📍 단일 스팟 코스입니다. 해당 장소를 방문하여 인증해보세요!
+          </p>
+        )}
         <ol className="space-y-0">
           {/* 시작 지점 표시 */}
           {route.startPoint &&


### PR DESCRIPTION
## 변경 사항\n\nRouteDetailContent 컴포넌트에서 단일 스팟 코스 표시를 개선합니다.\n\n### 수정 내용\n\n- 총 거리가 0인 경우(단일 스팟) 거리 메타 정보 숨김 처리\n- 단일 스팟 코스 시 안내 메시지 표시: \"📍 단일 스팟 코스입니다. 해당 장소를 방문하여 인증해보세요!\"\n\n### 관련 요구사항\n\n- Requirements 1.7: Route_Detail_Page는 스팟 1개 코스를 정상적으로 표시\n\nCloses #548