### PR TITLE
feat: SpotDetailData에 relations 필드 추가

### DIFF
--- a/src/hooks/useSpots.ts
+++ b/src/hooks/useSpots.ts
@@ -3,7 +3,12 @@ import {
   useSuspenseQuery,
   keepPreviousData,
 } from '@tanstack/react-query'
-import { SpotCategory, RelatedContent, ExternalLink } from '@/types'
+import {
+  SpotCategory,
+  RelatedContent,
+  ExternalLink,
+  SpotContentRelation,
+} from '@/types'
 import type { SpotStatus } from '@/types/report'
 import { API_ROUTES, buildUrl } from '@/lib/api-routes'
 
@@ -53,6 +58,8 @@ export interface SpotDetailData {
   firstReporterId?: string
   /** 최초 제보자 이름 (09-spot-report-wiki) */
   firstReporterName?: string
+  /** 스팟-작품 관계 목록 (30-spot-content-relation) */
+  relations?: SpotContentRelation[]
 }
 
 // API response types


### PR DESCRIPTION
Closes #630

## 변경 사항

- `src/hooks/useSpots.ts`의 `SpotDetailData` 인터페이스에 `relations?: SpotContentRelation[]` 필드 추가
- `SpotContentRelation` 타입 import 추가

## 관련 Requirements

- 5.1: 스팟 상세 API 응답에 relations 필드 포함