### PR TITLE
[feat] 코스/갤러리 페이지 온보딩 투어 연동

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -13,6 +13,9 @@ import {
   SkeletonBlock,
   GalleryGridSkeleton,
 } from '@/components/common/SkeletonUI'
+import OnboardingTour from '@/components/common/OnboardingTour'
+import { useOnboarding } from '@/hooks/useOnboarding'
+import { GALLERY_PAGE_STEPS } from '@/lib/tour-config'
 
 /**
  * 갤러리 탭 타입
@@ -45,6 +48,8 @@ function GalleryPageSkeleton() {
 function GalleryPageContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
+  const { isActive, currentStep, next, skip } =
+    useOnboarding(GALLERY_PAGE_STEPS)
 
   // 현재 활성 탭 (기본값: feed)
   const tabParam = searchParams.get('tab')
@@ -125,7 +130,10 @@ function GalleryPageContent() {
       </Suspense>
 
       {/* FloatingActionButton - 순례 인증 시작 */}
-      <FloatingActionButton onClick={handleFloatingButtonClick} />
+      <FloatingActionButton
+        onClick={handleFloatingButtonClick}
+        data-tour="upload-checkin"
+      />
 
       {/* SpotSearchModal - 스팟 검색 */}
       <SpotSearchModal
@@ -152,6 +160,16 @@ function GalleryPageContent() {
           badges={earnedBadges}
         />
       )}
+
+      {/* OnboardingTour - 신규 사용자 가이드 */}
+      <OnboardingTour
+        steps={GALLERY_PAGE_STEPS}
+        isActive={isActive}
+        currentStep={currentStep}
+        onNext={next}
+        onSkip={skip}
+        onComplete={skip}
+      />
     </main>
   )
 }

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -6,6 +6,9 @@ import { AppIcon } from '@/components/common/AppIcon'
 import { RouteListContent } from '@/components/route/RouteListContent'
 import { RecommendedRoutes } from '@/components/route/RecommendedRoutes'
 import { SkeletonBlock } from '@/components/common/SkeletonUI'
+import OnboardingTour from '@/components/common/OnboardingTour'
+import { useOnboarding } from '@/hooks/useOnboarding'
+import { ROUTE_PAGE_STEPS } from '@/lib/tour-config'
 
 /** 코스 목록 페이지 스켈레톤 */
 function RouteListSkeleton() {
@@ -39,6 +42,8 @@ function RouteListSkeleton() {
  * Requirements: 2.1, 2.2
  */
 export default function RoutesPage() {
+  const { isActive, currentStep, next, skip } = useOnboarding(ROUTE_PAGE_STEPS)
+
   return (
     <main className="min-h-screen bg-surface pt-14">
       <div className="mx-auto max-w-6xl px-4 py-6">
@@ -55,6 +60,7 @@ export default function RoutesPage() {
           </div>
           <Link
             href="/routes/create"
+            data-tour="start-route"
             className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700"
           >
             코스 만들기
@@ -76,6 +82,14 @@ export default function RoutesPage() {
           <RouteListContent />
         </Suspense>
       </div>
+      <OnboardingTour
+        steps={ROUTE_PAGE_STEPS}
+        isActive={isActive}
+        currentStep={currentStep}
+        onNext={next}
+        onSkip={skip}
+        onComplete={skip}
+      />
     </main>
   )
 }

--- a/src/components/gallery/FloatingActionButton.tsx
+++ b/src/components/gallery/FloatingActionButton.tsx
@@ -7,6 +7,7 @@ import { LoginRequiredModal } from '@/components/common'
 export interface FloatingActionButtonProps {
   onClick: () => void
   label?: string // default: "+ 순례 인증하기"
+  'data-tour'?: string
 }
 
 /**
@@ -20,6 +21,7 @@ export interface FloatingActionButtonProps {
 export function FloatingActionButton({
   onClick,
   label = '+ 순례 인증하기',
+  'data-tour': dataTour,
 }: FloatingActionButtonProps) {
   const { data: session } = useSession()
   const [showLoginModal, setShowLoginModal] = useState(false)
@@ -36,6 +38,7 @@ export function FloatingActionButton({
     <>
       <button
         onClick={handleClick}
+        data-tour={dataTour}
         className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full bg-primary px-6 py-3 font-semibold text-white shadow-lg transition-all hover:bg-primary-700 hover:shadow-xl active:scale-95"
         aria-label={label}
       >


### PR DESCRIPTION
## 변경 사항

코스(routes) 페이지와 갤러리(gallery) 페이지에 온보딩 투어를 연동합니다.

### 구현 내용

- `src/app/routes/page.tsx`: `useOnboarding` + `OnboardingTour` 연동, `data-tour="start-route"` 추가
- `src/app/gallery/page.tsx`: `useOnboarding` + `OnboardingTour` 연동, `data-tour="upload-checkin"` 추가
- `src/components/gallery/FloatingActionButton.tsx`: `data-tour` prop 지원 추가

### 관련 Requirements

- 3.3: 코스 페이지 온보딩 투어 스텝 표시
- 3.4: 갤러리 페이지 온보딩 투어 스텝 표시

Closes #569