### PR TITLE
[feat] CourseProgressStore persist 미들웨어 및 자동 진행 액션 추가

### DIFF
--- a/.kiro/steering/shell-safety.md
+++ b/.kiro/steering/shell-safety.md
@@ -17,6 +17,10 @@ git log --oneline
 
 # ❌ 괄호가 포함된 경로나 문자열을 직접 사용
 cat "file (copy).txt"
+
+# ❌ 괄호가 포함된 파일 경로를 따옴표 없이 사용 (Next.js route groups!)
+git add src/app/(main)/contents/page.tsx
+git commit -- src/app/(main)/layout.tsx
 ```
 
 ### 필수 사용 패턴
@@ -28,14 +32,25 @@ git log --oneline --no-decorate
 # ✅ 괄호가 포함될 수 있는 출력은 파이프로 처리하거나 옵션으로 제거
 git log --format="%h %s" -5
 
-# ✅ 파일 경로에 괄호가 있으면 따옴표로 감싸기
+# ✅ 파일 경로에 괄호가 있으면 반드시 작은따옴표로 감싸기
 cat 'file (copy).txt'
+
+# ✅ Next.js route group 경로 ((main), (auth) 등)는 반드시 따옴표 사용
+git add 'src/app/(main)/contents/page.tsx'
+git add 'src/app/(main)/'
+
+# ✅ 여러 파일 중 괄호 경로가 있으면 해당 파일만 따옴표
+git add 'src/app/(main)/contents/page.tsx' src/components/content/ContentListClient.tsx
+
+# ✅ glob 패턴으로 괄호 회피도 가능
+git add src/app/*/contents/page.tsx
 ```
 
 ### 적용 대상
 
 - `git log` → 항상 `--no-decorate` 또는 `--format` 사용
 - `git branch` → `--no-column` 사용 권장
+- `git add`, `git commit`, `git diff` 등 **파일 경로 인자** → `(main)`, `(auth)` 등 Next.js route group 경로는 **반드시 작은따옴표**로 감싸기
 - 모든 shell 명령어에서 출력에 괄호가 포함될 가능성이 있으면 사전에 제거 옵션 적용
 
 ### 이유

--- a/src/stores/courseProgressStore.ts
+++ b/src/stores/courseProgressStore.ts
@@ -5,7 +5,7 @@
  * startRoute 시 기존 Check-in 기록을 조회하여 자동 반영
  * persist 미들웨어로 브라우저 새로고침 후에도 상태 유지
  *
- * @requirements 2.1, 2.3, 3.5
+ * @requirements 2.1, 2.3, 3.1, 3.4, 3.5
  */
 
 import { create } from 'zustand'
@@ -25,6 +25,8 @@ interface CourseProgressState {
   startedAt: Date | null
   /** 네비게이션 활성 여부 */
   isNavigating: boolean
+  /** 배너 일시 숨김 여부 (dismiss 시 true) */
+  isBannerDismissed: boolean
 }
 
 interface CourseProgressActions {
@@ -52,6 +54,10 @@ interface CourseProgressActions {
   endRoute: () => void
   /** 전체 상태 리셋 */
   resetProgress: () => void
+  /** 배너 일시 숨김 */
+  dismissBanner: () => void
+  /** 배너 다시 표시 */
+  showBanner: () => void
 }
 
 type CourseProgressStore = CourseProgressState & CourseProgressActions
@@ -64,6 +70,7 @@ interface PersistedCourseProgress {
   checkedSpotIds: string[] // Set → Array로 직렬화
   startedAt: string | null // Date → ISO string
   isNavigating: boolean
+  isBannerDismissed: boolean
 }
 
 export const useCourseProgressStore = create<CourseProgressStore>()(
@@ -77,6 +84,7 @@ export const useCourseProgressStore = create<CourseProgressStore>()(
         checkedSpotIds: new Set<string>(),
         startedAt: null,
         isNavigating: false,
+        isBannerDismissed: false,
 
         startRoute: async (route: Route, userId: string) => {
           // 기존 Check-in 기록 조회하여 이미 인증된 스팟 자동 포함
@@ -111,6 +119,7 @@ export const useCourseProgressStore = create<CourseProgressStore>()(
               checkedSpotIds,
               startedAt: new Date(),
               isNavigating: true,
+              isBannerDismissed: false,
             },
             false,
             'courseProgress/startRoute'
@@ -206,10 +215,23 @@ export const useCourseProgressStore = create<CourseProgressStore>()(
               checkedSpotIds: new Set<string>(),
               startedAt: null,
               isNavigating: false,
+              isBannerDismissed: false,
             },
             false,
             'courseProgress/resetProgress'
           )
+        },
+
+        dismissBanner: () => {
+          set(
+            { isBannerDismissed: true },
+            false,
+            'courseProgress/dismissBanner'
+          )
+        },
+
+        showBanner: () => {
+          set({ isBannerDismissed: false }, false, 'courseProgress/showBanner')
         },
       }),
       {
@@ -231,6 +253,7 @@ export const useCourseProgressStore = create<CourseProgressStore>()(
           checkedSpotIds: Array.from(state.checkedSpotIds),
           startedAt: state.startedAt?.toISOString() ?? null,
           isNavigating: state.isNavigating,
+          isBannerDismissed: state.isBannerDismissed,
         }),
         // rehydrate 시 Array → Set, string → Date 변환
         merge: (persistedState, currentState) => {
@@ -259,3 +282,5 @@ export const useCurrentSpotIndex = () =>
   useCourseProgressStore((state) => state.currentSpotIndex)
 export const useCheckedSpotIds = () =>
   useCourseProgressStore((state) => state.checkedSpotIds)
+export const useIsBannerDismissed = () =>
+  useCourseProgressStore((state) => state.isBannerDismissed)

--- a/src/stores/courseProgressStore.ts
+++ b/src/stores/courseProgressStore.ts
@@ -3,12 +3,13 @@
  *
  * 현재 진행 중인 코스, 목표 스팟 인덱스, 인증 완료 스팟 목록 관리
  * startRoute 시 기존 Check-in 기록을 조회하여 자동 반영
+ * persist 미들웨어로 브라우저 새로고침 후에도 상태 유지
  *
- * @requirements 3.1, 3.2, 3.4
+ * @requirements 3.5
  */
 
 import { create } from 'zustand'
-import { devtools } from 'zustand/middleware'
+import { devtools, persist, createJSONStorage } from 'zustand/middleware'
 import type { Route } from '@/types/route'
 
 interface CourseProgressState {
@@ -48,101 +49,146 @@ interface CourseProgressActions {
 
 type CourseProgressStore = CourseProgressState & CourseProgressActions
 
+/** localStorage 직렬화 형태 */
+interface PersistedCourseProgress {
+  activeRouteId: string | null
+  activeRoute: Route | null
+  currentSpotIndex: number
+  checkedSpotIds: string[] // Set → Array로 직렬화
+  startedAt: string | null // Date → ISO string
+  isNavigating: boolean
+}
+
 export const useCourseProgressStore = create<CourseProgressStore>()(
   devtools(
-    (set, get) => ({
-      // 초기 상태
-      activeRouteId: null,
-      activeRoute: null,
-      currentSpotIndex: 0,
-      checkedSpotIds: new Set<string>(),
-      startedAt: null,
-      isNavigating: false,
+    persist(
+      (set, get) => ({
+        // 초기 상태
+        activeRouteId: null,
+        activeRoute: null,
+        currentSpotIndex: 0,
+        checkedSpotIds: new Set<string>(),
+        startedAt: null,
+        isNavigating: false,
 
-      startRoute: async (route: Route, userId: string) => {
-        // 기존 Check-in 기록 조회하여 이미 인증된 스팟 자동 포함
-        const checkedSpotIds = new Set<string>()
+        startRoute: async (route: Route, userId: string) => {
+          // 기존 Check-in 기록 조회하여 이미 인증된 스팟 자동 포함
+          const checkedSpotIds = new Set<string>()
 
-        try {
-          const res = await fetch(
-            `/api/checkins?userId=${encodeURIComponent(userId)}&limit=1000`
-          )
-          if (res.ok) {
-            const data = await res.json()
-            const checkedSpotIdSet = new Set(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              data.checkins.map((c: any) => c.spotId as string)
+          try {
+            const res = await fetch(
+              `/api/checkins?userId=${encodeURIComponent(userId)}&limit=1000`
             )
-            // 코스 내 스팟 중 이미 인증된 것만 포함
-            for (const spot of route.spots) {
-              if (checkedSpotIdSet.has(spot.spotId)) {
-                checkedSpotIds.add(spot.spotId)
+            if (res.ok) {
+              const data = await res.json()
+              const checkedSpotIdSet = new Set(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                data.checkins.map((c: any) => c.spotId as string)
+              )
+              // 코스 내 스팟 중 이미 인증된 것만 포함
+              for (const spot of route.spots) {
+                if (checkedSpotIdSet.has(spot.spotId)) {
+                  checkedSpotIds.add(spot.spotId)
+                }
               }
             }
+          } catch {
+            // 오프라인 등 실패 시 빈 Set으로 시작
           }
-        } catch {
-          // 오프라인 등 실패 시 빈 Set으로 시작
-        }
 
-        set(
-          {
-            activeRouteId: route.id,
-            activeRoute: route,
-            currentSpotIndex: 0,
-            checkedSpotIds,
-            startedAt: new Date(),
-            isNavigating: true,
-          },
-          false,
-          'courseProgress/startRoute'
-        )
-      },
-
-      checkInSpot: (spotId: string) => {
-        const { checkedSpotIds } = get()
-        const next = new Set(checkedSpotIds)
-        next.add(spotId)
-        set({ checkedSpotIds: next }, false, 'courseProgress/checkInSpot')
-      },
-
-      moveToNextSpot: () => {
-        const { currentSpotIndex, activeRoute } = get()
-        if (!activeRoute) return
-        const maxIndex = activeRoute.spots.length - 1
-        if (currentSpotIndex < maxIndex) {
           set(
-            { currentSpotIndex: currentSpotIndex + 1 },
+            {
+              activeRouteId: route.id,
+              activeRoute: route,
+              currentSpotIndex: 0,
+              checkedSpotIds,
+              startedAt: new Date(),
+              isNavigating: true,
+            },
             false,
-            'courseProgress/moveToNextSpot'
+            'courseProgress/startRoute'
           )
-        }
-      },
+        },
 
-      endRoute: () => {
-        set(
-          {
-            isNavigating: false,
-          },
-          false,
-          'courseProgress/endRoute'
-        )
-      },
+        checkInSpot: (spotId: string) => {
+          const { checkedSpotIds } = get()
+          const next = new Set(checkedSpotIds)
+          next.add(spotId)
+          set({ checkedSpotIds: next }, false, 'courseProgress/checkInSpot')
+        },
 
-      resetProgress: () => {
-        set(
-          {
-            activeRouteId: null,
-            activeRoute: null,
-            currentSpotIndex: 0,
-            checkedSpotIds: new Set<string>(),
-            startedAt: null,
-            isNavigating: false,
-          },
-          false,
-          'courseProgress/resetProgress'
-        )
-      },
-    }),
+        moveToNextSpot: () => {
+          const { currentSpotIndex, activeRoute } = get()
+          if (!activeRoute) return
+          const maxIndex = activeRoute.spots.length - 1
+          if (currentSpotIndex < maxIndex) {
+            set(
+              { currentSpotIndex: currentSpotIndex + 1 },
+              false,
+              'courseProgress/moveToNextSpot'
+            )
+          }
+        },
+
+        endRoute: () => {
+          set(
+            {
+              isNavigating: false,
+            },
+            false,
+            'courseProgress/endRoute'
+          )
+        },
+
+        resetProgress: () => {
+          set(
+            {
+              activeRouteId: null,
+              activeRoute: null,
+              currentSpotIndex: 0,
+              checkedSpotIds: new Set<string>(),
+              startedAt: null,
+              isNavigating: false,
+            },
+            false,
+            'courseProgress/resetProgress'
+          )
+        },
+      }),
+      {
+        name: 'course-progress',
+        storage: createJSONStorage(() =>
+          // SSR 환경에서 localStorage 접근 방지
+          typeof window !== 'undefined'
+            ? localStorage
+            : {
+                getItem: () => null,
+                setItem: () => {},
+                removeItem: () => {},
+              }
+        ),
+        partialize: (state): PersistedCourseProgress => ({
+          activeRouteId: state.activeRouteId,
+          activeRoute: state.activeRoute,
+          currentSpotIndex: state.currentSpotIndex,
+          checkedSpotIds: Array.from(state.checkedSpotIds),
+          startedAt: state.startedAt?.toISOString() ?? null,
+          isNavigating: state.isNavigating,
+        }),
+        // rehydrate 시 Array → Set, string → Date 변환
+        merge: (persistedState, currentState) => {
+          const persisted = persistedState as PersistedCourseProgress
+          return {
+            ...currentState,
+            ...persisted,
+            checkedSpotIds: new Set<string>(persisted.checkedSpotIds ?? []),
+            startedAt: persisted.startedAt
+              ? new Date(persisted.startedAt)
+              : null,
+          }
+        },
+      }
+    ),
     { name: 'course-progress-store' }
   )
 )

--- a/src/stores/courseProgressStore.ts
+++ b/src/stores/courseProgressStore.ts
@@ -5,7 +5,7 @@
  * startRoute 시 기존 Check-in 기록을 조회하여 자동 반영
  * persist 미들웨어로 브라우저 새로고침 후에도 상태 유지
  *
- * @requirements 3.5
+ * @requirements 2.1, 2.3, 3.5
  */
 
 import { create } from 'zustand'
@@ -37,8 +37,15 @@ interface CourseProgressActions {
   /**
    * 스팟 인증 완료 처리
    * ⚠️ 반드시 Check-in API(POST /api/checkins) 성공 후에만 호출
+   * 내부적으로 advanceToNextUnchecked()를 자동 호출
    */
   checkInSpot: (spotId: string) => void
+  /**
+   * 다음 미인증 스팟으로 자동 이동
+   * 현재 인덱스 이후부터 순환 탐색하여 다음 미인증 유효 스팟 찾기
+   * 모든 스팟 인증 완료 시 인덱스 유지 (완주 상태)
+   */
+  advanceToNextUnchecked: () => void
   /** 다음 스팟으로 이동 */
   moveToNextSpot: () => void
   /** 코스 종료 */
@@ -115,6 +122,56 @@ export const useCourseProgressStore = create<CourseProgressStore>()(
           const next = new Set(checkedSpotIds)
           next.add(spotId)
           set({ checkedSpotIds: next }, false, 'courseProgress/checkInSpot')
+          // 체크인 후 자동으로 다음 미인증 스팟으로 이동
+          get().advanceToNextUnchecked()
+        },
+
+        advanceToNextUnchecked: () => {
+          const { activeRoute, currentSpotIndex, checkedSpotIds } = get()
+          if (!activeRoute) return
+
+          // isAvailable이 false가 아닌 유효 스팟만 필터링
+          const availableSpots = activeRoute.spots.filter(
+            (s) => s.isAvailable !== false
+          )
+          const currentIdx = currentSpotIndex
+
+          // 현재 인덱스 이후부터 순환 탐색
+          for (let i = currentIdx + 1; i < availableSpots.length; i++) {
+            if (!checkedSpotIds.has(availableSpots[i].spotId)) {
+              // 원본 spots 배열 기준 인덱스 찾기
+              const originalIdx = activeRoute.spots.findIndex(
+                (s) => s.spotId === availableSpots[i].spotId
+              )
+              if (originalIdx !== -1) {
+                set(
+                  { currentSpotIndex: originalIdx },
+                  false,
+                  'courseProgress/advanceToNextUnchecked'
+                )
+              }
+              return
+            }
+          }
+
+          // 현재 인덱스 이전도 탐색 (순환)
+          for (let i = 0; i < currentIdx; i++) {
+            if (!checkedSpotIds.has(availableSpots[i].spotId)) {
+              const originalIdx = activeRoute.spots.findIndex(
+                (s) => s.spotId === availableSpots[i].spotId
+              )
+              if (originalIdx !== -1) {
+                set(
+                  { currentSpotIndex: originalIdx },
+                  false,
+                  'courseProgress/advanceToNextUnchecked'
+                )
+              }
+              return
+            }
+          }
+
+          // 모든 스팟 인증 완료 → 인덱스 유지 (완주 상태)
         },
 
         moveToNextSpot: () => {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #735

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

CourseProgressStore에 persist 미들웨어, advanceToNextUnchecked 액션, 배너 dismiss 상태를 추가한다.

---

## 📋 변경 사항

- [x] `persist` + `createJSONStorage` 미들웨어 적용 (localStorage key: `course-progress`)
- [x] `checkedSpotIds` Set ↔ Array 직렬화/역직렬화 구현
- [x] `startedAt` Date ↔ ISO string 변환 구현
- [x] SSR 환경 localStorage 접근 방지 (`typeof window !== 'undefined'` 체크)
- [x] `advanceToNextUnchecked()` 액션 구현 (순환 탐색, 완주 시 인덱스 유지)
- [x] `checkInSpot()` 내부에서 `advanceToNextUnchecked()` 자동 호출
- [x] `isBannerDismissed` 상태 추가
- [x] `dismissBanner()` / `showBanner()` 액션 추가
- [x] persist 대상에 `isBannerDismissed` 포함
- [x] `useIsBannerDismissed` 셀렉터 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

Requirements 2.1, 2.3, 3.1, 3.4, 3.5 대응
