### PR TITLE
feat: header에 가이드 다시 보기 옵션 추가

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -48,6 +48,15 @@ export function Header() {
           >
             스팟 등록
           </Link>
+          <button
+            onClick={() => {
+              localStorage.removeItem('not-a-trip-onboarding-completed')
+              window.location.reload()
+            }}
+            className="text-text-secondary text-sm transition hover:text-secondary-400"
+          >
+            가이드 다시 보기
+          </button>
           <Link
             href="/test/globe-fallback"
             className="text-sm text-yellow-400 transition hover:text-yellow-300"
@@ -184,6 +193,16 @@ export function Header() {
             >
               스팟 등록
             </Link>
+            <button
+              onClick={() => {
+                setIsMobileMenuOpen(false)
+                localStorage.removeItem('not-a-trip-onboarding-completed')
+                window.location.reload()
+              }}
+              className="text-text-secondary hover:text-text-primary block w-full rounded-lg px-3 py-2 text-left text-sm transition hover:bg-secondary-100"
+            >
+              📖 가이드 다시 보기
+            </button>
             <Link
               href="/test/globe-fallback"
               onClick={() => setIsMobileMenuOpen(false)}


### PR DESCRIPTION
## 변경 사항

Header 컴포넌트에 "가이드 다시 보기" 옵션을 추가하여 사용자가 온보딩 투어를 다시 볼 수 있도록 함.

### 구현 내용

- 데스크톱 네비게이션에 "가이드 다시 보기" 버튼 추가
- 모바일 드롭다운 메뉴에 "📖 가이드 다시 보기" 버튼 추가
- 클릭 시 localStorage에서 `not-a-trip-onboarding-completed` 키 제거 후 페이지 새로고침

### Requirements

- 3.10: 설정 메뉴 또는 도움말에서 "가이드 다시 보기" 옵션을 제공하여 Tour_State를 초기화할 수 있다

Closes #571