### PR TITLE
feat: 작품 관련 코스 조회 API route 구현

### DIFF
--- a/src/app/api/contents/[name]/courses/route.ts
+++ b/src/app/api/contents/[name]/courses/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { Route } from '@/types/route'
+
+/**
+ * GET /api/contents/[name]/courses - 작품 관련 코스 조회
+ * Requirements: 3.4, 3.5
+ *
+ * routes 컬렉션에서 relatedContentNames 필드로 매칭하여
+ * 해당 작품과 연관된 공개 코스 목록을 반환한다.
+ *
+ * - 존재하지 않는 작품명 시 빈 배열 반환
+ * - 비공개 코스는 제외 (isPublic: true 조건)
+ *
+ * Response: { courses: Route[], total: number }
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+): Promise<NextResponse> {
+  try {
+    const { name } = await params
+    const contentName = decodeURIComponent(name)
+
+    const routesCollection = await getCollection<Route>(COLLECTIONS.ROUTES)
+
+    const courses = await routesCollection
+      .find({
+        isPublic: true,
+        relatedContentNames: contentName,
+      })
+      .toArray()
+
+    return NextResponse.json({
+      courses,
+      total: courses.length,
+    })
+  } catch (error) {
+    console.error('Error fetching content courses:', error)
+    return NextResponse.json(
+      { error: '관련 코스 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 개요\n\n작품 관련 코스 조회 API Route를 생성합니다.\n\nCloses #710\n\n## 변경 내용\n\n- `src/app/api/contents/[name]/courses/route.ts` 신규 생성\n- `routes` 컬렉션에서 `relatedContentNames` 필드로 매칭\n- `{ isPublic: true, relatedContentNames: contentName }` 조건 쿼리\n- 응답 형식: `{ courses: Route[], total: number }`\n- 존재하지 않는 작품명 시 빈 배열 반환\n- URL 인코딩된 작품명 처리 (`decodeURIComponent`)\n\n## 테스트\n\n- [x] `npm run type-check` 통과\n\n## Requirements\n\n- 3.4: 관련 코스 섹션에 해당 작품과 연관된 순례 코스 목록 표시\n- 3.5: 관련 코스가 없을 때 관련 코스 섹션 숨김