### PR TITLE
feat: routeDetailContent에 shareButton 연동

### DIFF
--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -6,6 +6,8 @@ import { AppIcon } from '@/components/common/AppIcon'
 import dynamic from 'next/dynamic'
 import { useAuth } from '@/hooks/useAuth'
 import { useRouteNavigation } from '@/hooks/useRouteNavigation'
+import ShareButton from '@/components/common/ShareButton'
+import { formatRouteShareText } from '@/lib/share-utils'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import { GuidePanel } from '@/components/route/GuidePanel'
 import { CompletionEffect } from '@/components/route/CompletionEffect'
@@ -244,6 +246,11 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
               ✏️ 수정
             </button>
           )}
+          <ShareButton
+            title={route.name}
+            text={formatRouteShareText(route.name)}
+            variant="icon"
+          />
         </div>
       )}
 


### PR DESCRIPTION
## 변경 사항

RouteDetailContent 컴포넌트의 액션 버튼 영역에 ShareButton을 추가하여 코스 공유 기능을 연동합니다.

## 구현 내용

- ShareButton, formatRouteShareText import 추가
- 액션 버튼 영역(코스 시작/저장/수정 버튼 옆)에 ShareButton 배치
- variant='icon', title=route.name, text=formatRouteShareText(route.name)

## Requirements

- 2.2: Route_Detail_Page에 Share_Button 표시
- 2.7: 코스 공유 텍스트 형식
- 2.8: canonical URL 사용

Closes #560