### PR TITLE
fix: header handleResetTour localStorage 키 변경

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
 
   const handleResetTour = () => {
     try {
-      localStorage.removeItem('not-a-trip-onboarding-completed')
+      localStorage.removeItem('not-a-trip-onboarding-dismissed')
       window.location.reload()
     } catch {
       // localStorage 접근 실패 시 무시


### PR DESCRIPTION
## 변경 사항\n\nHeader 컴포넌트의 `handleResetTour` 함수에서 localStorage 키를 `not-a-trip-onboarding-completed`에서 `not-a-trip-onboarding-dismissed`로 변경\n\n## 변경 이유\n\n`useOnboarding` 훅이 새로운 localStorage 키 `not-a-trip-onboarding-dismissed`를 사용하도록 변경되었으므로, \"가이드 다시 보기\" 버튼도 새 키를 제거해야 가이드가 다시 표시된다.\n\n## 테스트\n\n- TypeScript 타입 체크 통과\n\nCloses #601