### PR TITLE
feat: 작품 허브 페이지 라우트 연결

### DIFF
--- a/src/app/(main)/contents/[name]/page.tsx
+++ b/src/app/(main)/contents/[name]/page.tsx
@@ -1,19 +1,42 @@
-import { ContentSpotsClient } from '@/components/content/ContentSpotsClient'
+import { Metadata } from 'next'
+import { ContentHubClient } from '@/components/content/ContentHubClient'
 
-interface ContentSpotsPageProps {
+interface ContentHubPageProps {
   params: Promise<{ name: string }>
 }
 
 /**
- * 작품별 스팟 모아보기 서버 컴포넌트
- * URL의 인코딩된 작품명을 디코딩하여 클라이언트 컴포넌트에 전달
- * Requirements: 4.1
+ * 작품 허브 페이지 메타데이터 생성
+ * SEO를 위한 동적 title/description 설정
  */
-export default async function ContentSpotsPage({
+export async function generateMetadata({
   params,
-}: ContentSpotsPageProps) {
+}: ContentHubPageProps): Promise<Metadata> {
   const { name } = await params
   const contentName = decodeURIComponent(name)
 
-  return <ContentSpotsClient contentName={contentName} />
+  return {
+    title: `${contentName} - 작품 허브 | Not a Trip`,
+    description: `${contentName} 관련 성지순례 스팟, 코스, 인증 정보를 한눈에 확인하세요.`,
+    openGraph: {
+      title: `${contentName} - 작품 허브`,
+      description: `${contentName} 관련 성지순례 스팟, 코스, 인증 정보를 한눈에 확인하세요.`,
+    },
+  }
+}
+
+/**
+ * 작품 허브 페이지 서버 컴포넌트
+ * URL의 인코딩된 작품명을 디코딩하여 ContentHubClient에 전달
+ * 뒤로가기 로직은 ContentHubClient 내부에서 처리:
+ * - history.length > 1이면 router.back()
+ * - 아니면 /contents로 이동
+ * - 버튼 레이블: "작품 목록으로"
+ * Requirements: 6.1, 6.2, 6.3, 6.4
+ */
+export default async function ContentHubPage({ params }: ContentHubPageProps) {
+  const { name } = await params
+  const contentName = decodeURIComponent(name)
+
+  return <ContentHubClient contentName={contentName} />
 }


### PR DESCRIPTION
## 개요\n\n기존 `/contents/[name]` 페이지에서 `ContentSpotsClient` 대신 `ContentHubClient`를 사용하도록 수정합니다.\n\n## 변경 사항\n\n- `ContentSpotsClient` → `ContentHubClient` 교체\n- SEO 메타데이터 생성 (`generateMetadata`) 추가\n- 뒤로가기 로직은 ContentHubClient에 이미 구현됨\n  - history.length > 1이면 router.back()\n  - 아니면 `/contents`로 이동\n  - 버튼 레이블: \"작품 목록으로\"\n\n## 테스트\n\n- `npm run type-check` 통과 확인\n\n## Requirements\n\n- 6.1, 6.2, 6.3, 6.4 대응\n\nCloses #720