### PR TITLE
feat: 공유 유틸리티 함수 생성

### DIFF
--- a/src/lib/share-utils.ts
+++ b/src/lib/share-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * 스팟/코스 공유 유틸리티
+ * Spec: 29-ux-quality-phase2
+ */
+
+/** 스팟 공유 텍스트 생성 */
+export function formatSpotShareText(
+  spotName: string,
+  contentName?: string
+): string {
+  if (contentName) {
+    return `[Not a Trip] ${contentName}의 성지순례 스팟 ${spotName}을 확인해보세요!`
+  }
+  return `[Not a Trip] 성지순례 스팟 ${spotName}을 확인해보세요!`
+}
+
+/** 코스 공유 텍스트 생성 */
+export function formatRouteShareText(routeName: string): string {
+  return `[Not a Trip] ${routeName} 순례 코스를 확인해보세요!`
+}
+
+/** Web Share API 지원 여부 확인 (HTTPS 환경 + navigator.share 존재) */
+export function canShare(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false
+  }
+  if (!navigator.share) {
+    return false
+  }
+  // HTTP 환경(localhost 제외)에서는 Web Share API 사용 불가
+  const isHttps = window.location.protocol === 'https:'
+  const isLocalhost = window.location.hostname === 'localhost'
+  return isHttps || isLocalhost
+}
+
+/** 공유 실행 (Web Share API → Clipboard 폴백) */
+export async function executeShare(data: {
+  title: string
+  text: string
+  url: string
+}): Promise<'shared' | 'copied' | 'cancelled'> {
+  if (canShare()) {
+    try {
+      await navigator.share(data)
+      return 'shared'
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return 'cancelled'
+      }
+      // 기타 에러 시 클립보드 폴백으로 전환
+    }
+  }
+  await navigator.clipboard.writeText(data.url)
+  return 'copied'
+}


### PR DESCRIPTION
## 변경 사항

스팟/코스 공유 기능을 위한 유틸리티 함수를 생성합니다.

### 구현 내용

- `src/lib/share-utils.ts` 신규 생성
- `formatSpotShareText(spotName, contentName?)` — 스팟 공유 텍스트 생성
  - contentName 있을 때: `[Not a Trip] ${contentName}의 성지순례 스팟 ${spotName}을 확인해보세요!`
  - contentName 없을 때: `[Not a Trip] 성지순례 스팟 ${spotName}을 확인해보세요!`
- `formatRouteShareText(routeName)` — 코스 공유 텍스트 생성
  - `[Not a Trip] ${routeName} 순례 코스를 확인해보세요!`
- `canShare()` — Web Share API 지원 여부 확인 (HTTPS 환경 + navigator.share 존재)
  - HTTP 환경에서는 localhost만 허용, 그 외 Clipboard 폴백으로 전환
- `executeShare(data)` — 공유 실행 (Web Share API → Clipboard 폴백)
  - AbortError 시 'cancelled' 반환
  - 기타 에러 시 클립보드 폴백으로 전환
  - 반환 타입: `Promise<'shared' | 'copied' | 'cancelled'>`

## Requirements

- 2.6, 2.7, 2.8, 2.9, 2.10, 2.11

Closes #552