### PR TITLE
feat: HeroSection 및 WelcomePageClient 수정

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,32 +1,21 @@
 'use client'
 
 import { forwardRef } from 'react'
-import dynamic from 'next/dynamic'
 import { CTAButton } from './CTAButton'
-import { GlobeFallback2D } from './GlobeFallback2D'
-import { GLOBE_DATA_POINTS } from './data/globeData'
+import { FloatingCardsCollage } from './FloatingCardsCollage'
 
 /**
  * 히어로 섹션 컴포넌트
- * 3D 지구본(또는 2D 폴백) + 가치 제안 카피 + CTA 버튼으로 구성
- * Requirements: 1.1, 1.2, 1.5, 1.6, 6.4, 7.4
+ * 플로팅 카드 콜라주 + 가치 제안 카피 + CTA 버튼으로 구성
+ * Requirements: 4.1, 4.2, 4.3, 4.4
  */
 
 interface HeroSectionProps {
-  isHighEnd: boolean
   reducedMotion: boolean
 }
 
-/** Globe3D를 dynamic import로 로드 (SSR 비활성화, 번들 분리) */
-const Globe3D = dynamic(() => import('./Globe3D').then((mod) => mod.Globe3D), {
-  ssr: false,
-  loading: () => (
-    <GlobeFallback2D className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]" />
-  ),
-})
-
 export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
-  function HeroSection({ isHighEnd, reducedMotion }, ref) {
+  function HeroSection({ reducedMotion }, ref) {
     return (
       <section
         ref={ref}
@@ -55,17 +44,12 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
             <CTAButton label="지도 탐색하기" href="/map" size="lg" />
           </header>
 
-          {/* 지구본 비주얼 영역 */}
+          {/* 플로팅 카드 콜라주 비주얼 영역 (Globe3D 대체) */}
           <div className="relative flex flex-1 items-center justify-center">
-            {/* 3D/2D 지구본 분기 렌더링 */}
-            {isHighEnd && !reducedMotion ? (
-              <Globe3D
-                dataPoints={GLOBE_DATA_POINTS}
-                className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]"
-              />
-            ) : (
-              <GlobeFallback2D className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]" />
-            )}
+            <FloatingCardsCollage
+              reducedMotion={reducedMotion}
+              className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]"
+            />
           </div>
         </div>
       </section>

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -70,7 +70,6 @@ export function WelcomePageClient() {
       ) : (
         <HeroSection
           ref={heroRef}
-          isHighEnd={isHighEnd}
           reducedMotion={reducedMotion}
         />
       )}
@@ -110,8 +109,15 @@ function HeroSkeleton() {
           <div className="h-6 w-48 animate-pulse rounded-md bg-neutral-200 dark:bg-neutral-700" />
           <div className="h-12 w-36 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" />
         </div>
-        <div className="flex flex-1 items-center justify-center">
-          <div className="h-64 w-64 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700 md:h-80 md:w-80" />
+        {/* 카드 콜라주 스켈레톤 (기존 원형 지구본 → 사각형 카드들) */}
+        <div className="relative flex flex-1 items-center justify-center">
+          <div className="relative h-64 w-64 md:h-80 md:w-80">
+            <div className="absolute left-2 top-4 h-20 w-16 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(-5deg)' }} />
+            <div className="absolute right-4 top-2 h-24 w-20 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(3deg)' }} />
+            <div className="absolute bottom-8 left-8 h-20 w-16 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(4deg)' }} />
+            <div className="absolute bottom-4 right-6 h-24 w-20 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(-3deg)' }} />
+            <div className="absolute left-1/2 top-1/2 h-20 w-16 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'translate(-50%, -50%) rotate(2deg)' }} />
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #654

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

> HeroSection에서 Globe3D/GlobeFallback2D를 FloatingCardsCollage로 교체하고, isHighEnd prop을 제거하여 reducedMotion만 사용하도록 수정

---

## 📋 변경 사항

- [x] HeroSection에서 Globe3D/GlobeFallback2D를 FloatingCardsCollage로 교체
- [x] HeroSection의 `isHighEnd` prop 제거, `reducedMotion`만 사용
- [x] WelcomePageClient에서 HeroSection에 `isHighEnd` prop 전달 제거
- [x] HeroSkeleton의 지구본 스켈레톤(원형)을 카드 콜라주 스켈레톤(사각형 카드들)으로 수정

---

## ✅ 체크리스트

- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3 대응
- Three.js 관련 import 제거 (Globe3D, GlobeFallback2D, globeData)
- 기존 텍스트, CTA, 레이아웃 구조 유지