### PR TITLE
[feat] Toast 컴포넌트 및 useToast 훅 생성

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+interface ToastProps {
+  message: string
+  isVisible: boolean
+  onClose: () => void
+  duration?: number
+}
+
+/**
+ * Toast 컴포넌트
+ *
+ * 하단 중앙에 위치하며 fade in/out 애니메이션을 제공한다.
+ * 3초(기본) 후 자동 사라짐.
+ *
+ * @requirements 2.5
+ */
+export default function Toast({ message, isVisible }: ToastProps) {
+  if (!isVisible && !message) return null
+
+  return (
+    <div
+      className={`fixed bottom-20 left-1/2 z-[9999] -translate-x-1/2 rounded-lg bg-gray-800 px-4 py-2.5 text-sm text-white shadow-lg transition-opacity duration-300 dark:bg-gray-700 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+      role="status"
+      aria-live="polite"
+    >
+      {message}
+    </div>
+  )
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState, useCallback, useRef } from 'react'
+
+interface UseToastReturn {
+  toast: { message: string; isVisible: boolean } | null
+  showToast: (message: string, duration?: number) => void
+  hideToast: () => void
+}
+
+/**
+ * useToast 훅
+ *
+ * 토스트 메시지 표시/숨김 상태를 관리한다.
+ * 기본 3초 후 자동 사라짐.
+ *
+ * @requirements 2.5
+ */
+export function useToast(): UseToastReturn {
+  const [toast, setToast] = useState<{
+    message: string
+    isVisible: boolean
+  } | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const hideToast = useCallback(() => {
+    setToast((prev) => (prev ? { ...prev, isVisible: false } : null))
+    // 애니메이션 완료 후 완전히 제거
+    setTimeout(() => setToast(null), 300)
+  }, [])
+
+  const showToast = useCallback(
+    (message: string, duration = 3000) => {
+      // 기존 타이머 정리
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+
+      setToast({ message, isVisible: true })
+
+      timerRef.current = setTimeout(() => {
+        hideToast()
+        timerRef.current = null
+      }, duration)
+    },
+    [hideToast]
+  )
+
+  return { toast, showToast, hideToast }
+}


### PR DESCRIPTION
## 개요

재사용 가능한 Toast 컴포넌트와 useToast 훅을 생성한다.

## 변경 사항

- `src/components/common/Toast.tsx` 신규 생성
  - 하단 중앙 위치 (`fixed bottom-20 left-1/2 -translate-x-1/2`)
  - fade in/out 애니메이션 (opacity transition 300ms)
  - ARIA 속성 (`role="status"`, `aria-live="polite"`)
- `src/hooks/useToast.ts` 신규 생성
  - 기본 3초 후 자동 사라짐
  - `showToast(message, duration?)` / `hideToast()` 인터페이스

## Requirements

- 2.5: Web Share API 미지원 시 클립보드 복사 + 토스트 메시지 표시

Closes #556