### PR TITLE
[feat] GuidePanel 단일 스팟 처리 확인 및 문서화

### DIFF
--- a/src/components/route/GuidePanel.tsx
+++ b/src/components/route/GuidePanel.tsx
@@ -62,7 +62,11 @@ export function calculateProgress(
  * NavigationPanel의 "현재 1개 스팟" 추적 방식 대신
  * "전체 스팟 체크리스트"를 한눈에 보여주는 가이드 UI.
  *
- * Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
+ * 단일 스팟 코스 처리 (Requirement 1.6):
+ * - isSingleSpot 조건으로 거리/시간 정보 미표시
+ * - 인증 UI는 스팟 수와 무관하게 항상 제공
+ *
+ * Requirements: 1.6, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
  */
 export function GuidePanel({
   spots,


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #576

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> GuidePanel 컴포넌트의 단일 스팟 처리 로직을 검증하고 Requirements 1.6 주석을 추가

---

## 📋 변경 사항

- [x] GuidePanel.tsx 단일 스팟 처리 로직 검증 완료
- [x] `isSingleSpot` 조건으로 거리/시간 정보 미표시 확인
- [x] 인증 UI가 스팟 수와 무관하게 제공됨 확인
- [x] Requirement 1.6 관련 JSDoc 주석 추가

### 검증 결과

기존 코드에서 이미 단일 스팟 처리가 올바르게 구현되어 있음:

1. `isSingleSpot = availableSpots.length === 1` 변수로 단일 스팟 감지
2. `!isSingleSpot && ...` 조건으로 거리/시간 정보 숨김
3. 인증 버튼("여기서 인증하기")은 스팟 수와 무관하게 항상 표시
4. 진행률 바도 단일 스팟(0/1, 1/1)에서 정상 동작

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

이 PR은 기존 코드의 단일 스팟 처리가 Requirements 1.6을 이미 충족하고 있음을 검증하고, 해당 요구사항 참조를 JSDoc 주석에 추가하는 작업입니다. 기능적 변경은 없습니다.