### PR TITLE
feat: 작품별 스팟 조회 API 엔드포인트 구현

### DIFF
--- a/src/app/api/spots/relations/by-content/route.ts
+++ b/src/app/api/spots/relations/by-content/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { SpotContentRelation } from '@/types'
+
+/**
+ * GET /api/spots/relations/by-content?contentName=... — 작품별 스팟 조회
+ * Requirements: 6.1, 6.4
+ *
+ * - 해당 contentName의 active 관계에서 고유 spotId 목록 반환
+ * - contentName 파라미터 누락 시 400
+ * - DB 오류 시 500
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url)
+    const contentName = searchParams.get('contentName')
+
+    if (!contentName) {
+      return NextResponse.json(
+        {
+          error: '잘못된 요청입니다',
+          details: 'contentName 파라미터가 필요합니다',
+        },
+        { status: 400 }
+      )
+    }
+
+    const relationsCollection = await getCollection<SpotContentRelation>(
+      COLLECTIONS.SPOT_CONTENT_RELATIONS
+    )
+
+    // contentName + active 상태의 관계에서 고유 spotId 추출
+    const relations = await relationsCollection
+      .find({ contentName, status: 'active' })
+      .project({ spotId: 1 })
+      .toArray()
+
+    const spotIds = [...new Set(relations.map((r) => r.spotId as string))]
+
+    return NextResponse.json({ spotIds, total: spotIds.length })
+  } catch (error) {
+    console.error('Error fetching spots by content:', error)
+    return NextResponse.json(
+      { error: '서버 오류가 발생했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈\n\n- Closes #620\n\n---\n\n## 📋 PR 타입\n\n- [x] ✨ **feat**: 새로운 기능 추가\n\n---\n\n## ✨ 작업 개요\n\n> 작품별 스팟 조회 API (`GET /api/spots/relations/by-content?contentName=...`) 엔드포인트를 구현한다.\n\n---\n\n## 📋 변경 사항\n\n- [x] `src/app/api/spots/relations/by-content/route.ts` 신규 생성\n- [x] contentName 파라미터로 active 상태의 고유 spotId 목록 반환\n- [x] contentName 누락 시 400 에러 응답\n- [x] DB 오류 시 500 에러 응답\n\n---\n\n## ✅ 체크리스트\n\n- [x] `npm run type-check` 통과\n- [x] 주요 기능 동작 확인\n\n---\n\n## 📝 추가 정보\n\n- Requirements 6.1, 6.4 대응\n- 기존 Relations API (`/api/spots/[id]/relations`)와 동일한 패턴 사용\n- `spot_content_relations` 컬렉션에서 contentName + active 상태 필터링 후 고유 spotId 추출