### PR TITLE
feat: 스팟 검색 API에 relations 기반 검색 추가

### DIFF
--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -108,16 +108,38 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }
     }
 
-    // 검색 필터 (Requirements 6.1, 6.2, 6.3, 6.4)
+    // 검색 필터 (Requirements 6.1, 6.2, 6.3, 6.4, 9.1, 9.2, 9.3)
     // - 빈 문자열이 아닌 경우에만 필터 적용 (6.4)
     // - name 또는 relatedContent.name 부분 일치 검색 (6.2)
+    // - spot_content_relations의 contentName 부분 일치 검색 (9.1)
     // - 대소문자 무시 (6.2)
     // - category와 AND 조건 결합 (6.3)
+    // - relations + relatedContent 결과 합산(union), 중복 제거 (9.2, 9.3)
     if (searchParam && searchParam.trim() !== '') {
       const escapedSearch = escapeRegex(searchParam.trim())
+
+      // spot_content_relations에서 contentName 부분 일치하는 spotId 조회
+      const relationsCollection = await getCollection(
+        COLLECTIONS.SPOT_CONTENT_RELATIONS
+      )
+      const matchingRelations = await relationsCollection
+        .find({
+          contentName: { $regex: escapedSearch, $options: 'i' },
+          status: 'active',
+        })
+        .project({ spotId: 1 })
+        .toArray()
+      const relationSpotIds = [
+        ...new Set(matchingRelations.map((r) => r.spotId as string)),
+      ]
+
+      // 기존 검색 조건 + relations 매칭 spotId 합산
       query.$or = [
         { name: { $regex: escapedSearch, $options: 'i' } },
         { 'relatedContent.name': { $regex: escapedSearch, $options: 'i' } },
+        ...(relationSpotIds.length > 0
+          ? [{ id: { $in: relationSpotIds } }]
+          : []),
       ]
     }
 


### PR DESCRIPTION
## 변경 사항\n\n스팟 검색 API(`GET /api/spots`)에서 검색어 입력 시 `spot_content_relations` 컬렉션의 `contentName` 부분 일치 검색을 추가합니다.\n\n### 구현 내용\n\n- 검색어 입력 시 `spot_content_relations`에서 `contentName` 부분 일치(case-insensitive regex) + `status: 'active'` 조건으로 `spotId` 목록 조회\n- 기존 `$or` 조건(name, relatedContent.name)에 relations 매칭 spotId를 `{ id: { $in: [...] } }` 조건으로 추가\n- `Set`을 사용하여 중복 spotId 제거\n- MongoDB의 `$or` 쿼리로 자연스럽게 결과 합산(union) 및 중복 스팟 제거\n\n### 관련 Requirements\n\n- 9.1: spot_content_relations에서 contentName 부분 일치 검색\n- 9.2: relations + relatedContent 결과 합산(union)\n- 9.3: 중복 스팟 제거\n\nCloses #642