### PR TITLE
[feat] 작품 목록 서버 컴포넌트 페이지 생성

### DIFF
--- a/src/app/(main)/contents/page.tsx
+++ b/src/app/(main)/contents/page.tsx
@@ -1,0 +1,127 @@
+import { Metadata } from 'next'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+import { ContentType } from '@/types'
+import { ContentListClient } from '@/components/content/ContentListClient'
+
+/**
+ * 작품 목록 페이지 메타데이터
+ */
+export const metadata: Metadata = {
+  title: '작품 탐색 | Not a Trip',
+  description:
+    '서비스에 등록된 모든 작품을 탐색하고, 관심 있는 작품의 성지순례 스팟을 찾아보세요.',
+}
+
+/**
+ * 작품 목록 아이템 인터페이스
+ */
+interface ContentListItem {
+  contentName: string
+  contentType: ContentType
+  spotCount: number
+  imageUrl: string | null
+}
+
+/**
+ * MongoDB aggregation 결과 인터페이스
+ */
+interface AggregationResult {
+  _id: {
+    contentName: string
+    contentType: ContentType
+  }
+  spotCount: number
+  contentId: string
+}
+
+/**
+ * ContentMaster 문서 인터페이스
+ */
+interface ContentMasterDocument {
+  normalizedName: string
+  displayName: string
+  imageUrl?: string
+  type?: ContentType
+  year?: number
+  spotCount: number
+}
+
+/**
+ * 서버 사이드에서 작품 목록 데이터를 조회
+ */
+async function fetchContents(): Promise<ContentListItem[]> {
+  try {
+    const relationsCollection = await getCollection(
+      COLLECTIONS.SPOT_CONTENT_RELATIONS
+    )
+    const contentMastersCollection = await getCollection<ContentMasterDocument>(
+      COLLECTIONS.CONTENT_MASTERS
+    )
+
+    // 1. spot_content_relations에서 작품별 spotCount 집계
+    const aggregationResult = await relationsCollection
+      .aggregate<AggregationResult>([
+        { $match: { status: 'active' } },
+        {
+          $group: {
+            _id: {
+              contentName: '$contentName',
+              contentType: '$contentType',
+            },
+            spotCount: { $sum: 1 },
+            contentId: { $first: '$contentId' },
+          },
+        },
+        { $sort: { spotCount: -1 } },
+      ])
+      .toArray()
+
+    // 2. content_masters에서 대표 이미지 조회
+    const contentNames = aggregationResult.map((item) =>
+      item._id.contentName.trim().toLowerCase()
+    )
+
+    const contentMasters = await contentMastersCollection
+      .find({
+        normalizedName: { $in: contentNames },
+        imageUrl: { $exists: true, $ne: '' },
+      })
+      .toArray()
+
+    // 정규화된 이름 -> 이미지 URL 맵 생성
+    const imageMap = new Map<string, string>()
+    for (const cm of contentMasters) {
+      if (cm.imageUrl) {
+        imageMap.set(cm.normalizedName, cm.imageUrl)
+      }
+    }
+
+    // 3. 응답 데이터 구성
+    const contents: ContentListItem[] = aggregationResult.map((item) => {
+      const normalizedName = item._id.contentName.trim().toLowerCase()
+      return {
+        contentName: item._id.contentName,
+        contentType: item._id.contentType,
+        spotCount: item.spotCount,
+        imageUrl: imageMap.get(normalizedName) || null,
+      }
+    })
+
+    return contents
+  } catch (error) {
+    console.error('Error fetching contents:', error)
+    return []
+  }
+}
+
+/**
+ * 작품 목록 서버 컴포넌트 페이지
+ * 서버 사이드에서 DB를 직접 조회하여 초기 데이터를 fetch하고
+ * ContentListClient에 전달
+ * Requirements: 2.1
+ */
+export default async function ContentsPage() {
+  const initialContents = await fetchContents()
+
+  return <ContentListClient initialContents={initialContents} />
+}

--- a/src/components/content/ContentListClient.tsx
+++ b/src/components/content/ContentListClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { ContentType } from '@/types'
+
+/**
+ * 작품 목록 아이템 인터페이스
+ */
+export interface ContentListItem {
+  contentName: string
+  contentType: ContentType
+  spotCount: number
+  imageUrl: string | null
+}
+
+interface ContentListClientProps {
+  initialContents: ContentListItem[]
+}
+
+/**
+ * 작품 목록 클라이언트 컴포넌트
+ * Task 3.2에서 필터/검색 기능과 함께 본격 구현 예정
+ * Requirements: 2.2, 2.5, 2.6, 2.7
+ */
+export function ContentListClient({ initialContents }: ContentListClientProps) {
+  return (
+    <main className="min-h-screen bg-surface pt-14">
+      <div className="mx-auto max-w-6xl px-4 py-6">
+        <h1 className="text-2xl font-bold text-main-text">작품 탐색</h1>
+        <p className="mt-1 text-sm text-sub-text">
+          등록된 작품을 탐색하고 성지순례 스팟을 찾아보세요
+        </p>
+
+        {initialContents.length === 0 ? (
+          <div className="mt-12 text-center text-sub-text">
+            <p>등록된 작품이 없습니다</p>
+          </div>
+        ) : (
+          <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+            {initialContents.map((content) => (
+              <div
+                key={`${content.contentName}-${content.contentType}`}
+                className="rounded-lg border border-neutral-200 bg-surface p-4"
+              >
+                <p className="font-medium text-main-text">
+                  {content.contentName}
+                </p>
+                <p className="text-xs text-sub-text">{content.contentType}</p>
+                <p className="text-xs text-sub-text">
+                  스팟 {content.spotCount}개
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## 개요\n\n작품 목록 페이지(`/contents`)의 서버 컴포넌트와 클라이언트 컴포넌트 기본 구조를 생성합니다.\n\n## 변경 사항\n\n- `src/app/(main)/contents/page.tsx` 생성 (서버 컴포넌트)\n  - 서버 사이드에서 DB 직접 조회하여 작품 목록 fetch\n  - ContentListClient에 initialContents props 전달\n  - 페이지 메타데이터 설정\n- `src/components/content/ContentListClient.tsx` 생성 (클라이언트 컴포넌트 기본 구조)\n  - 빈 상태 안내 메시지\n  - 그리드 레이아웃 기본 구조\n\n## Requirements\n\n- 2.1: `/contents` 경로에서 접근 가능\n\nCloses #712