### PR TITLE
fix: prettier 포맷팅 미적용 파일 수정

### DIFF
--- a/__tests__/onboarding-guide-fix/preservation.property.test.ts
+++ b/__tests__/onboarding-guide-fix/preservation.property.test.ts
@@ -77,12 +77,15 @@ const mixedStepsArb = fc
   .chain(({ inDomIds, notInDomIds }) => {
     const allIds = [...inDomIds, ...notInDomIds]
     // 셔플된 순서로 스텝 배열 생성
-    return fc.shuffledSubarray(allIds, { minLength: allIds.length, maxLength: allIds.length }).map(
-      (shuffled) => ({
+    return fc
+      .shuffledSubarray(allIds, {
+        minLength: allIds.length,
+        maxLength: allIds.length,
+      })
+      .map((shuffled) => ({
         inDomIds,
         steps: shuffled.map(tourStepFromId),
-      })
-    )
+      }))
   })
 
 // ============================================

--- a/scripts/migrate-relations.ts
+++ b/scripts/migrate-relations.ts
@@ -19,7 +19,9 @@ interface SpotDocument {
 }
 
 async function migrateRelations() {
-  console.log('🚀 relatedContent → spot_content_relations 마이그레이션 시작...\n')
+  console.log(
+    '🚀 relatedContent → spot_content_relations 마이그레이션 시작...\n'
+  )
 
   const { db } = await connectToDatabase()
   const spotsCollection = db.collection<SpotDocument>(COLLECTIONS.SPOTS)

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -103,7 +103,11 @@ export default function PilgrimageMap({
   }, [setCenter, setZoom])
 
   return (
-    <div ref={containerRef} data-tour="map-marker" className={`relative h-full w-full ${className}`}>
+    <div
+      ref={containerRef}
+      data-tour="map-marker"
+      className={`relative h-full w-full ${className}`}
+    >
       <MapContainer
         center={mapCenter}
         zoom={mapZoom}

--- a/src/lib/relation-utils.ts
+++ b/src/lib/relation-utils.ts
@@ -23,10 +23,7 @@ export function normalizeContentName(name: string): string {
 /**
  * contentId 생성: {spotId}_{normalizedName} 형식
  */
-export function generateContentId(
-  spotId: string,
-  contentName: string
-): string {
+export function generateContentId(spotId: string, contentName: string): string {
   const normalized = normalizeContentName(contentName)
   return `${spotId}_${normalized}`
 }

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -385,13 +385,13 @@ export interface UserLikeStatus {
 
 /** 관계 유형 */
 export type RelationType =
-  | 'scene_depicted'          // 장면 등장
-  | 'inspired_by'             // 모티프
-  | 'filming_location'        // 촬영지
-  | 'collaboration_event'     // 콜라보 이벤트
-  | 'merchandise_spot'        // 굿즈/전시
-  | 'fan_inferred'            // 팬 추정 성지
-  | 'promotional_reference'   // 홍보 등장
+  | 'scene_depicted' // 장면 등장
+  | 'inspired_by' // 모티프
+  | 'filming_location' // 촬영지
+  | 'collaboration_event' // 콜라보 이벤트
+  | 'merchandise_spot' // 굿즈/전시
+  | 'fan_inferred' // 팬 추정 성지
+  | 'promotional_reference' // 홍보 등장
 
 /** 신뢰도 */
 export type ConfidenceLevel = 'high' | 'medium' | 'low'


### PR DESCRIPTION
Closes #631

## 변경 사항

- 5개 파일에 `prettier --write` 적용하여 format:check CI 통과하도록 수정

## 대상 파일

- `__tests__/onboarding-guide-fix/preservation.property.test.ts`
- `scripts/migrate-relations.ts`
- `src/components/map/PilgrimageMap.tsx`
- `src/lib/relation-utils.ts`
- `src/types/spot.ts`