### PR TITLE
feat: entryPointSection 컴포넌트 구현

### DIFF
--- a/src/components/landing/EntryPointSection.tsx
+++ b/src/components/landing/EntryPointSection.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link'
+
+/**
+ * 랜딩 페이지 목적별 진입점 섹션
+ * "작품으로 찾기", "코스로 따라가기", "인증 둘러보기" 3개 카드 진입점
+ * 서버 컴포넌트 (인터랙션 없음, Link만 사용)
+ * Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7
+ */
+
+interface EntryPoint {
+  icon: string
+  title: string
+  description: string
+  href: string
+}
+
+const ENTRY_POINTS: EntryPoint[] = [
+  {
+    icon: '🎬',
+    title: '작품으로 찾기',
+    description: '좋아하는 작품의 성지를 탐색하세요',
+    href: '/contents',
+  },
+  {
+    icon: '🗺️',
+    title: '코스로 따라가기',
+    description: '큐레이션된 순례 코스를 따라가세요',
+    href: '/routes',
+  },
+  {
+    icon: '📸',
+    title: '인증 둘러보기',
+    description: '다른 순례자들의 인증을 구경하세요',
+    href: '/gallery',
+  },
+]
+
+export function EntryPointSection() {
+  return (
+    <section
+      className="bg-background py-16 md:py-24"
+      aria-label="목적별 진입점"
+    >
+      <div className="mx-auto max-w-6xl px-4">
+        {/* 헤더 */}
+        <header className="mb-12 text-center">
+          <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl">
+            어떤 방식으로{' '}
+            <span className="bg-gradient-to-r from-primary-400 to-purple-400 bg-clip-text text-transparent">
+              탐색
+            </span>
+            할까요?
+          </h2>
+          <p className="text-base text-white/50 md:text-lg">
+            목적에 맞는 경로를 선택하세요
+          </p>
+        </header>
+
+        {/* 진입점 카드 그리드 — 모바일 세로 스택, 태블릿 이상 가로 병렬 */}
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          {ENTRY_POINTS.map((entry) => (
+            <Link
+              key={entry.href}
+              href={entry.href}
+              className="group flex flex-col items-center rounded-xl border border-white/10 bg-white/5 p-8 text-center transition-all hover:border-primary-500/50 hover:bg-white/10 hover:shadow-lg hover:shadow-primary-500/10"
+            >
+              {/* 아이콘 */}
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-primary-500/30 bg-primary-500/10 text-3xl transition-transform group-hover:scale-110">
+                {entry.icon}
+              </div>
+
+              {/* 제목 */}
+              <h3 className="mb-2 text-lg font-semibold text-white">
+                {entry.title}
+              </h3>
+
+              {/* 설명 */}
+              <p className="text-sm leading-relaxed text-white/50">
+                {entry.description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## 변경 사항

랜딩 페이지에 목적별 진입점 섹션(EntryPointSection) 컴포넌트를 구현합니다.

## 구현 내용

- `src/components/landing/EntryPointSection.tsx` 생성
- 3개 진입점 카드: "작품으로 찾기"(/contents), "코스로 따라가기"(/routes), "인증 둘러보기"(/gallery)
- 각 진입점에 아이콘, 제목, 간단한 설명 포함
- 반응형 레이아웃: 모바일 세로 스택(grid-cols-1), 태블릿 이상 가로 병렬(grid-cols-3)
- hover 효과: border 색상 변경, 배경 밝기 증가, 아이콘 scale 애니메이션
- next/link 사용으로 클라이언트 사이드 네비게이션

## Requirements 대응

- 4.1: HeroSection 아래 배치 준비 (8.2에서 연결)
- 4.2: 3개 진입점 병렬 표시
- 4.3: 각 진입점에 아이콘, 제목, 설명 포함
- 4.4: "작품으로 찾기" → /contents
- 4.5: "코스로 따라가기" → /routes
- 4.6: "인증 둘러보기" → /gallery
- 4.7: 모바일 세로 스택, 태블릿 이상 가로 병렬

## 체크리스트

- [x] `npm run type-check` 통과
- [x] ESLint + Prettier 통과

Closes #724