### PR TITLE
[fix] map 페이지 useSearchParams Suspense boundary 누락 빌드 오류 수정

### DIFF
--- a/.kiro/steering/shell-safety.md
+++ b/.kiro/steering/shell-safety.md
@@ -17,6 +17,10 @@ git log --oneline
 
 # ❌ 괄호가 포함된 경로나 문자열을 직접 사용
 cat "file (copy).txt"
+
+# ❌ 괄호가 포함된 파일 경로를 따옴표 없이 사용 (Next.js route groups!)
+git add src/app/(main)/contents/page.tsx
+git commit -- src/app/(main)/layout.tsx
 ```
 
 ### 필수 사용 패턴
@@ -28,14 +32,25 @@ git log --oneline --no-decorate
 # ✅ 괄호가 포함될 수 있는 출력은 파이프로 처리하거나 옵션으로 제거
 git log --format="%h %s" -5
 
-# ✅ 파일 경로에 괄호가 있으면 따옴표로 감싸기
+# ✅ 파일 경로에 괄호가 있으면 반드시 작은따옴표로 감싸기
 cat 'file (copy).txt'
+
+# ✅ Next.js route group 경로 ((main), (auth) 등)는 반드시 따옴표 사용
+git add 'src/app/(main)/contents/page.tsx'
+git add 'src/app/(main)/'
+
+# ✅ 여러 파일 중 괄호 경로가 있으면 해당 파일만 따옴표
+git add 'src/app/(main)/contents/page.tsx' src/components/content/ContentListClient.tsx
+
+# ✅ glob 패턴으로 괄호 회피도 가능
+git add src/app/*/contents/page.tsx
 ```
 
 ### 적용 대상
 
 - `git log` → 항상 `--no-decorate` 또는 `--format` 사용
 - `git branch` → `--no-column` 사용 권장
+- `git add`, `git commit`, `git diff` 등 **파일 경로 인자** → `(main)`, `(auth)` 등 Next.js route group 경로는 **반드시 작은따옴표**로 감싸기
 - 모든 shell 명령어에서 출력에 괄호가 포함될 가능성이 있으면 사전에 제거 옵션 적용
 
 ### 이유

--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -3,7 +3,7 @@
 import { AppIcon } from '@/components/common/AppIcon'
 import dynamic from 'next/dynamic'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import { useSpots } from '@/hooks/useSpots'
 import CategoryFilter from '@/components/map/CategoryFilter'
 import ContentSearchFilter from '@/components/map/ContentSearchFilter'
@@ -39,14 +39,10 @@ const VALID_CATEGORIES: SpotCategory[] = [
 ]
 
 /**
- * 지도 메인 페이지 컴포넌트 (/map)
- * Requirements 1.1, 1.4, 2.1, 2.2를 만족하는 지도 기반 메인 페이지
- * - URL 파라미터(search, category)를 필터 스토어에 동기화
- * - useQuery로 필터 변경 시 지도 유지 (번쩍임 방지)
- * - 카테고리 필터링 지원
- * - filterStore 전역 상태 사용
+ * URL 파라미터를 필터 스토어에 동기화하는 내부 컴포넌트
+ * useSearchParams()는 반드시 Suspense boundary 안에서 사용해야 함
  */
-export default function MapPage() {
+function SearchParamsSyncer() {
   const searchParams = useSearchParams()
   const setSearchQuery = useFilterStore((s) => s.setSearchQuery)
   const setSelectedCategories = useFilterStore((s) => s.setSelectedCategories)
@@ -76,6 +72,18 @@ export default function MapPage() {
     }
   }, [searchParams, setSearchQuery, setSelectedCategories])
 
+  return null
+}
+
+/**
+ * 지도 메인 페이지 컴포넌트 (/map)
+ * Requirements 1.1, 1.4, 2.1, 2.2를 만족하는 지도 기반 메인 페이지
+ * - URL 파라미터(search, category)를 필터 스토어에 동기화
+ * - useQuery로 필터 변경 시 지도 유지 (번쩍임 방지)
+ * - 카테고리 필터링 지원
+ * - filterStore 전역 상태 사용
+ */
+export default function MapPage() {
   const { isActive, currentStep, next, skip, dismiss } = useOnboarding(
     MAP_PAGE_STEPS,
     'map'
@@ -83,6 +91,10 @@ export default function MapPage() {
 
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col bg-background">
+      {/* useSearchParams는 Suspense boundary 안에서만 사용 가능 */}
+      <Suspense fallback={null}>
+        <SearchParamsSyncer />
+      </Suspense>
       <MapContent />
       <OnboardingTour
         steps={MAP_PAGE_STEPS}


### PR DESCRIPTION
## 문제\n\n`npm run build` 실패:\n```\n⨯ useSearchParams() should be wrapped in a suspense boundary at page \"/map\"\n```\n\n## 원인\n\n`MapPage`에서 `useSearchParams()`를 직접 호출하고 있었으나, Next.js App Router 빌드 시 `useSearchParams()`는 반드시 `Suspense` boundary 안에 있어야 함.\n\n## 수정\n\n`useSearchParams()` 사용 로직을 `SearchParamsSyncer` 컴포넌트로 분리하고 `<Suspense fallback={null}>`으로 감쌈.\n\nCloses #733