### PR TITLE
feat: contentListClient 필터/검색 기능 구현

### DIFF
--- a/src/components/content/ContentListClient.tsx
+++ b/src/components/content/ContentListClient.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import { ContentType } from '@/types'
+import { useState, useMemo } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { ContentType, CONTENT_TYPE_CONFIG } from '@/types'
 
 /**
  * 작품 목록 아이템 인터페이스
@@ -16,12 +19,56 @@ interface ContentListClientProps {
   initialContents: ContentListItem[]
 }
 
+/** 타입 필터 옵션 (전체 + 각 ContentType) */
+const TYPE_FILTER_OPTIONS: { value: ContentType | 'all'; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: 'anime', label: '애니메이션' },
+  { value: 'movie', label: '영화' },
+  { value: 'drama', label: '드라마' },
+  { value: 'sports_team', label: '스포츠 팀' },
+  { value: 'artist', label: '아티스트' },
+  { value: 'game', label: '게임' },
+  { value: 'other', label: '기타' },
+]
+
+/**
+ * 작품 목록 필터링 로직 (순수 함수로 분리하여 테스트 가능)
+ */
+export function filterContents(
+  contents: ContentListItem[],
+  typeFilter: ContentType | 'all',
+  searchQuery: string
+): ContentListItem[] {
+  return contents.filter((item) => {
+    const matchesType = typeFilter === 'all' || item.contentType === typeFilter
+    const matchesSearch =
+      searchQuery.trim() === '' ||
+      item.contentName.toLowerCase().includes(searchQuery.trim().toLowerCase())
+    return matchesType && matchesSearch
+  })
+}
+
 /**
  * 작품 목록 클라이언트 컴포넌트
- * Task 3.2에서 필터/검색 기능과 함께 본격 구현 예정
  * Requirements: 2.2, 2.5, 2.6, 2.7
  */
 export function ContentListClient({ initialContents }: ContentListClientProps) {
+  const [typeFilter, setTypeFilter] = useState<ContentType | 'all'>('all')
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filteredContents = useMemo(
+    () => filterContents(initialContents, typeFilter, searchQuery),
+    [initialContents, typeFilter, searchQuery]
+  )
+
+  const handleResetFilters = () => {
+    setTypeFilter('all')
+    setSearchQuery('')
+  }
+
+  const hasNoContents = initialContents.length === 0
+  const hasNoResults = !hasNoContents && filteredContents.length === 0
+
   return (
     <main className="min-h-screen bg-surface pt-14">
       <div className="mx-auto max-w-6xl px-4 py-6">
@@ -30,29 +77,132 @@ export function ContentListClient({ initialContents }: ContentListClientProps) {
           등록된 작품을 탐색하고 성지순례 스팟을 찾아보세요
         </p>
 
-        {initialContents.length === 0 ? (
+        {/* 검색 입력 */}
+        <div className="mt-4">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="작품명으로 검색..."
+            aria-label="작품명 검색"
+            className="w-full rounded-lg border border-border bg-background px-4 py-2.5 text-sm text-main-text placeholder:text-sub-text focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        {/* 타입 필터 바 */}
+        <div
+          className="mt-3 flex flex-wrap gap-2"
+          role="group"
+          aria-label="작품 타입 필터"
+        >
+          {TYPE_FILTER_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => setTypeFilter(option.value)}
+              aria-pressed={typeFilter === option.value}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                typeFilter === option.value
+                  ? 'bg-primary text-white'
+                  : 'bg-background text-sub-text hover:bg-border hover:text-main-text'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 빈 상태: 등록된 작품 없음 */}
+        {hasNoContents && (
           <div className="mt-12 text-center text-sub-text">
             <p>등록된 작품이 없습니다</p>
           </div>
-        ) : (
+        )}
+
+        {/* 빈 상태: 필터/검색 결과 없음 */}
+        {hasNoResults && (
+          <div className="mt-12 text-center text-sub-text">
+            <p>조건에 맞는 작품이 없습니다</p>
+            <button
+              type="button"
+              onClick={handleResetFilters}
+              className="mt-3 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary/90"
+            >
+              필터 초기화
+            </button>
+          </div>
+        )}
+
+        {/* 작품 그리드 */}
+        {filteredContents.length > 0 && (
           <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-            {initialContents.map((content) => (
-              <div
+            {filteredContents.map((content) => (
+              <ContentCardPlaceholder
                 key={`${content.contentName}-${content.contentType}`}
-                className="rounded-lg border border-neutral-200 bg-surface p-4"
-              >
-                <p className="font-medium text-main-text">
-                  {content.contentName}
-                </p>
-                <p className="text-xs text-sub-text">{content.contentType}</p>
-                <p className="text-xs text-sub-text">
-                  스팟 {content.spotCount}개
-                </p>
-              </div>
+                content={content}
+              />
             ))}
           </div>
         )}
       </div>
     </main>
+  )
+}
+
+/**
+ * 작품 카드 플레이스홀더 (Task 4.1에서 ContentCard로 교체 예정)
+ */
+function ContentCardPlaceholder({ content }: { content: ContentListItem }) {
+  const typeConfig = CONTENT_TYPE_CONFIG[content.contentType]
+
+  return (
+    <Link
+      href={`/contents/${encodeURIComponent(content.contentName)}`}
+      className="group block overflow-hidden rounded-lg border border-border bg-background transition-shadow hover:shadow-md"
+    >
+      {/* 이미지 영역 */}
+      <div className="relative aspect-[4/3] w-full bg-border/30">
+        {content.imageUrl ? (
+          <Image
+            src={content.imageUrl}
+            alt={`${content.contentName} 대표 이미지`}
+            fill
+            className="object-cover transition-transform group-hover:scale-105"
+            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <Image
+              src={typeConfig.icon}
+              alt={typeConfig.label}
+              width={48}
+              height={48}
+              className="opacity-40"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 정보 영역 */}
+      <div className="p-3">
+        <p className="truncate text-sm font-medium text-main-text group-hover:text-primary">
+          {content.contentName}
+        </p>
+        <div className="mt-1 flex items-center gap-1.5">
+          <span
+            className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+            style={{
+              backgroundColor: typeConfig.bgColor,
+              color: typeConfig.fgColor,
+            }}
+          >
+            {typeConfig.label}
+          </span>
+          <span className="text-xs text-sub-text">
+            스팟 {content.spotCount}개
+          </span>
+        </div>
+      </div>
+    </Link>
   )
 }


### PR DESCRIPTION
## 변경 사항

ContentListClient 클라이언트 컴포넌트에 타입 필터, 검색 기능, 빈 상태 처리, 반응형 그리드 레이아웃을 구현합니다.

## 구현 내용

- typeFilter 상태 (전체/애니메이션/영화/드라마/스포츠 팀/아티스트/게임/기타)
- searchQuery 상태 (작품명 검색, 대소문자 무시)
- 클라이언트 사이드 필터링 로직 (`filterContents` 순수 함수로 분리)
- 빈 상태 안내 메시지 ("등록된 작품이 없습니다", "조건에 맞는 작품이 없습니다" + 필터 초기화)
- 그리드 레이아웃 (반응형: 모바일 2열, 태블릿 3열, 데스크톱 4열)
- ContentCard 플레이스홀더 (Task 4.1에서 교체 예정)

## Requirements

- 2.2: 카드 형태의 그리드 레이아웃으로 표시
- 2.5: 작품 타입별 필터링 기능
- 2.6: 작품명 검색 기능
- 2.7: 빈 상태 안내 메시지

## 테스트

- `npm run type-check` 통과 확인

Closes #714