### PR TITLE
[feat] ContentCard 컴포넌트 생성

### DIFF
--- a/src/components/content/ContentCard.tsx
+++ b/src/components/content/ContentCard.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { CONTENT_TYPE_CONFIG } from '@/types'
+import type { ContentListItem } from './ContentListClient'
+
+interface ContentCardProps {
+  content: ContentListItem
+}
+
+/**
+ * 작품 카드 컴포넌트
+ * Requirements: 2.3, 2.4
+ * - 작품명, 타입 라벨, 스팟 수, 대표 이미지 표시
+ * - 카드 클릭 시 /contents/{encodeURIComponent(contentName)} 이동
+ * - 이미지 로드 실패 시 플레이스홀더 아이콘 표시
+ * - 접근성: alt 텍스트, 키보드 네비게이션 (Link 컴포넌트)
+ */
+export function ContentCard({ content }: ContentCardProps) {
+  const [imageError, setImageError] = useState(false)
+  const typeConfig = CONTENT_TYPE_CONFIG[content.contentType]
+
+  return (
+    <Link
+      href={`/contents/${encodeURIComponent(content.contentName)}`}
+      className="group block overflow-hidden rounded-lg border border-border bg-background transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+    >
+      {/* 이미지 영역 */}
+      <div className="relative aspect-[4/3] w-full bg-border/30">
+        {content.imageUrl && !imageError ? (
+          <Image
+            src={content.imageUrl}
+            alt={`${content.contentName} 대표 이미지`}
+            fill
+            className="object-cover transition-transform group-hover:scale-105"
+            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <Image
+              src={typeConfig.icon}
+              alt={typeConfig.label}
+              width={48}
+              height={48}
+              className="opacity-40"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 정보 영역 */}
+      <div className="p-3">
+        <p className="truncate text-sm font-medium text-main-text group-hover:text-primary">
+          {content.contentName}
+        </p>
+        <div className="mt-1 flex items-center gap-1.5">
+          <span
+            className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+            style={{
+              backgroundColor: typeConfig.bgColor,
+              color: typeConfig.fgColor,
+            }}
+          >
+            {typeConfig.label}
+          </span>
+          <span className="text-xs text-sub-text">
+            스팟 {content.spotCount}개
+          </span>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/components/content/ContentListClient.tsx
+++ b/src/components/content/ContentListClient.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import Link from 'next/link'
-import Image from 'next/image'
-import { ContentType, CONTENT_TYPE_CONFIG } from '@/types'
+import { ContentType } from '@/types'
+import { ContentCard } from './ContentCard'
 
 /**
  * 작품 목록 아이템 인터페이스
@@ -137,7 +136,7 @@ export function ContentListClient({ initialContents }: ContentListClientProps) {
         {filteredContents.length > 0 && (
           <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
             {filteredContents.map((content) => (
-              <ContentCardPlaceholder
+              <ContentCard
                 key={`${content.contentName}-${content.contentType}`}
                 content={content}
               />
@@ -146,63 +145,5 @@ export function ContentListClient({ initialContents }: ContentListClientProps) {
         )}
       </div>
     </main>
-  )
-}
-
-/**
- * 작품 카드 플레이스홀더 (Task 4.1에서 ContentCard로 교체 예정)
- */
-function ContentCardPlaceholder({ content }: { content: ContentListItem }) {
-  const typeConfig = CONTENT_TYPE_CONFIG[content.contentType]
-
-  return (
-    <Link
-      href={`/contents/${encodeURIComponent(content.contentName)}`}
-      className="group block overflow-hidden rounded-lg border border-border bg-background transition-shadow hover:shadow-md"
-    >
-      {/* 이미지 영역 */}
-      <div className="relative aspect-[4/3] w-full bg-border/30">
-        {content.imageUrl ? (
-          <Image
-            src={content.imageUrl}
-            alt={`${content.contentName} 대표 이미지`}
-            fill
-            className="object-cover transition-transform group-hover:scale-105"
-            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center">
-            <Image
-              src={typeConfig.icon}
-              alt={typeConfig.label}
-              width={48}
-              height={48}
-              className="opacity-40"
-            />
-          </div>
-        )}
-      </div>
-
-      {/* 정보 영역 */}
-      <div className="p-3">
-        <p className="truncate text-sm font-medium text-main-text group-hover:text-primary">
-          {content.contentName}
-        </p>
-        <div className="mt-1 flex items-center gap-1.5">
-          <span
-            className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-            style={{
-              backgroundColor: typeConfig.bgColor,
-              color: typeConfig.fgColor,
-            }}
-          >
-            {typeConfig.label}
-          </span>
-          <span className="text-xs text-sub-text">
-            스팟 {content.spotCount}개
-          </span>
-        </div>
-      </div>
-    </Link>
   )
 }


### PR DESCRIPTION
## 변경 사항

- `src/components/content/ContentCard.tsx` 신규 생성
- `src/components/content/ContentListClient.tsx`에서 인라인 ContentCardPlaceholder 제거 후 ContentCard 사용

## 구현 내용

- 작품명, 타입 라벨, 스팟 수, 대표 이미지 표시
- 카드 클릭 시 `/contents/${encodeURIComponent(contentName)}` 이동
- 이미지 로드 실패 시 `onError` 핸들러로 플레이스홀더 아이콘 표시
- 접근성: alt 텍스트, `focus-visible` 링 스타일, 키보드 네비게이션 (Link 컴포넌트)

## 테스트

- `npm run type-check` 통과

## Requirements

- 2.3: 각 작품 카드에 작품명, 작품 타입, 등록된 스팟 수, 대표 이미지를 표시
- 2.4: 작품 카드 클릭 시 해당 작품의 Content_Hub_Page로 이동

Closes #716