### PR TITLE
feat: 자동완성 드롭다운에 작품 페이지 링크 추가

### DIFF
--- a/src/components/map/AutocompleteDropdown.tsx
+++ b/src/components/map/AutocompleteDropdown.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useCallback } from 'react'
+import Link from 'next/link'
 import { SpotCategory } from '@/types'
 import { CategoryIcon } from '@/components/common'
 import type { AutocompleteItem } from '@/hooks/useAutocomplete'
@@ -152,10 +153,21 @@ export default function AutocompleteDropdown({
                   {item.name}
                 </span>
               </div>
-              {/* 스팟 개수 */}
-              <span className="text-xs text-neutral-400 dark:text-neutral-500">
-                {item.count}개 스팟
-              </span>
+              <div className="flex items-center gap-2">
+                {/* 작품 페이지로 이동 링크 (Requirements 5.1, 5.2, 5.3) */}
+                <Link
+                  href={`/contents/${encodeURIComponent(item.name)}`}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  className="whitespace-nowrap rounded px-1.5 py-0.5 text-xs text-primary hover:bg-primary/10 hover:underline"
+                >
+                  작품 페이지로 이동
+                </Link>
+                {/* 스팟 개수 */}
+                <span className="text-xs text-neutral-400 dark:text-neutral-500">
+                  {item.count}개 스팟
+                </span>
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## 변경 사항\n\nAutocompleteDropdown 컴포넌트에 \"작품 페이지로 이동\" 링크를 추가합니다.\n\n### 구현 내용\n\n- 각 자동완성 항목에 \"작품 페이지로 이동\" Link 컴포넌트 추가\n- 링크 클릭 시 `/contents/${encodeURIComponent(contentName)}`으로 이동\n- `e.stopPropagation()`으로 부모 클릭 핸들러(onSelect) 방지\n- 기존 onSelect 동작(지도 필터링) 완전 유지\n- next/link 사용으로 클라이언트 사이드 네비게이션 지원\n\n## Requirements\n\n- 5.1: 자동완성 결과에 \"작품 페이지로 이동\" 링크 표시\n- 5.2: 링크 클릭 시 Content_Hub_Page로 이동\n- 5.3: 기존 작품 선택(지도 필터링) 동작 유지\n\n## 테스트\n\n- [x] `npm run type-check` 통과\n- [x] lint-staged 통과\n\nCloses #728"