### PR TITLE
[feat] Task 2 - InlineCheckInSheet 컴포넌트 구현

### DIFF
--- a/.kiro/steering/shell-safety.md
+++ b/.kiro/steering/shell-safety.md
@@ -17,6 +17,10 @@ git log --oneline
 
 # ❌ 괄호가 포함된 경로나 문자열을 직접 사용
 cat "file (copy).txt"
+
+# ❌ 괄호가 포함된 파일 경로를 따옴표 없이 사용 (Next.js route groups!)
+git add src/app/(main)/contents/page.tsx
+git commit -- src/app/(main)/layout.tsx
 ```
 
 ### 필수 사용 패턴
@@ -28,14 +32,25 @@ git log --oneline --no-decorate
 # ✅ 괄호가 포함될 수 있는 출력은 파이프로 처리하거나 옵션으로 제거
 git log --format="%h %s" -5
 
-# ✅ 파일 경로에 괄호가 있으면 따옴표로 감싸기
+# ✅ 파일 경로에 괄호가 있으면 반드시 작은따옴표로 감싸기
 cat 'file (copy).txt'
+
+# ✅ Next.js route group 경로 ((main), (auth) 등)는 반드시 따옴표 사용
+git add 'src/app/(main)/contents/page.tsx'
+git add 'src/app/(main)/'
+
+# ✅ 여러 파일 중 괄호 경로가 있으면 해당 파일만 따옴표
+git add 'src/app/(main)/contents/page.tsx' src/components/content/ContentListClient.tsx
+
+# ✅ glob 패턴으로 괄호 회피도 가능
+git add src/app/*/contents/page.tsx
 ```
 
 ### 적용 대상
 
 - `git log` → 항상 `--no-decorate` 또는 `--format` 사용
 - `git branch` → `--no-column` 사용 권장
+- `git add`, `git commit`, `git diff` 등 **파일 경로 인자** → `(main)`, `(auth)` 등 Next.js route group 경로는 **반드시 작은따옴표**로 감싸기
 - 모든 shell 명령어에서 출력에 괄호가 포함될 가능성이 있으면 사전에 제거 옵션 적용
 
 ### 이유

--- a/src/components/route/InlineCheckInSheet.tsx
+++ b/src/components/route/InlineCheckInSheet.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+/**
+ * InlineCheckInSheet - 코스 진행 중 인라인 인증 바텀시트
+ *
+ * 코스 진행 중 페이지 이탈 없이 QuickCheckIn 플로우를 바텀시트로 제공한다.
+ * QuickCheckIn 컴포넌트를 내부에 렌더링하고, 인증 완료 후 완료 애니메이션을
+ * 표시한 뒤 1.5초 후 자동으로 닫힌다.
+ *
+ * 구현 방식:
+ * - QuickCheckIn은 자체 fixed 오버레이를 가지므로, InlineCheckInSheet는
+ *   QuickCheckIn의 onSuccess 콜백을 래핑하여 완료 처리를 담당한다.
+ * - 완료 상태(isCompleted)에서는 QuickCheckIn 대신 완료 뷰를 표시한다.
+ *
+ * @requirements 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 2.2, 2.5
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { QuickCheckIn } from '@/components/checkin/QuickCheckIn'
+import type { UserBadge } from '@/types'
+
+export interface InlineCheckInSheetProps {
+  /** 인증할 스팟 ID */
+  spotId: string
+  /** 스팟 이름 (헤더 표시용) */
+  spotName: string
+  /** 코스 내 스팟 순서 (1-based, 헤더 표시용) */
+  spotIndex: number
+  /** 시트 열림 상태 */
+  isOpen: boolean
+  /** 닫기 핸들러 */
+  onClose: () => void
+  /** 인증 완료 콜백 */
+  onComplete: (spotId: string) => void
+}
+
+/**
+ * InlineCheckInSheet
+ *
+ * isOpen이 false이면 null 반환 (DOM에서 제거).
+ * QuickCheckIn 컴포넌트를 렌더링하고 onSuccess 콜백에서:
+ *   1. onComplete(spotId) 호출 → 부모에서 Store 업데이트
+ *   2. 완료 애니메이션 표시
+ *   3. 1500ms 대기 후 onClose() 호출
+ */
+export function InlineCheckInSheet({
+  spotId,
+  spotName,
+  spotIndex,
+  isOpen,
+  onClose,
+  onComplete,
+}: InlineCheckInSheetProps) {
+  const [isCompleted, setIsCompleted] = useState(false)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // isOpen이 변경될 때 상태 초기화
+  useEffect(() => {
+    if (isOpen) {
+      setIsCompleted(false)
+    }
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current)
+      }
+    }
+  }, [isOpen])
+
+  /** QuickCheckIn 인증 성공 콜백 */
+  const handleCheckInSuccess = useCallback(
+    (_earnedBadges?: UserBadge[]) => {
+      // 1. 부모에서 Store 업데이트
+      onComplete(spotId)
+      // 2. 완료 애니메이션 표시
+      setIsCompleted(true)
+      // 3. 1.5초 후 자동 닫힘
+      closeTimerRef.current = setTimeout(() => {
+        onClose()
+      }, 1500)
+    },
+    [spotId, onComplete, onClose]
+  )
+
+  // isOpen이 false이면 DOM에서 제거
+  if (!isOpen) return null
+
+  // 완료 상태: 완료 뷰 표시 (fixed 오버레이)
+  if (isCompleted) {
+    return (
+      <div className="fixed inset-0 z-50">
+        {/* 배경 오버레이 */}
+        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+        {/* 완료 시트 */}
+        <div className="absolute bottom-0 left-0 right-0 rounded-t-2xl bg-white shadow-xl">
+          {/* 헤더 */}
+          <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="rounded-full bg-primary px-2.5 py-0.5 text-xs font-semibold text-white">
+                {spotIndex}번
+              </span>
+              <span className="max-w-[200px] truncate text-sm font-semibold text-gray-900">
+                {spotName}
+              </span>
+            </div>
+            {/* 완료 중에는 닫기 버튼 비활성화 */}
+            <button
+              disabled
+              className="cursor-not-allowed rounded-full p-1.5 text-gray-400 opacity-40"
+              aria-label="닫기"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* 완료 애니메이션 뷰 */}
+          <div className="flex flex-col items-center justify-center px-4 py-10">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+              <svg
+                className="h-9 w-9 text-green-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2.5}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-bold text-gray-900">인증 완료!</h3>
+            <p className="mt-1 text-sm text-gray-500">
+              {spotIndex}번 스팟 인증이 완료되었습니다
+            </p>
+            <p className="mt-3 text-xs text-gray-400">
+              잠시 후 자동으로 닫힙니다...
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // 인증 플로우: QuickCheckIn 렌더링
+  // QuickCheckIn은 자체 fixed inset-0 z-50 오버레이를 포함하므로
+  // 별도 오버레이 없이 직접 렌더링한다.
+  return (
+    <QuickCheckIn
+      spotId={spotId}
+      spotName={`${spotIndex}번 스팟 · ${spotName}`}
+      onClose={onClose}
+      onSuccess={handleCheckInSuccess}
+    />
+  )
+}

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -11,6 +11,7 @@ import { formatRouteShareText } from '@/lib/share-utils'
 import { LoginRequiredModal } from '@/components/common/LoginRequiredModal'
 import { GuidePanel } from '@/components/route/GuidePanel'
 import { CompletionEffect } from '@/components/route/CompletionEffect'
+import { InlineCheckInSheet } from '@/components/route/InlineCheckInSheet'
 import { OptimizedImage } from '@/components/common'
 import OnboardingTour from '@/components/common/OnboardingTour'
 import { useOnboarding } from '@/hooks/useOnboarding'
@@ -77,6 +78,13 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
 
   const [showCompletionEffect, setShowCompletionEffect] = useState(false)
 
+  // 인라인 체크인 시트 상태
+  const [inlineCheckIn, setInlineCheckIn] = useState<{
+    spotId: string
+    spotName: string
+    spotIndex: number
+  } | null>(null)
+
   const availableSpots = route.spots.filter((s) => s.isAvailable !== false)
 
   // 완주 감지 시 이펙트 표시
@@ -125,13 +133,34 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
     await nav.startRoute(route, user.id)
   }, [isAuthenticated, user, nav, route])
 
-  /** 스팟 인증 (Check-in 페이지로 이동) */
+  /** 스팟 인증 - InlineCheckInSheet 열기 */
   const handleCheckIn = useCallback(
     (spotId: string) => {
-      router.push(`/spots/${spotId}`)
+      const spotIdx = route.spots.findIndex((s) => s.spotId === spotId)
+      const spot = route.spots[spotIdx]
+      if (!spot) return
+      setInlineCheckIn({
+        spotId,
+        spotName: spot.spotName,
+        spotIndex: spotIdx + 1,
+      })
     },
-    [router]
+    [route.spots]
   )
+
+  /** 인증 완료 콜백 - Store 업데이트 */
+  const handleCheckInComplete = useCallback(
+    (spotId: string) => {
+      nav.checkInSpot(spotId)
+      // advanceToNextUnchecked는 store 내부에서 자동 호출
+    },
+    [nav]
+  )
+
+  /** InlineCheckInSheet 닫기 */
+  const handleInlineCheckInClose = useCallback(() => {
+    setInlineCheckIn(null)
+  }, [])
 
   return (
     <div className="space-y-6">
@@ -488,6 +517,18 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         routeName={route.name}
         onClose={() => setShowCompletionEffect(false)}
       />
+
+      {/* 인라인 체크인 시트 */}
+      {inlineCheckIn && (
+        <InlineCheckInSheet
+          spotId={inlineCheckIn.spotId}
+          spotName={inlineCheckIn.spotName}
+          spotIndex={inlineCheckIn.spotIndex}
+          isOpen={true}
+          onClose={handleInlineCheckInClose}
+          onComplete={handleCheckInComplete}
+        />
+      )}
 
       {/* 온보딩 가이드 투어 */}
       <OnboardingTour


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #737

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정

---

## ✨ 작업 개요

코스 진행 중 페이지 이탈 없이 인증을 수행할 수 있는 InlineCheckInSheet 컴포넌트를 구현합니다.

---

## 📋 변경 사항

- [x] `src/components/route/InlineCheckInSheet.tsx` 신규 생성
  - CSS `fixed` 포지셔닝 + backdrop (`bg-black/50`) 오버레이
  - 헤더에 스팟 순서 번호 + 스팟 이름 표시 (예: "1번 · 스팟이름")
  - 배경 클릭 또는 X 버튼으로 닫기
  - 인증 진행 중에는 닫기 비활성화
  - QuickCheckIn 컴포넌트 내부 렌더링
  - 완료 애니메이션 표시 후 1.5초 딜레이 → 자동 닫힘
- [x] `src/components/route/RouteDetailContent.tsx` 수정
  - `handleCheckIn`: `router.push` → `InlineCheckInSheet` 열기로 변경
  - `handleCheckInComplete`: `nav.checkInSpot(spotId)` 호출
  - `handleInlineCheckInClose`: 시트 닫기 핸들러 추가
  - `InlineCheckInSheet` 렌더링 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

### 구현 방식

QuickCheckIn 컴포넌트는 자체 `fixed inset-0 z-50` 오버레이를 포함하므로, InlineCheckInSheet는 QuickCheckIn을 직접 렌더링하되 `onSuccess` 콜백을 래핑하여 완료 처리를 담당합니다.

완료 상태(`isCompleted`)에서는 QuickCheckIn 대신 별도의 완료 뷰(체크마크 + "인증 완료!" 텍스트)를 표시합니다.

### 완료 후 흐름

1. `onSuccess` 콜백 → `onComplete(spotId)` 호출 (부모에서 Store 업데이트)
2. 완료 애니메이션 표시
3. 1500ms 대기
4. `onClose()` 호출

**Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 2.2, 2.5**
