### PR TITLE
feat: checkInDetailModal 스팟/작품/코스 칩 추가

### DIFF
--- a/src/components/checkin/CheckInDetailModal.tsx
+++ b/src/components/checkin/CheckInDetailModal.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { CheckIn } from '@/types'
 import { AppIcon } from '@/components/common/AppIcon'
 import { ComparisonViewer } from './ComparisonViewer'
@@ -10,13 +12,23 @@ interface CheckInDetailModalProps {
   onClose: () => void
 }
 
+interface CourseInfo {
+  id: string
+  name: string
+}
+
 /**
  * 인증 상세 모달
+ * Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6
  */
 export function CheckInDetailModal({
   checkIn,
   onClose,
 }: CheckInDetailModalProps) {
+  const [spotName, setSpotName] = useState<string | null>(null)
+  const [courses, setCourses] = useState<CourseInfo[]>([])
+  const [chipsReady, setChipsReady] = useState(false)
+
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString('ko-KR', {
       year: 'numeric',
@@ -24,6 +36,52 @@ export function CheckInDetailModal({
       day: 'numeric',
     })
   }
+
+  // 스팟 이름 + 코스 목록 병렬 조회
+  useEffect(() => {
+    if (!checkIn.spotId) return
+
+    let cancelled = false
+
+    const fetchRelatedInfo = async () => {
+      try {
+        const [spotRes, coursesRes] = await Promise.allSettled([
+          fetch(`/api/spots/${checkIn.spotId}`),
+          fetch(`/api/spots/${checkIn.spotId}/courses`),
+        ])
+
+        if (cancelled) return
+
+        // 스팟 이름
+        if (spotRes.status === 'fulfilled' && spotRes.value.ok) {
+          const spotData = await spotRes.value.json()
+          if (!cancelled) setSpotName(spotData.name ?? null)
+        }
+
+        // 코스 목록
+        if (coursesRes.status === 'fulfilled' && coursesRes.value.ok) {
+          const coursesData = await coursesRes.value.json()
+          if (!cancelled) setCourses(coursesData.courses ?? [])
+        }
+      } catch {
+        // graceful degradation: 에러 시 칩 영역 숨김
+      } finally {
+        if (!cancelled) setChipsReady(true)
+      }
+    }
+
+    fetchRelatedInfo()
+
+    return () => {
+      cancelled = true
+    }
+  }, [checkIn.spotId])
+
+  const chipClass =
+    'inline-flex items-center gap-1 rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-100'
+
+  const hasChips = spotName || checkIn.contentName
+  const hasCourses = courses.length > 0
 
   return (
     <div
@@ -123,6 +181,59 @@ export function CheckInDetailModal({
             <span className="text-sm">{checkIn.likeCount}</span>
           </div>
         </div>
+
+        {/* 관련 정보 칩 섹션 — 로딩 완료 후 표시 */}
+        {chipsReady && (hasChips || hasCourses) && (
+          <div className="border-t px-4 py-3">
+            {/* 스팟 / 작품 칩 */}
+            {hasChips && (
+              <div className="flex flex-wrap gap-2">
+                {/* 스팟 칩 */}
+                {spotName && (
+                  <Link
+                    href={`/spots/${checkIn.spotId}`}
+                    className={chipClass}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    📍 {spotName}
+                  </Link>
+                )}
+
+                {/* 작품 칩 */}
+                {checkIn.contentName && (
+                  <Link
+                    href={`/contents/${encodeURIComponent(checkIn.contentName)}`}
+                    className={chipClass}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    🎬 {checkIn.contentName}
+                  </Link>
+                )}
+              </div>
+            )}
+
+            {/* 코스 섹션 */}
+            {hasCourses && (
+              <div className={hasChips ? 'mt-2' : ''}>
+                <p className="mb-1 text-xs text-gray-500">
+                  이 스팟이 포함된 코스
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {courses.map((course) => (
+                    <Link
+                      key={course.id}
+                      href={`/routes/${course.id}`}
+                      className={chipClass}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      🗺️ {course.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #743

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정

---

## ✨ 작업 개요

갤러리 인증 상세 모달에 스팟/작품/코스 연결 칩을 추가하여 감상에서 탐색으로 자연스럽게 전환되도록 강화한다.

---

## 📋 변경 사항

- [x] `CheckInDetailModal`에 스팟 이름 칩 + `/spots/{spotId}` 링크 추가
- [x] `CheckInDetailModal`에 작품명 칩 + `/contents/{contentName}` 링크 추가 (contentName 존재 시)
- [x] `CheckInDetailModal`에 "이 스팟이 포함된 코스" 섹션 + `/routes/{routeId}` 링크 추가
- [x] `GET /api/spots/{spotId}` 호출로 스팟 이름 조회
- [x] `GET /api/spots/{spotId}/courses` 호출로 코스 목록 조회
- [x] API 실패 시 칩 영역 숨김 (graceful degradation)
- [x] 로딩 완료 전 칩 영역 숨김 (chipsReady 상태)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6
- 스팟 이름과 코스 목록은 `Promise.allSettled`로 병렬 조회
- 작품 허브 링크: `/contents/{encodeURIComponent(contentName)}`
- 칩 스타일: 기존 프로젝트 패턴(`rounded-full bg-primary-50 px-2.5 py-1 text-xs`) 준수
