### PR TITLE
feat: 스팟 수정(PUT) 시 relations 동기화

### DIFF
--- a/src/app/api/spots/[id]/route.ts
+++ b/src/app/api/spots/[id]/route.ts
@@ -12,6 +12,7 @@ import {
   SpotContentRelation,
 } from '@/types'
 import { validateExternalLinks } from '@/lib/external-link-validation'
+import { convertRelatedContentToRelation } from '@/lib/relation-utils'
 
 // MongoDB document interface
 interface SpotDocument {
@@ -57,8 +58,9 @@ export async function GET(
     }
 
     // spot_content_relations에서 active 관계를 displayPriority 오름차순으로 조회
-    const relationsCollection =
-      await getCollection<SpotContentRelation>(COLLECTIONS.SPOT_CONTENT_RELATIONS)
+    const relationsCollection = await getCollection<SpotContentRelation>(
+      COLLECTIONS.SPOT_CONTENT_RELATIONS
+    )
     const relations = await relationsCollection
       .find({ spotId: spot.id, status: 'active' })
       .sort({ displayPriority: 1 })
@@ -192,6 +194,22 @@ export async function PUT(
       updateFields.externalLinks = body.externalLinks
 
     await collection.updateOne({ id }, { $set: updateFields })
+
+    // Relations 동기화: relatedContent 변경 시 기존 관계 삭제 후 재생성 (Requirements 10.2, 10.4)
+    if (updateFields.relatedContent !== undefined) {
+      const relationsCollection = await getCollection(
+        COLLECTIONS.SPOT_CONTENT_RELATIONS
+      )
+      // 기존 관계 삭제
+      await relationsCollection.deleteMany({ spotId: id })
+      // 새 관계 생성
+      if (updateFields.relatedContent.length > 0) {
+        const relations = updateFields.relatedContent.map((content, index) =>
+          convertRelatedContentToRelation(id, content, index)
+        )
+        await relationsCollection.insertMany(relations)
+      }
+    }
 
     return NextResponse.json({
       id,


### PR DESCRIPTION
## 변경 사항\n\n스팟 수정(PUT) API에서 `relatedContent`가 변경될 때 `spot_content_relations` 컬렉션과 동기화하는 로직을 추가합니다.\n\n### 구현 내용\n\n- `convertRelatedContentToRelation` 유틸리티 import 추가\n- PUT 핸들러에서 `relatedContent` 변경 감지 시:\n  - 해당 스팟의 기존 SpotContentRelation 문서 전체 삭제 (`deleteMany`)\n  - 새 `relatedContent` 배열 기반으로 SpotContentRelation 문서 재생성 (`insertMany`)\n\n### 관련 Requirements\n\n- 10.2: 스팟 수정 시 기존 SpotContentRelation 삭제 후 재생성\n- 10.4: 하위 호환성 유지 (relatedContent 필드도 저장)\n\nCloses #626