### PR TITLE
[feat] Task 14 - 마이그레이션 스크립트 작성

### DIFF
--- a/scripts/migrate-checkin-relations.ts
+++ b/scripts/migrate-checkin-relations.ts
@@ -1,0 +1,164 @@
+/**
+ * 체크인 relation 마이그레이션 스크립트
+ * Spec: multi-content-spot-structure
+ *
+ * 기존 체크인 데이터에 relationId/contentId/contentName/relationType을 추가한다.
+ * - 단일 relation 스팟: 자동 귀속 (resolved)
+ * - 다중 relation 스팟: 미분류 (unresolved)
+ * - 멱등성 보장: 이미 relationId가 있는 체크인은 건너뛴다.
+ *
+ * 실행: npx tsx scripts/migrate-checkin-relations.ts
+ */
+
+import { connectToDatabase, COLLECTIONS } from '../src/lib/db'
+
+interface CheckInDocument {
+  id: string
+  spotId: string
+  relationId?: string
+  contentId?: string
+  contentName?: string
+  relationType?: string
+  migrationStatus?: string | null
+  [key: string]: unknown
+}
+
+interface RelationDocument {
+  id: string
+  spotId: string
+  contentId: string
+  contentName: string
+  relationType: string
+  status: string
+  [key: string]: unknown
+}
+
+async function migrateCheckinRelations() {
+  console.log('🚀 체크인 relation 마이그레이션 시작...\n')
+
+  const { db } = await connectToDatabase()
+  const checkinsCollection = db.collection<CheckInDocument>(
+    COLLECTIONS.CHECKINS
+  )
+  const relationsCollection = db.collection<RelationDocument>(
+    COLLECTIONS.SPOT_CONTENT_RELATIONS
+  )
+
+  // 스크립트 시작 시 인덱스 생성 (L2 수정사항, Requirements 2.9~2.11)
+  console.log('📑 인덱스 생성 중...')
+
+  await checkinsCollection.createIndex(
+    { contentName: 1, createdAt: -1 },
+    { name: 'idx_contentName_createdAt' }
+  )
+  console.log('  ✅ idx_contentName_createdAt 생성 완료')
+
+  await checkinsCollection.createIndex(
+    { relationId: 1 },
+    { name: 'idx_relationId' }
+  )
+  console.log('  ✅ idx_relationId 생성 완료')
+
+  await checkinsCollection.createIndex(
+    { spotId: 1, userId: 1, contentName: 1 },
+    { name: 'idx_spotId_userId_contentName' }
+  )
+  console.log('  ✅ idx_spotId_userId_contentName 생성 완료')
+  console.log('')
+
+  // 통계 카운터
+  const stats = {
+    processed: 0,
+    resolved: 0,
+    unresolved: 0,
+    skipped: 0,
+    failed: 0,
+  }
+
+  // 멱등성 보장: relationId가 없는 체크인만 조회 (Requirements 7.5)
+  const cursor = checkinsCollection.find({
+    relationId: { $exists: false },
+  })
+
+  const totalCount = await checkinsCollection.countDocuments({
+    relationId: { $exists: false },
+  })
+  console.log(`📊 마이그레이션 대상 체크인: ${totalCount}건\n`)
+
+  for await (const checkin of cursor) {
+    stats.processed++
+
+    try {
+      // 해당 스팟의 active relations 조회 (Requirements 7.1)
+      const activeRelations = await relationsCollection
+        .find({ spotId: checkin.spotId, status: 'active' })
+        .toArray()
+
+      if (activeRelations.length === 0) {
+        // 0개: 건너뛰기 + 로그 (Requirements 7.4)
+        console.log(
+          `⏭️  스팟에 active relation 없음: spotId=${checkin.spotId}, checkinId=${checkin.id}`
+        )
+        stats.skipped++
+        continue
+      }
+
+      if (activeRelations.length === 1) {
+        // 1개: relation 정보 추가 + resolved (Requirements 7.2)
+        const relation = activeRelations[0]
+        await checkinsCollection.updateOne(
+          { id: checkin.id },
+          {
+            $set: {
+              relationId: relation.id,
+              contentId: relation.contentId,
+              contentName: relation.contentName,
+              relationType: relation.relationType,
+              migrationStatus: 'resolved',
+            },
+          }
+        )
+        stats.resolved++
+      } else {
+        // 2개+: migrationStatus = unresolved (Requirements 7.3)
+        await checkinsCollection.updateOne(
+          { id: checkin.id },
+          {
+            $set: {
+              migrationStatus: 'unresolved',
+            },
+          }
+        )
+        console.log(
+          `⚠️  운영자/사용자 보정 대상: checkinId=${checkin.id}, spotId=${checkin.spotId}, relations=${activeRelations.length}개`
+        )
+        stats.unresolved++
+      }
+    } catch (error) {
+      stats.failed++
+      console.error(
+        `❌ 처리 실패: checkinId=${checkin.id}`,
+        error instanceof Error ? error.message : error
+      )
+    }
+  }
+
+  // 실행 결과 요약 출력 (Requirements 7.6)
+  console.log('\n' + '='.repeat(40))
+  console.log('=== 마이그레이션 결과 ===')
+  console.log('='.repeat(40))
+  console.log(`처리: ${stats.processed}건`)
+  console.log(`Resolved: ${stats.resolved}건`)
+  console.log(`Unresolved: ${stats.unresolved}건`)
+  console.log(`건너뛰기: ${stats.skipped}건`)
+  console.log(`실패: ${stats.failed}건`)
+  console.log('='.repeat(40))
+  console.log('\n🎉 마이그레이션 완료!')
+
+  process.exit(0)
+}
+
+migrateCheckinRelations().catch((error) => {
+  console.error('❌ 마이그레이션 실패:', error)
+  process.exit(1)
+})

--- a/scripts/migrate-scene-contentname.ts
+++ b/scripts/migrate-scene-contentname.ts
@@ -1,0 +1,89 @@
+/**
+ * Scene contentName 마이그레이션 스크립트
+ * Spec: multi-content-spot-structure (H1 수정사항)
+ *
+ * Scene 문서에 contentName 필드가 없는 경우 animeTitle 값을 복사한다.
+ * 멱등성 보장: 이미 contentName이 있는 문서는 건너뛴다.
+ *
+ * 실행: npx tsx scripts/migrate-scene-contentname.ts
+ */
+
+import { connectToDatabase, COLLECTIONS } from '../src/lib/db'
+
+interface SceneDocument {
+  id: string
+  spotId: string
+  animeTitle: string
+  contentName?: string
+  [key: string]: unknown
+}
+
+async function migrateSceneContentName() {
+  console.log('🚀 Scene contentName 마이그레이션 시작...\n')
+
+  const { db } = await connectToDatabase()
+  const scenesCollection = db.collection<SceneDocument>(COLLECTIONS.SCENES)
+
+  // 통계 카운터
+  const stats = {
+    processed: 0,
+    updated: 0,
+    skippedNoTitle: 0,
+    failed: 0,
+  }
+
+  // contentName이 없는 Scene 문서만 조회 (멱등성 보장)
+  const cursor = scenesCollection.find({
+    contentName: { $exists: false },
+  })
+
+  const totalCount = await scenesCollection.countDocuments({
+    contentName: { $exists: false },
+  })
+  console.log(`📊 마이그레이션 대상 Scene: ${totalCount}건\n`)
+
+  for await (const scene of cursor) {
+    stats.processed++
+
+    try {
+      if (scene.animeTitle) {
+        // animeTitle → contentName 복사
+        await scenesCollection.updateOne(
+          { id: scene.id },
+          { $set: { contentName: scene.animeTitle } }
+        )
+        stats.updated++
+      } else {
+        // animeTitle이 없는 경우 건너뛰기
+        console.log(
+          `⏭️  animeTitle 없음: sceneId=${scene.id}, spotId=${scene.spotId}`
+        )
+        stats.skippedNoTitle++
+      }
+    } catch (error) {
+      stats.failed++
+      console.error(
+        `❌ 처리 실패: sceneId=${scene.id}`,
+        error instanceof Error ? error.message : error
+      )
+    }
+  }
+
+  // 결과 요약 출력
+  console.log('\n' + '='.repeat(40))
+  console.log('=== Scene contentName 마이그레이션 결과 ===')
+  console.log('='.repeat(40))
+  console.log(`처리: ${stats.processed}건`)
+  console.log(`업데이트: ${stats.updated}건`)
+  console.log(`건너뛰기 (animeTitle 없음): ${stats.skippedNoTitle}건`)
+  console.log(`실패: ${stats.failed}건`)
+  console.log('='.repeat(40))
+  console.log('\n🎉 Scene contentName 마이그레이션 완료!')
+
+  process.exit(0)
+}
+
+migrateSceneContentName().catch((error) => {
+  console.error('❌ 마이그레이션 실패:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## 변경 사항

체크인 relation 마이그레이션 스크립트와 Scene contentName 마이그레이션 스크립트를 구현합니다.

### 구현 내용

1. **`scripts/migrate-checkin-relations.ts`**
   - 스크립트 시작 시 인덱스 생성 (contentName+createdAt, relationId, spotId+userId+contentName)
   - 기존 체크인 순회 + relation 개수별 분기 로직
   - 멱등성 보장: relationId가 없는 체크인만 처리
   - 실행 결과 요약 출력

2. **`scripts/migrate-scene-contentname.ts`**
   - Scene 문서에 contentName이 없는 경우 animeTitle 값을 복사
   - 멱등성 보장: contentName이 이미 있는 문서는 건너뜀

## 테스트

- `npm run type-check` 통과 확인
- lint-staged 통과 확인

## 관련 Requirements

- Requirements 2.9~2.11, 7.1~7.6
- L2 수정사항, H1 수정사항

Closes #689