### PR TITLE
[fix] useOnboarding 훅 localStorage 로직 반전

### DIFF
--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react'
 
-const ONBOARDING_KEY = 'not-a-trip-onboarding-completed'
+const ONBOARDING_KEY = 'not-a-trip-onboarding-dismissed'
 
 export interface TourStep {
   /** 대상 요소의 CSS selector 또는 data-tour 속성값 */
@@ -20,14 +20,16 @@ export interface UseOnboardingReturn {
   currentStep: number
   next: () => void
   skip: () => void
+  dismiss: () => void
   reset: () => void
 }
 
 /**
- * localStorage에서 온보딩 완료 상태를 읽는다.
- * 접근 실패 시 null 반환 (graceful degradation).
+ * localStorage에서 온보딩 dismissed 상태를 읽는다.
+ * dismissed=true이면 가이드 숨김.
+ * 접근 실패 시 null 반환 (graceful degradation — 매번 표시).
  */
-function getStoredCompletion(): boolean | null {
+function getStoredDismissed(): boolean | null {
   try {
     const value = localStorage.getItem(ONBOARDING_KEY)
     return value === 'true'
@@ -37,12 +39,12 @@ function getStoredCompletion(): boolean | null {
 }
 
 /**
- * localStorage에 온보딩 완료 상태를 저장한다.
+ * localStorage에 온보딩 dismissed 상태를 저장한다.
  * 접근 실패 시 무시 (graceful degradation).
  */
-function setStoredCompletion(completed: boolean): void {
+function setStoredDismissed(dismissed: boolean): void {
   try {
-    if (completed) {
+    if (dismissed) {
       localStorage.setItem(ONBOARDING_KEY, 'true')
     } else {
       localStorage.removeItem(ONBOARDING_KEY)
@@ -64,7 +66,10 @@ function isTargetInDOM(target: string): boolean {
  * 현재 인덱스부터 DOM에 존재하는 다음 유효한 스텝 인덱스를 찾는다.
  * 유효한 스텝이 없으면 -1을 반환한다.
  */
-export function findNextValidStep(steps: TourStep[], fromIndex: number): number {
+export function findNextValidStep(
+  steps: TourStep[],
+  fromIndex: number
+): number {
   for (let i = fromIndex; i < steps.length; i++) {
     if (isTargetInDOM(steps[i].target)) {
       return i
@@ -76,12 +81,13 @@ export function findNextValidStep(steps: TourStep[], fromIndex: number): number 
 /**
  * useOnboarding 훅
  *
- * 신규 사용자 온보딩 가이드 투어의 상태를 관리한다.
- * - localStorage로 완료 상태를 추적
+ * 온보딩 가이드 투어의 상태를 관리한다.
+ * - dismissed 상태가 아니면 매번 투어 표시
+ * - "다시 보지 않기"(dismiss) 시 localStorage에 저장하여 이후 숨김
  * - DOM에 존재하지 않는 대상 요소는 자동 건너뛰기
  * - localStorage 접근 실패 시 매번 투어 표시 (graceful degradation)
  *
- * @requirements 3.1, 3.7, 3.8, 3.9, 3.12
+ * @requirements 1.2, 1.3, 2.2, 2.3, 2.4, 3.3
  */
 export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
   const [isActive, setIsActive] = useState(false)
@@ -93,10 +99,10 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
     if (initializedRef.current) return
     initializedRef.current = true
 
-    const completed = getStoredCompletion()
+    const dismissed = getStoredDismissed()
 
-    // localStorage 접근 실패(null 반환) 또는 미완료 시 투어 시작
-    if (completed === true) {
+    // dismissed=true일 때만 투어 비활성화, 그 외(false/null)에는 매번 활성화
+    if (dismissed === true) {
       setIsActive(false)
       return
     }
@@ -104,9 +110,8 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
     // 첫 번째 유효한 스텝 찾기
     const firstValid = findNextValidStep(steps, 0)
     if (firstValid === -1) {
-      // 모든 스텝의 대상 요소가 미존재 → 투어 자동 종료
+      // 모든 스텝의 대상 요소가 미존재 → 투어 자동 종료 (localStorage 저장 안 함)
       setIsActive(false)
-      setStoredCompletion(true)
       return
     }
 
@@ -118,9 +123,8 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
     const nextValid = findNextValidStep(steps, currentStep + 1)
 
     if (nextValid === -1) {
-      // 남은 유효한 스텝 없음 → 투어 완료
+      // 남은 유효한 스텝 없음 → 투어 종료 (localStorage 저장 안 함)
       setIsActive(false)
-      setStoredCompletion(true)
       return
     }
 
@@ -129,11 +133,15 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
 
   const skip = useCallback(() => {
     setIsActive(false)
-    setStoredCompletion(true)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setStoredDismissed(true)
+    setIsActive(false)
   }, [])
 
   const reset = useCallback(() => {
-    setStoredCompletion(false)
+    setStoredDismissed(false)
     initializedRef.current = false
 
     const firstValid = findNextValidStep(steps, 0)
@@ -146,5 +154,5 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
     setCurrentStep(firstValid)
   }, [steps])
 
-  return { isActive, currentStep, next, skip, reset }
+  return { isActive, currentStep, next, skip, dismiss, reset }
 }


### PR DESCRIPTION
## 🔗 관련 이슈\n\n- Closes #593\n\n---\n\n## 📋 PR 타입\n\n- [x] 🐛 **fix**: 버그 수정\n\n---\n\n## ✨ 작업 개요\n\n> `useOnboarding` 훅의 localStorage 로직을 \"최초 1회 표시 후 완료 저장\" 방식에서 \"매번 표시 + 다시 보지 않기\" 방식으로 반전\n\n---\n\n## 📋 변경 사항\n\n- [x] localStorage 키 변경: `not-a-trip-onboarding-completed` → `not-a-trip-onboarding-dismissed`\n- [x] `getStoredCompletion()` → `getStoredDismissed()` 함수명 변경\n- [x] `setStoredCompletion()` → `setStoredDismissed()` 함수명 변경\n- [x] 초기화 로직 반전: dismissed=true일 때만 투어 비활성화\n- [x] `skip()` 및 마지막 스텝 `next()`에서 localStorage 저장 제거\n- [x] `dismiss()` 콜백 추가: localStorage에 dismissed=true 저장 + isActive=false\n- [x] `UseOnboardingReturn` 인터페이스에 `dismiss: () => void` 추가\n- [x] `reset()` 함수 수정: `setStoredDismissed(false)` 호출\n- [x] 모든 스텝 대상 요소 미존재 시 localStorage 저장 제거\n\n---\n\n## ✅ 체크리스트\n\n- [x] `npm run type-check` 통과\n- [x] 주요 기능 동작 확인\n\n---\n\n## 📝 추가 정보\n\nRequirements 1.2, 1.3, 2.2, 2.3, 2.4, 3.3 대응"