### PR TITLE
feat: SameContentSpots 관계 기반 조회 전환

### DIFF
--- a/src/components/spot/SameContentSpots.tsx
+++ b/src/components/spot/SameContentSpots.tsx
@@ -4,27 +4,41 @@ import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useSpots, SpotPin } from '@/hooks/useSpots'
-import { RelatedContent, CATEGORY_CONFIG, SpotCategory } from '@/types'
+import {
+  RelatedContent,
+  SpotContentRelation,
+  CATEGORY_CONFIG,
+  SpotCategory,
+} from '@/types'
+import { getPrimaryRelation } from '@/lib/relation-utils'
 import { CategoryIcon } from '@/components/common'
 import { MapPinIcon } from '@/components/icons'
 
 interface SameContentSpotsProps {
   /** 현재 스팟 ID (자기 자신 제외용) */
   currentSpotId: string
-  /** 관련 작품 목록 */
-  relatedContent: RelatedContent[]
+  /** 스팟-작품 관계 목록 (우선) */
+  relations: SpotContentRelation[]
+  /** 관련 작품 목록 (폴백용, 과도기) */
+  relatedContent?: RelatedContent[]
 }
 
 /**
  * 같은 작품의 다른 스팟 목록 컴포넌트
- * 첫 번째 relatedContent.name 기준으로 검색하여 현재 스팟을 제외한 목록 표시
- * Requirements: 4.6, 4.7
+ * 대표 관계(displayPriority 최소)의 contentName 기준으로 by-content API 호출
+ * relations 없으면 기존 relatedContent[0].name 폴백
+ * Requirements: 6.1, 6.2, 6.3
  */
 export function SameContentSpots({
   currentSpotId,
+  relations,
   relatedContent,
 }: SameContentSpotsProps) {
-  const contentName = relatedContent[0]?.name
+  // relations 우선, relatedContent 폴백
+  const primaryRelation =
+    relations?.length > 0 ? getPrimaryRelation(relations) : undefined
+  const contentName = primaryRelation?.contentName ?? relatedContent?.[0]?.name
+
   const { data: spots, isLoading } = useSpots(
     undefined,
     contentName,

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -478,10 +478,12 @@ function SpotDetailContent({
         onConfirm={() => router.push('/auth/signin')}
       />
 
-      {/* 같은 작품의 다른 스팟 (Requirements 4.6, 4.7) */}
-      {spot.relatedContent && spot.relatedContent.length > 0 && (
+      {/* 같은 작품의 다른 스팟 (Requirements 6.1, 6.2, 6.3) */}
+      {((spot.relations && spot.relations.length > 0) ||
+        (spot.relatedContent && spot.relatedContent.length > 0)) && (
         <SameContentSpots
           currentSpotId={spot.id}
+          relations={spot.relations || []}
           relatedContent={spot.relatedContent}
         />
       )}


### PR DESCRIPTION
## 변경 사항

SameContentSpots 컴포넌트를 SpotContentRelation 기반으로 전환합니다.

### 주요 변경

- `SameContentSpots` props에 `relations: SpotContentRelation[]` 추가 (우선 사용)
- 기존 `relatedContent`는 optional 폴백용으로 유지 (과도기)
- `getPrimaryRelation`으로 대표 관계(displayPriority 최소) 선택하여 contentName 결정
- relations 비어있으면 기존 `relatedContent[0].name` 폴백
- `SpotDetailClient`에서 `spot.relations` 데이터를 SameContentSpots에 전달
- 렌더링 조건을 relations 또는 relatedContent 존재 시로 변경

### Requirements

- 6.1: spot_content_relations 기반 같은 contentName 스팟 조회
- 6.2: 대표 관계(displayPriority 최소) 기준 조회
- 6.3: 현재 스팟 결과 제외

Closes #638