### PR TITLE
feat: 랜딩 페이지 SocialProofSection 체크인 데이터 리팩토링

### DIFF
--- a/src/components/landing/ProofCard.tsx
+++ b/src/components/landing/ProofCard.tsx
@@ -14,6 +14,8 @@ import { CATEGORY_CONFIG, type SpotCategory } from '@/types/spot'
 interface ProofCardProps {
   categoryTag: SpotCategory
   spotName: string
+  /** 작품명 (체크인 데이터에서 전달) */
+  contentName?: string
   comment: string
   image?: string
   sceneImage?: string
@@ -22,6 +24,7 @@ interface ProofCardProps {
 export function ProofCard({
   categoryTag,
   spotName,
+  contentName,
   comment,
   image,
   sceneImage,
@@ -101,8 +104,19 @@ export function ProofCard({
           {categoryConfig.label}
         </span>
 
-        {/* 스팟 이름 */}
-        <h3 className="text-sm font-semibold text-main-text">{spotName}</h3>
+        {/* 스팟 이름 + 작품명 */}
+        <h3 className="text-sm font-semibold text-main-text">
+          {spotName}
+          {contentName && (
+            <span
+              className={`ml-1 text-xs font-normal ${
+                contentName === '(미분류)' ? 'text-gray-400' : 'text-sub-text'
+              }`}
+            >
+              · {contentName}
+            </span>
+          )}
+        </h3>
 
         {/* 코멘트 */}
         <p className="line-clamp-2 text-xs text-sub-text">{comment}</p>

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -11,12 +11,25 @@ import type { SpotCategory } from '@/types/spot'
  * 소셜 프루프 섹션 컴포넌트
  * 커뮤니티 가치 카피 + ProofCard 무한 순환 슬라이더
  * 자동 스크롤 + 수동 좌우 스와이프 + 데스크톱 화살표 지원
- * Requirements: 3.1, 3.2, 3.3, 3.4, 6.6, 7.4
+ * Requirements: 3.1, 3.2, 3.3, 3.4, 6.6, 7.4, 9.3, 9.4
  */
+
+/** 서버에서 전달받는 체크인 데이터 (M6 수정사항) */
+export interface SocialProofCheckin {
+  id: string
+  spotName: string
+  contentName?: string
+  migrationStatus?: 'resolved' | 'unresolved' | null
+  photoUrl: string
+  comment?: string
+  categoryTag: SpotCategory
+}
 
 interface SocialProofSectionProps {
   /** 카테고리별 실제 스팟 이미지 목록 */
   proofImages: Record<SpotCategory, string[]>
+  /** 서버에서 가져온 체크인 데이터 (contentName 포함) */
+  checkinData?: SocialProofCheckin[]
 }
 
 /** 자동 스크롤 간격 (ms) */
@@ -39,12 +52,52 @@ const CLONE_COUNT = 4
  * - 카테고리별로 순서대로 이미지를 배분
  * - 이미지가 없는 카테고리는 다른 카테고리의 이미지를 빌려옴
  * - sceneImage는 실제 장면 이미지가 없으므로 제거 (단일 실사 카드)
+ * - checkinData가 있으면 서버 체크인 데이터를 우선 사용
  */
-function getExtendedData(proofImages: Record<SpotCategory, string[]>) {
+function getExtendedData(
+  proofImages: Record<SpotCategory, string[]>,
+  checkinData?: SocialProofCheckin[]
+) {
   // 카테고리별 이미지 인덱스 카운터
   const counters: Record<string, number> = {}
 
-  const data: ProofData[] = PROOF_DUMMY_DATA.map((item) => {
+  // checkinData가 있으면 서버 데이터를 더미 데이터 앞에 배치
+  let baseData: ProofData[]
+
+  if (checkinData && checkinData.length > 0) {
+    // 서버 체크인 데이터를 ProofData 형태로 변환
+    const checkinProofData: ProofData[] = checkinData.map((checkin) => {
+      // contentName 표시 로직: Requirements 9.3, 9.4
+      let displayContentName: string | undefined
+      if (checkin.migrationStatus === 'unresolved') {
+        displayContentName = '(미분류)'
+      } else if (checkin.contentName) {
+        displayContentName = checkin.contentName
+      }
+
+      return {
+        id: `checkin-${checkin.id}`,
+        categoryTag: checkin.categoryTag,
+        spotName: checkin.spotName,
+        contentName: displayContentName,
+        comment: checkin.comment || '성지순례 인증!',
+        image: checkin.photoUrl,
+        sceneImage: undefined,
+      }
+    })
+
+    // 서버 데이터 + 더미 데이터 결합 (서버 데이터 우선)
+    baseData = [...checkinProofData, ...PROOF_DUMMY_DATA]
+  } else {
+    baseData = [...PROOF_DUMMY_DATA]
+  }
+
+  const data: ProofData[] = baseData.map((item) => {
+    // 이미 서버 체크인 데이터인 경우 이미지 교체 불필요
+    if (item.id.startsWith('checkin-')) {
+      return { ...item, sceneImage: undefined }
+    }
+
     const cat = item.categoryTag
     const images = proofImages[cat] || []
 
@@ -74,13 +127,16 @@ function getExtendedData(proofImages: Record<SpotCategory, string[]>) {
   return { extended: [...prefixClones, ...data, ...suffixClones], len }
 }
 
-export function SocialProofSection({ proofImages }: SocialProofSectionProps) {
+export function SocialProofSection({
+  proofImages,
+  checkinData,
+}: SocialProofSectionProps) {
   const sliderRef = useRef<HTMLDivElement>(null)
   const [isPaused, setIsPaused] = useState(false)
   const [isTransitioning, setIsTransitioning] = useState(false)
   const reducedMotion = usePrefersReducedMotion()
 
-  const { extended, len } = getExtendedData(proofImages)
+  const { extended, len } = getExtendedData(proofImages, checkinData)
   // 실제 인덱스 0 = extended 배열의 CLONE_COUNT 위치
   const [currentIndex, setCurrentIndex] = useState(CLONE_COUNT)
 
@@ -229,6 +285,7 @@ export function SocialProofSection({ proofImages }: SocialProofSectionProps) {
                   <ProofCard
                     categoryTag={proof.categoryTag}
                     spotName={proof.spotName}
+                    contentName={proof.contentName}
                     comment={proof.comment}
                     image={proof.image}
                     sceneImage={proof.sceneImage}

--- a/src/components/landing/data/fetchShowcaseSpots.ts
+++ b/src/components/landing/data/fetchShowcaseSpots.ts
@@ -264,3 +264,90 @@ export async function fetchProofImages(): Promise<
     return fallback
   }
 }
+
+/**
+ * 소셜 프루프 섹션에 표시할 최근 체크인 데이터를 가져온다.
+ * contentName, migrationStatus를 포함하여 작품명 표시 및 미분류 라벨 처리에 사용
+ *
+ * @returns SocialProofCheckin[] — 최근 체크인 10개 (contentName 포함)
+ */
+export interface SocialProofCheckinData {
+  id: string
+  spotName: string
+  contentName?: string
+  migrationStatus?: 'resolved' | 'unresolved' | null
+  photoUrl: string
+  comment?: string
+  categoryTag: SpotCategory
+}
+
+interface CheckinDocument {
+  id: string
+  spotId: string
+  photoUrl: string
+  comment?: string
+  contentName?: string
+  migrationStatus?: 'resolved' | 'unresolved' | null
+  createdAt: Date
+}
+
+export async function fetchSocialProofCheckins(): Promise<
+  SocialProofCheckinData[]
+> {
+  try {
+    const checkinsCollection = await getCollection<CheckinDocument>(
+      COLLECTIONS.CHECKINS
+    )
+    const spotsCollection = await getCollection<SpotDocument>('spots')
+
+    // 최근 체크인 10개 조회 (photoUrl이 있는 것만)
+    const recentCheckins = await checkinsCollection
+      .find({ photoUrl: { $exists: true, $ne: '' } })
+      .sort({ createdAt: -1 })
+      .limit(10)
+      .project({
+        id: 1,
+        spotId: 1,
+        photoUrl: 1,
+        comment: 1,
+        contentName: 1,
+        migrationStatus: 1,
+      })
+      .toArray()
+
+    if (recentCheckins.length === 0) {
+      return []
+    }
+
+    // 체크인에 연결된 스팟 정보 조회
+    const spotIds = [...new Set(recentCheckins.map((c) => c.spotId))]
+    const spots = await spotsCollection
+      .find({ id: { $in: spotIds } })
+      .project({ id: 1, name: 1, category: 1 })
+      .toArray()
+
+    const spotMap = new Map(spots.map((s) => [s.id, s]))
+
+    // 체크인 데이터를 SocialProofCheckinData로 변환
+    const results: SocialProofCheckinData[] = []
+    for (const checkin of recentCheckins) {
+      const spot = spotMap.get(checkin.spotId)
+      if (!spot) continue
+
+      results.push({
+        id: checkin.id,
+        spotName: spot.name,
+        contentName: checkin.contentName || undefined,
+        migrationStatus: checkin.migrationStatus,
+        photoUrl: checkin.photoUrl,
+        comment: checkin.comment,
+        categoryTag: (spot.category as SpotCategory) || 'other',
+      })
+    }
+
+    return results
+  } catch (error) {
+    console.error('[fetchSocialProofCheckins] 체크인 데이터 조회 실패:', error)
+    return []
+  }
+}

--- a/src/components/landing/data/proofData.ts
+++ b/src/components/landing/data/proofData.ts
@@ -11,6 +11,8 @@ export interface ProofData {
   id: string
   categoryTag: SpotCategory
   spotName: string
+  /** 작품명 (체크인 데이터에서 전달, 선택) */
+  contentName?: string
   comment: string
   /** 스팟 실제 사진 */
   image: string


### PR DESCRIPTION
## 개요\n\nSocialProofSection 컴포넌트를 리팩토링하여 서버에서 체크인 데이터(contentName 포함)를 전달받아 표시하는 구조로 변경합니다.\n\nCloses #682\n\n## 변경 사항\n\n### SocialProofSection props 확장 (11.1)\n- `SocialProofCheckin` 인터페이스 정의\n- `SocialProofSectionProps`에 `checkinData?: SocialProofCheckin[]` 추가\n\n### 서버 체크인 데이터 조회 (11.2)\n- `fetchSocialProofCheckins()` 함수 추가 (fetchShowcaseSpots.ts)\n- 최근 체크인 10개를 contentName, migrationStatus 포함하여 조회\n- welcome/page.tsx 서버 컴포넌트에서 호출하여 클라이언트로 전달\n\n### contentName 표시 (11.3)\n- ProofCard에 contentName prop 추가\n- 체크인에 contentName이 있으면 \"스팟명 · 작품명\" 형태로 표시\n\n### 미분류 라벨 (11.4)\n- migrationStatus === 'unresolved'인 체크인에 \"(미분류)\" 라벨 표시\n- 회색 스타일로 구분\n\n## Requirements\n\n- Requirements 9.3: 체크인의 contentName 존재 시 작품명 표시\n- Requirements 9.4: Unresolved 체크인에 \"(미분류)\" 라벨 표시\n- M6 수정사항: SocialProofSection props 인터페이스 확장\n\n## 테스트\n\n- [x] TypeScript 타입 체크 통과\n- [x] 서버 데이터 없을 때 기존 더미 데이터로 정상 동작\n- [x] 서버 데이터 있을 때 체크인 카드 우선 표시\n- [x] contentName 표시 확인\n- [x] 미분류 라벨 표시 확인"