### PR TITLE
feat: SpotPin 타입 및 API 응답에 contentName 필드 추가

### DIFF
--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -171,6 +171,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       thumbnailUrl: spot.photos[0] || '',
       category: spot.category,
       checkInCount: checkInCountMap.get(spot.id) || 0,
+      contentName: spot.relatedContent?.[0]?.name,
     }))
 
     return NextResponse.json({ spots: spotPins, total: spotPins.length })

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -271,6 +271,8 @@ export interface SpotPin {
   category?: SpotCategory
   /** 인증 수 (인기 스팟 표시용) */
   checkInCount?: number
+  /** 연결된 작품명 (relatedContent[0].name) */
+  contentName?: string
 }
 
 export interface SpotPreviewData {


### PR DESCRIPTION
## 개요\n\nSpotPin 타입에 `contentName` 필드를 추가하고, GET /api/spots 응답 매핑에서 `relatedContent[0].name`을 `contentName`으로 추출하도록 수정한다.\n\n## 변경 사항\n\n- `src/types/spot.ts`: SpotPin 인터페이스에 `contentName?: string` 추가\n- `src/app/api/spots/route.ts`: 매핑 로직에서 `spot.relatedContent?.[0]?.name`을 `contentName`으로 추출\n\n## 관련 Requirements\n\n- Requirements 2.1, 2.3, 2.4 (Spec 33-auth-flow-fix)\n\nCloses #700