### PR TITLE
[feat] 지도 페이지 온보딩 투어 연동

### DIFF
--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -12,6 +12,9 @@ import { SpotLoadingSkeleton } from '@/components/common/SpotLoadingSkeleton'
 import { SpotErrorDisplay } from '@/components/common/SpotErrorDisplay'
 import { EmptySearchOverlay } from '@/components/common/EmptySearchOverlay'
 import { EmptyFilterOverlay } from '@/components/common/EmptyFilterOverlay'
+import { useOnboarding } from '@/hooks/useOnboarding'
+import OnboardingTour from '@/components/common/OnboardingTour'
+import { MAP_PAGE_STEPS } from '@/lib/tour-config'
 
 // Leaflet은 SSR을 지원하지 않으므로 dynamic import 사용
 const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
@@ -27,9 +30,19 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
  * - filterStore 전역 상태 사용
  */
 export default function MapPage() {
+  const { isActive, currentStep, next, skip } = useOnboarding(MAP_PAGE_STEPS)
+
   return (
     <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
       <MapContent />
+      <OnboardingTour
+        steps={MAP_PAGE_STEPS}
+        isActive={isActive}
+        currentStep={currentStep}
+        onNext={next}
+        onSkip={skip}
+        onComplete={skip}
+      />
     </main>
   )
 }

--- a/src/components/map/CategoryFilter.tsx
+++ b/src/components/map/CategoryFilter.tsx
@@ -41,6 +41,7 @@ export default function CategoryFilter() {
 
   return (
     <div
+      data-tour="category-filter"
       className="scrollbar-hide flex items-center gap-2 overflow-x-auto px-1 py-1"
       onPointerDown={(e) => e.stopPropagation()}
       onWheel={(e) => e.stopPropagation()}

--- a/src/components/map/ContentSearchFilter.tsx
+++ b/src/components/map/ContentSearchFilter.tsx
@@ -109,6 +109,7 @@ export default function ContentSearchFilter({
   return (
     <div
       ref={containerRef}
+      data-tour="search-input"
       className={`relative flex-shrink-0 transition-all duration-300 ease-in-out ${
         isFocused ? 'w-72' : 'w-48 md:w-56'
       } ${className}`}

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -103,7 +103,7 @@ export default function PilgrimageMap({
   }, [setCenter, setZoom])
 
   return (
-    <div ref={containerRef} className={`relative h-full w-full ${className}`}>
+    <div ref={containerRef} data-tour="map-marker" className={`relative h-full w-full ${className}`}>
       <MapContainer
         center={mapCenter}
         zoom={mapZoom}


### PR DESCRIPTION
## 개요

지도 페이지(`/map`)에 온보딩 투어를 연동하고, 투어 대상 요소에 `data-tour` 속성을 추가한다.

## 변경 사항

- `src/app/(main)/map/page.tsx`: `useOnboarding` 훅 + `OnboardingTour` 컴포넌트 + `MAP_PAGE_STEPS` 연동
- `src/components/map/CategoryFilter.tsx`: `data-tour="category-filter"` 속성 추가
- `src/components/map/ContentSearchFilter.tsx`: `data-tour="search-input"` 속성 추가
- `src/components/map/PilgrimageMap.tsx`: `data-tour="map-marker"` 속성 추가

## 테스트

- `npm run type-check` 통과 확인

## 관련 Requirements

- Requirements 3.1, 3.2

Closes #585