### PR TITLE
feat: 페이지별 tour 설정 파일 생성

### DIFF
--- a/src/lib/tour-config.ts
+++ b/src/lib/tour-config.ts
@@ -1,0 +1,40 @@
+import type { TourStep } from '@/hooks/useOnboarding'
+
+export const MAP_PAGE_STEPS: TourStep[] = [
+  {
+    target: '[data-tour="category-filter"]',
+    title: '카테고리 필터',
+    description: '원하는 카테고리를 선택하여 스팟을 필터링할 수 있어요',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="search-input"]',
+    title: '스팟 검색',
+    description: '작품명이나 장소명으로 스팟을 검색해보세요',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="map-marker"]',
+    title: '마커 클릭',
+    description: '지도의 마커를 클릭하면 스팟 상세 정보를 볼 수 있어요',
+    placement: 'top',
+  },
+]
+
+export const ROUTE_PAGE_STEPS: TourStep[] = [
+  {
+    target: '[data-tour="start-route"]',
+    title: '코스 시작',
+    description: '코스 시작 버튼을 누르면 가이드 모드가 시작됩니다',
+    placement: 'top',
+  },
+]
+
+export const GALLERY_PAGE_STEPS: TourStep[] = [
+  {
+    target: '[data-tour="upload-checkin"]',
+    title: '인증샷 업로드',
+    description: '스팟에서 찍은 인증샷을 업로드하고 공유해보세요',
+    placement: 'bottom',
+  },
+]


### PR DESCRIPTION
## 변경 사항

페이지별 온보딩 투어 스텝 설정 파일을 생성합니다.

- `src/lib/tour-config.ts` 신규 생성
- `MAP_PAGE_STEPS`: 카테고리 필터 → 검색 입력 → 마커 클릭 순서
- `ROUTE_PAGE_STEPS`: 코스 시작 방법 안내
- `GALLERY_PAGE_STEPS`: 인증샷 업로드 방법 안내
- 각 스텝에 `data-tour` 속성 기반 target selector 정의

## Requirements

- 3.2, 3.3, 3.4

Closes #566