### PR TITLE
feat: relatedContentSection displayPriority 오름차순 정렬 강화

### DIFF
--- a/src/components/spot/RelatedContentSection.tsx
+++ b/src/components/spot/RelatedContentSection.tsx
@@ -49,11 +49,15 @@ export function RelatedContentSection({
 
   // relations가 있으면 relation 기반 렌더링
   if (relations && relations.length > 0) {
-    const hasMore = relations.length > initialDisplayCount
+    // displayPriority 오름차순 정렬 강화 (Requirements 10.4)
+    const sortedRelations = [...relations].sort(
+      (a, b) => a.displayPriority - b.displayPriority
+    )
+    const hasMore = sortedRelations.length > initialDisplayCount
     const displayedRelations = isExpanded
-      ? relations
-      : relations.slice(0, initialDisplayCount)
-    const remainingCount = relations.length - initialDisplayCount
+      ? sortedRelations
+      : sortedRelations.slice(0, initialDisplayCount)
+    const remainingCount = sortedRelations.length - initialDisplayCount
 
     return (
       <div className="overflow-hidden rounded-lg border border-border bg-surface shadow-md">


### PR DESCRIPTION
## 개요

스팟 상세 페이지의 RelatedContentSection 컴포넌트에서 `displayPriority` 오름차순 정렬을 강화합니다.

## 변경 사항

- `relations` 배열을 렌더링 전 `[...relations].sort((a, b) => a.displayPriority - b.displayPriority)` 로 정렬
- 기존 "더보기 (+N)" 버튼, 카드 정보 표시, 폴백 렌더링 로직 유지

## Requirements 대응

- Requirements 10.1: 대표 관계 3개 상단 카드 표시
- Requirements 10.2: "더보기 (+N)" 버튼
- Requirements 10.3: 작품명, 작품 타입 라벨, 관계 유형 한글 라벨 표시
- Requirements 10.4: displayPriority 오름차순 정렬
- Requirements 10.6: relations 비어있을 때 relatedContent 폴백

## 테스트

- `npm run type-check` 통과 확인

Closes #684