### PR TITLE
feat: RouteDetailContent에 OnboardingTour 연동

### DIFF
--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -12,6 +12,9 @@ import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import { GuidePanel } from '@/components/route/GuidePanel'
 import { CompletionEffect } from '@/components/route/CompletionEffect'
 import { OptimizedImage } from '@/components/common'
+import OnboardingTour from '@/components/common/OnboardingTour'
+import { useOnboarding } from '@/hooks/useOnboarding'
+import { ROUTE_DETAIL_STEPS } from '@/lib/tour-config'
 import type { Route, RouteDifficulty } from '@/types/route'
 import {
   getTravelMode,
@@ -67,6 +70,8 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
   const [showLoginModal, setShowLoginModal] = useState(false)
 
   const nav = useRouteNavigation()
+  const { isActive, currentStep, next, skip, dismiss } =
+    useOnboarding(ROUTE_DETAIL_STEPS)
 
   const [showCompletionEffect, setShowCompletionEffect] = useState(false)
 
@@ -218,6 +223,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         <div className="flex gap-3">
           <button
             onClick={handleStartRoute}
+            data-tour="start-route-btn"
             className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary py-3 text-sm font-semibold text-white transition-colors hover:bg-primary-600"
           >
             <AppIcon name="route" size={18} />
@@ -256,7 +262,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       )}
 
       {/* 코스 지도 */}
-      <div className="rounded-lg bg-surface p-4 shadow-sm">
+      <div className="rounded-lg bg-surface p-4 shadow-sm" data-tour="route-map">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 지도
         </h2>
@@ -270,7 +276,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       </div>
 
       {/* 스팟 순서 목록 */}
-      <div className="rounded-lg bg-surface p-4 shadow-sm">
+      <div className="rounded-lg bg-surface p-4 shadow-sm" data-tour="route-spots">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 순서 ({availableSpots.length}곳)
         </h2>
@@ -476,6 +482,17 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         isVisible={showCompletionEffect}
         routeName={route.name}
         onClose={() => setShowCompletionEffect(false)}
+      />
+
+      {/* 온보딩 가이드 투어 */}
+      <OnboardingTour
+        steps={ROUTE_DETAIL_STEPS}
+        isActive={isActive}
+        currentStep={currentStep}
+        onNext={next}
+        onSkip={skip}
+        onComplete={skip}
+        onDismiss={dismiss}
       />
     </div>
   )


### PR DESCRIPTION
## 개요\n\n코스 상세페이지(`RouteDetailContent.tsx`)에 `OnboardingTour` 컴포넌트를 연동하여 온보딩 가이드를 표시한다.\n\n## 변경 내용\n\n- `OnboardingTour`, `useOnboarding`, `ROUTE_DETAIL_STEPS` import 추가\n- `useOnboarding(ROUTE_DETAIL_STEPS)` 훅 호출 — isActive, currentStep, next, skip, dismiss 추출\n- JSX 하단에 `<OnboardingTour>` 컴포넌트 렌더링 (onDismiss={dismiss} prop 포함)\n- 가이드 대상 요소에 `data-tour` 속성 부여:\n  - `data-tour=\"route-map\"` — 코스 지도 영역\n  - `data-tour=\"start-route-btn\"` — 코스 시작 버튼\n  - `data-tour=\"route-spots\"` — 코스 순서 목록\n\n## 테스트\n\n- 코스 상세페이지 방문 시 온보딩 가이드 투어 표시 확인\n- data-tour 속성이 올바른 요소에 부여되었는지 확인\n\nCloses #599