### PR TITLE
feat: CourseProgressBanner 글로벌 플로팅 배너 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import {
   InstallToast,
   IosPwaGuide,
 } from '@/components/pwa'
+import { CourseProgressBanner } from '@/components/course/CourseProgressBanner'
 import JsonLd from '@/components/seo/JsonLd'
 import GoogleAnalytics from '@/components/seo/GoogleAnalytics'
 import { generateWebSiteJsonLd } from '@/lib/seo/json-ld'
@@ -79,6 +80,7 @@ export default function RootLayout({
         <Providers>
           <Header />
           <main>{children}</main>
+          <CourseProgressBanner />
           <InstallPromptListener />
           <InstallBottomSheet />
           <InstallToast />

--- a/src/components/course/CourseProgressBanner.tsx
+++ b/src/components/course/CourseProgressBanner.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useCourseProgressStore } from '@/stores/courseProgressStore'
+
+/**
+ * CourseProgressBanner - 코스 진행 중 글로벌 플로팅 배너
+ *
+ * 코스 진행 중 다른 페이지에서도 표시되는 하단 고정 배너.
+ * 현재 코스명, 진행률, "코스로 돌아가기" 버튼, 닫기 버튼을 포함한다.
+ *
+ * 표시 조건:
+ * - isNavigating === true
+ * - isBannerDismissed === false
+ * - 현재 경로가 /routes/{activeRouteId}가 아닌 경우
+ *
+ * @requirements 3.1, 3.2, 3.3, 3.4
+ */
+export function CourseProgressBanner() {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const {
+    isNavigating,
+    activeRouteId,
+    activeRoute,
+    isBannerDismissed,
+    dismissBanner,
+  } = useCourseProgressStore()
+
+  // 진행률 계산
+  const checkedSpotIds = useCourseProgressStore((state) => state.checkedSpotIds)
+  const availableSpots =
+    activeRoute?.spots.filter((s) => s.isAvailable !== false) ?? []
+  const progress =
+    availableSpots.length > 0
+      ? Math.round((checkedSpotIds.size / availableSpots.length) * 100)
+      : 0
+
+  // 표시 조건
+  const shouldShow =
+    isNavigating &&
+    !isBannerDismissed &&
+    activeRouteId !== null &&
+    pathname !== `/routes/${activeRouteId}`
+
+  if (!shouldShow) return null
+
+  return (
+    <div className="pb-safe fixed bottom-0 left-0 right-0 z-30">
+      <div className="mx-auto max-w-screen-md bg-primary text-white shadow-lg">
+        <div className="flex items-center gap-3 px-4 py-3">
+          {/* 코스명 + 진행률 */}
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold">
+              {activeRoute?.name}
+            </p>
+            <p className="text-xs text-primary-100">{progress}% 완료</p>
+          </div>
+
+          {/* 코스로 돌아가기 버튼 */}
+          <button
+            onClick={() => router.push(`/routes/${activeRouteId}`)}
+            className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-primary"
+          >
+            코스로 돌아가기
+          </button>
+
+          {/* 닫기 버튼 */}
+          <button
+            onClick={dismissBanner}
+            className="rounded-full p-1 text-white/80 hover:text-white"
+            aria-label="배너 닫기"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #739

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정

---

## ✨ 작업 개요

코스 진행 중 다른 페이지에서도 표시되는 글로벌 플로팅 배너 컴포넌트를 구현하고 layout.tsx에 배치한다.

---

## 📋 변경 사항

- [x] `src/components/course/CourseProgressBanner.tsx` 신규 생성
  - 하단 고정 플로팅 바 (z-30, pb-safe)
  - 코스명 (truncate) + 진행률 % + "코스로 돌아가기" 버튼 + X 닫기 버튼
  - 표시 조건: `isNavigating === true` AND `isBannerDismissed === false` AND 현재 경로 ≠ `/routes/{activeRouteId}`
  - "코스로 돌아가기" 클릭 시 `/routes/{activeRouteId}`로 이동
  - X 클릭 시 `dismissBanner()` 호출 (코스 진행 상태 유지)
- [x] `src/app/layout.tsx` 수정
  - `<main>` 아래, `<InstallPromptListener />` 위에 `<CourseProgressBanner />` 배치

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 3.1, 3.2, 3.3, 3.4, 3.6
- `usePathname()`은 CourseProgressBanner 내부에서 사용 (layout.tsx는 서버 컴포넌트)
- `pb-safe`는 iOS safe area 대응 (env(safe-area-inset-bottom))