### PR TITLE
[feat] CSS float 애니메이션 구현

### DIFF
--- a/src/components/landing/FloatingCardsCollage.tsx
+++ b/src/components/landing/FloatingCardsCollage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 
 import { FloatingCard } from './FloatingCard'
+import './floating-cards.css'
 import { MascotOverlay } from './MascotOverlay'
 import { CARD_PLACEMENTS, SHOWCASE_CARDS } from './data/showcaseCards'
 
@@ -85,7 +86,7 @@ export function FloatingCardsCollage({
         }
 
         return (
-          <div key={card.id} style={cardStyle}>
+          <div key={card.id} className="floating-card" style={cardStyle}>
             <FloatingCard
               card={card}
               index={index}

--- a/src/components/landing/floating-cards.css
+++ b/src/components/landing/floating-cards.css
@@ -1,0 +1,144 @@
+/**
+ * 플로팅 카드 CSS 애니메이션
+ * - 12개 카드별 고유 float keyframes (float-card-0 ~ float-card-11)
+ * - GPU 가속: transform 속성만 사용하여 60fps 유지
+ * - will-change: transform으로 합성 레이어 생성
+ * - prefers-reduced-motion: reduce 미디어 쿼리 존중
+ *
+ * Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 8.6
+ */
+
+/* ============================================
+   Base: GPU 가속 최적화
+   ============================================ */
+
+.floating-card {
+  will-change: transform;
+}
+
+/* ============================================
+   Keyframes: 12개 카드별 고유 float 애니메이션
+   - translateY: -8px ~ 8px (위아래 떠다님)
+   - translateX: -3px ~ 3px (좌우 미세 움직임)
+   - rotate: ±2deg (살짝 기울어짐 변화)
+   - 각 카드마다 다른 값으로 자연스러운 변화 연출
+   ============================================ */
+
+@keyframes float-card-0 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-10px) translateX(3px) rotate(2deg);
+  }
+}
+
+@keyframes float-card-1 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-8px) translateX(-2px) rotate(-1.5deg);
+  }
+}
+
+@keyframes float-card-2 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-12px) translateX(2px) rotate(1deg);
+  }
+}
+
+@keyframes float-card-3 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-7px) translateX(-3px) rotate(-2deg);
+  }
+}
+
+@keyframes float-card-4 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-9px) translateX(1px) rotate(1.5deg);
+  }
+}
+
+@keyframes float-card-5 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-11px) translateX(-1px) rotate(-1deg);
+  }
+}
+
+@keyframes float-card-6 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-8px) translateX(2px) rotate(2deg);
+  }
+}
+
+@keyframes float-card-7 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-10px) translateX(-2px) rotate(-1.8deg);
+  }
+}
+
+@keyframes float-card-8 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-6px) translateX(3px) rotate(1.2deg);
+  }
+}
+
+@keyframes float-card-9 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-12px) translateX(-1px) rotate(-2deg);
+  }
+}
+
+@keyframes float-card-10 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-9px) translateX(2px) rotate(1.8deg);
+  }
+}
+
+@keyframes float-card-11 {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateY(-7px) translateX(-3px) rotate(-1.5deg);
+  }
+}
+
+/* ============================================
+   접근성: prefers-reduced-motion 존중
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-card {
+    animation: none !important;
+    will-change: auto;
+  }
+}


### PR DESCRIPTION
## 개요

플로팅 카드 콜라주의 CSS float 애니메이션을 구현한다.

Closes #652

## 변경 사항

- `src/components/landing/floating-cards.css` 생성
  - 12개 카드별 고유 float keyframes 정의 (`float-card-0` ~ `float-card-11`)
  - `.floating-card` 클래스에 `will-change: transform` GPU 가속 최적화 적용
  - `@media (prefers-reduced-motion: reduce)` 미디어 쿼리로 애니메이션 비활성화
- `src/components/landing/FloatingCardsCollage.tsx` 수정
  - CSS 파일 import 추가
  - 카드 wrapper에 `floating-card` 클래스 적용

## 테스트

- `npm run type-check` 통과 확인

## Requirements

- 8.1: CSS keyframes로 구현 (JavaScript 애니메이션 라이브러리 미사용)
- 8.2: GPU 가속 속성(transform)만 사용하여 60fps 유지
- 8.3: 각 카드마다 다른 duration/delay 적용 (inline style)
- 8.4: ease-in-out 타이밍과 alternate 방향으로 부드러운 왕복 움직임
- 8.5: prefers-reduced-motion: reduce 미디어 쿼리 존중
- 8.6: will-change: transform 적용하여 합성 레이어 생성