### PR TITLE
OnboardingTour 컴포넌트에 다시 보지 않기 버튼 추가

### DIFF
--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -10,6 +10,7 @@ interface OnboardingTourProps {
   onNext: () => void
   onSkip: () => void
   onComplete: () => void
+  onDismiss?: () => void
 }
 
 interface TargetRect {
@@ -88,6 +89,7 @@ export default function OnboardingTour({
   onNext,
   onSkip,
   onComplete,
+  onDismiss,
 }: OnboardingTourProps) {
   const [targetRect, setTargetRect] = useState<TargetRect | null>(null)
   const [tooltipPos, setTooltipPos] = useState<TooltipPosition>({
@@ -225,13 +227,25 @@ export default function OnboardingTour({
         </p>
 
         <div className="flex items-center justify-between">
-          <button
-            onClick={onSkip}
-            className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
-            type="button"
-          >
-            건너뛰기
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onSkip}
+              className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+              type="button"
+            >
+              건너뛰기
+            </button>
+
+            {onDismiss && (
+              <button
+                onClick={onDismiss}
+                className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+                type="button"
+              >
+                다시 보지 않기
+              </button>
+            )}
+          </div>
 
           <div className="flex items-center gap-2">
             {/* 스텝 인디케이터 */}


### PR DESCRIPTION
## 변경 사항

OnboardingTour 컴포넌트에 "다시 보지 않기" 버튼을 추가하여 사용자가 온보딩 가이드를 영구적으로 숨길 수 있도록 한다.

### 주요 변경

- Props 인터페이스에 `onDismiss?: () => void` 추가 (optional로 하위 호환성 유지)
- 툴팁 하단 "건너뛰기" 버튼 옆에 "다시 보지 않기" 버튼 렌더링
- `onDismiss` prop이 없으면 "다시 보지 않기" 버튼 숨김
- 기존 "건너뛰기", "다음"/"완료" 버튼은 그대로 유지

### Requirements

- 1.5, 2.4, 2.5

Closes #595