### PR TITLE
fix: PBT 및 단위 테스트 TypeScript 타입 에러 수정

### DIFF
--- a/__tests__/multi-content-spot/checkin-creation.property.test.ts
+++ b/__tests__/multi-content-spot/checkin-creation.property.test.ts
@@ -89,9 +89,7 @@ function resolveRelationForCheckIn(
 /**
  * 체크인 문서에 스냅샷 필드를 적용하는 로직
  */
-function applyRelationSnapshot(
-  relation: SpotContentRelation | null
-): {
+function applyRelationSnapshot(relation: SpotContentRelation | null): {
   relationId?: string
   contentId?: string
   contentName?: string
@@ -164,7 +162,7 @@ describe('Property 2: Relation 개수별 분기 정확성', () => {
     fc.assert(
       fc.property(fc.constant([]), (emptyRelations) => {
         const result = resolveRelationForCheckIn(
-          emptyRelations as SpotContentRelation[]
+          emptyRelations as unknown as SpotContentRelation[]
         )
         expect(result.error).toBeUndefined()
         expect(result.relation).toBeNull()

--- a/__tests__/multi-content-spot/checkin.unit.test.ts
+++ b/__tests__/multi-content-spot/checkin.unit.test.ts
@@ -606,7 +606,7 @@ describe('QuickCheckIn — relation selector', () => {
 
   it('다중 relation 스팟에서 초기 selectedRelationId는 null', () => {
     // QuickCheckIn에서 relations.length >= 2일 때 selectedRelationId = null
-    const relationsCount = 3
+    const relationsCount: number = 3
     let selectedRelationId: string | null = null
 
     if (relationsCount >= 2) {


### PR DESCRIPTION
## 변경 사항
- `checkin-creation.property.test.ts`: `readonly []` → `SpotContentRelation[]` 캐스팅 시 `as unknown as` 중간 변환 추가
- `checkin.unit.test.ts`: 리터럴 타입 `3`과 `1` 비교 에러 → 변수에 `number` 타입 명시

## 테스트
- `npm run type-check` 통과
- `npx jest __tests__/multi-content-spot/` 전체 82 tests 통과

Closes #695