### PR TITLE
온보딩 가이드 UX 개선 - 페이지별 독립 키 및 UI 업그레이드

### DIFF
--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -30,8 +30,10 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
  * - filterStore 전역 상태 사용
  */
 export default function MapPage() {
-  const { isActive, currentStep, next, skip, dismiss } =
-    useOnboarding(MAP_PAGE_STEPS)
+  const { isActive, currentStep, next, skip, dismiss } = useOnboarding(
+    MAP_PAGE_STEPS,
+    'map'
+  )
 
   return (
     <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -48,8 +48,10 @@ function GalleryPageSkeleton() {
 function GalleryPageContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
-  const { isActive, currentStep, next, skip, dismiss } =
-    useOnboarding(GALLERY_PAGE_STEPS)
+  const { isActive, currentStep, next, skip, dismiss } = useOnboarding(
+    GALLERY_PAGE_STEPS,
+    'gallery'
+  )
 
   // 현재 활성 탭 (기본값: feed)
   const tabParam = searchParams.get('tab')

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -42,8 +42,10 @@ function RouteListSkeleton() {
  * Requirements: 2.1, 2.2
  */
 export default function RoutesPage() {
-  const { isActive, currentStep, next, skip, dismiss } =
-    useOnboarding(ROUTE_PAGE_STEPS)
+  const { isActive, currentStep, next, skip, dismiss } = useOnboarding(
+    ROUTE_PAGE_STEPS,
+    'routes'
+  )
 
   return (
     <main className="min-h-screen bg-surface pt-14">
@@ -69,19 +71,21 @@ export default function RoutesPage() {
         </div>
 
         {/* 추천 코스 섹션 - Requirements: 4.1, 4.2 */}
-        <RecommendedRoutes />
+        <div data-tour="route-content">
+          <RecommendedRoutes />
 
-        {/* 구분선 */}
-        <div className="my-6 border-t border-neutral-200" />
+          {/* 구분선 */}
+          <div className="my-6 border-t border-neutral-200" />
 
-        {/* 전체 코스 목록 */}
-        <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-main-text">
-          <AppIcon name="route" size={20} />
-          전체 코스
-        </h2>
-        <Suspense fallback={<RouteListSkeleton />}>
-          <RouteListContent />
-        </Suspense>
+          {/* 전체 코스 목록 */}
+          <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-main-text">
+            <AppIcon name="route" size={20} />
+            전체 코스
+          </h2>
+          <Suspense fallback={<RouteListSkeleton />}>
+            <RouteListContent />
+          </Suspense>
+        </div>
       </div>
       <OnboardingTour
         steps={ROUTE_PAGE_STEPS}

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -216,13 +216,13 @@ export default function OnboardingTour({
         ref={tooltipRef}
         id={tooltipId}
         role="tooltip"
-        className="fixed z-[10000] w-72 max-w-[calc(100vw-32px)] rounded-xl bg-white p-4 shadow-xl dark:bg-gray-800"
+        className="fixed z-[10000] w-80 max-w-[calc(100vw-32px)] rounded-xl bg-white p-5 shadow-2xl dark:bg-gray-800"
         style={{ top: tooltipPos.top, left: tooltipPos.left }}
       >
-        <h3 className="mb-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
+        <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-gray-100">
           {step.title}
         </h3>
-        <p className="mb-4 text-xs leading-relaxed text-gray-600 dark:text-gray-300">
+        <p className="mb-5 text-sm leading-relaxed text-gray-600 dark:text-gray-300">
           {step.description}
         </p>
 
@@ -230,7 +230,7 @@ export default function OnboardingTour({
           <div className="flex items-center gap-2">
             <button
               onClick={onSkip}
-              className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+              className="text-sm text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
               type="button"
             >
               건너뛰기
@@ -239,7 +239,7 @@ export default function OnboardingTour({
             {onDismiss && (
               <button
                 onClick={onDismiss}
-                className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+                className="text-sm text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
                 type="button"
               >
                 다시 보지 않기
@@ -247,16 +247,16 @@ export default function OnboardingTour({
             )}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             {/* 스텝 인디케이터 */}
-            <span className="text-xs text-gray-400">
+            <span className="text-sm text-gray-400">
               {currentStep + 1}/{steps.length}
             </span>
 
             <button
               ref={nextButtonRef}
               onClick={handleNext}
-              className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-primary-700 active:bg-primary-800"
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 active:bg-primary-800"
               type="button"
             >
               {isLastStep ? '완료' : '다음'}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,7 +13,11 @@ export function Header() {
 
   const handleResetTour = () => {
     try {
-      localStorage.removeItem('not-a-trip-onboarding-dismissed')
+      // 모든 페이지별 온보딩 키 초기화
+      const keys = Object.keys(localStorage).filter((k) =>
+        k.startsWith('not-a-trip-onboarding')
+      )
+      keys.forEach((k) => localStorage.removeItem(k))
       window.location.reload()
     } catch {
       // localStorage 접근 실패 시 무시

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -70,8 +70,10 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
   const [showLoginModal, setShowLoginModal] = useState(false)
 
   const nav = useRouteNavigation()
-  const { isActive, currentStep, next, skip, dismiss } =
-    useOnboarding(ROUTE_DETAIL_STEPS)
+  const { isActive, currentStep, next, skip, dismiss } = useOnboarding(
+    ROUTE_DETAIL_STEPS,
+    'route-detail'
+  )
 
   const [showCompletionEffect, setShowCompletionEffect] = useState(false)
 
@@ -223,7 +225,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         <div className="flex gap-3">
           <button
             onClick={handleStartRoute}
-            data-tour="start-route-btn"
+            data-tour="route-start-btn"
             className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary py-3 text-sm font-semibold text-white transition-colors hover:bg-primary-600"
           >
             <AppIcon name="route" size={18} />
@@ -262,7 +264,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       )}
 
       {/* 코스 지도 */}
-      <div className="rounded-lg bg-surface p-4 shadow-sm" data-tour="route-map">
+      <div className="rounded-lg bg-surface p-4 shadow-sm">
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 지도
         </h2>
@@ -276,7 +278,10 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
       </div>
 
       {/* 스팟 순서 목록 */}
-      <div className="rounded-lg bg-surface p-4 shadow-sm" data-tour="route-spots">
+      <div
+        className="rounded-lg bg-surface p-4 shadow-sm"
+        data-tour="route-spot-list"
+      >
         <h2 className="text-text-primary mb-3 text-lg font-semibold">
           코스 순서 ({availableSpots.length}곳)
         </h2>

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react'
 
-const ONBOARDING_KEY = 'not-a-trip-onboarding-dismissed'
+const ONBOARDING_KEY_PREFIX = 'not-a-trip-onboarding'
 
 export interface TourStep {
   /** 대상 요소의 CSS selector 또는 data-tour 속성값 */
@@ -25,13 +25,23 @@ export interface UseOnboardingReturn {
 }
 
 /**
+ * 페이지별 localStorage 키를 생성한다.
+ * pageKey가 없으면 기본 키를 사용한다.
+ */
+function getStorageKey(pageKey?: string): string {
+  return pageKey
+    ? `${ONBOARDING_KEY_PREFIX}-${pageKey}-dismissed`
+    : `${ONBOARDING_KEY_PREFIX}-dismissed`
+}
+
+/**
  * localStorage에서 온보딩 dismissed 상태를 읽는다.
  * dismissed=true이면 가이드 숨김.
  * 접근 실패 시 null 반환 (graceful degradation — 매번 표시).
  */
-function getStoredDismissed(): boolean | null {
+function getStoredDismissed(key: string): boolean | null {
   try {
-    const value = localStorage.getItem(ONBOARDING_KEY)
+    const value = localStorage.getItem(key)
     return value === 'true'
   } catch {
     return null
@@ -42,12 +52,12 @@ function getStoredDismissed(): boolean | null {
  * localStorage에 온보딩 dismissed 상태를 저장한다.
  * 접근 실패 시 무시 (graceful degradation).
  */
-function setStoredDismissed(dismissed: boolean): void {
+function setStoredDismissed(key: string, dismissed: boolean): void {
   try {
     if (dismissed) {
-      localStorage.setItem(ONBOARDING_KEY, 'true')
+      localStorage.setItem(key, 'true')
     } else {
-      localStorage.removeItem(ONBOARDING_KEY)
+      localStorage.removeItem(key)
     }
   } catch {
     // localStorage 접근 실패 시 무시
@@ -86,20 +96,25 @@ export function findNextValidStep(
  * - "다시 보지 않기"(dismiss) 시 localStorage에 저장하여 이후 숨김
  * - DOM에 존재하지 않는 대상 요소는 자동 건너뛰기
  * - localStorage 접근 실패 시 매번 투어 표시 (graceful degradation)
+ * - pageKey로 페이지별 독립적인 dismissed 상태 관리
  *
  * @requirements 1.2, 1.3, 2.2, 2.3, 2.4, 3.3
  */
-export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
+export function useOnboarding(
+  steps: TourStep[],
+  pageKey?: string
+): UseOnboardingReturn {
   const [isActive, setIsActive] = useState(false)
   const [currentStep, setCurrentStep] = useState(0)
   const initializedRef = useRef(false)
+  const storageKey = getStorageKey(pageKey)
 
   // 마운트 시 localStorage 확인하여 투어 시작 여부 결정
   useEffect(() => {
     if (initializedRef.current) return
     initializedRef.current = true
 
-    const dismissed = getStoredDismissed()
+    const dismissed = getStoredDismissed(storageKey)
 
     // dismissed=true일 때만 투어 비활성화, 그 외(false/null)에는 매번 활성화
     if (dismissed === true) {
@@ -117,7 +132,7 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
 
     setIsActive(true)
     setCurrentStep(firstValid)
-  }, [steps])
+  }, [steps, storageKey])
 
   const next = useCallback(() => {
     const nextValid = findNextValidStep(steps, currentStep + 1)
@@ -136,12 +151,12 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
   }, [])
 
   const dismiss = useCallback(() => {
-    setStoredDismissed(true)
+    setStoredDismissed(storageKey, true)
     setIsActive(false)
-  }, [])
+  }, [storageKey])
 
   const reset = useCallback(() => {
-    setStoredDismissed(false)
+    setStoredDismissed(storageKey, false)
     initializedRef.current = false
 
     const firstValid = findNextValidStep(steps, 0)
@@ -152,7 +167,7 @@ export function useOnboarding(steps: TourStep[]): UseOnboardingReturn {
 
     setIsActive(true)
     setCurrentStep(firstValid)
-  }, [steps])
+  }, [steps, storageKey])
 
   return { isActive, currentStep, next, skip, dismiss, reset }
 }

--- a/src/lib/tour-config.ts
+++ b/src/lib/tour-config.ts
@@ -3,20 +3,23 @@ import type { TourStep } from '@/hooks/useOnboarding'
 export const MAP_PAGE_STEPS: TourStep[] = [
   {
     target: '[data-tour="category-filter"]',
-    title: '카테고리 필터',
-    description: '원하는 카테고리를 선택하여 스팟을 필터링할 수 있어요',
+    title: '🎯 카테고리 필터',
+    description:
+      '애니메이션, 영화/드라마, 스포츠 등 원하는 카테고리를 선택하면 해당 스팟만 지도에 표시됩니다. 여러 카테고리를 동시에 선택할 수도 있어요!',
     placement: 'bottom',
   },
   {
     target: '[data-tour="search-input"]',
-    title: '스팟 검색',
-    description: '작품명이나 장소명으로 스팟을 검색해보세요',
+    title: '🔍 스팟 검색',
+    description:
+      '작품명(예: 봇치 더 록), 장소명, 아티스트명으로 검색하면 관련 스팟을 빠르게 찾을 수 있어요. 입력하면 자동완성 추천이 나타납니다.',
     placement: 'bottom',
   },
   {
     target: '[data-tour="map-marker"]',
-    title: '마커 클릭',
-    description: '지도의 마커를 클릭하면 스팟 상세 정보를 볼 수 있어요',
+    title: '📍 지도 탐색',
+    description:
+      '지도 위의 마커를 클릭하면 스팟의 상세 정보를 확인할 수 있어요. 사진, 작품 속 장면, 주변 편의시설 정보까지 한눈에 볼 수 있습니다.',
     placement: 'top',
   },
 ]
@@ -24,8 +27,33 @@ export const MAP_PAGE_STEPS: TourStep[] = [
 export const ROUTE_PAGE_STEPS: TourStep[] = [
   {
     target: '[data-tour="start-route"]',
-    title: '코스 시작',
-    description: '코스 시작 버튼을 누르면 가이드 모드가 시작됩니다',
+    title: '🗺️ 나만의 순례 코스 만들기',
+    description:
+      '여기서 새로운 순례 코스를 만들 수 있어요! 좋아하는 스팟들을 모아 나만의 코스를 구성하고, 다른 순례자들과 공유해보세요.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="route-content"]',
+    title: '📋 코스 둘러보기',
+    description:
+      '공식 추천 코스, 인기 코스, 전체 코스 목록에서 관심 있는 코스를 선택해보세요. 코스를 클릭하면 상세 정보와 스팟 순서를 확인할 수 있어요.',
+    placement: 'top',
+  },
+]
+
+export const ROUTE_DETAIL_STEPS: TourStep[] = [
+  {
+    target: '[data-tour="route-start-btn"]',
+    title: '🚀 코스 시작하기',
+    description:
+      '이 버튼을 누르면 가이드 모드가 시작됩니다! 각 스팟을 순서대로 방문하며 GPS 기반 인증을 할 수 있어요.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="route-spot-list"]',
+    title: '📍 스팟 순서 확인',
+    description:
+      '코스에 포함된 스팟들의 순서와 이동 거리/시간을 확인할 수 있어요. 코스 시작 후에는 각 스팟에서 인증하기 버튼이 활성화됩니다.',
     placement: 'top',
   },
 ]
@@ -33,29 +61,9 @@ export const ROUTE_PAGE_STEPS: TourStep[] = [
 export const GALLERY_PAGE_STEPS: TourStep[] = [
   {
     target: '[data-tour="upload-checkin"]',
-    title: '인증샷 업로드',
-    description: '스팟에서 찍은 인증샷을 업로드하고 공유해보세요',
-    placement: 'bottom',
-  },
-]
-
-export const ROUTE_DETAIL_STEPS: TourStep[] = [
-  {
-    target: '[data-tour="route-map"]',
-    title: '코스 지도',
-    description: '코스에 포함된 스팟들의 위치를 지도에서 확인할 수 있어요',
-    placement: 'bottom',
-  },
-  {
-    target: '[data-tour="start-route-btn"]',
-    title: '코스 시작',
-    description: '코스 시작 버튼을 누르면 순서대로 스팟을 방문할 수 있어요',
-    placement: 'top',
-  },
-  {
-    target: '[data-tour="route-spots"]',
-    title: '코스 순서',
-    description: '코스에 포함된 스팟 목록을 순서대로 확인해보세요',
+    title: '📸 순례 인증하기',
+    description:
+      '성지순례 스팟에 방문했다면 이 버튼을 눌러 인증샷을 업로드해보세요! GPS로 위치를 확인하고, 인증 뱃지도 획득할 수 있어요.',
     placement: 'top',
   },
 ]


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #605

---

## 📋 PR 타입

- [x] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정

---

## ✨ 작업 개요

> 온보딩 가이드 투어의 UX를 개선한다. 페이지별 독립 키 시스템, 가이드 텍스트 개선, 툴팁 UI 크기 업그레이드를 적용한다.

---

## 📋 변경 사항

- [x] `useOnboarding` 훅에 `pageKey` 파라미터 추가 (페이지별 독립 dismissed 상태)
- [x] 가이드 텍스트에 이모지 추가 및 설명문 상세화
- [x] ROUTE_PAGE_STEPS에 "코스 둘러보기" 스텝 추가
- [x] 온보딩 툴팁 UI 크기 업그레이드 (w-72→w-80, text-xs→text-sm)
- [x] Header "가이드 다시 보기" 시 모든 페이지별 키 일괄 초기화
- [x] ROUTE_DETAIL_STEPS target 정리 (`route-start-btn`, `route-spot-list`)
- [x] routes 페이지에 `data-tour="route-content"` wrapper 추가
- [x] 각 페이지에 pageKey 적용 (map, routes, gallery, route-detail)

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] `npm run build` 통과
- [x] prettier 포맷팅 확인
- [x] 속성 기반 테스트 5개 모두 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- stash@{1}에 있던 이전 작업 내용을 현재 구현(dismiss 기능)과 병합하여 적용
- 페이지별 독립 키 형식: `not-a-trip-onboarding-{pageKey}-dismissed`
- 기존 단일 키(`not-a-trip-onboarding-dismissed`)도 pageKey 없이 호출 시 호환 유지