### PR TITLE
feat: header에 작품 탐색 링크 추가

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -61,6 +61,16 @@ export function Header() {
               홈
             </Link>
             <Link
+              href="/contents"
+              className={`text-sm transition hover:text-secondary-400 ${
+                pathname.startsWith('/contents')
+                  ? 'font-semibold text-secondary-400'
+                  : 'text-text-secondary'
+              }`}
+            >
+              작품 탐색
+            </Link>
+            <Link
               href="/gallery"
               className="text-text-secondary text-sm transition hover:text-secondary-400"
             >
@@ -196,6 +206,17 @@ export function Header() {
                 className="text-text-secondary hover:text-text-primary block rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
               >
                 홈
+              </Link>
+              <Link
+                href="/contents"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className={`block rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100 ${
+                  pathname.startsWith('/contents')
+                    ? 'font-semibold text-secondary-400'
+                    : 'text-text-secondary hover:text-text-primary'
+                }`}
+              >
+                작품 탐색
               </Link>
               <Link
                 href="/gallery"


### PR DESCRIPTION
## 변경 사항\n\n헤더 네비게이션에 \"작품 탐색\" 링크를 추가하여 작품 목록 페이지(`/contents`)로의 진입점을 제공합니다.\n\n### 구현 내용\n\n- 데스크톱 네비게이션: \"홈\" 다음 위치에 \"작품 탐색\" 링크 추가\n- 모바일 드롭다운 메뉴: \"홈\" 다음 위치에 \"작품 탐색\" 항목 추가\n- 클릭 시 `/contents` 경로로 이동\n- 활성 상태: `pathname.startsWith('/contents')` 조건으로 판별\n\n### 테스트\n\n- [x] `npm run type-check` 통과\n- [x] lint-staged 통과\n\n### Requirements\n\n- 1.1, 1.2, 1.3, 1.4 대응\n\nCloses #722