### PR TITLE
feat: spotDetailClient에 shareButton 연동

### DIFF
--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -48,6 +48,8 @@ import {
   MapPinIcon,
   AlertTriangleIcon,
 } from '@/components/icons'
+import ShareButton from '@/components/common/ShareButton'
+import { formatSpotShareText } from '@/lib/share-utils'
 
 // 지도 컴포넌트를 동적으로 로드 (SSR 방지)
 const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
@@ -155,28 +157,40 @@ function SpotDetailPage({ spot, spotId, facilities }: SpotDetailPageProps) {
               </h1>
             </div>
 
-            {/* 수정/삭제 버튼 - 관리자 또는 본인 스팟인 경우 표시 */}
-            {(hasEditPermission || hasDeletePermission) && (
-              <div className="flex gap-2">
-                {hasEditPermission && (
-                  <Link
-                    href={`/spots/${spotId}/edit`}
-                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
-                  >
-                    수정
-                  </Link>
+            <div className="flex items-center gap-2">
+              {/* 공유 버튼 */}
+              <ShareButton
+                title={spot.name}
+                text={formatSpotShareText(
+                  spot.name,
+                  spot.relatedContent?.[0]?.name
                 )}
-                {hasDeletePermission && (
-                  <button
-                    onClick={handleDelete}
-                    disabled={isDeleting}
-                    className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {isDeleting ? '삭제 중...' : '삭제'}
-                  </button>
-                )}
-              </div>
-            )}
+                variant="icon"
+              />
+
+              {/* 수정/삭제 버튼 - 관리자 또는 본인 스팟인 경우 표시 */}
+              {(hasEditPermission || hasDeletePermission) && (
+                <div className="flex gap-2">
+                  {hasEditPermission && (
+                    <Link
+                      href={`/spots/${spotId}/edit`}
+                      className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary-50"
+                    >
+                      수정
+                    </Link>
+                  )}
+                  {hasDeletePermission && (
+                    <button
+                      onClick={handleDelete}
+                      disabled={isDeleting}
+                      className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isDeleting ? '삭제 중...' : '삭제'}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 변경 사항

스팟 상세 페이지(SpotDetailClient)의 헤더 영역에 ShareButton을 추가하여 공유 기능을 연동합니다.

## 구현 내용

- ShareButton 및 formatSpotShareText import 추가
- 헤더 영역에 ShareButton 배치 (variant='icon')
- 공유 텍스트: `formatSpotShareText(spot.name, spot.relatedContent[0]?.name)`
- 공유 URL: 현재 페이지 canonical URL (ShareButton 내부에서 window.location.href 사용)

## Requirements

- 2.1: Spot_Detail_Page SHALL 헤더 영역에 Share_Button을 표시한다
- 2.6: 공유 텍스트 형식 준수
- 2.8: canonical URL 사용

Closes #558