### PR TITLE
SpotSearchModal 검색 결과에 작품명 표시 추가

### DIFF
--- a/src/components/gallery/SpotSearchModal.tsx
+++ b/src/components/gallery/SpotSearchModal.tsx
@@ -74,6 +74,7 @@ export function SpotSearchModal({
         name: spot.name,
         thumbnailUrl: spot.thumbnailUrl,
         category: spot.category,
+        contentName: spot.contentName,
       }))
 
       setSearchResults(results)
@@ -315,11 +316,16 @@ export function SpotSearchModal({
                       <p className="truncate font-medium text-neutral-900">
                         {spot.name}
                       </p>
+                      {spot.contentName && (
+                        <p className="truncate text-sm text-primary">
+                          {spot.contentName}
+                        </p>
+                      )}
                       {spot.category &&
                         CATEGORY_CONFIG[
                           spot.category as keyof typeof CATEGORY_CONFIG
                         ] && (
-                          <p className="text-sm text-neutral-500">
+                          <p className="text-xs text-neutral-500">
                             {
                               CATEGORY_CONFIG[
                                 spot.category as keyof typeof CATEGORY_CONFIG


### PR DESCRIPTION
## 변경 사항\n\nSpotSearchModal 검색 결과 항목에 연결된 작품명(contentName)을 표시하여 동명 스팟을 구분할 수 있도록 개선합니다.\n\n### 구현 내용\n\n- 검색 결과 매핑 시 API 응답의 `contentName` 필드 포함\n- 검색 결과 항목에 `contentName` 표시 영역 추가 (primary 색상)\n- `contentName`이 없는 경우 작품명 영역 비표시, 카테고리만 표시\n- 카테고리 라벨 텍스트 크기를 `text-xs`로 조정하여 정보 계층 구분\n\n## Requirements\n\n- 2.1: 검색 결과 항목에 연결된 작품명(contentName) 표시\n- 2.2: 검색 결과 항목에 카테고리 라벨 표시\n- 2.3: 작품이 없는 경우 작품명 영역 비워두고 카테고리만 표시\n\nCloses #702