### PR TITLE
chore: spot_content_relations 인덱스 초기화 스크립트 작성

### DIFF
--- a/scripts/init-relation-indexes.ts
+++ b/scripts/init-relation-indexes.ts
@@ -1,0 +1,44 @@
+/**
+ * spot_content_relations 컬렉션 인덱스 초기화 스크립트
+ * Spec: 30-spot-content-relation
+ *
+ * 실행: npx tsx scripts/init-relation-indexes.ts
+ */
+
+import { connectToDatabase, COLLECTIONS } from '../src/lib/db'
+
+async function initRelationIndexes() {
+  const { db } = await connectToDatabase()
+  const collection = db.collection(COLLECTIONS.SPOT_CONTENT_RELATIONS)
+
+  console.log('🔧 spot_content_relations 인덱스 생성 시작...')
+
+  // 1. spotId 단일 인덱스 — 스팟별 관계 조회
+  const spotIdResult = await collection.createIndex({ spotId: 1 })
+  console.log(`✅ spotId 인덱스 생성 완료: ${spotIdResult}`)
+
+  // 2. contentName 단일 인덱스 — 작품별 스팟 조회
+  const contentNameResult = await collection.createIndex({ contentName: 1 })
+  console.log(`✅ contentName 인덱스 생성 완료: ${contentNameResult}`)
+
+  // 3. { spotId, contentName } 복합 유니크 인덱스 — 중복 방지
+  const compoundResult = await collection.createIndex(
+    { spotId: 1, contentName: 1 },
+    { unique: true }
+  )
+  console.log(
+    `✅ { spotId, contentName } 복합 유니크 인덱스 생성 완료: ${compoundResult}`
+  )
+
+  // 4. status 단일 인덱스 — 상태별 필터링
+  const statusResult = await collection.createIndex({ status: 1 })
+  console.log(`✅ status 인덱스 생성 완료: ${statusResult}`)
+
+  console.log('🎉 모든 spot_content_relations 인덱스 생성 완료!')
+  process.exit(0)
+}
+
+initRelationIndexes().catch((error) => {
+  console.error('❌ 인덱스 생성 실패:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #612

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [x] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

`spot_content_relations` 컬렉션에 필요한 인덱스를 생성하는 초기화 스크립트를 작성한다.

---

## 📋 변경 사항

- [x] `scripts/init-relation-indexes.ts` 생성
- [x] `spotId` 단일 인덱스 생성
- [x] `contentName` 단일 인덱스 생성
- [x] `{ spotId, contentName }` 복합 유니크 인덱스 생성 (중복 방지)
- [x] `status` 단일 인덱스 생성
- [x] 각 인덱스 생성 후 결과 콘솔 출력
- [x] 에러 발생 시 적절한 에러 메시지 출력

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 기존 `setup-route-indexes.ts` 패턴과 동일한 연결 방식 사용

---

## 📝 추가 정보

- **실행 방법**: `npx tsx scripts/init-relation-indexes.ts`
- **Requirements**: 2.1, 2.2, 2.3, 2.4, 2.5
- **Spec**: 30-spot-content-relation (Task 1.3)