### PR TITLE
feat: 스팟 상세 API 응답에 relations 필드 추가

### DIFF
--- a/src/app/api/spots/[id]/route.ts
+++ b/src/app/api/spots/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCollection } from '@/lib/db'
+import { getCollection, COLLECTIONS } from '@/lib/db'
 import { auth } from '@/lib/auth'
 import { canEditSpot, canDeleteSpot } from '@/lib/auth-utils'
 import {
@@ -9,6 +9,7 @@ import {
   RelatedContent,
   UpdateSpotInput,
   ExternalLink,
+  SpotContentRelation,
 } from '@/types'
 import { validateExternalLinks } from '@/lib/external-link-validation'
 
@@ -55,6 +56,14 @@ export async function GET(
       return NextResponse.json({ error: 'Spot not found' }, { status: 404 })
     }
 
+    // spot_content_relations에서 active 관계를 displayPriority 오름차순으로 조회
+    const relationsCollection =
+      await getCollection<SpotContentRelation>(COLLECTIONS.SPOT_CONTENT_RELATIONS)
+    const relations = await relationsCollection
+      .find({ spotId: spot.id, status: 'active' })
+      .sort({ displayPriority: 1 })
+      .toArray()
+
     const spotResponse: SpotResponse = {
       id: spot.id,
       name: spot.name,
@@ -75,7 +84,7 @@ export async function GET(
       isGuestSpot: spot.isGuestSpot,
     }
 
-    return NextResponse.json(spotResponse)
+    return NextResponse.json({ ...spotResponse, relations })
   } catch (error) {
     console.error('Error fetching spot detail:', error)
     return NextResponse.json(


### PR DESCRIPTION
## 🔗 관련 이슈\n\n- Closes #622\n\n---\n\n## 📋 PR 타입\n\n- [x] ✨ **feat**: 새로운 기능 추가\n\n---\n\n## ✨ 작업 개요\n\n> 스팟 상세 API 응답에 `spot_content_relations` 컬렉션 기반 `relations` 필드를 추가하여 하위 호환성을 유지하면서 새 관계 데이터를 제공한다.\n\n---\n\n## 📋 변경 사항\n\n- [x] `src/app/api/spots/[id]/route.ts` GET 핸들러에서 `spot_content_relations` 컬렉션 조회 추가\n- [x] active 상태 관계를 displayPriority 오름차순으로 정렬하여 응답에 포함\n- [x] 기존 `relatedContent` 필드 유지 (하위 호환성)\n- [x] `COLLECTIONS` 상수 및 `SpotContentRelation` 타입 import 추가\n\n---\n\n## ✅ 체크리스트\n\n- [x] `npm run type-check` 통과\n- [x] 기존 relatedContent 필드 유지\n- [x] relations 필드 active 필터링 + displayPriority 정렬\n\n---\n\n## 📝 추가 정보\n\nRequirements 5.1, 5.2, 5.3 대응. 과도기 동안 relatedContent와 relations 필드를 병행 반환한다.