### PR TITLE
feat: checkin 및 scene 타입에 relation 필드 추가

### DIFF
--- a/src/types/checkin.ts
+++ b/src/types/checkin.ts
@@ -3,6 +3,8 @@
  * Spec: 07-pilgrimage-checkin
  */
 
+import { RelationType } from './spot'
+
 // ============================================
 // CheckIn (인증) 타입
 // ============================================
@@ -24,6 +26,18 @@ export interface CheckIn {
   comment?: string
   /** 좋아요 수 */
   likeCount: number
+  // === relation 기반 필드 ===
+  /** SpotContentRelation ID 참조 */
+  relationId?: string
+  /** 콘텐츠 식별자 스냅샷 */
+  contentId?: string
+  /** 작품명 스냅샷 */
+  contentName?: string
+  /** 관계 유형 스냅샷 */
+  relationType?: RelationType
+  /** 마이그레이션 상태: resolved | unresolved | null(신규) */
+  migrationStatus?: 'resolved' | 'unresolved' | null
+  // ================================
   createdAt: Date
   updatedAt?: Date
 }
@@ -35,6 +49,8 @@ export interface CheckInInput {
   sceneImageUrl?: string
   visitedAt: Date
   comment?: string
+  /** 선택된 relation ID (다중 작품 스팟에서 필수) */
+  relationId?: string
 }
 
 /** 인증 목록 조회 필터 */

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -349,6 +349,8 @@ export interface Scene {
   spotId: string
   imageUrl: string
   animeTitle: string
+  /** 작품명 (animeTitle에서 매핑, 새 필드) */
+  contentName?: string
   episodeInfo?: string
   description?: string
   likeCount: number


### PR DESCRIPTION
## 개요\n\nMulti-Content Spot Structure 스펙 Task 1 구현.\n체크인과 씬 타입을 확장하여 relation 기반 구조를 지원합니다.\n\n## 변경 사항\n\n### `src/types/checkin.ts`\n- `CheckIn` 인터페이스에 `relationId`, `contentId`, `contentName`, `relationType`, `migrationStatus` 필드 추가\n- `CheckInInput` 인터페이스에 `relationId` 필드 추가\n- `RelationType` import 추가\n\n### `src/types/spot.ts`\n- `Scene` 인터페이스에 `contentName?: string` 필드 추가\n\n## 관련 Requirements\n\n- Requirements 2.1~2.6\n- H1 수정사항\n\nCloses #662