### PR TITLE
fix: 기존 페이지 OnboardingTour에 onDismiss prop 추가

### DIFF
--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -30,7 +30,8 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
  * - filterStore 전역 상태 사용
  */
 export default function MapPage() {
-  const { isActive, currentStep, next, skip } = useOnboarding(MAP_PAGE_STEPS)
+  const { isActive, currentStep, next, skip, dismiss } =
+    useOnboarding(MAP_PAGE_STEPS)
 
   return (
     <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
@@ -42,6 +43,7 @@ export default function MapPage() {
         onNext={next}
         onSkip={skip}
         onComplete={skip}
+        onDismiss={dismiss}
       />
     </main>
   )

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -48,7 +48,7 @@ function GalleryPageSkeleton() {
 function GalleryPageContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
-  const { isActive, currentStep, next, skip } =
+  const { isActive, currentStep, next, skip, dismiss } =
     useOnboarding(GALLERY_PAGE_STEPS)
 
   // 현재 활성 탭 (기본값: feed)
@@ -169,6 +169,7 @@ function GalleryPageContent() {
         onNext={next}
         onSkip={skip}
         onComplete={skip}
+        onDismiss={dismiss}
       />
     </main>
   )

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -42,7 +42,8 @@ function RouteListSkeleton() {
  * Requirements: 2.1, 2.2
  */
 export default function RoutesPage() {
-  const { isActive, currentStep, next, skip } = useOnboarding(ROUTE_PAGE_STEPS)
+  const { isActive, currentStep, next, skip, dismiss } =
+    useOnboarding(ROUTE_PAGE_STEPS)
 
   return (
     <main className="min-h-screen bg-surface pt-14">
@@ -89,6 +90,7 @@ export default function RoutesPage() {
         onNext={next}
         onSkip={skip}
         onComplete={skip}
+        onDismiss={dismiss}
       />
     </main>
   )


### PR DESCRIPTION
## 변경 사항\n\n기존 페이지(지도, 코스 목록, 갤러리)의 OnboardingTour 컴포넌트에 `onDismiss` prop을 추가하여 \"다시 보지 않기\" 버튼 기능을 활성화한다.\n\n## 변경 파일\n\n- `src/app/(main)/map/page.tsx`: `useOnboarding` 반환값에서 `dismiss` 추출, `OnboardingTour`에 `onDismiss={dismiss}` prop 추가\n- `src/app/routes/page.tsx`: 동일\n- `src/app/gallery/page.tsx`: 동일\n\n## 테스트\n\n- TypeScript 타입 체크 통과\n- lint/prettier 통과\n\nCloses #603