### PR TITLE
[feat] MascotOverlay 컴포넌트 구현

### DIFF
--- a/src/components/landing/MascotOverlay.tsx
+++ b/src/components/landing/MascotOverlay.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Image from 'next/image'
+
+/**
+ * MascotOverlay 컴포넌트
+ * 마스코트(흰 고양이)를 카드 콜라주 우하단에 자연스럽게 배치한다.
+ * - 미세한 float 애니메이션 (위아래 2~3px 움직임)
+ * - 모바일에서 크기 축소
+ * - reducedMotion=true 시 정적 배치
+ *
+ * Requirements: 3.1, 3.2, 3.3, 3.4
+ */
+
+interface MascotOverlayProps {
+  /** 모션 감소 설정 */
+  reducedMotion: boolean
+  /** 추가 CSS 클래스 */
+  className?: string
+}
+
+/** 마스코트 이미지 경로 */
+const MASCOT_IMAGE_PATH = '/icons/raw/0329/캐릭터_메인_최종.webp'
+
+export function MascotOverlay({ reducedMotion, className = '' }: MascotOverlayProps) {
+  return (
+    <div
+      className={`absolute bottom-2 right-2 z-10 md:bottom-4 md:right-4 ${className}`}
+      aria-hidden="true"
+    >
+      <div
+        className={`relative h-12 w-12 md:h-20 md:w-20 lg:h-24 lg:w-24 ${
+          reducedMotion ? '' : 'animate-mascot-float'
+        }`}
+      >
+        <Image
+          src={MASCOT_IMAGE_PATH}
+          alt=""
+          fill
+          sizes="(max-width: 768px) 48px, (max-width: 1024px) 80px, 96px"
+          className="object-contain drop-shadow-lg"
+          priority={false}
+        />
+      </div>
+    </div>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -87,6 +87,15 @@ const config: Config = {
         'screen-safe':
           'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
       },
+      keyframes: {
+        'mascot-float': {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-3px)' },
+        },
+      },
+      animation: {
+        'mascot-float': 'mascot-float 3s ease-in-out infinite',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #648

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

히어로 섹션 플로팅 카드 콜라주 위에 마스코트(흰 고양이) 이미지를 오버레이하는 MascotOverlay 컴포넌트를 구현한다.

---

## 📋 변경 사항

- [x] `src/components/landing/MascotOverlay.tsx` 컴포넌트 생성
- [x] 마스코트 이미지를 카드 콜라주 우하단에 absolute 배치 (Req 3.1)
- [x] CSS 기반 mascot-float 애니메이션 (위아래 3px, 3초 주기) 적용 (Req 3.2)
- [x] `reducedMotion=true` 시 애니메이션 비활성화 (Req 3.3)
- [x] 모바일 48px, 태블릿 80px, 데스크톱 96px 반응형 크기 조절 (Req 3.4)
- [x] Tailwind config에 mascot-float keyframes 추가

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- 마스코트 이미지: `/icons/raw/0329/캐릭터_메인_최종.webp` 사용
- Next.js Image 컴포넌트로 최적화 (lazy loading, sizes 속성)
- `aria-hidden="true"` 적용 (장식 요소)