### PR TITLE
feat: 스팟별 Relations API 엔드포인트 구현

### DIFF
--- a/src/app/api/spots/[id]/relations/route.ts
+++ b/src/app/api/spots/[id]/relations/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { SpotContentRelation } from '@/types'
+
+/**
+ * GET /api/spots/[id]/relations - 스팟별 관계 목록 조회
+ * Requirements: 4.1, 4.2, 4.3, 4.4, 4.5
+ *
+ * - active 상태의 SpotContentRelation만 반환
+ * - displayPriority 오름차순 정렬
+ * - 스팟 미존재 시 404, DB 오류 시 500
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: spotId } = await params
+
+    // 스팟 존재 여부 확인
+    const spotsCollection = await getCollection(COLLECTIONS.SPOTS)
+    const spot = await spotsCollection.findOne({ id: spotId })
+
+    if (!spot) {
+      return NextResponse.json(
+        { error: '스팟을 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    // active 상태의 관계를 displayPriority 오름차순으로 조회
+    const relationsCollection = await getCollection<SpotContentRelation>(
+      COLLECTIONS.SPOT_CONTENT_RELATIONS
+    )
+
+    const relations = await relationsCollection
+      .find({ spotId, status: 'active' })
+      .sort({ displayPriority: 1 })
+      .toArray()
+
+    return NextResponse.json({ relations, total: relations.length })
+  } catch (error) {
+    console.error('Error fetching spot relations:', error)
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #618

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 스팟별 SpotContentRelation 목록을 조회하는 Relations API 엔드포인트를 구현합니다.

---

## 📋 변경 사항

- [x] `src/app/api/spots/[id]/relations/route.ts` 신규 생성
- [x] `GET /api/spots/[id]/relations` — active 상태 관계를 displayPriority 오름차순 반환
- [x] 관계 없을 시 `{ relations: [], total: 0 }` 반환
- [x] 존재하지 않는 스팟 ID → 404 에러 처리
- [x] DB 오류 → 500 에러 처리

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (type-check)
- [x] 기존 API 패턴과 일관된 구현

---

## 📝 추가 정보

- Spec: `.kiro/specs/30-spot-content-relation/` Task 4.1
- Requirements: 4.1, 4.2, 4.3, 4.4, 4.5 대응