### PR TITLE
feat: spot_content_relations 컬렉션 상수 및 API 경로 추가

### DIFF
--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -15,6 +15,8 @@ export const API_ROUTES = {
     DETAIL: (id: string) => `/api/spots/${id}`,
     FACILITIES: (id: string) => `/api/spots/${id}/facilities`,
     SCENES: (id: string) => `/api/spots/${id}/scenes`,
+    RELATIONS: (id: string) => `/api/spots/${id}/relations`,
+    BY_CONTENT: '/api/spots/relations/by-content',
     COMMUNITY_SUMMARY: '/api/spots/community-summary',
   },
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -106,6 +106,8 @@ export const COLLECTIONS = {
   FACILITY_VOTES: 'facility_votes',
   // 인증 시스템 계정 연동 컬렉션 (15-oauth-integration)
   ACCOUNTS: 'accounts',
+  // 스팟-작품 관계 컬렉션 (30-spot-content-relation)
+  SPOT_CONTENT_RELATIONS: 'spot_content_relations',
 } as const
 
 /**


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #610

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> SpotContentRelation 독립 엔티티 마이그레이션을 위한 DB 컬렉션 상수 및 API 경로 추가

---

## 📋 변경 사항

- [x] `src/lib/db.ts`의 `COLLECTIONS`에 `SPOT_CONTENT_RELATIONS: 'spot_content_relations'` 추가
- [x] `src/lib/api-routes.ts`의 `API_ROUTES.SPOTS`에 `RELATIONS` 경로 추가
- [x] `src/lib/api-routes.ts`의 `API_ROUTES.SPOTS`에 `BY_CONTENT` 경로 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (type-check 통과)
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Spec: `.kiro/specs/30-spot-content-relation/`
- Requirements 2.1 대응
