### PR TITLE
feat: SpotContentRelation 타입 및 enum 정의 추가

### DIFF
--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -378,3 +378,85 @@ export interface UserLikeStatus {
   liked: boolean
   likeCount: number
 }
+
+// ============================================
+// SpotContentRelation Types (스팟-작품 관계)
+// ============================================
+
+/** 관계 유형 */
+export type RelationType =
+  | 'scene_depicted'          // 장면 등장
+  | 'inspired_by'             // 모티프
+  | 'filming_location'        // 촬영지
+  | 'collaboration_event'     // 콜라보 이벤트
+  | 'merchandise_spot'        // 굿즈/전시
+  | 'fan_inferred'            // 팬 추정 성지
+  | 'promotional_reference'   // 홍보 등장
+
+/** 신뢰도 */
+export type ConfidenceLevel = 'high' | 'medium' | 'low'
+
+/** 공식성 */
+export type Officialness =
+  | 'official'
+  | 'community_verified'
+  | 'user_submitted'
+  | 'unverified'
+
+/** 관계 상태 */
+export type RelationStatus = 'active' | 'expired' | 'scheduled' | 'archived'
+
+/** 관계 유형 한글 라벨 */
+export const RELATION_TYPE_LABELS: Record<RelationType, string> = {
+  scene_depicted: '장면 등장',
+  inspired_by: '모티프',
+  filming_location: '촬영지',
+  collaboration_event: '콜라보 이벤트',
+  merchandise_spot: '굿즈/전시',
+  fan_inferred: '팬 추정 성지',
+  promotional_reference: '홍보 등장',
+}
+
+/** SpotContentRelation 엔티티 */
+export interface SpotContentRelation {
+  /** 고유 ID */
+  id: string
+  /** 연결된 스팟 ID */
+  spotId: string
+  /** 콘텐츠 식별자 ({spotId}_{normalizedContentName}) */
+  contentId: string
+  /** 작품명 */
+  contentName: string
+  /** 작품 타입 */
+  contentType: ContentType
+  /** 작품 대표 이미지 URL */
+  contentImageUrl?: string
+  /** 관계 유형 */
+  relationType: RelationType
+  /** 신뢰도 */
+  confidenceLevel: ConfidenceLevel
+  /** 공식성 */
+  officialness: Officialness
+  /** 표시 우선순위 (낮을수록 먼저) */
+  displayPriority: number
+  /** 관계 상태 */
+  status: RelationStatus
+  /** 요약 설명 */
+  summary?: string
+  /** 시작일 (기간성 관계) */
+  startDate?: Date
+  /** 종료일 (기간성 관계) */
+  endDate?: Date
+  /** 증거 수 */
+  sourceCount?: number
+  /** 검증 점수 */
+  verificationScore?: number
+  /** 생성자 ID */
+  createdBy?: string
+  /** 수정자 ID */
+  updatedBy?: string
+  /** 생성일 */
+  createdAt: Date
+  /** 수정일 */
+  updatedAt: Date
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #608

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> `src/types/spot.ts`에 SpotContentRelation 독립 엔티티 관련 타입, enum, 상수를 추가한다.

---

## 📋 변경 사항

- [x] `RelationType` 타입 정의 (7가지 관계 유형: scene_depicted, inspired_by, filming_location, collaboration_event, merchandise_spot, fan_inferred, promotional_reference)
- [x] `ConfidenceLevel` 타입 정의 (high, medium, low)
- [x] `Officialness` 타입 정의 (official, community_verified, user_submitted, unverified)
- [x] `RelationStatus` 타입 정의 (active, expired, scheduled, archived)
- [x] `RELATION_TYPE_LABELS` 한글 라벨 상수 추가
- [x] `SpotContentRelation` 인터페이스 정의 (모든 필수/선택 필드 포함)
- [x] `contentImageUrl` 선택 필드 포함

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 타입 정의만 추가하여 기존 기능에 영향 없음

---

## 📝 추가 정보

- Spec: `.kiro/specs/30-spot-content-relation/`
- Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8
- 기존 코드에 영향 없는 순수 타입 추가