### PR TITLE
feat: SpotDetailClient 데이터 전달 경로 변경

### DIFF
--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -50,6 +50,10 @@ import {
 } from '@/components/icons'
 import ShareButton from '@/components/common/ShareButton'
 import { formatSpotShareText } from '@/lib/share-utils'
+import {
+  getContentNamesFromRelations,
+  getPrimaryContentName,
+} from '@/lib/relation-utils'
 
 // 지도 컴포넌트를 동적으로 로드 (SSR 방지)
 const SpotDetailMap = dynamic(() => import('@/components/map/SpotDetailMap'), {
@@ -163,7 +167,7 @@ function SpotDetailPage({ spot, spotId, facilities }: SpotDetailPageProps) {
                 title={spot.name}
                 text={formatSpotShareText(
                   spot.name,
-                  spot.relatedContent?.[0]?.name
+                  getPrimaryContentName(spot.relations, spot.relatedContent)
                 )}
                 variant="icon"
               />
@@ -489,8 +493,14 @@ function SpotDetailContent({
       )}
 
       {/* 관련 순례 코스 */}
-      {spot.relatedContent && spot.relatedContent.length > 0 && (
-        <RelatedRoutes contentNames={spot.relatedContent.map((c) => c.name)} />
+      {((spot.relations && spot.relations.length > 0) ||
+        (spot.relatedContent && spot.relatedContent.length > 0)) && (
+        <RelatedRoutes
+          contentNames={getContentNamesFromRelations(
+            spot.relations,
+            spot.relatedContent
+          )}
+        />
       )}
 
       {/* Related Content - 맨 아래 */}


### PR DESCRIPTION
## 변경 사항\n\nSpotDetailClient에서 ShareButton과 RelatedRoutes의 데이터 전달 경로를 relation-utils 유틸리티 함수 기반으로 변경합니다.\n\n## 주요 변경\n\n- `getContentNamesFromRelations`, `getPrimaryContentName` import 추가\n- ShareButton text: `getPrimaryContentName(spot.relations, spot.relatedContent)` 사용\n- RelatedRoutes: `getContentNamesFromRelations(spot.relations, spot.relatedContent)` 전달\n- RelatedRoutes 렌더링 조건: relations 또는 relatedContent 존재 시로 변경\n\n## Requirements\n\n- 7.1, 7.2, 7.3, 7.4\n\nCloses #640