### PR TITLE
feat: 스팟 삭제(DELETE) 시 관련 relations 함께 삭제

### DIFF
--- a/src/app/api/spots/[id]/route.ts
+++ b/src/app/api/spots/[id]/route.ts
@@ -272,6 +272,12 @@ export async function DELETE(
     const postsCollection = await getCollection('posts')
     await postsCollection.updateMany({ spotId: id }, { $unset: { spotId: '' } })
 
+    // 연관 데이터 삭제 (spot_content_relations) - Requirements 10.3
+    const relationsCollection = await getCollection(
+      COLLECTIONS.SPOT_CONTENT_RELATIONS
+    )
+    await relationsCollection.deleteMany({ spotId: id })
+
     // 스팟 삭제
     await collection.deleteOne({ id })
 


### PR DESCRIPTION
## 🔗 관련 이슈\n\n- Closes #628\n\n---\n\n## 📋 PR 타입\n\n- [x] ✨ **feat**: 새로운 기능 추가\n\n---\n\n## ✨ 작업 개요\n\n스팟 삭제 시 해당 스팟의 모든 SpotContentRelation 문서를 함께 삭제하여 데이터 정합성 유지\n\n---\n\n## 📋 변경 사항\n\n- [x] DELETE 핸들러에 `spot_content_relations` 컬렉션 삭제 로직 추가\n- [x] `relationsCollection.deleteMany({ spotId: id })` 호출\n\n---\n\n## ✅ 체크리스트\n\n- [x] `npm run type-check` 통과\n- [x] 주요 기능 동작 확인\n\n---\n\n## 📝 추가 정보\n\n- Requirements 10.3 대응\n- 기존 scenes, posts 삭제 로직과 동일한 패턴으로 구현