### PR TITLE
[ui] 랜딩 페이지 전면 개편 — 발견형 히어로 + 실사 이미지 + 구조 개선

### DIFF
--- a/.kiro/specs/30-spot-content-relation/tasks.md
+++ b/.kiro/specs/30-spot-content-relation/tasks.md
@@ -7,26 +7,26 @@
 ## Tasks
 
 - [ ] 1. 데이터 모델 및 DB 설정
-  - [ ] 1.1 SpotContentRelation 타입 및 enum 정의
+  - [x] 1.1 SpotContentRelation 타입 및 enum 정의
     - `src/types/spot.ts`에 `RelationType`, `ConfidenceLevel`, `Officialness`, `RelationStatus` 타입 추가
     - `RELATION_TYPE_LABELS` 한글 라벨 상수 추가
     - `SpotContentRelation` 인터페이스 정의 (id, spotId, contentId, contentName, contentType, relationType, confidenceLevel, officialness, displayPriority, status, summary, startDate, endDate, sourceCount, verificationScore, createdBy, updatedBy, createdAt, updatedAt)
     - `contentImageUrl` 선택 필드 포함
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8_
 
-  - [ ] 1.2 DB 컬렉션 상수 및 API 경로 추가
+  - [x] 1.2 DB 컬렉션 상수 및 API 경로 추가
     - `src/lib/db.ts`의 `COLLECTIONS`에 `SPOT_CONTENT_RELATIONS: 'spot_content_relations'` 추가
     - `src/lib/api-routes.ts`의 `API_ROUTES.SPOTS`에 `RELATIONS: (id: string) => /api/spots/${id}/relations`, `BY_CONTENT: '/api/spots/relations/by-content'` 추가
     - _Requirements: 2.1_
 
-  - [ ] 1.3 MongoDB 인덱스 초기화 스크립트 작성
+  - [x] 1.3 MongoDB 인덱스 초기화 스크립트 작성
     - `scripts/init-relation-indexes.ts` 생성
     - `spotId` 단일 인덱스, `contentName` 단일 인덱스, `{ spotId, contentName }` 복합 유니크 인덱스, `status` 단일 인덱스 생성
     - 실행 결과 콘솔 출력
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
 
 - [ ] 2. 변환 유틸리티 및 마이그레이션 스크립트
-  - [ ] 2.1 RelatedContent → SpotContentRelation 변환 유틸리티 작성
+  - [x] 2.1 RelatedContent → SpotContentRelation 변환 유틸리티 작성
     - `src/lib/relation-utils.ts` 신규 생성
     - `normalizeContentName(name: string): string` — contentId 생성용 정규화 함수
     - `generateContentId(spotId: string, contentName: string): string` — `{spotId}_{normalizedName}` 형식
@@ -73,7 +73,7 @@
     - fast-check 100회 이상, 태그: `Feature: 30-spot-content-relation, Property 5: 마이그레이션 중복 건너뛰기`
     - **Validates: Requirements 3.6**
 
-  - [ ] 2.7 마이그레이션 스크립트 작성
+  - [x] 2.7 마이그레이션 스크립트 작성
     - `scripts/migrate-relations.ts` 생성
     - spots 컬렉션 전체 조회 → relatedContent 존재 시 각 항목을 SpotContentRelation으로 변환
     - 중복 `(spotId, contentName)` 체크 후 건너뛰기 및 로그 기록
@@ -81,18 +81,18 @@
     - `convertRelatedContentToRelation` 유틸리티 재사용
     - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8_
 
-- [ ] 3. 체크포인트 — 데이터 모델 및 변환 유틸리티 검증
+- [x] 3. 체크포인트 — 데이터 모델 및 변환 유틸리티 검증
   - Ensure all tests pass, ask the user if questions arise.
 
 - [ ] 4. Relations API 엔드포인트 구현
-  - [ ] 4.1 스팟별 Relations API 구현
+  - [x] 4.1 스팟별 Relations API 구현
     - `src/app/api/spots/[id]/relations/route.ts` 신규 생성
     - `GET /api/spots/[id]/relations` — 해당 스팟의 active 상태 관계를 displayPriority 오름차순으로 반환
     - 관계 없을 시 `{ relations: [], total: 0 }` 반환
     - 존재하지 않는 스팟 ID → 404, DB 오류 → 500
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
 
-  - [ ] 4.2 작품별 스팟 조회 API 구현
+  - [x] 4.2 작품별 스팟 조회 API 구현
     - `src/app/api/spots/relations/by-content/route.ts` 신규 생성
     - `GET /api/spots/relations/by-content?contentName=...` — 해당 contentName의 active 관계에서 고유 spotId 목록 반환
     - contentName 파라미터 누락 시 400
@@ -113,24 +113,24 @@
     - **Validates: Requirements 6.1, 6.4**
 
 - [ ] 5. 스팟 상세 API 확장 및 CRUD 동기화
-  - [ ] 5.1 스팟 상세 API 응답에 relations 필드 추가
+  - [x] 5.1 스팟 상세 API 응답에 relations 필드 추가
     - `src/app/api/spots/[id]/route.ts` GET 수정
     - spot 조회 후 spot_content_relations에서 active 관계를 displayPriority 오름차순으로 조회
     - 응답에 기존 `relatedContent` 유지 + `relations` 필드 추가
     - _Requirements: 5.1, 5.2, 5.3_
 
-  - [ ] 5.2 스팟 등록(POST) 시 relations 동기화
+  - [x] 5.2 스팟 등록(POST) 시 relations 동기화
     - `src/app/api/spots/route.ts` POST 수정
     - relatedContent 배열의 각 항목을 spot_content_relations에 SpotContentRelation으로 생성
     - `convertRelatedContentToRelation` 유틸리티 재사용
     - _Requirements: 10.1, 10.4_
 
-  - [ ] 5.3 스팟 수정(PUT) 시 relations 동기화
+  - [x] 5.3 스팟 수정(PUT) 시 relations 동기화
     - `src/app/api/spots/[id]/route.ts` PUT 수정
     - relatedContent 변경 시 해당 스팟의 기존 관계 삭제 후 새 relatedContent 기반 재생성
     - _Requirements: 10.2, 10.4_
 
-  - [ ] 5.4 스팟 삭제(DELETE) 시 relations 삭제
+  - [x] 5.4 스팟 삭제(DELETE) 시 relations 삭제
     - `src/app/api/spots/[id]/route.ts` DELETE 수정
     - 스팟 삭제 시 해당 스팟의 모든 SpotContentRelation 문서 함께 삭제
     - _Requirements: 10.3_
@@ -142,16 +142,16 @@
     - fast-check 100회 이상, 태그: `Feature: 30-spot-content-relation, Property 12: CRUD 동기화 일관성`
     - **Validates: Requirements 10.1, 10.2, 10.3, 10.4**
 
-- [ ] 6. 체크포인트 — API 및 CRUD 동기화 검증
+- [x] 6. 체크포인트 — API 및 CRUD 동기화 검증
   - Ensure all tests pass, ask the user if questions arise.
 
 - [ ] 7. React Query 훅 및 SpotDetailData 확장
-  - [ ] 7.1 SpotDetailData에 relations 필드 추가
+  - [x] 7.1 SpotDetailData에 relations 필드 추가
     - `src/hooks/useSpots.ts`의 `SpotDetailData` 인터페이스에 `relations?: SpotContentRelation[]` 필드 추가
     - import 경로 추가
     - _Requirements: 5.1_
 
-  - [ ] 7.2 useSpotRelations 훅 생성
+  - [x] 7.2 useSpotRelations 훅 생성
     - `src/hooks/useSpotRelations.ts` 신규 생성
     - `useSpotRelations(spotId)` — `GET /api/spots/[id]/relations` 호출
     - `useSpotsByContent(contentName)` — `GET /api/spots/relations/by-content?contentName=...` 호출
@@ -159,7 +159,7 @@
     - _Requirements: 4.1, 6.1, 6.4_
 
 - [ ] 8. UI 컴포넌트 전환
-  - [ ] 8.1 RelatedContentSection 관계 기반 렌더링 전환
+  - [x] 8.1 RelatedContentSection 관계 기반 렌더링 전환
     - `src/components/spot/RelatedContentSection.tsx` 수정
     - props에 `relations: SpotContentRelation[]` 추가, 기존 `contents` 폴백용 유지
     - relations 우선 렌더링: 대표 관계 최대 3개 카드 → "더보기 (+N)" → 나머지 펼침
@@ -168,14 +168,14 @@
     - relations 비어있고 contents도 비어있으면 섹션 숨김
     - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7_
 
-  - [ ] 8.2 SameContentSpots 관계 기반 조회 전환
+  - [x] 8.2 SameContentSpots 관계 기반 조회 전환
     - `src/components/spot/SameContentSpots.tsx` 수정
     - props에 `relations: SpotContentRelation[]` 추가, 기존 `relatedContent` 폴백용 유지
     - 대표 관계(displayPriority 최소)의 contentName 기준으로 by-content API 호출
     - relations 없으면 기존 relatedContent[0].name 폴백
     - _Requirements: 6.1, 6.2, 6.3_
 
-  - [ ] 8.3 SpotDetailClient 데이터 전달 경로 변경
+  - [x] 8.3 SpotDetailClient 데이터 전달 경로 변경
     - `src/components/spot/SpotDetailClient.tsx` 수정
     - `spot.relations`를 RelatedContentSection, SameContentSpots, RelatedRoutes에 전달
     - ShareButton의 공유 텍스트에 `getPrimaryContentName(spot.relations, spot.relatedContent)` 사용
@@ -183,7 +183,7 @@
     - SameContentSpots/RelatedRoutes 렌더링 조건을 relations 또는 relatedContent 존재 시로 변경
     - _Requirements: 7.1, 7.2, 7.3, 7.4_
 
-  - [ ] 8.4 share-utils 관계 기반 대표 작품명 전환
+  - [x] 8.4 share-utils 관계 기반 대표 작품명 전환
     - `src/lib/share-utils.ts` 수정
     - `formatSpotShareText` 시그니처 확장 또는 SpotDetailClient에서 호출 시 `getPrimaryContentName` 결과 전달
     - _Requirements: 7.2, 7.4_
@@ -210,7 +210,7 @@
     - **Validates: Requirements 8.3, 8.4, 8.5, 8.7**
 
 - [ ] 9. 검색 필터 호환성
-  - [ ] 9.1 스팟 검색 API에 relations 기반 검색 추가
+  - [x] 9.1 스팟 검색 API에 relations 기반 검색 추가
     - `src/app/api/spots/route.ts` GET 수정
     - 검색어 입력 시 spot_content_relations에서 contentName 부분 일치하는 spotId 목록 조회
     - 기존 relatedContent.name 검색 결과와 합산(union), 중복 spotId 제거
@@ -223,7 +223,7 @@
     - fast-check 100회 이상, 태그: `Feature: 30-spot-content-relation, Property 11: 검색 합산 및 중복 제거`
     - **Validates: Requirements 9.1, 9.2, 9.3**
 
-- [ ] 10. 최종 체크포인트 — 전체 기능 검증
+- [x] 10. 최종 체크포인트 — 전체 기능 검증
   - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes

--- a/.kiro/specs/32-landing-hero-floating-cards/.config.kiro
+++ b/.kiro/specs/32-landing-hero-floating-cards/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "b6647e74-a4ed-48e6-82df-cea5ec8c58d2", "workflowType": "design-first", "specType": "feature"}

--- a/.kiro/specs/32-landing-hero-floating-cards/design.md
+++ b/.kiro/specs/32-landing-hero-floating-cards/design.md
@@ -1,0 +1,508 @@
+# Design Document: Landing Hero Floating Cards
+
+## Overview
+
+랜딩 페이지 히어로 섹션의 Three.js 3D 지구본을 "플로팅 카드 콜라주"로 교체한다. 현재 지구본은 카테고리 아이콘만 표시하여 시각적으로 밋밋하고, 회색 반투명 구체가 단조로우며, Three.js 의존성(`three`, `@react-three/fiber`, `@react-three/drei`)이 번들 사이즈를 크게 증가시킨다.
+
+새로운 플로팅 카드 콜라주는 실제 스팟 사진과 작품명이 표시된 카드들이 다크 배경 위에서 천천히 떠다니는 Pinterest/Dribbble 스타일의 시각적으로 풍부한 레이아웃이다. CSS 애니메이션 기반으로 구현하여 Three.js 의존성을 완전히 제거하고, 마스코트(흰 고양이)는 카드 콜라주 위에 자연스럽게 통합한다. 모바일에서도 카드 수와 크기를 조절하여 최적의 경험을 제공한다.
+
+## Architecture
+
+```mermaid
+graph TD
+    WPC[WelcomePageClient] --> HS[HeroSection]
+    HS --> FCC[FloatingCardsCollage]
+    HS --> CTA[CTAButton]
+    
+    FCC --> FC1[FloatingCard ×N]
+    FCC --> MC[MascotOverlay]
+    
+    FC1 --> |CSS keyframes| ANI[float-card-N animations]
+    MC --> |static/subtle animation| MANI[mascot-float animation]
+    
+    FCC --> |데이터| SCD[SHOWCASE_CARDS 정적 데이터]
+    
+    subgraph "제거 대상"
+        G3D[Globe3D]
+        GF2D[GlobeFallback2D]
+        MW[MascotWalker]
+        GD[globeData.ts]
+    end
+    
+    subgraph "번들 제거"
+        THREE[three]
+        RTF[@react-three/fiber]
+        RTD[@react-three/drei]
+    end
+```
+
+## Sequence Diagrams
+
+### 히어로 섹션 렌더링 플로우
+
+```mermaid
+sequenceDiagram
+    participant WPC as WelcomePageClient
+    participant HS as HeroSection
+    participant FCC as FloatingCardsCollage
+    participant FC as FloatingCard
+    participant MC as MascotOverlay
+
+    WPC->>HS: render(reducedMotion)
+    HS->>FCC: render(reducedMotion)
+    
+    FCC->>FCC: SHOWCASE_CARDS 정적 데이터 로드
+    
+    loop 각 카드 (모바일: 6장, 데스크톱: 12장)
+        FCC->>FC: render(card, index, reducedMotion)
+        FC->>FC: CSS float-card-{index} 애니메이션 적용
+        Note over FC: reducedMotion=true → 애니메이션 비활성화
+    end
+    
+    FCC->>MC: render(마스코트 이미지)
+    MC->>MC: subtle float 애니메이션 적용
+```
+
+### 반응형 카드 배치 플로우
+
+```mermaid
+sequenceDiagram
+    participant V as Viewport
+    participant FCC as FloatingCardsCollage
+    participant CSS as CSS Grid/Absolute
+
+    V->>FCC: 화면 크기 감지
+    
+    alt 모바일 (< 768px)
+        FCC->>CSS: 6장 카드, 작은 크기
+        CSS->>CSS: 2열 그리드 + 엇갈림 배치
+    else 태블릿 (768px ~ 1024px)
+        FCC->>CSS: 9장 카드, 중간 크기
+        CSS->>CSS: 3열 그리드 + 엇갈림 배치
+    else 데스크톱 (> 1024px)
+        FCC->>CSS: 12장 카드, 큰 크기
+        CSS->>CSS: absolute 위치 + 자유 배치
+    end
+```
+
+## Components and Interfaces
+
+### Component 1: FloatingCardsCollage
+
+**Purpose**: 히어로 섹션의 비주얼 영역. 여러 장의 스팟 카드가 떠다니는 콜라주를 렌더링한다.
+
+```typescript
+interface FloatingCardsCollageProps {
+  /** 모션 감소 설정 (prefers-reduced-motion) */
+  reducedMotion: boolean
+  /** 추가 CSS 클래스 */
+  className?: string
+}
+```
+
+**Responsibilities**:
+- SHOWCASE_CARDS 정적 데이터에서 카드 목록을 가져와 렌더링
+- 반응형 카드 수 조절 (모바일 6장, 태블릿 9장, 데스크톱 12장)
+- 각 카드에 고유한 float 애니메이션 딜레이/속도 부여
+- 마스코트 오버레이를 카드 콜라주 위에 배치
+- reducedMotion=true 시 애니메이션 비활성화 (정적 배치)
+- 접근성: `role="img"`, `aria-label` 제공
+
+### Component 2: FloatingCard
+
+**Purpose**: 개별 플로팅 카드. 스팟 이미지와 작품명을 표시한다.
+
+```typescript
+interface ShowcaseCard {
+  /** 카드 ID */
+  id: string
+  /** 스팟 이름 */
+  spotName: string
+  /** 관련 작품명 */
+  contentName: string
+  /** 카테고리 */
+  category: SpotCategory
+  /** 이미지 URL (정적 에셋 또는 외부 URL) */
+  imageUrl: string
+}
+
+interface FloatingCardProps {
+  /** 카드 데이터 */
+  card: ShowcaseCard
+  /** 카드 인덱스 (애니메이션 딜레이 계산용) */
+  index: number
+  /** 모션 감소 설정 */
+  reducedMotion: boolean
+  /** 카드 크기 variant */
+  size: 'sm' | 'md' | 'lg'
+}
+```
+
+**Responsibilities**:
+- Next.js Image 컴포넌트로 이미지 최적화 (lazy loading, WebP)
+- 카테고리별 accent 색상 표시 (하단 바 또는 테두리)
+- 다크 테마에 어울리는 카드 스타일 (반투명 배경, 미세한 글로우)
+- 호버 시 살짝 확대 + 그림자 강화 (데스크톱)
+- 각 카드마다 고유한 CSS 애니메이션 (float 방향, 속도, 딜레이 다름)
+
+### Component 3: MascotOverlay
+
+**Purpose**: 마스코트(흰 고양이)를 카드 콜라주 위에 자연스럽게 배치한다.
+
+```typescript
+interface MascotOverlayProps {
+  /** 모션 감소 설정 */
+  reducedMotion: boolean
+  /** 추가 CSS 클래스 */
+  className?: string
+}
+```
+
+**Responsibilities**:
+- 마스코트 이미지를 카드 콜라주 우하단에 배치
+- 미세한 float 애니메이션 (위아래 2~3px 움직임)
+- 모바일에서는 크기 축소 또는 숨김 처리
+- reducedMotion=true 시 정적 배치
+
+### Component 4: HeroSection (수정)
+
+**Purpose**: 기존 HeroSection에서 Globe3D/GlobeFallback2D를 FloatingCardsCollage로 교체한다.
+
+```typescript
+interface HeroSectionProps {
+  /** reducedMotion 설정 (isHighEnd는 더 이상 불필요) */
+  reducedMotion: boolean
+}
+```
+
+**Responsibilities**:
+- 기존 `isHighEnd` prop 제거 (Three.js 분기 불필요)
+- Globe3D/GlobeFallback2D 대신 FloatingCardsCollage 렌더링
+- 텍스트 + CTA 영역은 기존 유지
+- 레이아웃: 모바일은 텍스트 위 + 카드 아래, 데스크톱은 좌우 배치
+
+## Data Models
+
+### ShowcaseCard (정적 데이터)
+
+```typescript
+interface ShowcaseCard {
+  id: string
+  spotName: string
+  contentName: string
+  category: SpotCategory
+  imageUrl: string
+}
+```
+
+**Validation Rules**:
+- `id`는 고유해야 함
+- `imageUrl`은 유효한 이미지 경로 (정적 에셋 또는 외부 URL)
+- `category`는 SpotCategory 유니온 타입 중 하나
+
+### SHOWCASE_CARDS 정적 데이터
+
+```typescript
+/**
+ * 히어로 섹션에 표시할 쇼케이스 카드 데이터
+ * - 12장 (데스크톱 전체 표시, 모바일은 6장만)
+ * - 6개 카테고리 균형 배분 (카테고리당 2장)
+ * - 실제 스팟 데이터 기반 (globeData.ts의 대표 스팟 활용)
+ */
+const SHOWCASE_CARDS: ShowcaseCard[] = [
+  {
+    id: 'sc-1',
+    spotName: '가마쿠라코코마에역',
+    contentName: '슬램덩크',
+    category: 'animation',
+    imageUrl: '/images/showcase/kamakura.webp',
+  },
+  // ... 총 12장
+]
+```
+
+### 카드 배치 설정
+
+```typescript
+/**
+ * 각 카드의 위치/크기/애니메이션 설정
+ * 데스크톱에서 absolute 배치 시 사용
+ */
+interface CardPlacement {
+  /** top 위치 (%) */
+  top: number
+  /** left 위치 (%) */
+  left: number
+  /** 회전 각도 (deg) */
+  rotate: number
+  /** 카드 크기 */
+  size: 'sm' | 'md' | 'lg'
+  /** 애니메이션 딜레이 (s) */
+  delay: number
+  /** 애니메이션 주기 (s) */
+  duration: number
+  /** z-index */
+  zIndex: number
+}
+
+const CARD_PLACEMENTS: CardPlacement[] = [
+  { top: 5, left: 10, rotate: -8, size: 'lg', delay: 0, duration: 6, zIndex: 3 },
+  { top: 15, left: 55, rotate: 5, size: 'md', delay: 0.5, duration: 7, zIndex: 2 },
+  { top: 40, left: 5, rotate: 3, size: 'md', delay: 1, duration: 8, zIndex: 2 },
+  { top: 35, left: 65, rotate: -5, size: 'lg', delay: 1.5, duration: 6.5, zIndex: 3 },
+  { top: 60, left: 25, rotate: 7, size: 'sm', delay: 2, duration: 7.5, zIndex: 1 },
+  { top: 65, left: 70, rotate: -3, size: 'md', delay: 0.8, duration: 8.5, zIndex: 2 },
+  { top: 10, left: 35, rotate: -12, size: 'sm', delay: 1.2, duration: 7, zIndex: 1 },
+  { top: 50, left: 45, rotate: 10, size: 'sm', delay: 1.8, duration: 6, zIndex: 1 },
+  { top: 75, left: 10, rotate: -6, size: 'sm', delay: 2.5, duration: 8, zIndex: 1 },
+  { top: 80, left: 50, rotate: 4, size: 'md', delay: 0.3, duration: 7, zIndex: 2 },
+  { top: 25, left: 80, rotate: -10, size: 'sm', delay: 1.6, duration: 6.5, zIndex: 1 },
+  { top: 55, left: 85, rotate: 8, size: 'sm', delay: 2.2, duration: 7.5, zIndex: 1 },
+]
+```
+
+## Algorithmic Pseudocode
+
+### 카드 Float 애니메이션 알고리즘
+
+```typescript
+/**
+ * 각 카드에 고유한 float 애니메이션을 생성하는 알고리즘
+ * 
+ * ALGORITHM generateFloatAnimation
+ * INPUT: index (카드 인덱스), placement (CardPlacement)
+ * OUTPUT: CSS animation 속성 문자열
+ * 
+ * 1. 기본 translateY 범위: -8px ~ 8px (카드가 위아래로 떠다님)
+ * 2. 미세한 translateX 범위: -3px ~ 3px (좌우 미세 움직임)
+ * 3. 미세한 rotate 범위: ±2deg (살짝 기울어짐 변화)
+ * 4. duration: placement.duration (6~8.5초, 카드마다 다름)
+ * 5. delay: placement.delay (0~2.5초, 카드마다 다름)
+ * 6. timing: ease-in-out (부드러운 왕복)
+ * 7. iteration: infinite (무한 반복)
+ * 8. direction: alternate (왕복)
+ */
+function getFloatStyle(index: number, placement: CardPlacement): React.CSSProperties {
+  // 각 카드마다 다른 float 패턴을 위해 index 기반 오프셋 계산
+  const yOffset = 8 + (index % 3) * 2       // 8~12px
+  const xOffset = 2 + (index % 4)           // 2~5px
+  const rotateOffset = 1 + (index % 3)      // 1~3deg
+
+  return {
+    animation: `float-${index} ${placement.duration}s ease-in-out ${placement.delay}s infinite alternate`,
+    // CSS keyframes는 글로벌 스타일시트에 정의
+  }
+}
+```
+
+**Preconditions:**
+- `index`는 0 이상의 정수
+- `placement`는 유효한 CardPlacement 객체
+
+**Postconditions:**
+- 반환된 스타일은 유효한 CSS animation 속성
+- 각 카드의 애니메이션은 서로 다른 타이밍을 가짐
+
+### 반응형 카드 수 결정 알고리즘
+
+```typescript
+/**
+ * ALGORITHM selectVisibleCards
+ * INPUT: allCards (ShowcaseCard[]), viewportWidth (number)
+ * OUTPUT: visibleCards (ShowcaseCard[])
+ * 
+ * 1. IF viewportWidth < 768 THEN count = 6
+ * 2. ELSE IF viewportWidth < 1024 THEN count = 9
+ * 3. ELSE count = 12
+ * 4. RETURN allCards.slice(0, count)
+ * 
+ * 카테고리 균형을 위해 SHOWCASE_CARDS는 카테고리 순환 배치:
+ * [anim, sports, movie, music, game, other, anim, sports, movie, music, game, other]
+ * → 6장 슬라이스 시 각 카테고리 1장씩 보장
+ */
+```
+
+**Preconditions:**
+- `allCards`는 12장, 카테고리 순환 배치
+- `viewportWidth`는 양수
+
+**Postconditions:**
+- 반환 배열 길이: 6, 9, 또는 12
+- 6장 슬라이스 시 6개 카테고리 각 1장 보장
+
+## Key Functions with Formal Specifications
+
+### Function 1: FloatingCardsCollage
+
+```typescript
+function FloatingCardsCollage({ reducedMotion, className }: FloatingCardsCollageProps): JSX.Element
+```
+
+**Preconditions:**
+- `reducedMotion`은 boolean 값
+- SHOWCASE_CARDS 데이터가 12장 이상 존재
+
+**Postconditions:**
+- 반응형 카드 수만큼 FloatingCard 렌더링
+- reducedMotion=true 시 모든 카드 애니메이션 비활성화
+- MascotOverlay가 카드 위에 렌더링
+- `role="img"`, `aria-label` 접근성 속성 포함
+
+### Function 2: FloatingCard
+
+```typescript
+function FloatingCard({ card, index, reducedMotion, size }: FloatingCardProps): JSX.Element
+```
+
+**Preconditions:**
+- `card`는 유효한 ShowcaseCard 객체
+- `index`는 0 이상의 정수
+- `size`는 'sm' | 'md' | 'lg' 중 하나
+
+**Postconditions:**
+- Next.js Image 컴포넌트로 이미지 렌더링 (lazy loading)
+- 카테고리별 accent 색상 적용
+- reducedMotion=false 시 float 애니메이션 적용
+- 호버 시 scale(1.05) + shadow 강화 (데스크톱)
+
+### Function 3: getCategoryAccentColor
+
+```typescript
+function getCategoryAccentColor(category: SpotCategory): string
+```
+
+**Preconditions:**
+- `category`는 유효한 SpotCategory 값
+
+**Postconditions:**
+- 해당 카테고리의 CSS 변수 기반 accent 색상 문자열 반환
+- 알 수 없는 카테고리 시 기본 색상 반환
+
+## Example Usage
+
+```typescript
+// HeroSection에서 FloatingCardsCollage 사용
+export function HeroSection({ reducedMotion }: HeroSectionProps) {
+  return (
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-16">
+      {/* 배경 그라데이션 */}
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-primary-900/20 via-transparent to-transparent" />
+
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col items-center gap-8 lg:flex-row lg:gap-12">
+        {/* 텍스트 + CTA */}
+        <header className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
+          <h1>관광지가 아닌 <span className="text-primary-500">성지</span>를 탐험하세요</h1>
+          <p>애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등...</p>
+          <CTAButton label="지도 탐색하기" href="/map" size="lg" />
+        </header>
+
+        {/* 플로팅 카드 콜라주 (Globe3D 대체) */}
+        <FloatingCardsCollage
+          reducedMotion={reducedMotion}
+          className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]"
+        />
+      </div>
+    </section>
+  )
+}
+
+// FloatingCard 개별 사용 예시
+<FloatingCard
+  card={{
+    id: 'sc-1',
+    spotName: '가마쿠라코코마에역',
+    contentName: '슬램덩크',
+    category: 'animation',
+    imageUrl: '/images/showcase/kamakura.webp',
+  }}
+  index={0}
+  reducedMotion={false}
+  size="lg"
+/>
+```
+
+## Correctness Properties
+
+1. **카드 수 일관성**: ∀ viewportWidth, 표시되는 카드 수는 정확히 6(모바일), 9(태블릿), 12(데스크톱) 중 하나
+2. **카테고리 균형**: 6장 표시 시 6개 카테고리가 각 1장씩 포함됨
+3. **애니메이션 독립성**: ∀ card_i, card_j (i ≠ j), card_i.delay ≠ card_j.delay ∨ card_i.duration ≠ card_j.duration
+4. **reducedMotion 준수**: reducedMotion=true → ∀ card, animation = 'none'
+5. **접근성**: FloatingCardsCollage는 항상 `role="img"`와 `aria-label`을 가짐
+6. **이미지 최적화**: ∀ card, 이미지는 Next.js Image 컴포넌트로 렌더링 (lazy loading, WebP)
+7. **Three.js 제거**: 빌드 후 번들에 `three`, `@react-three/fiber`, `@react-three/drei` 미포함
+8. **다크 테마 호환**: 카드 배경과 텍스트가 다크 모드에서 가독성 유지
+
+## Error Handling
+
+### Error Scenario 1: 이미지 로드 실패
+
+**Condition**: ShowcaseCard의 imageUrl이 404 또는 네트워크 오류
+**Response**: Next.js Image의 `onError` 콜백으로 감지, 카테고리 아이콘 폴백 이미지 표시
+**Recovery**: 카드 자체는 유지하되 이미지만 폴백으로 대체. 사용자 경험에 영향 최소화
+
+### Error Scenario 2: 정적 이미지 에셋 누락
+
+**Condition**: `/images/showcase/` 디렉토리에 이미지 파일이 없는 경우
+**Response**: 빌드 타임에 감지 불가하므로, 런타임에 onError 폴백 처리
+**Recovery**: 카테고리별 기본 아이콘(`/icons/categories/{category}.webp`)을 폴백으로 사용
+
+### Error Scenario 3: CSS 애니메이션 미지원 브라우저
+
+**Condition**: 매우 오래된 브라우저에서 CSS keyframes 미지원
+**Response**: 카드가 정적 위치에 표시됨 (graceful degradation)
+**Recovery**: 애니메이션 없이도 카드 콜라주 레이아웃은 유지됨
+
+## Testing Strategy
+
+### Unit Testing Approach
+
+- FloatingCard 컴포넌트: 카드 데이터가 올바르게 렌더링되는지 확인
+- getCategoryAccentColor: 모든 카테고리에 대해 올바른 색상 반환 확인
+- SHOWCASE_CARDS 데이터: 12장, 카테고리 균형 배분 확인
+- reducedMotion prop: true 시 애니메이션 클래스 미적용 확인
+
+### Property-Based Testing Approach
+
+**Property Test Library**: fast-check
+
+- **카테고리 균형 속성**: 임의의 카드 배열에서 처음 6장을 슬라이스했을 때 6개 카테고리가 모두 포함되는지
+- **애니메이션 고유성 속성**: 임의의 인덱스 쌍에 대해 delay 또는 duration이 다른지
+- **카드 배치 범위 속성**: 모든 CardPlacement의 top/left가 0~100% 범위 내인지
+
+### Integration Testing Approach
+
+- HeroSection이 FloatingCardsCollage를 올바르게 렌더링하는지
+- WelcomePageClient에서 HeroSection으로 reducedMotion prop이 전달되는지
+- Three.js 관련 import가 완전히 제거되었는지 (번들 분석)
+
+## Performance Considerations
+
+1. **번들 사이즈 개선**: Three.js(`three` ~600KB gzipped) + `@react-three/fiber` + `@react-three/drei` 제거로 초기 로드 크게 감소
+2. **이미지 최적화**: Next.js Image 컴포넌트의 자동 WebP 변환, lazy loading, srcSet 활용
+3. **CSS 애니메이션**: GPU 가속 속성(`transform`, `opacity`)만 사용하여 60fps 유지
+4. **will-change 최적화**: 플로팅 카드에 `will-change: transform` 적용하여 합성 레이어 생성
+5. **이미지 사이즈**: 쇼케이스 이미지는 최대 400x300px WebP로 제한 (카드 크기에 맞춤)
+6. **정적 데이터**: API 호출 없이 정적 데이터 사용으로 네트워크 요청 제거
+
+## Security Considerations
+
+- 외부 이미지 URL 사용 시 `next.config.ts`의 `images.remotePatterns` 설정 필요
+- 정적 에셋 사용 시 보안 이슈 없음
+- 사용자 입력 데이터 없음 (정적 쇼케이스 데이터)
+
+## Dependencies
+
+### 제거 대상
+- `three` (^0.183.2) — 3D 렌더링 엔진
+- `@react-three/fiber` (^9.5.0) — React Three.js 바인딩
+- `@react-three/drei` (^10.7.7) — Three.js 유틸리티
+- `@types/three` (^0.183.1) — Three.js 타입 정의
+
+### 유지
+- `next` (^15.1.0) — Next.js Image 컴포넌트
+- `tailwindcss` (^3.4.17) — 스타일링
+- CSS keyframes — 플로팅 애니메이션 (추가 의존성 없음)
+
+### 신규 추가 없음
+- Framer Motion 등 추가 애니메이션 라이브러리 불필요
+- 순수 CSS 애니메이션으로 충분

--- a/.kiro/specs/32-landing-hero-floating-cards/requirements.md
+++ b/.kiro/specs/32-landing-hero-floating-cards/requirements.md
@@ -1,0 +1,105 @@
+# Requirements: Landing Hero Floating Cards
+
+## 소개
+
+랜딩 페이지 히어로 섹션의 Three.js 3D 지구본을 "플로팅 카드 콜라주"로 교체한다. 실제 스팟 사진과 작품명이 표시된 카드들이 다크 배경 위에서 천천히 떠다니는 Pinterest/Dribbble 스타일의 시각적으로 풍부한 레이아웃으로, CSS 애니메이션 기반으로 구현하여 Three.js 의존성을 완전히 제거하고 번들 사이즈를 개선한다.
+
+## 용어 사전
+
+- **FloatingCardsCollage**: 히어로 섹션의 비주얼 영역. 여러 장의 스팟 카드가 떠다니는 콜라주 컴포넌트
+- **FloatingCard**: 개별 플로팅 카드. 스팟 이미지 + 작품명 + 카테고리 accent 색상을 표시
+- **ShowcaseCard**: 쇼케이스 카드 데이터 타입. 정적 데이터로 관리
+- **MascotOverlay**: 마스코트(흰 고양이)를 카드 콜라주 위에 오버레이하는 컴포넌트
+- **CardPlacement**: 각 카드의 위치, 크기, 애니메이션 설정을 정의하는 배치 데이터
+- **Float Animation**: CSS keyframes 기반의 카드 떠다니기 애니메이션 (translateY + translateX + rotate)
+
+## Requirements
+
+### Requirement 1: FloatingCardsCollage 컴포넌트
+
+#### 인수 조건
+
+1. THE FloatingCardsCollage SHALL 12장의 정적 쇼케이스 카드 데이터(SHOWCASE_CARDS)를 기반으로 FloatingCard를 렌더링한다
+2. THE FloatingCardsCollage SHALL 반응형으로 카드 수를 조절한다: 모바일(< 768px) 6장, 태블릿(768px ~ 1024px) 9장, 데스크톱(> 1024px) 12장
+3. THE FloatingCardsCollage SHALL 6장 표시 시 6개 카테고리(animation, sports, movie_drama, music, game, other)가 각 1장씩 포함되도록 SHOWCASE_CARDS를 카테고리 순환 배치한다
+4. THE FloatingCardsCollage SHALL 각 카드에 고유한 float 애니메이션(딜레이, 주기, 방향)을 부여하여 자연스러운 떠다니기 효과를 제공한다
+5. THE FloatingCardsCollage SHALL `reducedMotion=true` 시 모든 카드의 애니메이션을 비활성화하고 정적 배치한다
+6. THE FloatingCardsCollage SHALL `role="img"`와 `aria-label="다양한 성지순례 스팟을 보여주는 플로팅 카드 콜라주"` 접근성 속성을 포함한다
+7. THE FloatingCardsCollage SHALL MascotOverlay를 카드 콜라주 위에 렌더링한다
+
+### Requirement 2: FloatingCard 컴포넌트
+
+#### 인수 조건
+
+1. THE FloatingCard SHALL Next.js Image 컴포넌트로 스팟 이미지를 렌더링하여 자동 WebP 변환과 lazy loading을 적용한다
+2. THE FloatingCard SHALL 카드 하단에 작품명(contentName)을 표시한다
+3. THE FloatingCard SHALL 카테고리별 accent 색상을 카드 하단 바 또는 테두리로 표시한다
+4. THE FloatingCard SHALL 다크 테마에 어울리는 스타일을 적용한다: 반투명 배경, 미세한 글로우, 둥근 모서리
+5. THE FloatingCard SHALL 데스크톱에서 호버 시 `scale(1.05)` 확대와 그림자 강화 효과를 적용한다
+6. THE FloatingCard SHALL 이미지 로드 실패 시 카테고리 기본 아이콘(`/icons/categories/{category}.webp`)을 폴백으로 표시한다
+7. THE FloatingCard SHALL 3가지 크기 variant(sm, md, lg)를 지원한다
+
+### Requirement 3: MascotOverlay 컴포넌트
+
+#### 인수 조건
+
+1. THE MascotOverlay SHALL 마스코트(흰 고양이) 이미지를 카드 콜라주 우하단에 배치한다
+2. THE MascotOverlay SHALL 미세한 float 애니메이션(위아래 2~3px)을 적용한다
+3. THE MascotOverlay SHALL `reducedMotion=true` 시 애니메이션을 비활성화하고 정적 배치한다
+4. THE MascotOverlay SHALL 모바일에서 크기를 축소하여 카드 콜라주와 겹치지 않도록 한다
+
+### Requirement 4: HeroSection 수정
+
+#### 인수 조건
+
+1. THE HeroSection SHALL Globe3D 및 GlobeFallback2D 대신 FloatingCardsCollage를 렌더링한다
+2. THE HeroSection SHALL `isHighEnd` prop을 제거하고 `reducedMotion`만 전달받는다
+3. THE HeroSection SHALL 기존 텍스트(h1, p) 및 CTAButton 영역을 그대로 유지한다
+4. THE HeroSection SHALL 모바일에서 텍스트 위 + 카드 아래, 데스크톱에서 좌우 배치 레이아웃을 유지한다
+
+### Requirement 5: WelcomePageClient 수정
+
+#### 인수 조건
+
+1. THE WelcomePageClient SHALL HeroSection에 `isHighEnd` prop 전달을 제거한다
+2. THE WelcomePageClient SHALL HeroSection에 `reducedMotion` prop만 전달한다
+3. THE WelcomePageClient SHALL `useDeviceCapability` 훅의 `isHighEnd` 결과를 HeroSection에 사용하지 않는다 (다른 섹션에서 사용 시 유지)
+
+### Requirement 6: Three.js 의존성 제거
+
+#### 인수 조건
+
+1. THE project SHALL `three`, `@react-three/fiber`, `@react-three/drei` 패키지를 dependencies에서 제거한다
+2. THE project SHALL `@types/three` 패키지를 devDependencies에서 제거한다
+3. THE project SHALL Globe3D.tsx, GlobeFallback2D.tsx, MascotWalker.tsx, data/globeData.ts 파일을 삭제한다
+4. THE project SHALL 삭제된 파일에 대한 모든 import 참조를 제거한다
+5. THE project SHALL `npm run type-check` 통과를 확인한다
+
+### Requirement 7: 쇼케이스 카드 데이터
+
+#### 인수 조건
+
+1. THE SHOWCASE_CARDS SHALL 12장의 카드 데이터를 포함한다
+2. THE SHOWCASE_CARDS SHALL 6개 카테고리를 균형 배분한다 (카테고리당 2장)
+3. THE SHOWCASE_CARDS SHALL 카테고리 순환 배치한다: [anim, sports, movie, music, game, other, anim, sports, movie, music, game, other]
+4. THE SHOWCASE_CARDS SHALL 각 카드에 id, spotName, contentName, category, imageUrl 필드를 포함한다
+5. THE SHOWCASE_CARDS SHALL 이미지로 `/images/showcase/` 디렉토리의 정적 WebP 파일을 참조한다
+
+### Requirement 8: CSS 애니메이션
+
+#### 인수 조건
+
+1. THE float animation SHALL CSS keyframes로 구현한다 (JavaScript 애니메이션 라이브러리 미사용)
+2. THE float animation SHALL GPU 가속 속성(`transform`, `opacity`)만 사용하여 60fps를 유지한다
+3. THE float animation SHALL 각 카드마다 다른 duration(6~8.5초)과 delay(0~2.5초)를 적용한다
+4. THE float animation SHALL `ease-in-out` 타이밍과 `alternate` 방향으로 부드러운 왕복 움직임을 제공한다
+5. THE float animation SHALL `prefers-reduced-motion: reduce` 미디어 쿼리를 존중한다
+6. THE FloatingCard SHALL `will-change: transform`을 적용하여 합성 레이어를 생성한다
+
+### Requirement 9: 이미지 최적화
+
+#### 인수 조건
+
+1. THE FloatingCard SHALL Next.js Image 컴포넌트를 사용하여 자동 WebP 변환, lazy loading, srcSet을 적용한다
+2. THE showcase images SHALL 최대 400x300px 크기의 WebP 포맷으로 제공한다
+3. THE FloatingCard SHALL 각 이미지에 의미 있는 alt 텍스트(`{spotName} - {contentName}`)를 제공한다

--- a/.kiro/specs/32-landing-hero-floating-cards/tasks.md
+++ b/.kiro/specs/32-landing-hero-floating-cards/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Landing Hero Floating Cards
+
+## Task 1: 쇼케이스 카드 데이터 및 타입 정의
+
+- [x] 1.1 `src/components/landing/data/showcaseCards.ts`에 ShowcaseCard 인터페이스와 CardPlacement 인터페이스를 정의한다
+  - Requirements: 7.4
+- [x] 1.2 SHOWCASE_CARDS 정적 데이터 12장을 카테고리 순환 배치로 생성한다 (카테고리당 2장: [anim, sports, movie, music, game, other] × 2)
+  - Requirements: 7.1, 7.2, 7.3
+- [x] 1.3 CARD_PLACEMENTS 배치 데이터 12개를 정의한다 (top, left, rotate, size, delay, duration, zIndex)
+  - Requirements: 8.3
+- [x] 1.4 getCategoryAccentColor 유틸 함수를 구현한다 (기존 CATEGORY_CONFIG 활용)
+  - Requirements: 2.3
+
+## Task 2: FloatingCard 컴포넌트 구현
+
+- [x] 2.1 `src/components/landing/FloatingCard.tsx`에 FloatingCard 컴포넌트를 구현한다
+  - Requirements: 2.1, 2.2, 2.3, 2.4, 2.7
+- [x] 2.2 Next.js Image 컴포넌트로 이미지 렌더링 및 onError 폴백 처리를 구현한다
+  - Requirements: 2.1, 2.6, 9.1, 9.3
+- [x] 2.3 데스크톱 호버 효과(scale + shadow)를 구현한다
+  - Requirements: 2.5
+- [x] 2.4 3가지 크기 variant(sm: 120×90, md: 160×120, lg: 200×150)를 구현한다
+  - Requirements: 2.7
+
+## Task 3: MascotOverlay 컴포넌트 구현
+
+- [x] 3.1 `src/components/landing/MascotOverlay.tsx`에 마스코트 오버레이 컴포넌트를 구현한다
+  - Requirements: 3.1, 3.2, 3.3, 3.4
+
+## Task 4: FloatingCardsCollage 컴포넌트 구현
+
+- [x] 4.1 `src/components/landing/FloatingCardsCollage.tsx`에 콜라주 컴포넌트를 구현한다
+  - Requirements: 1.1, 1.4, 1.6, 1.7
+- [x] 4.2 반응형 카드 수 조절 로직을 구현한다 (모바일 6장, 태블릿 9장, 데스크톱 12장)
+  - Requirements: 1.2, 1.3
+- [x] 4.3 reducedMotion 처리를 구현한다 (true 시 애니메이션 비활성화)
+  - Requirements: 1.5, 8.5
+
+## Task 5: CSS Float 애니메이션 구현
+
+- [x] 5.1 `src/components/landing/floating-cards.css`에 12개 카드별 고유 float keyframes를 정의한다
+  - Requirements: 8.1, 8.2, 8.3, 8.4
+- [x] 5.2 `will-change: transform` 및 GPU 가속 최적화를 적용한다
+  - Requirements: 8.6
+- [x] 5.3 `prefers-reduced-motion: reduce` 미디어 쿼리를 추가한다
+  - Requirements: 8.5
+
+## Task 6: HeroSection 및 WelcomePageClient 수정
+
+- [x] 6.1 HeroSection에서 Globe3D/GlobeFallback2D를 FloatingCardsCollage로 교체한다
+  - Requirements: 4.1, 4.3, 4.4
+- [x] 6.2 HeroSection의 `isHighEnd` prop을 제거하고 `reducedMotion`만 사용하도록 수정한다
+  - Requirements: 4.2
+- [x] 6.3 WelcomePageClient에서 HeroSection에 `isHighEnd` prop 전달을 제거한다
+  - Requirements: 5.1, 5.2, 5.3
+- [x] 6.4 HeroSkeleton의 지구본 스켈레톤을 카드 콜라주 스켈레톤으로 수정한다
+
+## Task 7: Three.js 의존성 제거 및 파일 정리
+
+- [x] 7.1 Globe3D.tsx, GlobeFallback2D.tsx, MascotWalker.tsx, data/globeData.ts 파일을 삭제한다
+  - Requirements: 6.3
+- [x] 7.2 삭제된 파일에 대한 모든 import 참조를 제거한다
+  - Requirements: 6.4
+- [x] 7.3 `three`, `@react-three/fiber`, `@react-three/drei`, `@types/three` 패키지를 제거한다 (`npm uninstall`)
+  - Requirements: 6.1, 6.2
+- [x] 7.4 `npm run type-check`로 타입 에러가 없는지 확인한다
+  - Requirements: 6.5
+
+## Task 8: 쇼케이스 이미지 에셋 준비
+
+- [x] 8.1 `/public/images/showcase/` 디렉토리를 생성하고 12장의 placeholder WebP 이미지를 배치한다
+  - Requirements: 7.5, 9.2
+- [x] 8.2 이미지가 없는 경우를 위한 카테고리별 폴백 이미지 경로를 확인한다
+  - Requirements: 2.6
+
+## Task 9: Checkpoint — 변경사항 검증
+
+- [x] 9.1 `npm run type-check` 통과 확인
+- [~] 9.2 `npm run build` 성공 확인
+- [~] 9.3 Three.js 관련 패키지가 번들에서 제거되었는지 확인
+- [~] 9.4 사용자가 직접 앱을 실행하여 히어로 섹션의 플로팅 카드 콜라주를 검증

--- a/.kiro/steering/shell-safety.md
+++ b/.kiro/steering/shell-safety.md
@@ -1,0 +1,43 @@
+---
+inclusion: always
+priority: 2
+---
+
+# Shell 명령어 안전 규칙
+
+## 🚨 bash에서 괄호 포함 문자열 금지
+
+이 프로젝트의 shell은 **bash**입니다. bash에서 `(`, `)` 문자가 명령어에 포함되면 `syntax error near unexpected token '('` 에러가 발생합니다.
+
+### 절대 금지 패턴
+
+```bash
+# ❌ git log에 --decorate 기본값으로 괄호가 출력됨
+git log --oneline
+
+# ❌ 괄호가 포함된 경로나 문자열을 직접 사용
+cat "file (copy).txt"
+```
+
+### 필수 사용 패턴
+
+```bash
+# ✅ git log는 항상 --no-decorate 옵션 사용
+git log --oneline --no-decorate
+
+# ✅ 괄호가 포함될 수 있는 출력은 파이프로 처리하거나 옵션으로 제거
+git log --format="%h %s" -5
+
+# ✅ 파일 경로에 괄호가 있으면 따옴표로 감싸기
+cat 'file (copy).txt'
+```
+
+### 적용 대상
+
+- `git log` → 항상 `--no-decorate` 또는 `--format` 사용
+- `git branch` → `--no-column` 사용 권장
+- 모든 shell 명령어에서 출력에 괄호가 포함될 가능성이 있으면 사전에 제거 옵션 적용
+
+### 이유
+
+Windows bash 환경에서 명령어 출력에 `(` 또는 `)`가 포함되면 shell이 이를 subshell 구문으로 해석하려다 syntax error를 발생시킵니다. 이는 명령어 자체의 문제가 아니라 출력이 다음 프롬프트에 영향을 주는 환경 특성입니다.

--- a/next.config.ts
+++ b/next.config.ts
@@ -88,6 +88,12 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'commons.wikimedia.org',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
         hostname: 'myanimelist.net',
         port: '',
         pathname: '/**',

--- a/scripts/seed-real-spots.ts
+++ b/scripts/seed-real-spots.ts
@@ -336,7 +336,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '하루나산 (이니셜D)',
     description:
       '"이니셜D"의 주요 배경인 아키나산의 모델이 된 실제 산. 구불구불한 도로에서 작품 속 레이싱의 분위기를 느낄 수 있다.',
-    photos: ['https://commons.wikimedia.org/wiki/Special:FilePath/Haruna00.JPG'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Haruna00.JPG',
+    ],
     address: '일본 군마현 다카사키시 하루나산',
     coordinates: { lat: 36.4719, lng: 138.8911 },
     category: 'animation',
@@ -1125,7 +1127,9 @@ const MUSIC_SPOTS: SeedSpot[] = [
     name: '올림픽공원 체조경기장 (KSPO DOME)',
     description:
       '한국 최대 규모의 실내 공연장 중 하나로, 수많은 K-POP 콘서트가 열리는 곳입니다. 팬들에게 "체조경기장"으로 친숙한 공연 성지입니다.',
-    photos: ['https://commons.wikimedia.org/wiki/Special:FilePath/%EC%98%AC%EB%A6%BC%ED%94%BD%EC%B2%B4%EC%A1%B0.jpg'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/%EC%98%AC%EB%A6%BC%ED%94%BD%EC%B2%B4%EC%A1%B0.jpg',
+    ],
     address: '대한민국 서울특별시 송파구 올림픽로 424',
     coordinates: { lat: 37.5209, lng: 127.115 },
     category: 'music',

--- a/scripts/seed-real-spots.ts
+++ b/scripts/seed-real-spots.ts
@@ -258,7 +258,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '하코네 유모토 (에반게리온)',
     description:
       '"신세기 에반게리온"의 제3신도쿄시 모델이 된 지역. 에반게리온 관련 상점과 전시물을 곳곳에서 찾아볼 수 있다.',
-    photos: ['https://picsum.photos/seed/hakone-yumoto/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Hakone-yumoto.jpg',
+    ],
     address: '일본 가나가와현 아시가라시모군 하코네마치 유모토',
     coordinates: { lat: 35.2285, lng: 139.1039 },
     category: 'animation',
@@ -279,7 +281,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '메이지무라 박물관 (귀멸의 칼날)',
     description:
       '"귀멸의 칼날"에 등장하는 나비저택의 모델이 된 건물들이 있는 야외 박물관. 다이쇼 시대의 건축물들을 통해 작품 속 분위기를 느낄 수 있다.',
-    photos: ['https://picsum.photos/seed/meijimura-museum/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Meiji%20Mura%2020220718%2004.jpg',
+    ],
     address: '일본 아이치현 이누야마시 우치야마 1',
     coordinates: { lat: 35.3347, lng: 136.9405 },
     category: 'animation',
@@ -296,7 +300,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '히타시 오야마댐 (진격의 거인)',
     description:
       '"진격의 거인" 작가 이사야마 하지메의 고향에 위치한 댐. 작품 속 거대한 벽을 연상시키며, 에렌, 미카사, 아르민의 동상이 세워져 있다.',
-    photos: ['https://picsum.photos/seed/hitashi-oyamadam/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Oyama%20Dam.jpg',
+    ],
     address: '일본 오이타현 히타시 오야마마치 니시 오야마',
     coordinates: { lat: 33.2505, lng: 130.9881 },
     category: 'animation',
@@ -313,7 +319,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '구마모토현 루피 동상 (원피스)',
     description:
       '"원피스" 작가 오다 에이치로의 고향인 구마모토현에 설치된 루피 동상. 현 내 여러 곳에 밀짚모자 해적단 멤버들의 동상이 흩어져 있어 찾아보는 재미가 있다.',
-    photos: ['https://picsum.photos/seed/kumamoto-luffy-statue/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Kumamoto%20Prefectural%20office%20new.jpg',
+    ],
     address: '일본 구마모토현 구마모토시 주오구 테토리혼초 4-1 (구마모토현청)',
     coordinates: { lat: 32.7937, lng: 130.7304 },
     category: 'animation',
@@ -328,7 +336,7 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '하루나산 (이니셜D)',
     description:
       '"이니셜D"의 주요 배경인 아키나산의 모델이 된 실제 산. 구불구불한 도로에서 작품 속 레이싱의 분위기를 느낄 수 있다.',
-    photos: ['https://picsum.photos/seed/haruna-mountain/800/600'],
+    photos: ['https://commons.wikimedia.org/wiki/Special:FilePath/Haruna00.JPG'],
     address: '일본 군마현 다카사키시 하루나산',
     coordinates: { lat: 36.4719, lng: 138.8911 },
     category: 'animation',
@@ -343,7 +351,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '가부키초 (은혼)',
     description:
       '"은혼"의 가부키초의 모델이 된 도쿄 신주쿠의 번화가. 작품 속 코믹하고 활기찬 분위기를 실제로 체험할 수 있다.',
-    photos: ['https://picsum.photos/seed/kabukicho/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Kabukicho%20%2853084208633%29.jpg',
+    ],
     address: '일본 도쿄도 신주쿠구 가부키초',
     coordinates: { lat: 35.6938, lng: 139.7036 },
     category: 'animation',
@@ -358,7 +368,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '자연휴양림 나루토 소용돌이 (나루토)',
     description:
       '"나루토"의 주인공 이름과 같은 지명을 가진 도쿠시마현 나루토시의 거대한 소용돌이. 작품의 세계관과 연결되는 상징적인 장소이다.',
-    photos: ['https://picsum.photos/seed/naruto-whirlpool/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Naruto%20whirlpools%2020170609-3.jpg',
+    ],
     address: '일본 도쿠시마현 나루토시 나루토초 토사도마리',
     coordinates: { lat: 34.2307, lng: 134.6496 },
     category: 'animation',
@@ -375,7 +387,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '쿠알라룸푸르 타워 (드래곤볼)',
     description:
       '"드래곤볼"의 카린탑 모델 중 하나로 알려진 쿠알라룸푸르 타워. 거대한 외형이 작품 속 신비로운 분위기를 연상시킨다.',
-    photos: ['https://picsum.photos/seed/kuala-lumpur-tower/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Kuala%20Lumpur%20Tower.JPG',
+    ],
     address: '말레이시아 쿠알라룸푸르 잘란 판타이 바루',
     coordinates: { lat: 3.1528, lng: 101.7039 },
     category: 'animation',
@@ -392,7 +406,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '시부야 스크램블 교차로 (주술회전)',
     description:
       '"주술회전" 시부야 사변의 배경이 된 세계적으로 유명한 교차로. 작품 속 긴박감 넘치는 전투 장면을 떠올리게 한다.',
-    photos: ['https://picsum.photos/seed/shibuya-scramble/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Shibuya%20Scramble%20crossing.jpg',
+    ],
     address: '일본 도쿄도 시부야구 도겐자카 2-2-1',
     coordinates: { lat: 35.6591, lng: 139.703 },
     category: 'animation',
@@ -409,7 +425,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '시부야109 (최애의 아이)',
     description:
       '"최애의 아이"에서 아이돌 활동과 관련된 장소로 자주 언급되는 시부야의 랜드마크. 아이돌 문화의 중심지임을 느낄 수 있다.',
-    photos: ['https://picsum.photos/seed/shibuya109/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Shibuya%20109%20-01.jpg',
+    ],
     address: '일본 도쿄도 시부야구 도겐자카 2-29-1',
     coordinates: { lat: 35.6596, lng: 139.6998 },
     category: 'animation',
@@ -426,7 +444,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '모토스코 캠프장 (유루캠△)',
     description:
       '"유루캠△"의 주요 캠핑 장소 중 하나로, 후지산이 아름답게 보이는 경치를 자랑한다. 작품처럼 캠핑을 즐기기에 완벽한 곳.',
-    photos: ['https://picsum.photos/seed/motosuko-camp/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Lake%20Motosu%20%282015-12-17%29.jpg',
+    ],
     address: '일본 야마나시현 미나미코마군 후지카와구치코정 모토스 10450',
     coordinates: { lat: 35.4851, lng: 138.6186 },
     category: 'animation',
@@ -443,7 +463,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '시모키타자와 (봇치 더 록!)',
     description:
       '"봇치 더 록!"의 주요 배경이 되는 라이브하우스 거리. 인디 밴드의 성지로, 작품 속 꿈을 쫓는 소녀들의 열정을 느낄 수 있다.',
-    photos: ['https://picsum.photos/seed/shimokitazawa/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Shimokitazawa.jpg',
+    ],
     address: '일본 도쿄도 세타가야구 기타자와',
     coordinates: { lat: 35.6609, lng: 139.6666 },
     category: 'animation',
@@ -460,7 +482,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '뉘른베르크 (프리렌)',
     description:
       '"장송의 프리렌"의 중세 유럽풍 배경에 영감을 준 독일의 도시 중 하나. 아름다운 중세 건축물과 분위기에서 작품의 여운을 느낄 수 있다.',
-    photos: ['https://picsum.photos/seed/nuremberg/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Nuremberg%20old%20town%20nov%202020.jpg',
+    ],
     address: '독일 바이에른주 뉘른베르크',
     coordinates: { lat: 49.4521, lng: 11.0767 },
     category: 'animation',
@@ -477,7 +501,9 @@ const ANIMATION_SPOTS: SeedSpot[] = [
     name: '사이타마 스타디움 2002 (블루 록)',
     description:
       '"블루 록"과 같은 축구 애니메이션의 경기장 장면에서 영감을 받을 수 있는 대규모 축구 경기장. 실제 축구 경기의 열기를 느낄 수 있다.',
-    photos: ['https://picsum.photos/seed/saitama-stadium/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Saitama%20stadium2002-1.jpg',
+    ],
     address: '일본 사이타마현 사이타마시 미도리구 나카노 500',
     coordinates: { lat: 35.9044, lng: 139.7161 },
     category: 'animation',
@@ -701,7 +727,9 @@ const SPORTS_SPOTS: SeedSpot[] = [
     name: '산티아고 베르나베우 (레알 마드리드)',
     description:
       '레알 마드리드의 홈구장 산티아고 베르나베우입니다. 최근 대규모 리모델링을 거쳐 최첨단 시설을 갖춘 경기장으로 재탄생했습니다.',
-    photos: ['https://picsum.photos/seed/bernabeu/800/600'],
+    photos: [
+      'https://commons.wikimedia.org/wiki/Special:FilePath/Santiago%20Bernabeu%20Stadium.jpg',
+    ],
     address: '스페인 마드리드 Av. de Concha Espina, 1',
     coordinates: { lat: 40.4531, lng: -3.6883 },
     category: 'sports',
@@ -1097,7 +1125,7 @@ const MUSIC_SPOTS: SeedSpot[] = [
     name: '올림픽공원 체조경기장 (KSPO DOME)',
     description:
       '한국 최대 규모의 실내 공연장 중 하나로, 수많은 K-POP 콘서트가 열리는 곳입니다. 팬들에게 "체조경기장"으로 친숙한 공연 성지입니다.',
-    photos: ['https://picsum.photos/seed/kspo-dome/800/600'],
+    photos: ['https://commons.wikimedia.org/wiki/Special:FilePath/%EC%98%AC%EB%A6%BC%ED%94%BD%EC%B2%B4%EC%A1%B0.jpg'],
     address: '대한민국 서울특별시 송파구 올림픽로 424',
     coordinates: { lat: 37.5209, lng: 127.115 },
     category: 'music',

--- a/scripts/update-spot-photos.ts
+++ b/scripts/update-spot-photos.ts
@@ -1,0 +1,166 @@
+/**
+ * spots.photos를 실제 장소 사진 URL로 보강하는 스크립트
+ *
+ * 기본 동작:
+ * - 현재 photos가 비어 있거나 picsum/icons 같은 플레이스홀더일 때만 업데이트
+ * - 이미 실사진이 들어간 스팟은 건드리지 않음
+ *
+ * 옵션:
+ * - --dry-run: 실제 반영 없이 대상만 출력
+ * - --force: 현재 값과 무관하게 대상 스팟을 모두 덮어씀
+ *
+ * 실행:
+ * - npx tsx scripts/update-spot-photos.ts
+ * - npx tsx scripts/update-spot-photos.ts --dry-run
+ * - npx tsx scripts/update-spot-photos.ts --force
+ */
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { MongoClient } from 'mongodb'
+import { REAL_SPOT_PHOTO_FALLBACKS } from '../src/components/landing/data/realSpotPhotoFallbacks'
+
+interface SpotDocument {
+  id: string
+  name?: string
+  photos?: string[]
+  updatedAt?: Date
+}
+
+function loadEnv() {
+  try {
+    const envPath = resolve(process.cwd(), '.env.local')
+    const envContent = readFileSync(envPath, 'utf-8')
+
+    envContent.split('\n').forEach((line) => {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) return
+
+      const [key, ...valueParts] = trimmed.split('=')
+      if (!key || valueParts.length === 0) return
+
+      process.env[key.trim()] = valueParts.join('=').trim()
+    })
+  } catch {
+    // eslint-disable-next-line no-console
+    console.error(
+      '.env.local 파일을 읽지 못했습니다. 기존 환경변수를 사용합니다.'
+    )
+  }
+}
+
+function isPlaceholderPhoto(url?: string | null): boolean {
+  if (!url) return true
+  return url.includes('picsum.photos/seed/') || url.startsWith('/icons/')
+}
+
+loadEnv()
+
+const mongoUri = process.env.MONGODB_URI
+
+if (!mongoUri) {
+  // eslint-disable-next-line no-console
+  console.error('MONGODB_URI 환경변수가 설정되지 않았습니다.')
+  process.exit(1)
+}
+
+const MONGODB_URI: string = mongoUri
+
+async function updateSpotPhotos() {
+  const client = new MongoClient(MONGODB_URI)
+  const isDryRun = process.argv.includes('--dry-run')
+  const isForce = process.argv.includes('--force')
+
+  try {
+    await client.connect()
+    const db = client.db()
+    const collection = db.collection<SpotDocument>('spots')
+
+    const spotIds = Object.keys(REAL_SPOT_PHOTO_FALLBACKS)
+    const spots = await collection.find({ id: { $in: spotIds } }).toArray()
+    const spotsById = new Map(spots.map((spot) => [spot.id, spot]))
+
+    const updates = spotIds.flatMap((spotId) => {
+      const fallback = REAL_SPOT_PHOTO_FALLBACKS[spotId]
+      const spot = spotsById.get(spotId)
+
+      if (!spot || !fallback) return []
+
+      const currentPhoto = spot.photos?.[0] ?? null
+      const shouldUpdate = isForce || isPlaceholderPhoto(currentPhoto)
+
+      if (!shouldUpdate) return []
+
+      return [
+        {
+          updateOne: {
+            filter: { id: spotId },
+            update: {
+              $set: {
+                photos: [fallback.imageUrl],
+                updatedAt: new Date(),
+              },
+            },
+          },
+        },
+      ]
+    })
+
+    const missingIds = spotIds.filter((spotId) => !spotsById.has(spotId))
+
+    // eslint-disable-next-line no-console
+    console.log(`대상 fallback 스팟: ${spotIds.length}개`)
+    // eslint-disable-next-line no-console
+    console.log(`DB에서 찾은 스팟: ${spots.length}개`)
+    // eslint-disable-next-line no-console
+    console.log(`업데이트 예정: ${updates.length}개`)
+
+    if (missingIds.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log('\nDB에 없는 스팟 ID:')
+      missingIds.forEach((spotId) => {
+        // eslint-disable-next-line no-console
+        console.log(`- ${spotId}`)
+      })
+    }
+
+    if (updates.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log('\n업데이트할 스팟이 없습니다.')
+      return
+    }
+
+    // eslint-disable-next-line no-console
+    console.log('\n업데이트 대상:')
+    updates.forEach((op) => {
+      const spotId = op.updateOne.filter.id
+      const spot = spotsById.get(spotId)
+      const nextPhoto = REAL_SPOT_PHOTO_FALLBACKS[spotId]?.imageUrl
+      // eslint-disable-next-line no-console
+      console.log(`- ${spotId} | ${spot?.name ?? 'unknown'} -> ${nextPhoto}`)
+    })
+
+    if (isDryRun) {
+      // eslint-disable-next-line no-console
+      console.log('\n--dry-run 모드라서 실제 업데이트는 수행하지 않았습니다.')
+      return
+    }
+
+    const result = await collection.bulkWrite(updates, { ordered: false })
+
+    // eslint-disable-next-line no-console
+    console.log('\n업데이트 완료')
+    // eslint-disable-next-line no-console
+    console.log(`- matched: ${result.matchedCount}`)
+    // eslint-disable-next-line no-console
+    console.log(`- modified: ${result.modifiedCount}`)
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('spots.photos 업데이트 중 오류가 발생했습니다:', error)
+    process.exit(1)
+  } finally {
+    await client.close()
+  }
+}
+
+updateSpotPhotos()

--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -1,7 +1,7 @@
 /**
  * 랜딩 페이지 전용 레이아웃
- * 라이트/다크 모드 구분 없이 항상 다크 모드로 고정 렌더링
- * Header/Footer 없이 풀스크린 랜딩 경험 제공
+ * - 항상 다크 모드로 고정
+ * - 글로벌 헤더가 숨겨지므로 별도 스페이서 불필요
  * Requirements: 6.3, 6.7
  */
 export default function LandingLayout({

--- a/src/app/(landing)/welcome/page.tsx
+++ b/src/app/(landing)/welcome/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from 'next'
 import { WelcomePageClient } from '@/components/landing/WelcomePageClient'
-import { fetchShowcaseSpots, fetchCategoryImages, fetchProofImages } from '@/components/landing/data/fetchShowcaseSpots'
+import {
+  fetchShowcaseSpots,
+  fetchCategoryImages,
+  fetchProofImages,
+} from '@/components/landing/data/fetchShowcaseSpots'
 
 export const metadata: Metadata = {
   title: '환영합니다',

--- a/src/app/(landing)/welcome/page.tsx
+++ b/src/app/(landing)/welcome/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { WelcomePageClient } from '@/components/landing/WelcomePageClient'
+import { fetchShowcaseSpots, fetchCategoryImages, fetchProofImages } from '@/components/landing/data/fetchShowcaseSpots'
 
 export const metadata: Metadata = {
   title: '환영합니다',
@@ -12,6 +13,17 @@ export const metadata: Metadata = {
   },
 }
 
-export default function WelcomePage() {
-  return <WelcomePageClient />
+export default async function WelcomePage() {
+  const [showcaseSpots, categoryImages, proofImages] = await Promise.all([
+    fetchShowcaseSpots(),
+    fetchCategoryImages(),
+    fetchProofImages(),
+  ])
+  return (
+    <WelcomePageClient
+      showcaseSpots={showcaseSpots}
+      categoryImages={categoryImages}
+      proofImages={proofImages}
+    />
+  )
 }

--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -7,7 +7,11 @@ import { useEffect } from 'react'
 import { useSpots } from '@/hooks/useSpots'
 import CategoryFilter from '@/components/map/CategoryFilter'
 import ContentSearchFilter from '@/components/map/ContentSearchFilter'
-import { useSelectedCategories, useSearchQuery, useFilterStore } from '@/stores/filterStore'
+import {
+  useSelectedCategories,
+  useSearchQuery,
+  useFilterStore,
+} from '@/stores/filterStore'
 import { MapSkeleton } from '@/components/common/SkeletonUI'
 import { SpotLoadingSkeleton } from '@/components/common/SpotLoadingSkeleton'
 import { SpotErrorDisplay } from '@/components/common/SpotErrorDisplay'
@@ -26,7 +30,12 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
 
 /** 유효한 카테고리 값 목록 */
 const VALID_CATEGORIES: SpotCategory[] = [
-  'animation', 'sports', 'movie_drama', 'music', 'game', 'other',
+  'animation',
+  'sports',
+  'movie_drama',
+  'music',
+  'game',
+  'other',
 ]
 
 /**
@@ -52,9 +61,11 @@ export default function MapPage() {
 
     // category: 있으면 해당 카테고리만, 없으면 전체 카테고리
     if (categoryParam) {
-      const categories = categoryParam.split(',').filter(
-        (c): c is SpotCategory => VALID_CATEGORIES.includes(c as SpotCategory)
-      )
+      const categories = categoryParam
+        .split(',')
+        .filter((c): c is SpotCategory =>
+          VALID_CATEGORIES.includes(c as SpotCategory)
+        )
       if (categories.length > 0) {
         setSelectedCategories(categories)
       } else {

--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -2,11 +2,12 @@
 
 import { AppIcon } from '@/components/common/AppIcon'
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
 import { useSpots } from '@/hooks/useSpots'
 import CategoryFilter from '@/components/map/CategoryFilter'
 import ContentSearchFilter from '@/components/map/ContentSearchFilter'
-import { useSelectedCategories, useSearchQuery } from '@/stores/filterStore'
+import { useSelectedCategories, useSearchQuery, useFilterStore } from '@/stores/filterStore'
 import { MapSkeleton } from '@/components/common/SkeletonUI'
 import { SpotLoadingSkeleton } from '@/components/common/SpotLoadingSkeleton'
 import { SpotErrorDisplay } from '@/components/common/SpotErrorDisplay'
@@ -15,6 +16,7 @@ import { EmptyFilterOverlay } from '@/components/common/EmptyFilterOverlay'
 import { useOnboarding } from '@/hooks/useOnboarding'
 import OnboardingTour from '@/components/common/OnboardingTour'
 import { MAP_PAGE_STEPS } from '@/lib/tour-config'
+import type { SpotCategory } from '@/types'
 
 // Leaflet은 SSR을 지원하지 않으므로 dynamic import 사용
 const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
@@ -22,21 +24,54 @@ const PilgrimageMap = dynamic(() => import('@/components/map/PilgrimageMap'), {
   loading: () => <MapSkeleton />,
 })
 
+/** 유효한 카테고리 값 목록 */
+const VALID_CATEGORIES: SpotCategory[] = [
+  'animation', 'sports', 'movie_drama', 'music', 'game', 'other',
+]
+
 /**
  * 지도 메인 페이지 컴포넌트 (/map)
  * Requirements 1.1, 1.4, 2.1, 2.2를 만족하는 지도 기반 메인 페이지
+ * - URL 파라미터(search, category)를 필터 스토어에 동기화
  * - useQuery로 필터 변경 시 지도 유지 (번쩍임 방지)
  * - 카테고리 필터링 지원
  * - filterStore 전역 상태 사용
  */
 export default function MapPage() {
+  const searchParams = useSearchParams()
+  const setSearchQuery = useFilterStore((s) => s.setSearchQuery)
+  const setSelectedCategories = useFilterStore((s) => s.setSelectedCategories)
+
+  // URL 파라미터 → 필터 스토어 동기화 (URL이 source of truth)
+  useEffect(() => {
+    const searchParam = searchParams.get('search')
+    const categoryParam = searchParams.get('category')
+
+    // search: 있으면 적용, 없으면 초기화
+    setSearchQuery(searchParam || '')
+
+    // category: 있으면 해당 카테고리만, 없으면 전체 카테고리
+    if (categoryParam) {
+      const categories = categoryParam.split(',').filter(
+        (c): c is SpotCategory => VALID_CATEGORIES.includes(c as SpotCategory)
+      )
+      if (categories.length > 0) {
+        setSelectedCategories(categories)
+      } else {
+        setSelectedCategories([...VALID_CATEGORIES])
+      }
+    } else {
+      setSelectedCategories([...VALID_CATEGORIES])
+    }
+  }, [searchParams, setSearchQuery, setSelectedCategories])
+
   const { isActive, currentStep, next, skip, dismiss } = useOnboarding(
     MAP_PAGE_STEPS,
     'map'
   )
 
   return (
-    <main className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
+    <div className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
       <MapContent />
       <OnboardingTour
         steps={MAP_PAGE_STEPS}
@@ -47,7 +82,7 @@ export default function MapPage() {
         onComplete={skip}
         onDismiss={dismiss}
       />
-    </main>
+    </div>
   )
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,7 +78,7 @@ export default function RootLayout({
         <JsonLd data={generateWebSiteJsonLd()} />
         <Providers>
           <Header />
-          <main className="pt-14">{children}</main>
+          <main>{children}</main>
           <InstallPromptListener />
           <InstallBottomSheet />
           <InstallToast />

--- a/src/components/common/OptimizedImage.tsx
+++ b/src/components/common/OptimizedImage.tsx
@@ -10,8 +10,19 @@ interface OptimizedImageProps extends Omit<
 }
 
 /**
+ * 외부 URL인지 판별 (http:// 또는 https://)
+ */
+function isExternalUrl(src: ImageProps['src']): boolean {
+  if (typeof src === 'string') {
+    return src.startsWith('http://') || src.startsWith('https://')
+  }
+  return false
+}
+
+/**
  * OptimizedImage - next/image 래퍼 컴포넌트
- * blur placeholder를 자동 적용하여 로딩 중 UX 개선
+ * - blur placeholder를 자동 적용하여 로딩 중 UX 개선
+ * - 외부 URL은 unoptimized로 처리 (프록시 리다이렉트 문제 방지)
  *
  * @requirements 1.1, 5.4
  */
@@ -20,5 +31,13 @@ export function OptimizedImage({
   ...props
 }: OptimizedImageProps) {
   const blurProps = disableBlur ? {} : blurPlaceholderProps
-  return <Image {...blurProps} {...props} />
+  const shouldSkipOptimization = isExternalUrl(props.src)
+
+  return (
+    <Image
+      {...blurProps}
+      {...props}
+      unoptimized={shouldSkipOptimization || props.unoptimized}
+    />
+  )
 }

--- a/src/components/landing/ConversionSection.tsx
+++ b/src/components/landing/ConversionSection.tsx
@@ -58,28 +58,32 @@ export const ConversionSection = forwardRef<
           </p>
         </header>
 
-        {/* CTA 영역 — isStandalone 분기 */}
+        {/* CTA 영역 — 지도 탐색 우선, 앱 설치 보조 */}
         <div className="flex flex-col items-center gap-4">
-          {!isStandalone && (
-            <button
-              type="button"
-              onClick={handleInstall}
-              className="inline-flex items-center justify-center rounded-lg bg-primary-500 px-8 py-4 text-lg font-semibold text-white transition-colors duration-200 hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 active:scale-[0.98]"
-            >
-              🛂 여권 발급받기 (앱 설치)
-            </button>
-          )}
-          {showFallbackMsg && (
-            <p className="animate-fade-slide-in text-sm text-sub-text">
-              브라우저 메뉴에서 &quot;홈 화면에 추가&quot;로 설치할 수 있어요
-            </p>
-          )}
           <CTAButton
-            label="지도 탐색하기"
+            label="지도에서 탐색 시작"
             href="/map"
             size="lg"
-            variant={isStandalone ? 'primary' : 'secondary'}
+            variant="primary"
           />
+          {!isStandalone && (
+            <>
+              <button
+                type="button"
+                onClick={handleInstall}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 bg-white/5 px-6 py-3 text-base font-medium text-white/70 backdrop-blur-sm transition hover:bg-white/10 hover:text-white"
+              >
+                <span>📲</span>
+                <span>앱으로 설치하기</span>
+              </button>
+              {showFallbackMsg && (
+                <p className="animate-fade-slide-in text-sm text-sub-text">
+                  브라우저 메뉴에서 &quot;홈 화면에 추가&quot;로 설치할 수
+                  있어요
+                </p>
+              )}
+            </>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/landing/FloatingCard.tsx
+++ b/src/components/landing/FloatingCard.tsx
@@ -3,18 +3,18 @@
 import Image from 'next/image'
 import { useState } from 'react'
 
+import type { SpotCategory } from '@/types/spot'
 import type { ShowcaseCard } from './data/showcaseCards'
 import { getCategoryAccentColor } from './data/showcaseCards'
 
 /**
  * FloatingCard 컴포넌트
  * 히어로 섹션 플로팅 카드 콜라주의 개별 카드
- * - Next.js Image 컴포넌트로 이미지 최적화 (lazy loading, WebP)
- * - 카테고리별 accent 색상 하단 바 표시
+ * - 카테고리별 그라데이션 배경 + 아이콘을 기본으로 표시
+ * - 실제 이미지가 있으면 이미지로 오버레이
  * - 다크 테마 스타일: 반투명 배경, 미세한 글로우, 둥근 모서리
  * - 데스크톱 호버: scale(1.05) + 그림자 강화
  * - 3가지 크기 variant: sm(120×90), md(160×120), lg(200×150)
- * - 이미지 로드 실패 시 카테고리 기본 아이콘 폴백
  *
  * Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 9.1, 9.3
  */
@@ -44,40 +44,136 @@ const TEXT_SIZE_CONFIG = {
   lg: 'text-sm',
 } as const
 
+/** 크기별 아이콘 크기 */
+const ICON_SIZE_CONFIG = {
+  sm: 32,
+  md: 40,
+  lg: 52,
+} as const
+
+/** 카테고리 한글 레이블 (태그용 짧은 버전) */
+const CATEGORY_LABEL: Record<SpotCategory, string> = {
+  animation: '애니',
+  sports: '스포츠',
+  movie_drama: '영화',
+  music: '음악',
+  game: '게임',
+  other: '기타',
+}
+
+/**
+ * 카테고리별 그라데이션 배경
+ * 이미지가 없어도 시각적으로 풍부하게 보이도록 기본 배경으로 사용
+ */
+const CATEGORY_GRADIENT: Record<SpotCategory, string> = {
+  animation: 'linear-gradient(135deg, #1a1040 0%, #2d1b69 50%, #1a0a3d 100%)',
+  sports: 'linear-gradient(135deg, #0a2010 0%, #1a4a20 50%, #0a1a08 100%)',
+  movie_drama: 'linear-gradient(135deg, #1a0a0a 0%, #4a1010 50%, #2a0808 100%)',
+  music: 'linear-gradient(135deg, #0a0a2a 0%, #1a1a5a 50%, #0a0a3a 100%)',
+  game: 'linear-gradient(135deg, #0a1a2a 0%, #103050 50%, #081520 100%)',
+  other: 'linear-gradient(135deg, #1a1a1a 0%, #2a2a3a 50%, #151520 100%)',
+}
+
 export function FloatingCard({
   card,
   index,
   reducedMotion,
   size,
 }: FloatingCardProps) {
-  const [imgError, setImgError] = useState(false)
+  // 이미지가 실제로 유효한지 (1px placeholder 제외)
+  const [imageValid, setImageValid] = useState(false)
+  const [iconError, setIconError] = useState(false)
 
   const { width, height } = SIZE_CONFIG[size]
   const accentColor = getCategoryAccentColor(card.category)
-  const fallbackSrc = `/icons/categories/${card.category}.webp`
+  const iconSrc = `/icons/categories/${card.category}.webp`
   const altText = `${card.spotName} - ${card.contentName}`
+  const iconSize = ICON_SIZE_CONFIG[size]
 
   return (
     <div
-      className="group relative overflow-hidden rounded-lg border border-white/10 bg-white/5 shadow-lg backdrop-blur-sm transition-all duration-300 will-change-transform hover:scale-105 hover:shadow-2xl hover:shadow-white/10"
-      style={{ width, height }}
+      className="group relative overflow-hidden rounded-lg border border-white/10 shadow-lg backdrop-blur-sm transition-all duration-300 will-change-transform hover:scale-105 hover:shadow-2xl hover:shadow-white/10"
+      style={{
+        width,
+        height,
+        background: CATEGORY_GRADIENT[card.category],
+      }}
       data-index={index}
       data-reduced-motion={reducedMotion}
     >
-      {/* 이미지 영역 */}
-      <div className="relative h-full w-full">
-        <Image
-          src={imgError ? fallbackSrc : card.imageUrl}
-          alt={altText}
-          fill
-          sizes={`${width}px`}
-          className="object-cover"
-          onError={() => setImgError(true)}
-        />
-      </div>
+      {/* 배경 하이라이트 효과 */}
+      <div
+        className="absolute inset-0 opacity-15"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.2) 0%, transparent 50%), radial-gradient(circle at 75% 75%, rgba(255,255,255,0.08) 0%, transparent 40%)',
+        }}
+      />
+
+      {/* 카테고리 아이콘 (이미지 없을 때 중앙 표시) */}
+      {!imageValid && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          {!iconError ? (
+            <Image
+              src={iconSrc}
+              alt={card.category}
+              width={iconSize}
+              height={iconSize}
+              className="opacity-50 drop-shadow-lg"
+              onError={() => setIconError(true)}
+            />
+          ) : (
+            <div
+              className="rounded-full opacity-40"
+              style={{
+                width: iconSize,
+                height: iconSize,
+                backgroundColor: accentColor,
+              }}
+            />
+          )}
+        </div>
+      )}
+
+      {/* accent 글로우 (하단) */}
+      <div
+        className="absolute inset-0 opacity-25"
+        style={{
+          background: `radial-gradient(ellipse at 50% 110%, ${accentColor} 0%, transparent 65%)`,
+        }}
+      />
+
+      {/* 실제 이미지 (유효한 경우에만 표시) */}
+      <Image
+        src={card.imageUrl}
+        alt={altText}
+        fill
+        sizes={`${width}px`}
+        className={`object-cover transition-opacity duration-300 ${imageValid ? 'opacity-100' : 'opacity-0'}`}
+        onLoad={(e) => {
+          // 1px placeholder 이미지 감지: naturalWidth/naturalHeight가 1이면 무시
+          const img = e.currentTarget
+          if (img.naturalWidth > 1 && img.naturalHeight > 1) {
+            setImageValid(true)
+          }
+        }}
+        onError={() => setImageValid(false)}
+      />
 
       {/* 작품명 오버레이 */}
-      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-2 pb-1.5 pt-4">
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 pb-1.5 pt-6">
+        {/* 카테고리 태그 */}
+        <div
+          className="mb-1 inline-flex items-center rounded px-1.5 py-0.5"
+          style={{ backgroundColor: `${accentColor}33` }}
+        >
+          <span
+            className="text-[9px] font-semibold uppercase tracking-wide"
+            style={{ color: accentColor }}
+          >
+            {CATEGORY_LABEL[card.category]}
+          </span>
+        </div>
         <p
           className={`truncate font-medium text-white/90 ${TEXT_SIZE_CONFIG[size]}`}
         >
@@ -87,7 +183,7 @@ export function FloatingCard({
 
       {/* 카테고리 accent 하단 바 */}
       <div
-        className="absolute inset-x-0 bottom-0 h-0.5"
+        className="absolute inset-x-0 bottom-0 h-[2px]"
         style={{ backgroundColor: accentColor }}
       />
     </div>

--- a/src/components/landing/FloatingCardsCollage.tsx
+++ b/src/components/landing/FloatingCardsCollage.tsx
@@ -5,12 +5,13 @@ import { useEffect, useState } from 'react'
 import { FloatingCard } from './FloatingCard'
 import './floating-cards.css'
 import { MascotOverlay } from './MascotOverlay'
-import { CARD_PLACEMENTS, SHOWCASE_CARDS } from './data/showcaseCards'
+import { CARD_PLACEMENTS } from './data/showcaseCards'
+import type { ShowcaseCard } from './data/showcaseCards'
 
 /**
  * FloatingCardsCollage 컴포넌트
  * 히어로 섹션의 비주얼 영역. 여러 장의 스팟 카드가 떠다니는 콜라주를 렌더링한다.
- * - SHOWCASE_CARDS 정적 데이터에서 카드 목록을 가져와 렌더링
+ * - 서버에서 fetch한 실제 스팟 데이터(showcaseSpots)를 기반으로 렌더링
  * - 반응형 카드 수 조절 (모바일 6장, 태블릿 9장, 데스크톱 12장)
  * - 각 카드에 고유한 float 애니메이션 딜레이/속도 부여
  * - MascotOverlay를 카드 콜라주 위에 배치
@@ -23,6 +24,8 @@ import { CARD_PLACEMENTS, SHOWCASE_CARDS } from './data/showcaseCards'
 interface FloatingCardsCollageProps {
   /** 모션 감소 설정 (prefers-reduced-motion) */
   reducedMotion: boolean
+  /** 서버에서 fetch한 쇼케이스 스팟 데이터 */
+  showcaseSpots: ShowcaseCard[]
   /** 추가 CSS 클래스 */
   className?: string
 }
@@ -32,10 +35,6 @@ interface FloatingCardsCollageProps {
  * - 모바일(< 768px): 6장
  * - 태블릿(768px ~ 1024px): 9장
  * - 데스크톱(> 1024px): 12장
- *
- * SHOWCASE_CARDS는 카테고리 순환 배치:
- * [anim, sports, movie, music, game, other, anim, sports, movie, music, game, other]
- * → 6장 슬라이스 시 각 카테고리 1장씩 보장
  */
 function getCardCount(width: number): number {
   if (width < 768) return 6
@@ -45,15 +44,14 @@ function getCardCount(width: number): number {
 
 export function FloatingCardsCollage({
   reducedMotion,
+  showcaseSpots,
   className = '',
 }: FloatingCardsCollageProps) {
   const [cardCount, setCardCount] = useState(12)
 
   useEffect(() => {
-    // 초기 카드 수 설정
     setCardCount(getCardCount(window.innerWidth))
 
-    // 리사이즈 이벤트로 반응형 카드 수 조절
     function handleResize() {
       setCardCount(getCardCount(window.innerWidth))
     }
@@ -62,18 +60,17 @@ export function FloatingCardsCollage({
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 
-  const visibleCards = SHOWCASE_CARDS.slice(0, cardCount)
+  const visibleCards = showcaseSpots.slice(0, cardCount)
 
   return (
     <div
-      className={`relative overflow-hidden ${className}`}
+      className={`relative ${className}`}
       role="img"
       aria-label="다양한 성지순례 스팟을 보여주는 플로팅 카드 콜라주"
     >
       {visibleCards.map((card, index) => {
         const placement = CARD_PLACEMENTS[index]
 
-        // 카드 위치 및 애니메이션 스타일
         const cardStyle: React.CSSProperties = {
           position: 'absolute',
           top: `${placement.top}%`,
@@ -97,7 +94,7 @@ export function FloatingCardsCollage({
         )
       })}
 
-      {/* 마스코트 오버레이 (카드 콜라주 위에 렌더링) */}
+      {/* 마스코트 오버레이 */}
       <MascotOverlay reducedMotion={reducedMotion} />
     </div>
   )

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,58 +1,218 @@
 'use client'
 
-import { forwardRef } from 'react'
-import { CTAButton } from './CTAButton'
+import { forwardRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { FloatingCardsCollage } from './FloatingCardsCollage'
+import { LandingHeader } from './LandingHeader'
+import type { ShowcaseCard } from './data/showcaseCards'
 
 /**
- * 히어로 섹션 컴포넌트
- * 플로팅 카드 콜라주 + 가치 제안 카피 + CTA 버튼으로 구성
+ * 히어로 섹션 컴포넌트 — 발견형 검색 히어로
+ * - 랜딩 전용 미니 헤더
+ * - 강한 카피 + 검색창 + 카테고리 칩 6개
+ * - 우측 플로팅 카드 콜라주 (실제 스팟 썸네일)
  * Requirements: 4.1, 4.2, 4.3, 4.4
  */
 
 interface HeroSectionProps {
   reducedMotion: boolean
+  showcaseSpots: ShowcaseCard[]
 }
 
+const CATEGORY_CHIPS = [
+  { label: '🎌 애니메이션', value: 'animation' },
+  { label: '⚽ 스포츠', value: 'sports' },
+  { label: '🎬 영화/드라마', value: 'movie_drama' },
+  { label: '🎵 음악', value: 'music' },
+  { label: '🎮 게임', value: 'game' },
+  { label: '✨ 기타', value: 'other' },
+]
+
 export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
-  function HeroSection({ reducedMotion }, ref) {
+  function HeroSection({ reducedMotion, showcaseSpots }, ref) {
+    const router = useRouter()
+    const [query, setQuery] = useState('')
+
+    const handleSearch = (e: React.FormEvent) => {
+      e.preventDefault()
+      if (query.trim()) {
+        router.push(`/map?search=${encodeURIComponent(query.trim())}`)
+      } else {
+        router.push('/map')
+      }
+    }
+
+    const handleChip = (category: string) => {
+      router.push(`/map?category=${category}`)
+    }
+
     return (
       <section
         ref={ref}
-        className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-16"
+        className="relative flex min-h-screen flex-col overflow-hidden bg-background"
         aria-label="히어로 섹션"
       >
-        {/* 배경 그라데이션 */}
-        <div
-          className="pointer-events-none absolute inset-0 bg-gradient-to-b from-primary-50/30 via-transparent to-transparent dark:from-primary-900/20"
-          aria-hidden="true"
-        />
+        {/* 랜딩 전용 미니 헤더 */}
+        <LandingHeader />
 
-        <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col items-center gap-8 lg:flex-row lg:gap-12">
-          {/* 텍스트 + CTA 영역 */}
-          <header className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
-            <h1 className="mb-4 text-3xl font-bold leading-tight text-main-text md:text-4xl lg:text-5xl">
+        {/* 배경 글로우 블롭 */}
+        <div
+          className="pointer-events-none absolute inset-0 overflow-hidden"
+          aria-hidden="true"
+        >
+          <div
+            className="absolute -left-40 -top-40 h-[600px] w-[600px] rounded-full opacity-20 blur-[140px]"
+            style={{
+              background:
+                'radial-gradient(circle, #7c3aed 0%, transparent 70%)',
+            }}
+          />
+          <div
+            className="absolute -bottom-32 right-0 h-[500px] w-[500px] rounded-full opacity-15 blur-[120px]"
+            style={{
+              background:
+                'radial-gradient(circle, #1d4ed8 0%, transparent 70%)',
+            }}
+          />
+          <div
+            className="opacity-8 absolute left-1/2 top-1/2 h-[400px] w-[800px] -translate-x-1/2 -translate-y-1/2 rounded-full blur-[100px]"
+            style={{
+              background:
+                'radial-gradient(ellipse, #6d28d9 0%, transparent 70%)',
+            }}
+          />
+        </div>
+
+        {/* 메인 콘텐츠 */}
+        <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-1 flex-col items-center gap-8 px-4 pb-16 pt-24 lg:flex-row lg:items-center lg:gap-12 lg:pt-0">
+          {/* 좌측: 텍스트 + 검색 + 칩 */}
+          <div className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
+            {/* 상단 뱃지 */}
+            <div className="mb-5 inline-flex items-center gap-1.5 rounded-full border border-primary-500/30 bg-primary-500/10 px-3 py-1 text-xs font-medium text-primary-400">
+              <span>🗺️</span>
+              <span>팬들만 아는 특별한 여행지 플랫폼</span>
+            </div>
+
+            {/* 헤드라인 */}
+            <h1 className="mb-4 text-4xl font-bold leading-tight text-white md:text-5xl lg:text-6xl">
               관광지가 아닌
               <br />
-              <span className="text-primary-500">성지</span>를 탐험하세요
+              <span className="bg-gradient-to-r from-primary-400 to-purple-400 bg-clip-text text-transparent">
+                성지
+              </span>
+              를 탐험하세요
             </h1>
-            <p className="mb-8 max-w-md text-base text-sub-text md:text-lg">
+
+            <p className="mb-8 max-w-md text-base text-white/60 md:text-lg">
               애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등
               <br className="hidden sm:block" />
               팬들만 아는 특별한 여행지를 발견하세요.
             </p>
-            <CTAButton label="지도 탐색하기" href="/map" size="lg" />
-          </header>
 
-          {/* 플로팅 카드 콜라주 비주얼 영역 */}
+            {/* 검색창 */}
+            <form onSubmit={handleSearch} className="mb-5 w-full max-w-md">
+              <div className="bg-white/8 focus-within:bg-white/12 flex overflow-hidden rounded-xl border border-white/15 backdrop-blur-md transition-all focus-within:border-primary-500/60">
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="작품명, 장소명으로 검색..."
+                  className="flex-1 bg-transparent px-4 py-3 text-sm text-white placeholder-white/40 outline-none"
+                  aria-label="성지 검색"
+                />
+                <button
+                  type="submit"
+                  className="flex items-center gap-1.5 bg-primary-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-primary-600 active:scale-95"
+                  aria-label="검색"
+                >
+                  <SearchIcon />
+                  <span className="hidden sm:inline">탐색</span>
+                </button>
+              </div>
+            </form>
+
+            {/* 카테고리 칩 */}
+            <div className="flex flex-wrap justify-center gap-2 lg:justify-start">
+              {CATEGORY_CHIPS.map((chip) => (
+                <button
+                  key={chip.value}
+                  type="button"
+                  onClick={() => handleChip(chip.value)}
+                  className="bg-white/8 rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-white/70 backdrop-blur-sm transition hover:border-primary-500/50 hover:bg-primary-500/15 hover:text-white active:scale-95"
+                >
+                  {chip.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 우측: 플로팅 카드 콜라주 */}
           <div className="relative flex flex-1 items-center justify-center">
+            {/* 콜라주 뒤 글로우 */}
+            <div
+              className="pointer-events-none absolute inset-0 rounded-full opacity-25 blur-[70px]"
+              style={{
+                background:
+                  'radial-gradient(circle, #7c3aed 0%, transparent 65%)',
+              }}
+              aria-hidden="true"
+            />
             <FloatingCardsCollage
               reducedMotion={reducedMotion}
-              className="h-72 w-72 md:h-[400px] md:w-[400px] lg:h-[500px] lg:w-[500px]"
+              showcaseSpots={showcaseSpots}
+              className="h-80 w-80 md:h-[480px] md:w-[480px] lg:h-[min(640px,55vh)] lg:w-[min(640px,55vh)]"
             />
+          </div>
+        </div>
+
+        {/* 하단 스크롤 힌트 */}
+        <div
+          className="relative z-10 flex justify-center pb-8"
+          aria-hidden="true"
+        >
+          <div className="flex flex-col items-center gap-1 text-white/30">
+            <span className="text-xs">스크롤하여 더 보기</span>
+            <ChevronDownIcon />
           </div>
         </div>
       </section>
     )
   }
 )
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.35-4.35" />
+    </svg>
+  )
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  )
+}

--- a/src/components/landing/HowItWorksSection.tsx
+++ b/src/components/landing/HowItWorksSection.tsx
@@ -1,0 +1,93 @@
+/**
+ * HowItWorks 섹션
+ * "이런 식으로 찾습니다" — 4단계 플로우
+ * 서버 컴포넌트 (인터랙션 없음)
+ */
+
+const STEPS = [
+  {
+    step: '01',
+    icon: '🔍',
+    title: '작품/아티스트 검색',
+    description: '좋아하는 애니메이션, 영화, 아티스트 이름으로 검색하세요',
+  },
+  {
+    step: '02',
+    icon: '🗺️',
+    title: '지도에서 확인',
+    description: '전 세계 성지 스팟이 지도 위에 핀으로 표시됩니다',
+  },
+  {
+    step: '03',
+    icon: '📸',
+    title: '현장 방문 & 인증',
+    description: '직접 방문하고 사진으로 순례 인증을 남기세요',
+  },
+  {
+    step: '04',
+    icon: '🏅',
+    title: '뱃지 & 코스 완성',
+    description: '인증을 쌓아 뱃지를 모으고 나만의 순례 코스를 만드세요',
+  },
+]
+
+export function HowItWorksSection() {
+  return (
+    <section className="bg-background py-16 md:py-24" aria-label="이용 방법">
+      {/* 섹션 디바이더 */}
+      <div
+        className="mb-16 h-px bg-gradient-to-r from-transparent via-primary-500/30 to-transparent"
+        aria-hidden="true"
+      />
+
+      <div className="mx-auto max-w-6xl px-4">
+        {/* 헤더 */}
+        <header className="mb-12 text-center md:mb-16">
+          <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl lg:text-4xl">
+            이런 식으로{' '}
+            <span className="bg-gradient-to-r from-primary-400 to-purple-400 bg-clip-text text-transparent">
+              찾습니다
+            </span>
+          </h2>
+          <p className="text-base text-white/50 md:text-lg">
+            4단계로 나만의 성지순례를 시작하세요
+          </p>
+        </header>
+
+        {/* 스텝 그리드 */}
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {STEPS.map((step, index) => (
+            <div
+              key={step.step}
+              className="relative flex flex-col items-center text-center"
+            >
+              {/* 연결선 (마지막 제외) */}
+              {index < STEPS.length - 1 && (
+                <div
+                  className="absolute left-[calc(50%+40px)] top-8 hidden h-px w-[calc(100%-80px)] bg-gradient-to-r from-primary-500/40 to-primary-500/10 lg:block"
+                  aria-hidden="true"
+                />
+              )}
+
+              {/* 아이콘 원 */}
+              <div className="relative mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-primary-500/30 bg-primary-500/10 text-2xl">
+                {step.icon}
+                {/* 스텝 번호 */}
+                <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary-500 text-[10px] font-bold text-white">
+                  {index + 1}
+                </span>
+              </div>
+
+              <h3 className="mb-2 text-base font-semibold text-white">
+                {step.title}
+              </h3>
+              <p className="text-sm leading-relaxed text-white/50">
+                {step.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import Link from 'next/link'
+import { AppIcon } from '@/components/common/AppIcon'
+import { useAuth } from '@/hooks/useAuth'
+
+/**
+ * 랜딩 페이지 전용 미니 헤더
+ * 로고 / 지도 탐색 / 로그인 만 표시
+ */
+export function LandingHeader() {
+  const { isAuthenticated, isLoading } = useAuth()
+
+  return (
+    <header className="absolute inset-x-0 top-0 z-50 flex items-center justify-between px-6 py-4">
+      {/* 로고 */}
+      <Link href="/" className="flex items-center gap-2">
+        <AppIcon name="logo" size="2xl" className="max-h-8" />
+        <span className="text-lg font-bold text-white">Not a Trip</span>
+      </Link>
+
+      {/* 우측 액션 */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/map"
+          className="hidden rounded-lg border border-white/20 bg-white/10 px-4 py-1.5 text-sm font-medium text-white backdrop-blur-sm transition hover:bg-white/20 sm:block"
+        >
+          지도 탐색
+        </Link>
+        {!isLoading && !isAuthenticated && (
+          <Link
+            href="/auth/signin"
+            className="rounded-lg bg-primary-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-primary-600"
+          >
+            로그인
+          </Link>
+        )}
+        {!isLoading && isAuthenticated && (
+          <Link
+            href="/map"
+            className="rounded-lg bg-primary-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-primary-600"
+          >
+            탐색 시작
+          </Link>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/src/components/landing/MascotOverlay.tsx
+++ b/src/components/landing/MascotOverlay.tsx
@@ -22,7 +22,10 @@ interface MascotOverlayProps {
 /** 마스코트 이미지 경로 */
 const MASCOT_IMAGE_PATH = '/icons/raw/0329/캐릭터_메인_최종.webp'
 
-export function MascotOverlay({ reducedMotion, className = '' }: MascotOverlayProps) {
+export function MascotOverlay({
+  reducedMotion,
+  className = '',
+}: MascotOverlayProps) {
   return (
     <div
       className={`absolute bottom-2 right-2 z-10 md:bottom-4 md:right-4 ${className}`}

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -3,7 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ProofCard } from './ProofCard'
 import { PROOF_DUMMY_DATA } from './data/proofData'
+import type { ProofData } from './data/proofData'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+import type { SpotCategory } from '@/types/spot'
 
 /**
  * 소셜 프루프 섹션 컴포넌트
@@ -11,6 +13,11 @@ import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
  * 자동 스크롤 + 수동 좌우 스와이프 + 데스크톱 화살표 지원
  * Requirements: 3.1, 3.2, 3.3, 3.4, 6.6, 7.4
  */
+
+interface SocialProofSectionProps {
+  /** 카테고리별 실제 스팟 이미지 목록 */
+  proofImages: Record<SpotCategory, string[]>
+}
 
 /** 자동 스크롤 간격 (ms) */
 const AUTO_SCROLL_INTERVAL = 3500
@@ -25,17 +32,41 @@ const CARD_GAP = 16
  * [clone-last-N] [original-0 ... original-N] [clone-first-N]
  * 클론 영역에 도달하면 transition 없이 원본 위치로 점프한다.
  */
-const CLONE_COUNT = 4 // 앞뒤로 복제할 카드 수
+const CLONE_COUNT = 4
 
-function getExtendedData() {
-  const data = PROOF_DUMMY_DATA
+/**
+ * proofData에 실제 스팟 이미지를 주입하고 무한 순환용 클론을 생성한다.
+ * - 카테고리별로 순서대로 이미지를 배분
+ * - 이미지가 없는 카테고리는 다른 카테고리의 이미지를 빌려옴
+ * - sceneImage는 실제 장면 이미지가 없으므로 제거 (단일 실사 카드)
+ */
+function getExtendedData(proofImages: Record<SpotCategory, string[]>) {
+  // 카테고리별 이미지 인덱스 카운터
+  const counters: Record<string, number> = {}
+
+  const data: ProofData[] = PROOF_DUMMY_DATA.map((item) => {
+    const cat = item.categoryTag
+    const images = proofImages[cat] || []
+
+    let img: string | undefined
+    if (images.length > 0) {
+      const idx = counters[cat] ?? 0
+      counters[cat] = idx + 1
+      img = images[idx % images.length]
+    }
+
+    return {
+      ...item,
+      image: img || item.image, // DB 이미지가 있으면 사용, 없으면 원본 유지
+      sceneImage: undefined, // 실제 장면 이미지가 없으므로 제거 → 단일 카드
+    }
+  })
+
   const len = data.length
-  // 뒤쪽 클론: 마지막 CLONE_COUNT개
   const prefixClones = data.slice(-CLONE_COUNT).map((d, i) => ({
     ...d,
     id: `clone-pre-${i}`,
   }))
-  // 앞쪽 클론: 처음 CLONE_COUNT개
   const suffixClones = data.slice(0, CLONE_COUNT).map((d, i) => ({
     ...d,
     id: `clone-suf-${i}`,
@@ -43,13 +74,13 @@ function getExtendedData() {
   return { extended: [...prefixClones, ...data, ...suffixClones], len }
 }
 
-export function SocialProofSection() {
+export function SocialProofSection({ proofImages }: SocialProofSectionProps) {
   const sliderRef = useRef<HTMLDivElement>(null)
   const [isPaused, setIsPaused] = useState(false)
-  const [isTransitioning, setIsTransitioning] = useState(true)
+  const [isTransitioning, setIsTransitioning] = useState(false)
   const reducedMotion = usePrefersReducedMotion()
 
-  const { extended, len } = getExtendedData()
+  const { extended, len } = getExtendedData(proofImages)
   // 실제 인덱스 0 = extended 배열의 CLONE_COUNT 위치
   const [currentIndex, setCurrentIndex] = useState(CLONE_COUNT)
 

--- a/src/components/landing/StorytellingSection.tsx
+++ b/src/components/landing/StorytellingSection.tsx
@@ -3,27 +3,33 @@
 import { useRef, useEffect } from 'react'
 import { CATEGORY_STORIES } from './data/categoryStories'
 import { CategoryCard } from './CategoryCard'
+import type { SpotCategory } from '@/types/spot'
 
 /**
  * 카테고리 스토리텔링 섹션
  * GSAP ScrollTrigger 기반 3D 팝업북 스타일 스크롤 애니메이션
  * Requirements: 2.1, 2.2, 2.3, 2.9, 5.3, 6.5, 7.6
- *
- * - isHighEnd === true && reducedMotion === false: GSAP 3D 팝업북 애니메이션
- * - isHighEnd === false: 단순 CSS 애니메이션 (페이드인/슬라이드인)
- * - reducedMotion === true: GSAP 비활성화, 정적 레이아웃
  */
 
 interface StorytellingSectionProps {
   isHighEnd: boolean
   reducedMotion: boolean
+  /** 카테고리별 대표 스팟 이미지 URL */
+  categoryImages: Record<SpotCategory, string>
 }
 
 export function StorytellingSection({
   isHighEnd,
   reducedMotion,
+  categoryImages,
 }: StorytellingSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // 카테고리 스토리에 실제 이미지 적용
+  const storiesWithImages = CATEGORY_STORIES.map((story) => ({
+    ...story,
+    spotImage: categoryImages[story.category] || story.spotImage,
+  }))
 
   // GSAP 애니메이션: 고성능 + 모션 허용 시에만 로드
   if (isHighEnd && !reducedMotion) {
@@ -32,15 +38,16 @@ export function StorytellingSection({
         containerRef={containerRef}
         isHighEnd={isHighEnd}
         reducedMotion={reducedMotion}
+        stories={storiesWithImages}
       />
     )
   }
 
-  // CSS 폴백: 저사양 또는 reduced-motion
   return (
     <StorytellingSectionFallback
       isHighEnd={isHighEnd}
       reducedMotion={reducedMotion}
+      stories={storiesWithImages}
     />
   )
 }
@@ -53,13 +60,13 @@ function StorytellingSectionWithGSAP({
   containerRef,
   isHighEnd,
   reducedMotion,
+  stories,
 }: {
   containerRef: React.RefObject<HTMLDivElement | null>
   isHighEnd: boolean
   reducedMotion: boolean
+  stories: typeof CATEGORY_STORIES
 }) {
-  // GSAP는 dynamic import로 로드하여 번들 분리
-  // useGSAP 훅은 scope 옵션으로 컨텍스트 자동 정리
   useGSAPAnimation(containerRef)
 
   return (
@@ -68,7 +75,6 @@ function StorytellingSectionWithGSAP({
       aria-label="카테고리 스토리텔링"
     >
       <div className="mx-auto max-w-6xl px-4">
-        {/* 섹션 헤더 */}
         <header className="mb-12 text-center md:mb-16">
           <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
             어떤 <span className="text-primary-500">덕질</span>을 하시나요?
@@ -78,12 +84,11 @@ function StorytellingSectionWithGSAP({
           </p>
         </header>
 
-        {/* 카테고리 카드 그리드 */}
         <div
           ref={containerRef}
           className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
         >
-          {CATEGORY_STORIES.map((story, index) => (
+          {stories.map((story, index) => (
             <div
               key={story.category}
               className="gsap-card"
@@ -114,9 +119,11 @@ function StorytellingSectionWithGSAP({
 function StorytellingSectionFallback({
   isHighEnd,
   reducedMotion,
+  stories,
 }: {
   isHighEnd: boolean
   reducedMotion: boolean
+  stories: typeof CATEGORY_STORIES
 }) {
   return (
     <section
@@ -124,7 +131,6 @@ function StorytellingSectionFallback({
       aria-label="카테고리 스토리텔링"
     >
       <div className="mx-auto max-w-6xl px-4">
-        {/* 섹션 헤더 */}
         <header className="mb-12 text-center md:mb-16">
           <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
             어떤 <span className="text-primary-500">덕질</span>을 하시나요?
@@ -134,9 +140,8 @@ function StorytellingSectionFallback({
           </p>
         </header>
 
-        {/* 카테고리 카드 그리드 — CSS 애니메이션 */}
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {CATEGORY_STORIES.map((story, index) => (
+          {stories.map((story, index) => (
             <div
               key={story.category}
               className={

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { HeroSection } from './HeroSection'
+import { HowItWorksSection } from './HowItWorksSection'
 import { StorytellingSection } from './StorytellingSection'
 import { SocialProofSection } from './SocialProofSection'
 import { ConversionSection } from './ConversionSection'
@@ -11,13 +12,28 @@ import { useDeviceCapability } from '@/hooks/useDeviceCapability'
 import { useScrollPosition } from '@/hooks/useScrollPosition'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { usePwaStore } from '@/stores/pwaStore'
+import type { ShowcaseCard } from './data/showcaseCards'
+import type { SpotCategory } from '@/types/spot'
 
 /**
  * 랜딩 페이지 클라이언트 컴포넌트
  * 모든 섹션을 통합하고 디바이스 능력/스크롤/모션 훅을 연결
  * Requirements: 5.2, 5.3, 5.4, 6.1, 6.2, 6.3
  */
-export function WelcomePageClient() {
+interface WelcomePageClientProps {
+  /** 서버에서 fetch한 쇼케이스 스팟 데이터 */
+  showcaseSpots: ShowcaseCard[]
+  /** 카테고리별 대표 스팟 이미지 URL */
+  categoryImages: Record<SpotCategory, string>
+  /** 소셜 프루프용 카테고리별 스팟 이미지 목록 */
+  proofImages: Record<SpotCategory, string[]>
+}
+
+export function WelcomePageClient({
+  showcaseSpots,
+  categoryImages,
+  proofImages,
+}: WelcomePageClientProps) {
   const router = useRouter()
   const { isHighEnd, isReady } = useDeviceCapability()
   const reducedMotion = usePrefersReducedMotion()
@@ -64,26 +80,33 @@ export function WelcomePageClient() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* 디바이스 감지 완료 전 스켈레톤 */}
-      {!isReady ? (
-        <HeroSkeleton />
-      ) : (
-        <HeroSection
-          ref={heroRef}
-          reducedMotion={reducedMotion}
-        />
-      )}
+      {/* 히어로 — SSR 시점부터 바로 렌더 (스켈레톤 없음) */}
+      <HeroSection
+        ref={heroRef}
+        reducedMotion={reducedMotion}
+        showcaseSpots={showcaseSpots}
+      />
+
+      {/* HowItWorks — 4단계 플로우 */}
+      <HowItWorksSection />
 
       {/* StorytellingSection — 카테고리 스토리텔링 */}
-      {isReady && (
-        <StorytellingSection
-          isHighEnd={isHighEnd}
-          reducedMotion={reducedMotion}
-        />
-      )}
+      <div
+        className="h-px bg-gradient-to-r from-transparent via-primary-500/30 to-transparent"
+        aria-hidden="true"
+      />
+      <StorytellingSection
+        isHighEnd={isReady ? isHighEnd : false}
+        reducedMotion={reducedMotion}
+        categoryImages={categoryImages}
+      />
 
       {/* SocialProofSection — 자동 스크롤 슬라이더 */}
-      <SocialProofSection />
+      <div
+        className="h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
+        aria-hidden="true"
+      />
+      <SocialProofSection proofImages={proofImages} />
 
       {/* ConversionSection — PWA 설치 유도 전환 영역 */}
       <ConversionSection ref={conversionRef} isStandalone={isStandalone} />
@@ -96,31 +119,6 @@ export function WelcomePageClient() {
         onExploreClick={handleExploreClick}
       />
     </div>
-  )
-}
-
-/** 디바이스 감지 중 표시할 히어로 스켈레톤 */
-function HeroSkeleton() {
-  return (
-    <section className="flex min-h-screen items-center justify-center bg-background px-4">
-      <div className="mx-auto flex w-full max-w-6xl flex-col items-center gap-8 lg:flex-row lg:gap-12">
-        <div className="flex flex-1 flex-col items-center gap-4 lg:items-start">
-          <div className="h-10 w-64 animate-pulse rounded-md bg-neutral-200 dark:bg-neutral-700" />
-          <div className="h-6 w-48 animate-pulse rounded-md bg-neutral-200 dark:bg-neutral-700" />
-          <div className="h-12 w-36 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" />
-        </div>
-        {/* 카드 콜라주 스켈레톤 (기존 원형 지구본 → 사각형 카드들) */}
-        <div className="relative flex flex-1 items-center justify-center">
-          <div className="relative h-64 w-64 md:h-80 md:w-80">
-            <div className="absolute left-2 top-4 h-20 w-16 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(-5deg)' }} />
-            <div className="absolute right-4 top-2 h-24 w-20 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(3deg)' }} />
-            <div className="absolute bottom-8 left-8 h-20 w-16 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(4deg)' }} />
-            <div className="absolute bottom-4 right-6 h-24 w-20 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'rotate(-3deg)' }} />
-            <div className="absolute left-1/2 top-1/2 h-20 w-16 -translate-x-1/2 -translate-y-1/2 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700" style={{ transform: 'translate(-50%, -50%) rotate(2deg)' }} />
-          </div>
-        </div>
-      </div>
-    </section>
   )
 }
 

--- a/src/components/landing/data/fetchShowcaseSpots.ts
+++ b/src/components/landing/data/fetchShowcaseSpots.ts
@@ -1,0 +1,219 @@
+import { getCollection } from '@/lib/db'
+import type { SpotCategory } from '@/types/spot'
+import type { ShowcaseCard } from './showcaseCards'
+import { REAL_SPOT_PHOTO_FALLBACKS } from './realSpotPhotoFallbacks'
+import { CARD_PLACEMENTS } from './showcaseCards'
+
+/**
+ * 카테고리 순환 순서 (6장 슬라이스 시 각 카테고리 1장씩 보장)
+ */
+const CATEGORY_ORDER: SpotCategory[] = [
+  'animation',
+  'sports',
+  'movie_drama',
+  'music',
+  'game',
+  'other',
+]
+
+interface SpotDocument {
+  id: string
+  name: string
+  photos: string[]
+  category?: SpotCategory
+  relatedContent?: { name: string }[]
+}
+
+function isPlaceholderPhoto(url?: string | null): boolean {
+  if (!url) return true
+  return url.includes('picsum.photos/seed/') || url.startsWith('/icons/')
+}
+
+function resolveLandingPhoto(
+  spotId: string,
+  photoUrl?: string | null
+): string | null {
+  if (photoUrl && !isPlaceholderPhoto(photoUrl)) {
+    return photoUrl
+  }
+
+  return REAL_SPOT_PHOTO_FALLBACKS[spotId]?.imageUrl ?? photoUrl ?? null
+}
+
+/**
+ * DB에서 카테고리별 대표 스팟을 가져와 ShowcaseCard 배열로 반환한다.
+ * - 카테고리당 최대 2장, 총 12장 (CARD_PLACEMENTS 수에 맞춤)
+ * - 카테고리 순환 배치: [anim, sports, movie, music, game, other] × 2
+ * - 썸네일(photos[0])이 있는 스팟 우선 선택
+ * - 스팟이 부족하면 SHOWCASE_CARDS 정적 데이터로 보완
+ *
+ * Server Component 전용 (DB 직접 접근)
+ */
+export async function fetchShowcaseSpots(): Promise<ShowcaseCard[]> {
+  const maxCards = CARD_PLACEMENTS.length // 12
+
+  try {
+    const collection = await getCollection<SpotDocument>('spots')
+
+    // 카테고리별로 썸네일 있는 스팟 2개씩 조회
+    const spotsByCategory = await Promise.all(
+      CATEGORY_ORDER.map(async (category) => {
+        const spots = await collection
+          .find({
+            category,
+            'photos.0': { $exists: true, $ne: '' },
+          })
+          .project({
+            id: 1,
+            name: 1,
+            photos: 1,
+            category: 1,
+            relatedContent: 1,
+          })
+          .limit(2)
+          .toArray()
+        return { category, spots }
+      })
+    )
+
+    // 카테고리 순환 배치로 카드 생성
+    // 1차 순환: 각 카테고리 1번째 스팟
+    // 2차 순환: 각 카테고리 2번째 스팟
+    const cards: ShowcaseCard[] = []
+
+    for (let round = 0; round < 2; round++) {
+      for (const { category, spots } of spotsByCategory) {
+        if (cards.length >= maxCards) break
+        const spot = spots[round]
+        if (!spot) continue
+
+        const contentName = spot.relatedContent?.[0]?.name || spot.name
+        const imageUrl = resolveLandingPhoto(spot.id, spot.photos[0])
+
+        if (!imageUrl) continue
+
+        cards.push({
+          id: `showcase-${spot.id}-${round}`,
+          spotName: spot.name,
+          contentName,
+          category: spot.category ?? category,
+          imageUrl,
+        })
+      }
+    }
+
+    // 카드가 충분하면 반환
+    if (cards.length >= 6) {
+      return cards
+    }
+
+    // 스팟이 너무 적으면 정적 데이터로 보완
+    const { SHOWCASE_CARDS } = await import('./showcaseCards')
+    const staticCards = SHOWCASE_CARDS.slice(cards.length)
+    return [...cards, ...staticCards].slice(0, maxCards)
+  } catch (error) {
+    // DB 연결 실패 시 정적 데이터 폴백
+    console.error('[fetchShowcaseSpots] DB 조회 실패, 정적 데이터 사용:', error)
+    const { SHOWCASE_CARDS } = await import('./showcaseCards')
+    return SHOWCASE_CARDS
+  }
+}
+
+/**
+ * 카테고리별 대표 스팟 이미지 URL을 반환한다.
+ * categoryStories, proofData 등에서 플레이스홀더 아이콘 대신 사용
+ *
+ * @returns Record<SpotCategory, string> — 카테고리별 첫 번째 스팟 사진 URL
+ */
+export async function fetchCategoryImages(): Promise<
+  Record<SpotCategory, string>
+> {
+  const iconFallback: Record<SpotCategory, string> = {
+    animation: '/icons/categories/animation.webp',
+    sports: '/icons/categories/sports.webp',
+    movie_drama: '/icons/categories/movie_drama.webp',
+    music: '/icons/categories/music.webp',
+    game: '/icons/categories/game.webp',
+    other: '/icons/categories/other.webp',
+  }
+
+  try {
+    const collection = await getCollection<SpotDocument>('spots')
+
+    const results = await Promise.all(
+      CATEGORY_ORDER.map(async (category) => {
+        const spot = await collection.findOne(
+          { category, 'photos.0': { $exists: true, $ne: '' } },
+          { projection: { id: 1, photos: 1 } }
+        )
+        return {
+          category,
+          imageUrl: spot ? resolveLandingPhoto(spot.id, spot.photos[0]) : null,
+        }
+      })
+    )
+
+    const images = { ...iconFallback }
+    for (const { category, imageUrl } of results) {
+      if (imageUrl) {
+        images[category] = imageUrl
+      }
+    }
+
+    // 아이콘 폴백만 남은 카테고리는 그대로 둠 (다른 카테고리 이미지를 빌려오면 혼동)
+    return images
+  } catch {
+    return iconFallback
+  }
+}
+
+/**
+ * 소셜 프루프 카드에 사용할 카테고리별 스팟 이미지 목록을 반환한다.
+ * 카테고리별 최대 4장, 총 최대 24장의 실제 스팟 사진 URL
+ *
+ * @returns Record<SpotCategory, string[]> — 카테고리별 스팟 사진 URL 배열
+ */
+export async function fetchProofImages(): Promise<
+  Record<SpotCategory, string[]>
+> {
+  const fallback: Record<SpotCategory, string[]> = {
+    animation: [],
+    sports: [],
+    movie_drama: [],
+    music: [],
+    game: [],
+    other: [],
+  }
+
+  try {
+    const collection = await getCollection<SpotDocument>('spots')
+
+    const results = await Promise.all(
+      CATEGORY_ORDER.map(async (category) => {
+        const spots = await collection
+          .find({
+            category,
+            'photos.0': { $exists: true, $ne: '' },
+          })
+          .project({ id: 1, photos: 1 })
+          .limit(4)
+          .toArray()
+        return {
+          category,
+          images: spots
+            .map((s) => resolveLandingPhoto(s.id, s.photos[0]))
+            .filter((url): url is string => Boolean(url)),
+        }
+      })
+    )
+
+    const images = { ...fallback }
+    for (const { category, images: imgs } of results) {
+      images[category] = imgs
+    }
+
+    return images
+  } catch {
+    return fallback
+  }
+}

--- a/src/components/landing/data/realSpotPhotoFallbacks.ts
+++ b/src/components/landing/data/realSpotPhotoFallbacks.ts
@@ -4,6 +4,10 @@ export interface RealSpotPhotoFallback {
   license: string
 }
 
+function wikimediaFilePath(fileName: string): string {
+  return `https://commons.wikimedia.org/wiki/Special:FilePath/${encodeURIComponent(fileName)}`
+}
+
 export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
   {
     'REAL-ANI-001': {
@@ -19,6 +23,94 @@ export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
       sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Jiufen.jpg',
       license: 'CC BY 3.0',
     },
+    'REAL-ANI-010': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/d/d4/Outside_of_Akihabara.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Outside_of_Akihabara.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-012': {
+      imageUrl: wikimediaFilePath('Hakone-yumoto.jpg'),
+      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Hakone-yumoto.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-013': {
+      imageUrl: wikimediaFilePath('Meiji Mura 20220718 04.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Meiji_Mura_20220718_04.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-014': {
+      imageUrl: wikimediaFilePath('Oyama Dam.jpg'),
+      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Oyama_Dam.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-015': {
+      imageUrl: wikimediaFilePath('Kumamoto Prefectural office new.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Kumamoto_Prefectural_office_new.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-016': {
+      imageUrl: wikimediaFilePath('Haruna00.JPG'),
+      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Haruna00.JPG',
+      license: 'CC BY-SA 3.0',
+    },
+    'REAL-ANI-017': {
+      imageUrl: wikimediaFilePath('Kabukicho (53084208633).jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Kabukicho_(53084208633).jpg',
+      license: 'CC BY 2.0',
+    },
+    'REAL-ANI-018': {
+      imageUrl: wikimediaFilePath('Naruto whirlpools 20170609-3.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Naruto_whirlpools_20170609-3.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-019': {
+      imageUrl: wikimediaFilePath('Kuala Lumpur Tower.JPG'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Kuala_Lumpur_Tower.JPG',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-020': {
+      imageUrl: wikimediaFilePath('Shibuya Scramble crossing.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Shibuya_Scramble_crossing.jpg',
+      license: 'CC0 1.0',
+    },
+    'REAL-ANI-021': {
+      imageUrl: wikimediaFilePath('Shibuya 109 -01.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Shibuya_109_-01.jpg',
+      license: 'CC BY-SA 3.0',
+    },
+    'REAL-ANI-022': {
+      imageUrl: wikimediaFilePath('Lake Motosu (2015-12-17).jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Lake_Motosu_(2015-12-17).jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-023': {
+      imageUrl: wikimediaFilePath('Shimokitazawa.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Shimokitazawa.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-024': {
+      imageUrl: wikimediaFilePath('Nuremberg old town nov 2020.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Nuremberg_old_town_nov_2020.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-025': {
+      imageUrl: wikimediaFilePath('Saitama stadium2002-1.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Saitama_stadium2002-1.jpg',
+      license: 'CC BY-SA 3.0',
+    },
     'REAL-SPO-001': {
       imageUrl:
         'https://upload.wikimedia.org/wikipedia/commons/f/ff/Camp_Nou.jpg',
@@ -31,6 +123,12 @@ export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
       sourcePageUrl:
         'https://commons.wikimedia.org/wiki/File:Old_Trafford_1.jpg',
       license: 'Public domain',
+    },
+    'REAL-SPO-004': {
+      imageUrl: wikimediaFilePath('Santiago Bernabeu Stadium.jpg'),
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Santiago_Bernabeu_Stadium.jpg',
+      license: 'CC BY-SA 4.0',
     },
     'REAL-MOV-001': {
       imageUrl:
@@ -52,6 +150,13 @@ export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
       sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Tokyo_Dome.jpg',
       license: 'CC BY-SA 1.0',
     },
+    'REAL-MUS-006': {
+      imageUrl:
+        'https://commons.wikimedia.org/wiki/Special:FilePath/%EC%98%AC%EB%A6%BC%ED%94%BD%EC%B2%B4%EC%A1%B0.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:%EC%98%AC%EB%A6%BC%ED%94%BD%EC%B2%B4%EC%A1%B0.jpg',
+      license: 'CC BY-SA 4.0',
+    },
     'REAL-GAM-002': {
       imageUrl:
         'https://upload.wikimedia.org/wikipedia/commons/6/6a/Nintendo_Tokyo_%28PXL_20231220_022539971%29.jpg',
@@ -65,12 +170,5 @@ export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
       sourcePageUrl:
         'https://commons.wikimedia.org/wiki/File:Mega_Tokyo_Pok%C3%A9mon_Center_1.jpg',
       license: 'CC BY 3.0',
-    },
-    'REAL-ANI-010': {
-      imageUrl:
-        'https://upload.wikimedia.org/wikipedia/commons/d/d4/Outside_of_Akihabara.jpg',
-      sourcePageUrl:
-        'https://commons.wikimedia.org/wiki/File:Outside_of_Akihabara.jpg',
-      license: 'CC BY-SA 4.0',
     },
   }

--- a/src/components/landing/data/realSpotPhotoFallbacks.ts
+++ b/src/components/landing/data/realSpotPhotoFallbacks.ts
@@ -1,0 +1,76 @@
+export interface RealSpotPhotoFallback {
+  imageUrl: string
+  sourcePageUrl: string
+  license: string
+}
+
+export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
+  {
+    'REAL-ANI-001': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/5/52/Suga_Shrine_stairs_low-angle_20161113-071158.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Suga_Shrine_stairs_low-angle_20161113-071158.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+    'REAL-ANI-003': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/7/7f/Jiufen.jpg',
+      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Jiufen.jpg',
+      license: 'CC BY 3.0',
+    },
+    'REAL-SPO-001': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/f/ff/Camp_Nou.jpg',
+      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Camp_Nou.jpg',
+      license: 'CC BY 2.0',
+    },
+    'REAL-SPO-002': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/6/68/Old_Trafford_1.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Old_Trafford_1.jpg',
+      license: 'Public domain',
+    },
+    'REAL-MOV-001': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/8/83/GlenfinnanViaduct.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:GlenfinnanViaduct.jpg',
+      license: 'Public domain',
+    },
+    'REAL-MUS-001': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/c/ce/Abbey_Road_Crossing.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Abbey_Road_Crossing.jpg',
+      license: 'CC BY 2.0',
+    },
+    'REAL-MUS-002': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/2/25/Tokyo_Dome.jpg',
+      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Tokyo_Dome.jpg',
+      license: 'CC BY-SA 1.0',
+    },
+    'REAL-GAM-002': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/6/6a/Nintendo_Tokyo_%28PXL_20231220_022539971%29.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Nintendo_Tokyo_(PXL_20231220_022539971).jpg',
+      license: 'CC BY 4.0',
+    },
+    'REAL-GAM-003': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/e/ec/Mega_Tokyo_Pok%C3%A9mon_Center_1.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Mega_Tokyo_Pok%C3%A9mon_Center_1.jpg',
+      license: 'CC BY 3.0',
+    },
+    'REAL-ANI-010': {
+      imageUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/d/d4/Outside_of_Akihabara.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Outside_of_Akihabara.jpg',
+      license: 'CC BY-SA 4.0',
+    },
+  }

--- a/src/components/landing/data/realSpotPhotoFallbacks.ts
+++ b/src/components/landing/data/realSpotPhotoFallbacks.ts
@@ -147,9 +147,10 @@ export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
     },
     'REAL-MUS-002': {
       imageUrl:
-        'https://upload.wikimedia.org/wikipedia/commons/2/25/Tokyo_Dome.jpg',
-      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Tokyo_Dome.jpg',
-      license: 'CC BY-SA 1.0',
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Tokyo_Dome_side_view.jpg/1280px-Tokyo_Dome_side_view.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Tokyo_Dome_side_view.jpg',
+      license: 'CC BY-SA 3.0',
     },
     'REAL-MUS-006': {
       imageUrl:

--- a/src/components/landing/data/realSpotPhotoFallbacks.ts
+++ b/src/components/landing/data/realSpotPhotoFallbacks.ts
@@ -32,7 +32,8 @@ export const REAL_SPOT_PHOTO_FALLBACKS: Record<string, RealSpotPhotoFallback> =
     },
     'REAL-ANI-012': {
       imageUrl: wikimediaFilePath('Hakone-yumoto.jpg'),
-      sourcePageUrl: 'https://commons.wikimedia.org/wiki/File:Hakone-yumoto.jpg',
+      sourcePageUrl:
+        'https://commons.wikimedia.org/wiki/File:Hakone-yumoto.jpg',
       license: 'CC BY-SA 4.0',
     },
     'REAL-ANI-013': {

--- a/src/components/landing/data/showcaseCards.ts
+++ b/src/components/landing/data/showcaseCards.ts
@@ -7,18 +7,19 @@ import { CATEGORY_CONFIG } from '@/types/spot'
 
 /**
  * 쇼케이스 카드 데이터 타입
- * 히어로 섹션 플로팅 카드 콜라주에 표시할 정적 카드 데이터
+ * 히어로 섹션 플로팅 카드 콜라주에 표시할 카드 데이터
+ * - 정적 데이터 또는 실제 스팟 데이터 기반으로 생성
  */
 export interface ShowcaseCard {
   /** 카드 고유 ID */
   id: string
   /** 스팟 이름 */
   spotName: string
-  /** 관련 작품명 */
+  /** 관련 작품명 (없으면 스팟 이름 사용) */
   contentName: string
   /** 카테고리 */
   category: SpotCategory
-  /** 이미지 URL (정적 에셋) */
+  /** 이미지 URL */
   imageUrl: string
 }
 
@@ -158,18 +159,113 @@ export const SHOWCASE_CARDS: ShowcaseCard[] = [
  * - zIndex: 겹침 순서
  */
 export const CARD_PLACEMENTS: CardPlacement[] = [
-  { top: 5, left: 10, rotate: -8, size: 'lg', delay: 0, duration: 6, zIndex: 3 },
-  { top: 15, left: 55, rotate: 5, size: 'md', delay: 0.5, duration: 7, zIndex: 2 },
-  { top: 40, left: 5, rotate: 3, size: 'md', delay: 1, duration: 8, zIndex: 2 },
-  { top: 35, left: 65, rotate: -5, size: 'lg', delay: 1.5, duration: 6.5, zIndex: 3 },
-  { top: 60, left: 25, rotate: 7, size: 'sm', delay: 2, duration: 7.5, zIndex: 1 },
-  { top: 65, left: 70, rotate: -3, size: 'md', delay: 0.8, duration: 8.5, zIndex: 2 },
-  { top: 10, left: 35, rotate: -12, size: 'sm', delay: 1.2, duration: 7, zIndex: 1 },
-  { top: 50, left: 45, rotate: 10, size: 'sm', delay: 1.8, duration: 6, zIndex: 1 },
-  { top: 75, left: 10, rotate: -6, size: 'sm', delay: 2.5, duration: 8, zIndex: 1 },
-  { top: 80, left: 50, rotate: 4, size: 'md', delay: 0.3, duration: 7, zIndex: 2 },
-  { top: 25, left: 80, rotate: -10, size: 'sm', delay: 1.6, duration: 6.5, zIndex: 1 },
-  { top: 55, left: 85, rotate: 8, size: 'sm', delay: 2.2, duration: 7.5, zIndex: 1 },
+  // 좌상단 영역
+  { top: 2, left: 2, rotate: -8, size: 'lg', delay: 0, duration: 6, zIndex: 3 },
+  {
+    top: 8,
+    left: 48,
+    rotate: 5,
+    size: 'md',
+    delay: 0.5,
+    duration: 7,
+    zIndex: 2,
+  },
+  // 중상단 영역
+  {
+    top: 30,
+    left: -2,
+    rotate: 3,
+    size: 'md',
+    delay: 1,
+    duration: 8,
+    zIndex: 2,
+  },
+  {
+    top: 28,
+    left: 58,
+    rotate: -5,
+    size: 'lg',
+    delay: 1.5,
+    duration: 6.5,
+    zIndex: 3,
+  },
+  // 중앙 영역
+  {
+    top: 52,
+    left: 18,
+    rotate: 7,
+    size: 'sm',
+    delay: 2,
+    duration: 7.5,
+    zIndex: 1,
+  },
+  {
+    top: 55,
+    left: 62,
+    rotate: -3,
+    size: 'md',
+    delay: 0.8,
+    duration: 8.5,
+    zIndex: 2,
+  },
+  // 좌측 중간
+  {
+    top: 5,
+    left: 28,
+    rotate: -12,
+    size: 'sm',
+    delay: 1.2,
+    duration: 7,
+    zIndex: 1,
+  },
+  // 중앙 하단
+  {
+    top: 44,
+    left: 38,
+    rotate: 10,
+    size: 'sm',
+    delay: 1.8,
+    duration: 6,
+    zIndex: 1,
+  },
+  // 하단 영역
+  {
+    top: 72,
+    left: 2,
+    rotate: -6,
+    size: 'sm',
+    delay: 2.5,
+    duration: 8,
+    zIndex: 1,
+  },
+  {
+    top: 76,
+    left: 44,
+    rotate: 4,
+    size: 'md',
+    delay: 0.3,
+    duration: 7,
+    zIndex: 2,
+  },
+  // 우측 영역
+  {
+    top: 18,
+    left: 78,
+    rotate: -10,
+    size: 'sm',
+    delay: 1.6,
+    duration: 6.5,
+    zIndex: 1,
+  },
+  {
+    top: 50,
+    left: 82,
+    rotate: 8,
+    size: 'sm',
+    delay: 2.2,
+    duration: 7.5,
+    zIndex: 1,
+  },
 ]
 
 // ============================================

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,11 @@ export function Header() {
   const pathname = usePathname()
 
   // 랜딩 페이지에서는 헤더 숨김
-  if (HIDDEN_HEADER_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
+  if (
+    HIDDEN_HEADER_PATHS.some(
+      (p) => pathname === p || pathname.startsWith(p + '/')
+    )
+  ) {
     return null
   }
 
@@ -39,222 +43,222 @@ export function Header() {
       {/* 헤더 높이만큼 스페이서 (fixed 헤더 아래 콘텐츠 밀어내기) */}
       <div className="h-14" aria-hidden="true" />
       <header className="fixed left-0 right-0 top-0 z-[1100] border-b border-border bg-surface/95 pt-safe-top backdrop-blur-sm">
-      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
-        {/* 로고 */}
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-text-primary flex items-center gap-1.5 text-xl font-bold">
-            <AppIcon name="logo" size="2xl" className="max-h-8" />
-            Not a Trip
-          </span>
-        </Link>
-
-        {/* 데스크톱 네비게이션 */}
-        <nav className="hidden items-center gap-6 md:flex">
-          <Link
-            href="/"
-            className="text-text-secondary text-sm transition hover:text-secondary-400"
-          >
-            홈
+        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
+          {/* 로고 */}
+          <Link href="/" className="flex items-center gap-2">
+            <span className="text-text-primary flex items-center gap-1.5 text-xl font-bold">
+              <AppIcon name="logo" size="2xl" className="max-h-8" />
+              Not a Trip
+            </span>
           </Link>
-          <Link
-            href="/gallery"
-            className="text-text-secondary text-sm transition hover:text-secondary-400"
-          >
-            순례 인증
-          </Link>
-          <Link
-            href="/routes"
-            className="text-text-secondary text-sm transition hover:text-secondary-400"
-          >
-            순례 코스
-          </Link>
-          <Link
-            href="/spots/register"
-            className="text-text-secondary text-sm transition hover:text-secondary-400"
-          >
-            스팟 등록
-          </Link>
-          <button
-            onClick={handleResetTour}
-            className="text-text-secondary text-sm transition hover:text-secondary-400"
-          >
-            📖 가이드 다시 보기
-          </button>
-          <Link
-            href="/test/globe-fallback"
-            className="text-sm text-yellow-400 transition hover:text-yellow-300"
-          >
-            🧪 테스트
-          </Link>
-          {isAuthenticated && user?.role === 'admin' && (
-            <Link
-              href="/admin"
-              className="text-sm text-orange-400 transition hover:text-orange-300"
-            >
-              ⚙️ 관리자
-            </Link>
-          )}
-        </nav>
 
-        {/* 인증 영역 + 모바일 메뉴 버튼 */}
-        <div className="flex items-center gap-3">
-          {isLoading ? (
-            <div className="h-8 w-20 animate-pulse rounded bg-muted/30" />
-          ) : isAuthenticated && user ? (
-            <div className="flex items-center gap-3">
-              <Link
-                href="/settings/account"
-                className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-secondary-100"
-              >
-                {user.image ? (
-                  <Image
-                    src={user.image}
-                    alt={user.name || '프로필'}
-                    width={28}
-                    height={28}
-                    className="h-7 w-7 rounded-full object-cover"
-                    referrerPolicy="no-referrer"
-                  />
-                ) : (
-                  <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-secondary-100">
-                    <AppIcon name="profile-front" size="xl" />
-                  </div>
-                )}
-                <span className="text-text-secondary hidden text-sm sm:block">
-                  {user.name || user.email}
-                </span>
-              </Link>
-              <button
-                onClick={() => logout()}
-                className="rounded-lg bg-neutral-300 px-3 py-1.5 text-sm text-white transition hover:bg-neutral-400"
-              >
-                로그아웃
-              </button>
-            </div>
-          ) : (
-            <Link
-              href="/auth/signin"
-              className="rounded-lg bg-primary px-3 py-1.5 text-sm text-white transition hover:bg-primary-600"
-            >
-              로그인
-            </Link>
-          )}
-
-          {/* 테마 토글 */}
-          <ThemeSelector />
-
-          {/* 모바일 햄버거 버튼 */}
-          <button
-            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            className="text-text-secondary hover:text-text-primary flex h-9 w-9 items-center justify-center rounded-lg transition hover:bg-secondary-100 md:hidden"
-            aria-label="메뉴 열기"
-          >
-            {isMobileMenuOpen ? (
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            ) : (
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M4 6h16M4 12h16M4 18h16"
-                />
-              </svg>
-            )}
-          </button>
-        </div>
-      </div>
-
-      {/* 모바일 드롭다운 메뉴 */}
-      {isMobileMenuOpen && (
-        <nav className="border-t border-border bg-surface/95 backdrop-blur-sm md:hidden">
-          <div className="space-y-1 px-4 py-3">
+          {/* 데스크톱 네비게이션 */}
+          <nav className="hidden items-center gap-6 md:flex">
             <Link
               href="/"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="text-text-secondary hover:text-text-primary block rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              className="text-text-secondary text-sm transition hover:text-secondary-400"
             >
               홈
             </Link>
             <Link
               href="/gallery"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              className="text-text-secondary text-sm transition hover:text-secondary-400"
             >
-              <AppIcon name="gallery" size="sm" />
               순례 인증
             </Link>
             <Link
               href="/routes"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              className="text-text-secondary text-sm transition hover:text-secondary-400"
             >
-              <AppIcon name="map" size="sm" />
               순례 코스
             </Link>
             <Link
               href="/spots/register"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="text-text-secondary hover:text-text-primary block rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              className="text-text-secondary text-sm transition hover:text-secondary-400"
             >
               스팟 등록
             </Link>
             <button
-              onClick={() => {
-                setIsMobileMenuOpen(false)
-                handleResetTour()
-              }}
-              className="text-text-secondary hover:text-text-primary block w-full rounded-lg px-3 py-2 text-left text-sm transition hover:bg-secondary-100"
+              onClick={handleResetTour}
+              className="text-text-secondary text-sm transition hover:text-secondary-400"
             >
               📖 가이드 다시 보기
             </button>
             <Link
               href="/test/globe-fallback"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="block rounded-lg px-3 py-2 text-sm text-yellow-400 transition hover:bg-secondary-100 hover:text-yellow-300"
+              className="text-sm text-yellow-400 transition hover:text-yellow-300"
             >
               🧪 테스트
             </Link>
             {isAuthenticated && user?.role === 'admin' && (
               <Link
                 href="/admin"
-                onClick={() => setIsMobileMenuOpen(false)}
-                className="block rounded-lg px-3 py-2 text-sm text-orange-400 transition hover:bg-secondary-100 hover:text-orange-300"
+                className="text-sm text-orange-400 transition hover:text-orange-300"
               >
                 ⚙️ 관리자
               </Link>
             )}
-            {isAuthenticated && (
+          </nav>
+
+          {/* 인증 영역 + 모바일 메뉴 버튼 */}
+          <div className="flex items-center gap-3">
+            {isLoading ? (
+              <div className="h-8 w-20 animate-pulse rounded bg-muted/30" />
+            ) : isAuthenticated && user ? (
+              <div className="flex items-center gap-3">
+                <Link
+                  href="/settings/account"
+                  className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-secondary-100"
+                >
+                  {user.image ? (
+                    <Image
+                      src={user.image}
+                      alt={user.name || '프로필'}
+                      width={28}
+                      height={28}
+                      className="h-7 w-7 rounded-full object-cover"
+                      referrerPolicy="no-referrer"
+                    />
+                  ) : (
+                    <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-secondary-100">
+                      <AppIcon name="profile-front" size="xl" />
+                    </div>
+                  )}
+                  <span className="text-text-secondary hidden text-sm sm:block">
+                    {user.name || user.email}
+                  </span>
+                </Link>
+                <button
+                  onClick={() => logout()}
+                  className="rounded-lg bg-neutral-300 px-3 py-1.5 text-sm text-white transition hover:bg-neutral-400"
+                >
+                  로그아웃
+                </button>
+              </div>
+            ) : (
               <Link
-                href="/settings/account"
+                href="/auth/signin"
+                className="rounded-lg bg-primary px-3 py-1.5 text-sm text-white transition hover:bg-primary-600"
+              >
+                로그인
+              </Link>
+            )}
+
+            {/* 테마 토글 */}
+            <ThemeSelector />
+
+            {/* 모바일 햄버거 버튼 */}
+            <button
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+              className="text-text-secondary hover:text-text-primary flex h-9 w-9 items-center justify-center rounded-lg transition hover:bg-secondary-100 md:hidden"
+              aria-label="메뉴 열기"
+            >
+              {isMobileMenuOpen ? (
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* 모바일 드롭다운 메뉴 */}
+        {isMobileMenuOpen && (
+          <nav className="border-t border-border bg-surface/95 backdrop-blur-sm md:hidden">
+            <div className="space-y-1 px-4 py-3">
+              <Link
+                href="/"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="text-text-secondary hover:text-text-primary block rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              >
+                홈
+              </Link>
+              <Link
+                href="/gallery"
                 onClick={() => setIsMobileMenuOpen(false)}
                 className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
               >
-                <AppIcon name="profile" size="sm" />
-                계정 설정
+                <AppIcon name="gallery" size="sm" />
+                순례 인증
               </Link>
-            )}
-          </div>
-        </nav>
-      )}
-    </header>
+              <Link
+                href="/routes"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              >
+                <AppIcon name="map" size="sm" />
+                순례 코스
+              </Link>
+              <Link
+                href="/spots/register"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="text-text-secondary hover:text-text-primary block rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+              >
+                스팟 등록
+              </Link>
+              <button
+                onClick={() => {
+                  setIsMobileMenuOpen(false)
+                  handleResetTour()
+                }}
+                className="text-text-secondary hover:text-text-primary block w-full rounded-lg px-3 py-2 text-left text-sm transition hover:bg-secondary-100"
+              >
+                📖 가이드 다시 보기
+              </button>
+              <Link
+                href="/test/globe-fallback"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="block rounded-lg px-3 py-2 text-sm text-yellow-400 transition hover:bg-secondary-100 hover:text-yellow-300"
+              >
+                🧪 테스트
+              </Link>
+              {isAuthenticated && user?.role === 'admin' && (
+                <Link
+                  href="/admin"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                  className="block rounded-lg px-3 py-2 text-sm text-orange-400 transition hover:bg-secondary-100 hover:text-orange-300"
+                >
+                  ⚙️ 관리자
+                </Link>
+              )}
+              {isAuthenticated && (
+                <Link
+                  href="/settings/account"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                  className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
+                >
+                  <AppIcon name="profile" size="sm" />
+                  계정 설정
+                </Link>
+              )}
+            </div>
+          </nav>
+        )}
+      </header>
     </>
   )
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,13 +3,23 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
+import { usePathname } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { ThemeSelector } from '@/components/common/ThemeToggle'
 import { AppIcon } from '@/components/common/AppIcon'
 
+/** 헤더를 숨길 경로 목록 (랜딩 페이지) */
+const HIDDEN_HEADER_PATHS = ['/welcome']
+
 export function Header() {
   const { user, isAuthenticated, isLoading, logout } = useAuth()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const pathname = usePathname()
+
+  // 랜딩 페이지에서는 헤더 숨김
+  if (HIDDEN_HEADER_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
+    return null
+  }
 
   const handleResetTour = () => {
     try {
@@ -25,7 +35,10 @@ export function Header() {
   }
 
   return (
-    <header className="fixed left-0 right-0 top-0 z-[1100] border-b border-border bg-surface/95 pt-safe-top backdrop-blur-sm">
+    <>
+      {/* 헤더 높이만큼 스페이서 (fixed 헤더 아래 콘텐츠 밀어내기) */}
+      <div className="h-14" aria-hidden="true" />
+      <header className="fixed left-0 right-0 top-0 z-[1100] border-b border-border bg-surface/95 pt-safe-top backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
         {/* 로고 */}
         <Link href="/" className="flex items-center gap-2">
@@ -242,5 +255,6 @@ export function Header() {
         </nav>
       )}
     </header>
+    </>
   )
 }

--- a/src/components/map/HoverTooltip.tsx
+++ b/src/components/map/HoverTooltip.tsx
@@ -10,10 +10,20 @@ interface HoverTooltipProps {
   isVisible: boolean
 }
 
+// 카테고리별 이모지 아이콘 (텍스트 렌더링용)
+const CATEGORY_EMOJI: Record<SpotCategory, string> = {
+  animation: '🎬',
+  sports: '⚽',
+  movie_drama: '🎥',
+  music: '🎵',
+  game: '🎮',
+  other: '📍',
+}
+
 // 카테고리별 아이콘 가져오기
 const getCategoryIcon = (category?: SpotCategory): string => {
   if (!category) return '📍'
-  return CATEGORY_CONFIG[category]?.icon || '📍'
+  return CATEGORY_EMOJI[category] || '📍'
 }
 
 // 카테고리별 라벨 가져오기

--- a/src/components/map/SpotPreview.tsx
+++ b/src/components/map/SpotPreview.tsx
@@ -148,6 +148,7 @@ export default function SpotPreview({ className = '' }: SpotPreviewProps) {
                 className="object-cover"
                 sizes="384px"
                 priority
+                unoptimized={spot.photoUrl.startsWith('http')}
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center bg-accent-surface">

--- a/src/components/mobile/SwipeableGallery.tsx
+++ b/src/components/mobile/SwipeableGallery.tsx
@@ -166,6 +166,7 @@ export default function SwipeableGallery({
               className="h-full w-full object-cover"
               priority={index === 0}
               draggable={false}
+              unoptimized={src.startsWith('http')}
               {...(index === 0 ? {} : blurPlaceholderProps)}
             />
           </div>

--- a/src/components/spot/ExternalLinkCard.tsx
+++ b/src/components/spot/ExternalLinkCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { memo } from 'react'
+import Image from 'next/image'
 import { ExternalLink, LINK_TYPE_CONFIG } from '@/types'
 
 /**
@@ -45,12 +46,18 @@ export const ExternalLinkCard = memo(function ExternalLinkCard({
       }}
     >
       {/* 아이콘 */}
-      <span className="relative flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-xl">
+      <span className="relative flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full">
         <span
           className="absolute inset-0 rounded-full"
           style={{ backgroundColor: config.color, opacity: 0.08 }}
         />
-        {config.icon}
+        <Image
+          src={config.icon}
+          alt={config.label}
+          width={24}
+          height={24}
+          className="relative z-10"
+        />
       </span>
 
       {/* 텍스트 영역 */}

--- a/src/components/spot/ExternalLinkForm.tsx
+++ b/src/components/spot/ExternalLinkForm.tsx
@@ -1,12 +1,22 @@
 'use client'
 
 import { useState, useCallback } from 'react'
+import Image from 'next/image'
 import {
   ExternalLink,
   ExternalLinkType,
   LINK_TYPE_CONFIG,
   SpotCategory,
 } from '@/types'
+
+/** select option용 링크 타입 이모지 매핑 */
+const LINK_TYPE_EMOJI: Record<ExternalLinkType, string> = {
+  official: '🏠',
+  ticket: '🎫',
+  schedule: '📅',
+  sns: '📱',
+  other: '🔗',
+}
 
 /**
  * ExternalLinkForm 컴포넌트 Props
@@ -115,7 +125,7 @@ function AddLinkForm({
             {(Object.keys(LINK_TYPE_CONFIG) as ExternalLinkType[]).map(
               (key) => (
                 <option key={key} value={key}>
-                  {LINK_TYPE_CONFIG[key].icon} {LINK_TYPE_CONFIG[key].label}
+                  {LINK_TYPE_EMOJI[key]} {LINK_TYPE_CONFIG[key].label}
                 </option>
               )
             )}
@@ -186,12 +196,18 @@ function LinkItem({
   return (
     <div className="flex items-center gap-3 rounded-lg border border-border bg-surface p-3">
       {/* 아이콘 */}
-      <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-base">
+      <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full">
         <span
           className="absolute inset-0 rounded-full"
           style={{ backgroundColor: config.color, opacity: 0.08 }}
         />
-        {config.icon}
+        <Image
+          src={config.icon}
+          alt={config.label}
+          width={20}
+          height={20}
+          className="relative z-10"
+        />
       </span>
 
       {/* 텍스트 */}

--- a/src/components/spot/SameContentSpots.tsx
+++ b/src/components/spot/SameContentSpots.tsx
@@ -111,6 +111,7 @@ function SameContentSpotCard({ spot }: { spot: SpotPin }) {
             sizes="160px"
             className="object-cover transition-transform duration-300 group-hover:scale-105"
             onError={() => setImageError(true)}
+            unoptimized={spot.thumbnailUrl.startsWith('http')}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -353,6 +353,7 @@ function SpotDetailContent({
                     sizes="(max-width: 768px) 100vw, 50vw"
                     className="object-cover transition-transform duration-300 hover:scale-105"
                     priority={index === 0}
+                    unoptimized={photo.startsWith('http')}
                     {...(index === 0 ? {} : blurPlaceholderProps)}
                   />
                 </div>

--- a/src/components/spot/SpotForm.tsx
+++ b/src/components/spot/SpotForm.tsx
@@ -13,6 +13,16 @@ import {
   ExternalLink,
 } from '@/types'
 import { ExternalLinkForm } from '@/components/spot/ExternalLinkForm'
+
+/** select option용 카테고리 이모지 매핑 */
+const CATEGORY_EMOJI: Record<SpotCategory, string> = {
+  animation: '🎬',
+  sports: '⚽',
+  movie_drama: '🎥',
+  music: '🎵',
+  game: '🎮',
+  other: '📍',
+}
 import {
   ErrorMessages,
   UserInfoBanner,
@@ -146,7 +156,7 @@ export function SpotForm({
               <option value="">카테고리를 선택하세요</option>
               {(Object.keys(CATEGORY_CONFIG) as SpotCategory[]).map((key) => (
                 <option key={key} value={key}>
-                  {CATEGORY_CONFIG[key].icon} {CATEGORY_CONFIG[key].label}
+                  {CATEGORY_EMOJI[key]} {CATEGORY_CONFIG[key].label}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
## 변경 사항

### 히어로 섹션 전면 개편
- Three.js 3D 지구본 → 플로팅 카드 콜라주로 교체 (CSS 애니메이션 기반)
- 발견형 검색 히어로: 검색창 + 카테고리 칩 6개 추가
- 검색/카테고리 칩 클릭 시 `/map?search=...`, `/map?category=...`로 이동
- 배경 글로우 블롭 + 스크롤 힌트 추가
- 콜라주 컨테이너 뷰포트 상대값 적용

### 랜딩 전용 헤더 분리
- 글로벌 헤더를 `/welcome` 경로에서 숨김
- 랜딩 전용 미니 헤더 (로고 / 지도 탐색 / 로그인)
- 루트 레이아웃 `pt-14` 제거 → Header 컴포넌트 자체에 스페이서 포함
- `-mt-14` 우회 제거

### SSR 본문 렌더
- `isReady` 체크 제거 → 히어로가 SSR 시점부터 바로 렌더
- HeroSkeleton 삭제
- StorytellingSection은 GSAP만 점진적 로드

### MapPage URL 파라미터 동기화
- `useSearchParams()`로 `search`, `category` URL 파라미터를 filterStore에 동기화
- 파라미터 없을 때 스토어 초기화 (누적 상태 방지)
- `<main>` → `<div>`로 변경 (시맨틱 중첩 해소)

### 실사 이미지 기반 통일
- DB에서 카테고리별 대표 스팟 사진 조회 → 히어로/스토리텔링/소셜프루프에 주입
- `realSpotPhotoFallbacks.ts` — Wikimedia Commons 기반 실사 폴백 데이터
- `update-spot-photos.ts` 스크립트로 DB 스팟에 실제 사진 URL 반영
- 소셜 프루프 sceneImage 제거 → 단일 실사 카드로 통일
- 다른 카테고리 이미지 빌려오기 로직 제거 (혼동 방지)

### 신규 섹션
- HowItWorks 4단계 플로우 섹션 추가
- 섹션 간 그라데이션 디바이더 추가

### ConversionSection CTA 순서 변경
- "지도에서 탐색 시작" 우선 → "앱으로 설치하기" 보조

### 기타
- SocialProofSection 화살표 버튼 초기 동작 안 되는 버그 수정
- shell-safety steering 규칙 추가
- next.config 이미지 도메인 추가

## 테스트

- `npm run type-check` 통과
- 로컬 `/welcome` 페이지에서 히어로/검색/카테고리 칩/소셜 프루프 동작 확인
- `/map?category=game`, `/map?search=슬램덩크` URL 동기화 확인

Closes #660