### PR TITLE
refactor: 로그인 필요 모달 자체 완결형 네비게이션으로 리팩토링

### DIFF
--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -17,7 +17,6 @@ import Link from 'next/link'
  */
 export default function ReportDetailPage() {
   const params = useParams()
-  const router = useRouter()
   const reportId = params.id as string
   const { user, isLoading: authLoading, isAuthenticated } = useAuth()
   const { data: report, isLoading, error } = useReportDetail(reportId)
@@ -32,7 +31,6 @@ export default function ReportDetailPage() {
         isOpen={true}
         title="로그인이 필요한 서비스입니다"
         description="제보 상세를 확인하려면 로그인이 필요합니다."
-        onConfirm={() => router.push('/auth/signin')}
       />
     )
   }

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { SpotReportForm } from '@/components/report/SpotReportForm'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
@@ -11,7 +10,6 @@ import Link from 'next/link'
  * Requirements: 1.1
  */
 export default function NewReportPage() {
-  const router = useRouter()
   const { user, isLoading, isAuthenticated } = useAuth()
 
   // 로딩 중
@@ -44,7 +42,6 @@ export default function NewReportPage() {
         isOpen={true}
         title="로그인이 필요한 서비스입니다"
         description="성지 제보를 하려면 로그인이 필요합니다."
-        onConfirm={() => router.push('/auth/signin')}
       />
     )
   }

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { MyReportList } from '@/components/report/MyReportList'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
@@ -11,7 +10,6 @@ import Link from 'next/link'
  * Requirements: 1.6, 2.2
  */
 export default function MyReportsPage() {
-  const router = useRouter()
   const { user, isLoading, isAuthenticated } = useAuth()
 
   if (isLoading) {
@@ -42,7 +40,6 @@ export default function MyReportsPage() {
         isOpen={true}
         title="로그인이 필요한 서비스입니다"
         description="내 제보 목록을 확인하려면 로그인이 필요합니다."
-        onConfirm={() => router.push('/auth/signin')}
       />
     )
   }

--- a/src/app/spots/[id]/edit/page.tsx
+++ b/src/app/spots/[id]/edit/page.tsx
@@ -103,11 +103,6 @@ export default function SpotEditPage() {
     }
   }, [isAuthenticated, authLoading])
 
-  // 로그인 페이지로 이동
-  const handleLoginConfirm = () => {
-    router.push(`/auth/signin?callbackUrl=/spots/${spotId}/edit`)
-  }
-
   // 취소 핸들러
   const handleCancel = () => {
     if (confirm('수정 중인 내용이 있습니다. 정말 취소하시겠습니까?')) {
@@ -150,7 +145,6 @@ export default function SpotEditPage() {
           isOpen={showLoginModal}
           title="로그인이 필요한 서비스입니다"
           description="스팟을 수정하려면 로그인이 필요합니다."
-          onConfirm={handleLoginConfirm}
         />
       </main>
     )
@@ -172,7 +166,6 @@ export default function SpotEditPage() {
           isOpen={true}
           title="로그인이 필요한 서비스입니다"
           description="스팟을 수정하려면 로그인이 필요합니다."
-          onConfirm={handleLoginConfirm}
         />
       </main>
     )

--- a/src/app/spots/register/page.tsx
+++ b/src/app/spots/register/page.tsx
@@ -41,11 +41,6 @@ export default function SpotRegisterPage() {
     }
   }, [isAuthenticated, isLoading])
 
-  // 로그인 페이지로 이동
-  const handleLoginConfirm = () => {
-    router.push('/auth/signin?callbackUrl=/spots/register')
-  }
-
   // 취소 핸들러
   const handleCancel = () => {
     if (
@@ -79,7 +74,6 @@ export default function SpotRegisterPage() {
           isOpen={showLoginModal}
           title="로그인이 필요한 서비스입니다"
           description="스팟을 등록하려면 로그인이 필요합니다."
-          onConfirm={handleLoginConfirm}
         />
       </main>
     )

--- a/src/components/checkin/CheckInButton.tsx
+++ b/src/components/checkin/CheckInButton.tsx
@@ -105,7 +105,7 @@ export function CheckInButton({
 
       <LoginRequiredModal
         isOpen={showLoginModal}
-        onConfirm={() => setShowLoginModal(false)}
+        onClose={() => setShowLoginModal(false)}
         description="순례 인증을 하려면 로그인이 필요합니다."
       />
     </>

--- a/src/components/common/LoginRequiredModal.tsx
+++ b/src/components/common/LoginRequiredModal.tsx
@@ -1,24 +1,40 @@
 'use client'
 
+import { useRouter, usePathname } from 'next/navigation'
+
 interface LoginRequiredModalProps {
   isOpen: boolean
   title?: string
   description?: string
-  onConfirm: () => void
+  callbackUrl?: string
+  onClose?: () => void
 }
 
 /**
  * 로그인 필요 모달 컴포넌트
  *
  * 로그인이 필요한 기능에 접근할 때 표시되는 공통 모달입니다.
+ * 확인 버튼 클릭 시 자체적으로 `/auth/signin?callbackUrl=...`로 이동합니다.
+ *
+ * Requirements: 1.1, 1.2, 1.3, 1.4
  */
 export function LoginRequiredModal({
   isOpen,
   title = '로그인이 필요한 서비스입니다',
   description = '이 기능을 사용하려면 로그인이 필요합니다.',
-  onConfirm,
+  callbackUrl,
+  onClose,
 }: LoginRequiredModalProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+
   if (!isOpen) return null
+
+  const handleConfirm = () => {
+    const targetUrl = callbackUrl || pathname || '/'
+    const encodedCallback = encodeURIComponent(targetUrl)
+    router.push(`/auth/signin?callbackUrl=${encodedCallback}`)
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
@@ -49,7 +65,7 @@ export function LoginRequiredModal({
           로그인 페이지로 이동합니다.
         </p>
         <button
-          onClick={onConfirm}
+          onClick={handleConfirm}
           className="w-full rounded-lg bg-primary py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-700"
         >
           로그인하러 가기

--- a/src/components/gallery/FloatingActionButton.tsx
+++ b/src/components/gallery/FloatingActionButton.tsx
@@ -67,7 +67,7 @@ export function FloatingActionButton({
 
       <LoginRequiredModal
         isOpen={showLoginModal}
-        onConfirm={() => setShowLoginModal(false)}
+        onClose={() => setShowLoginModal(false)}
         description="순례 인증을 하려면 로그인이 필요합니다."
       />
     </>

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -461,7 +461,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         isOpen={showLoginModal}
         title="로그인이 필요합니다"
         description="코스 시작 및 저장 기능을 사용하려면 로그인이 필요합니다."
-        onConfirm={() => router.push('/auth/signin')}
+        onClose={() => setShowLoginModal(false)}
       />
 
       {/* 가이드 모드 하단 패널 */}

--- a/src/components/spot/FacilityReportForm.tsx
+++ b/src/components/spot/FacilityReportForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
 import { FacilityType, OtakuFacilityType } from '@/types'
 import {
   LockerSize,
@@ -454,7 +453,6 @@ export default function FacilityReportForm({
   spotCoordinates,
 }: FacilityReportFormProps) {
   const { data: session } = useSession()
-  const router = useRouter()
   const [inputMode, setInputMode] = useState<InputMode>(null)
   const [formData, setFormData] = useState<FormData>(getInitialFormData)
   const [errors, setErrors] = useState<FormErrors>({})
@@ -998,10 +996,7 @@ export default function FacilityReportForm({
 
       <LoginRequiredModal
         isOpen={showLoginModal}
-        onConfirm={() => {
-          setShowLoginModal(false)
-          router.push('/auth/signin')
-        }}
+        onClose={() => setShowLoginModal(false)}
         description="편의시설을 제보하려면 로그인이 필요합니다."
       />
     </>

--- a/src/components/spot/MicroVoteButton.tsx
+++ b/src/components/spot/MicroVoteButton.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
 import { LoginRequiredModal } from '@/components/common'
 import { API_ROUTES } from '@/lib/api-routes'
 
@@ -33,7 +32,6 @@ export default function MicroVoteButton({
   onVoteComplete,
 }: MicroVoteButtonProps) {
   const { data: session } = useSession()
-  const router = useRouter()
   const [vote, setVote] = useState<boolean | null>(currentVote)
   const [isLoading, setIsLoading] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
@@ -102,10 +100,7 @@ export default function MicroVoteButton({
 
       <LoginRequiredModal
         isOpen={showLoginModal}
-        onConfirm={() => {
-          setShowLoginModal(false)
-          router.push('/auth/signin')
-        }}
+        onClose={() => setShowLoginModal(false)}
         description="투표하려면 로그인이 필요합니다."
       />
     </>

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -480,7 +480,6 @@ function SpotDetailContent({
             ? '상태 신고를 하려면 로그인이 필요합니다.'
             : '정보 보완 제보를 하려면 로그인이 필요합니다.'
         }
-        onConfirm={() => router.push('/auth/signin')}
       />
 
       {/* 같은 작품의 다른 스팟 (Requirements 6.1, 6.2, 6.3) */}


### PR DESCRIPTION
## 변경 사항\n\nLoginRequiredModal 컴포넌트를 자체 완결형으로 리팩토링합니다.\n\n- `onConfirm` prop 제거, `callbackUrl?: string`과 `onClose?: () => void` prop 추가\n- 내부에서 `useRouter` + `usePathname` 사용하여 확인 버튼 클릭 시 `/auth/signin?callbackUrl={encodeURIComponent(pathname)}` 이동 구현\n- `callbackUrl` prop이 전달되면 해당 값 사용, 없으면 `usePathname()` 결과 사용\n- `usePathname()` 반환값이 null인 경우 기본값 `/` 사용\n- 모든 사용처에서 `onConfirm` 제거 및 불필요한 `useRouter` import 정리\n\n## Requirements\n\n- 1.1, 1.2, 1.3, 1.4\n\nCloses #698