### PR TITLE
[chore] shell-safety steering에 Next.js route group 경로 규칙 추가

### DIFF
--- a/.kiro/steering/shell-safety.md
+++ b/.kiro/steering/shell-safety.md
@@ -17,6 +17,10 @@ git log --oneline
 
 # ❌ 괄호가 포함된 경로나 문자열을 직접 사용
 cat "file (copy).txt"
+
+# ❌ 괄호가 포함된 파일 경로를 따옴표 없이 사용 (Next.js route groups!)
+git add src/app/(main)/contents/page.tsx
+git commit -- src/app/(main)/layout.tsx
 ```
 
 ### 필수 사용 패턴
@@ -28,14 +32,25 @@ git log --oneline --no-decorate
 # ✅ 괄호가 포함될 수 있는 출력은 파이프로 처리하거나 옵션으로 제거
 git log --format="%h %s" -5
 
-# ✅ 파일 경로에 괄호가 있으면 따옴표로 감싸기
+# ✅ 파일 경로에 괄호가 있으면 반드시 작은따옴표로 감싸기
 cat 'file (copy).txt'
+
+# ✅ Next.js route group 경로 ((main), (auth) 등)는 반드시 따옴표 사용
+git add 'src/app/(main)/contents/page.tsx'
+git add 'src/app/(main)/'
+
+# ✅ 여러 파일 중 괄호 경로가 있으면 해당 파일만 따옴표
+git add 'src/app/(main)/contents/page.tsx' src/components/content/ContentListClient.tsx
+
+# ✅ glob 패턴으로 괄호 회피도 가능
+git add src/app/*/contents/page.tsx
 ```
 
 ### 적용 대상
 
 - `git log` → 항상 `--no-decorate` 또는 `--format` 사용
 - `git branch` → `--no-column` 사용 권장
+- `git add`, `git commit`, `git diff` 등 **파일 경로 인자** → `(main)`, `(auth)` 등 Next.js route group 경로는 **반드시 작은따옴표**로 감싸기
 - 모든 shell 명령어에서 출력에 괄호가 포함될 가능성이 있으면 사전에 제거 옵션 적용
 
 ### 이유


### PR DESCRIPTION
## 개요\n\nshell-safety steering 파일에 Next.js route group 경로 관련 규칙을 추가합니다.\n\n## 변경 사항\n\n- bash에서 `(main)`, `(auth)` 등 괄호가 포함된 Next.js route group 경로를 git 명령어에 사용할 때 반드시 작은따옴표로 감싸야 하는 규칙 명시\n- 금지 패턴 및 올바른 패턴 예시 추가\n- 적용 대상에 `git add`, `git commit`, `git diff` 등 파일 경로 인자 사용 시 주의사항 추가