### PR TITLE
feat: 랜딩 페이지 FloatingCard "+N" 배지 추가

### DIFF
--- a/src/components/landing/FloatingCard.tsx
+++ b/src/components/landing/FloatingCard.tsx
@@ -92,7 +92,7 @@ export function FloatingCard({
 
   return (
     <div
-      className="group relative overflow-hidden rounded-lg border border-white/10 shadow-lg backdrop-blur-sm transition-all duration-300 will-change-transform hover:scale-105 hover:shadow-2xl hover:shadow-white/10"
+      className="group relative rounded-lg border border-white/10 shadow-lg backdrop-blur-sm transition-all duration-300 will-change-transform hover:scale-105 hover:shadow-2xl hover:shadow-white/10"
       style={{
         width,
         height,
@@ -101,91 +101,113 @@ export function FloatingCard({
       data-index={index}
       data-reduced-motion={reducedMotion}
     >
-      {/* 배경 하이라이트 효과 */}
-      <div
-        className="absolute inset-0 opacity-15"
-        style={{
-          backgroundImage:
-            'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.2) 0%, transparent 50%), radial-gradient(circle at 75% 75%, rgba(255,255,255,0.08) 0%, transparent 40%)',
-        }}
-      />
-
-      {/* 카테고리 아이콘 (이미지 없을 때 중앙 표시) */}
-      {!imageValid && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          {!iconError ? (
-            <Image
-              src={iconSrc}
-              alt={card.category}
-              width={iconSize}
-              height={iconSize}
-              className="opacity-50 drop-shadow-lg"
-              onError={() => setIconError(true)}
-            />
-          ) : (
-            <div
-              className="rounded-full opacity-40"
-              style={{
-                width: iconSize,
-                height: iconSize,
-                backgroundColor: accentColor,
-              }}
-            />
-          )}
-        </div>
-      )}
-
-      {/* accent 글로우 (하단) */}
-      <div
-        className="absolute inset-0 opacity-25"
-        style={{
-          background: `radial-gradient(ellipse at 50% 110%, ${accentColor} 0%, transparent 65%)`,
-        }}
-      />
-
-      {/* 실제 이미지 (유효한 경우에만 표시) */}
-      <Image
-        src={card.imageUrl}
-        alt={altText}
-        fill
-        sizes={`${width}px`}
-        className={`object-cover transition-opacity duration-300 ${imageValid ? 'opacity-100' : 'opacity-0'}`}
-        onLoad={(e) => {
-          // 1px placeholder 이미지 감지: naturalWidth/naturalHeight가 1이면 무시
-          const img = e.currentTarget
-          if (img.naturalWidth > 1 && img.naturalHeight > 1) {
-            setImageValid(true)
-          }
-        }}
-        onError={() => setImageValid(false)}
-      />
-
-      {/* 작품명 오버레이 */}
-      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 pb-1.5 pt-6">
-        {/* 카테고리 태그 */}
-        <div
-          className="mb-1 inline-flex items-center rounded px-1.5 py-0.5"
-          style={{ backgroundColor: `${accentColor}33` }}
-        >
-          <span
-            className="text-[9px] font-semibold uppercase tracking-wide"
-            style={{ color: accentColor }}
+      {/* "+N" 배지 — 다중 작품 스팟에서만 표시 (Requirements 9.1, 9.2, 9.5) */}
+      {card.additionalContentNames &&
+        card.additionalContentNames.length > 0 && (
+          <div
+            className="absolute -right-1 -top-1 z-20 flex items-center justify-center rounded-full border border-white/20 bg-white/90 shadow-md backdrop-blur-sm"
+            style={{
+              width: size === 'sm' ? 22 : size === 'md' ? 26 : 30,
+              height: size === 'sm' ? 22 : size === 'md' ? 26 : 30,
+            }}
           >
-            {CATEGORY_LABEL[card.category]}
-          </span>
-        </div>
-        <p
-          className={`truncate font-medium text-white/90 ${TEXT_SIZE_CONFIG[size]}`}
-        >
-          {card.contentName}
-        </p>
-      </div>
+            <span
+              className={`font-bold text-gray-800 ${size === 'sm' ? 'text-[9px]' : size === 'md' ? 'text-[10px]' : 'text-xs'}`}
+            >
+              +{card.additionalContentNames.length}
+            </span>
+          </div>
+        )}
 
-      {/* 카테고리 accent 하단 바 */}
-      <div
-        className="absolute inset-x-0 bottom-0 h-[2px]"
-        style={{ backgroundColor: accentColor }}
-      />
+      {/* 카드 내부 콘텐츠 (overflow-hidden 적용) */}
+      <div className="absolute inset-0 overflow-hidden rounded-lg">
+        {/* 배경 하이라이트 효과 */}
+        <div
+          className="absolute inset-0 opacity-15"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 25% 25%, rgba(255,255,255,0.2) 0%, transparent 50%), radial-gradient(circle at 75% 75%, rgba(255,255,255,0.08) 0%, transparent 40%)',
+          }}
+        />
+
+        {/* 카테고리 아이콘 (이미지 없을 때 중앙 표시) */}
+        {!imageValid && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            {!iconError ? (
+              <Image
+                src={iconSrc}
+                alt={card.category}
+                width={iconSize}
+                height={iconSize}
+                className="opacity-50 drop-shadow-lg"
+                onError={() => setIconError(true)}
+              />
+            ) : (
+              <div
+                className="rounded-full opacity-40"
+                style={{
+                  width: iconSize,
+                  height: iconSize,
+                  backgroundColor: accentColor,
+                }}
+              />
+            )}
+          </div>
+        )}
+
+        {/* accent 글로우 (하단) */}
+        <div
+          className="absolute inset-0 opacity-25"
+          style={{
+            background: `radial-gradient(ellipse at 50% 110%, ${accentColor} 0%, transparent 65%)`,
+          }}
+        />
+
+        {/* 실제 이미지 (유효한 경우에만 표시) */}
+        <Image
+          src={card.imageUrl}
+          alt={altText}
+          fill
+          sizes={`${width}px`}
+          className={`object-cover transition-opacity duration-300 ${imageValid ? 'opacity-100' : 'opacity-0'}`}
+          onLoad={(e) => {
+            // 1px placeholder 이미지 감지: naturalWidth/naturalHeight가 1이면 무시
+            const img = e.currentTarget
+            if (img.naturalWidth > 1 && img.naturalHeight > 1) {
+              setImageValid(true)
+            }
+          }}
+          onError={() => setImageValid(false)}
+        />
+
+        {/* 작품명 오버레이 */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 pb-1.5 pt-6">
+          {/* 카테고리 태그 */}
+          <div
+            className="mb-1 inline-flex items-center rounded px-1.5 py-0.5"
+            style={{ backgroundColor: `${accentColor}33` }}
+          >
+            <span
+              className="text-[9px] font-semibold uppercase tracking-wide"
+              style={{ color: accentColor }}
+            >
+              {CATEGORY_LABEL[card.category]}
+            </span>
+          </div>
+          <p
+            className={`truncate font-medium text-white/90 ${TEXT_SIZE_CONFIG[size]}`}
+          >
+            {card.contentName}
+          </p>
+        </div>
+
+        {/* 카테고리 accent 하단 바 */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-[2px]"
+          style={{ backgroundColor: accentColor }}
+        />
+      </div>
+      {/* 카드 내부 콘텐츠 wrapper 닫기 */}
     </div>
   )
 }

--- a/src/components/landing/data/fetchShowcaseSpots.ts
+++ b/src/components/landing/data/fetchShowcaseSpots.ts
@@ -1,4 +1,5 @@
 import { getCollection } from '@/lib/db'
+import { COLLECTIONS } from '@/lib/db'
 import type { SpotCategory } from '@/types/spot'
 import type { ShowcaseCard } from './showcaseCards'
 import { REAL_SPOT_PHOTO_FALLBACKS } from './realSpotPhotoFallbacks'
@@ -22,6 +23,13 @@ interface SpotDocument {
   photos: string[]
   category?: SpotCategory
   relatedContent?: { name: string }[]
+}
+
+interface RelationDocument {
+  spotId: string
+  contentName: string
+  status: string
+  displayPriority: number
 }
 
 function isPlaceholderPhoto(url?: string | null): boolean {
@@ -81,6 +89,35 @@ export async function fetchShowcaseSpots(): Promise<ShowcaseCard[]> {
     // 2차 순환: 각 카테고리 2번째 스팟
     const cards: ShowcaseCard[] = []
 
+    // 모든 스팟 ID 수집 후 일괄 relations 조회
+    const allSpots = spotsByCategory.flatMap(({ spots }) => spots)
+    const spotIds = allSpots.map((s) => s.id)
+
+    let relationsBySpotId: Record<string, string[]> = {}
+    try {
+      const relationsCollection = await getCollection<RelationDocument>(
+        COLLECTIONS.SPOT_CONTENT_RELATIONS
+      )
+      const relations = await relationsCollection
+        .find({ spotId: { $in: spotIds }, status: 'active' })
+        .sort({ displayPriority: 1 })
+        .project({ spotId: 1, contentName: 1 })
+        .toArray()
+
+      // spotId별 contentName 목록 그룹화
+      for (const rel of relations) {
+        if (!relationsBySpotId[rel.spotId]) {
+          relationsBySpotId[rel.spotId] = []
+        }
+        if (!relationsBySpotId[rel.spotId].includes(rel.contentName)) {
+          relationsBySpotId[rel.spotId].push(rel.contentName)
+        }
+      }
+    } catch {
+      // relations 조회 실패 시 빈 객체로 진행 (additionalContentNames 없이)
+      relationsBySpotId = {}
+    }
+
     for (let round = 0; round < 2; round++) {
       for (const { category, spots } of spotsByCategory) {
         if (cards.length >= maxCards) break
@@ -92,10 +129,20 @@ export async function fetchShowcaseSpots(): Promise<ShowcaseCard[]> {
 
         if (!imageUrl) continue
 
+        // additionalContentNames: 대표 작품명을 제외한 나머지 작품명
+        const allContentNames = relationsBySpotId[spot.id] || []
+        const additionalContentNames = allContentNames.filter(
+          (name) => name !== contentName
+        )
+
         cards.push({
           id: `showcase-${spot.id}-${round}`,
           spotName: spot.name,
           contentName,
+          additionalContentNames:
+            additionalContentNames.length > 0
+              ? additionalContentNames
+              : undefined,
           category: spot.category ?? category,
           imageUrl,
         })

--- a/src/components/landing/data/showcaseCards.ts
+++ b/src/components/landing/data/showcaseCards.ts
@@ -17,6 +17,8 @@ export interface ShowcaseCard {
   spotName: string
   /** 관련 작품명 (없으면 스팟 이름 사용) */
   contentName: string
+  /** 추가 작품명 목록 ("+N" 배지 계산용) */
+  additionalContentNames?: string[]
   /** 카테고리 */
   category: SpotCategory
   /** 이미지 URL */


### PR DESCRIPTION
## 개요

랜딩 페이지 FloatingCard에 다중 작품 스팟의 "+N" 배지를 표시하는 기능 구현

Closes #680

## 변경 사항

### 데이터 레이어
- `ShowcaseCard` 인터페이스에 `additionalContentNames?: string[]` 필드 추가
- `fetchShowcaseSpots()`에서 `spot_content_relations` 컬렉션 조회하여 스팟별 추가 작품명 반환
- 대표 작품명을 제외한 나머지 작품명을 `additionalContentNames`로 전달

### UI 컴포넌트
- `FloatingCard`에 "+N" 배지 렌더링 로직 추가
- 배지는 카드 우상단에 pill 형태로 표시
- 카드 크기(sm/md/lg)별 배지 크기 조정
- `overflow-hidden`을 내부 wrapper로 이동하여 배지 잘림 방지

## Requirements 대응

- Requirements 9.1: 대표 작품명 + "+N" 배지 표시
- Requirements 9.2: 단일 작품 스팟에서는 배지 미표시
- Requirements 9.5: 카드 크기 무관 배지 잘림 방지

## 테스트

- [x] `npm run type-check` 통과
- [x] ESLint + Prettier 통과 (pre-commit hook)