### PR TITLE
[feat] 공유 유틸리티 canShare HTTP 환경 판별 수정

### DIFF
--- a/src/lib/share-utils.ts
+++ b/src/lib/share-utils.ts
@@ -21,16 +21,14 @@ export function formatRouteShareText(routeName: string): string {
 
 /** Web Share API 지원 여부 확인 (HTTPS 환경 + navigator.share 존재) */
 export function canShare(): boolean {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+  if (typeof navigator === 'undefined' || !navigator.share) {
     return false
   }
-  if (!navigator.share) {
+  // HTTP 환경(localhost 개발 환경 포함)에서는 false 반환 (Requirement 2.11)
+  if (typeof window !== 'undefined' && window.location.protocol !== 'https:') {
     return false
   }
-  // HTTP 환경(localhost 제외)에서는 Web Share API 사용 불가
-  const isHttps = window.location.protocol === 'https:'
-  const isLocalhost = window.location.hostname === 'localhost'
-  return isHttps || isLocalhost
+  return true
 }
 
 /** 공유 실행 (Web Share API → Clipboard 폴백) */


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #580

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> `canShare()` 함수의 HTTP 환경 판별 로직을 Requirement 2.11에 맞게 수정

---

## 📋 변경 사항

- [x] `canShare()` — localhost 포함 모든 HTTP 환경에서 `false` 반환하도록 수정
- [x] HTTPS 프로토콜에서만 Web Share API 사용 허용

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirement 2.11: HTTP 환경(localhost 개발 환경 등)에서는 Web Share API를 사용하지 않고 Clipboard Fallback으로 자동 전환
- 기존 코드는 localhost를 예외 처리하여 HTTP에서도 Web Share API를 허용했으나, 요구사항에 맞게 HTTPS만 허용하도록 변경