### PR TITLE
feat: tour-config에 코스 상세페이지용 ROUTE_DETAIL_STEPS 추가

### DIFF
--- a/src/lib/tour-config.ts
+++ b/src/lib/tour-config.ts
@@ -38,3 +38,24 @@ export const GALLERY_PAGE_STEPS: TourStep[] = [
     placement: 'bottom',
   },
 ]
+
+export const ROUTE_DETAIL_STEPS: TourStep[] = [
+  {
+    target: '[data-tour="route-map"]',
+    title: '코스 지도',
+    description: '코스에 포함된 스팟들의 위치를 지도에서 확인할 수 있어요',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="start-route-btn"]',
+    title: '코스 시작',
+    description: '코스 시작 버튼을 누르면 순서대로 스팟을 방문할 수 있어요',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="route-spots"]',
+    title: '코스 순서',
+    description: '코스에 포함된 스팟 목록을 순서대로 확인해보세요',
+    placement: 'top',
+  },
+]


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #597

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 코스 상세페이지용 온보딩 투어 스텝(`ROUTE_DETAIL_STEPS`)을 tour-config에 추가

---

## 📋 변경 사항

- [x] `src/lib/tour-config.ts`에 `ROUTE_DETAIL_STEPS` 배열 추가
- [x] 스텝 1: 코스 지도 영역 안내 (`[data-tour="route-map"]`)
- [x] 스텝 2: 코스 시작 버튼 안내 (`[data-tour="start-route-btn"]`)
- [x] 스텝 3: 코스 순서 목록 안내 (`[data-tour="route-spots"]`)

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 기존 tour-config 패턴과 동일한 구조 사용

---

## 📝 추가 정보

- Requirements 1.1, 2.1 대응
- Task 3.4에서 RouteDetailContent에 연동 시 사용될 data-tour 속성값과 일치