### PR TITLE
feat: 스팟 등록(POST) 시 spot_content_relations 동기화

### DIFF
--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCollection } from '@/lib/db'
+import { getCollection, COLLECTIONS } from '@/lib/db'
 import { auth } from '@/lib/auth'
 import {
   SpotPin,
@@ -9,6 +9,7 @@ import {
   ExternalLink,
 } from '@/types'
 import { validateExternalLinks } from '@/lib/external-link-validation'
+import { convertRelatedContentToRelation } from '@/lib/relation-utils'
 
 /**
  * 정규식 특수문자 이스케이프 처리
@@ -251,6 +252,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     await collection.insertOne(newSpot)
+
+    // spot_content_relations 동기화 (Requirements 10.1, 10.4)
+    if (newSpot.relatedContent && newSpot.relatedContent.length > 0) {
+      const relationsCollection = await getCollection(
+        COLLECTIONS.SPOT_CONTENT_RELATIONS
+      )
+      const relations = newSpot.relatedContent.map((content, index) =>
+        convertRelatedContentToRelation(newSpot.id, content, index)
+      )
+      await relationsCollection.insertMany(relations)
+    }
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #624

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> 스팟 등록(POST /api/spots) 시 relatedContent 배열을 spot_content_relations 컬렉션에도 동기화하여 독립 엔티티 구조를 유지한다.

---

## 📋 변경 사항

- [x] `src/app/api/spots/route.ts` POST 핸들러에 relations 동기화 로직 추가
- [x] `convertRelatedContentToRelation` 유틸리티를 사용하여 SpotContentRelation 문서 생성
- [x] `spot_content_relations` 컬렉션에 일괄 삽입 (insertMany)
- [x] 기존 `relatedContent` 필드 저장은 하위 호환성을 위해 유지

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] TypeScript 타입 체크 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 10.1, 10.4 대응
- Spec: `.kiro/specs/30-spot-content-relation/tasks.md` Task 5.2
- 스팟 삽입 후 relatedContent가 비어있지 않은 경우에만 relations 동기화 수행