### PR TITLE
[feat] RouteDetailContent 단일 스팟 코스 표시 확인

### DIFF
--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -55,7 +55,8 @@ function formatDistance(meters: number): string {
 /**
  * RouteDetailContent - 코스 상세 콘텐츠
  * RouteMap + 스팟 순서 목록 + 거리/시간 + 코스 시작/저장 버튼
- * Requirements: 1.4, 2.3, 2.4, 3.1
+ * 단일 스팟(1개) 코스도 정상 표시: 코스 순서 섹션에 단일 스팟 안내 메시지 포함
+ * Requirements: 1.4, 1.7, 2.3, 2.4, 3.1
  */
 export function RouteDetailContent({ route }: RouteDetailContentProps) {
   const router = useRouter()


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #578

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> RouteDetailContent 컴포넌트에서 스팟 1개 코스가 정상적으로 표시되는지 검증하고, JSDoc 주석에 Requirement 1.7 참조를 추가

---

## 📋 변경 사항

- [x] RouteDetailContent.tsx 단일 스팟 코스 표시 정상 동작 확인
- [x] 코스 순서 섹션에 단일 스팟만 나열되는지 확인 (availableSpots.length === 1 조건 처리 존재)
- [x] 단일 스팟 안내 메시지 "📍 단일 스팟 코스입니다" 표시 확인
- [x] 이동 거리/시간 정보가 첫 스팟에 불필요하게 표시되지 않는지 확인 (idx > 0 조건)
- [x] JSDoc 주석에 Requirement 1.7 참조 추가 및 단일 스팟 처리 설명 보강

---

## 🔍 검증 결과

기존 코드가 이미 단일 스팟 코스를 정상적으로 처리하고 있음을 확인:

1. **코스 순서 헤더**: `코스 순서 (1곳)` 정상 표시
2. **단일 스팟 안내 메시지**: `availableSpots.length === 1` 조건으로 안내 메시지 표시
3. **이동 거리/시간**: `idx > 0` 조건으로 첫 스팟에는 이동 정보 미표시
4. **시작 지점 → 첫 스팟 거리**: 정상 표시
5. **코스 지도**: RouteMap에 spots 배열 전달, 1개여도 정상 동작
6. **GuidePanel**: Task 1.4에서 단일 스팟 처리 완료

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

Requirements 1.7 대응 — 코드 변경 최소화 (주석 보강만 수행). 기존 구현이 이미 단일 스팟 코스를 올바르게 처리하고 있었음.