### PR TITLE
feat: 유저 프로필 GET API 8개 구현

### DIFF
--- a/src/app/api/users/[id]/bookmarks/route.ts
+++ b/src/app/api/users/[id]/bookmarks/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/bookmarks - 유저가 저장한 코스 목록
+ * Requirements: 9.2
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const bookmarksCollection = await getCollection(COLLECTIONS.ROUTE_BOOKMARKS)
+    const routesCollection = await getCollection(COLLECTIONS.ROUTES)
+    const usersCollection = await getCollection(COLLECTIONS.USERS)
+
+    const bookmarks = await bookmarksCollection
+      .find({ userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = await Promise.all(
+      bookmarks.map(async (bookmark) => {
+        let routeDoc = null
+        try {
+          routeDoc = await routesCollection.findOne({
+            _id: new ObjectId(bookmark.routeId),
+          })
+        } catch {
+          routeDoc = null
+        }
+
+        let authorName = '알 수 없음'
+        if (routeDoc?.authorId) {
+          try {
+            const author = await usersCollection.findOne({
+              _id: new ObjectId(routeDoc.authorId),
+            })
+            authorName = author?.name || routeDoc.authorName || '알 수 없음'
+          } catch {
+            authorName = routeDoc.authorName || '알 수 없음'
+          }
+        }
+
+        return {
+          id: bookmark.routeId,
+          name: routeDoc?.name || '삭제된 코스',
+          authorName,
+          spotCount: routeDoc?.spots?.length ?? 0,
+          bookmarkedAt:
+            bookmark.createdAt instanceof Date
+              ? bookmark.createdAt.toISOString()
+              : bookmark.createdAt,
+        }
+      })
+    )
+
+    return NextResponse.json({ bookmarks: result })
+  } catch (error) {
+    console.error('Error fetching user bookmarks:', error)
+    return NextResponse.json(
+      { error: '저장한 코스 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/comments/route.ts
+++ b/src/app/api/users/[id]/comments/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/comments - 유저의 댓글 목록
+ * Requirements: 9.8
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const commentsCollection = await getCollection(COLLECTIONS.COMMENTS)
+    const postsCollection = await getCollection(COLLECTIONS.POSTS)
+
+    const comments = await commentsCollection
+      .find({ userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = await Promise.all(
+      comments.map(async (comment) => {
+        let postDoc = null
+        try {
+          postDoc = await postsCollection.findOne({
+            _id: new ObjectId(comment.postId),
+          })
+        } catch {
+          postDoc = null
+        }
+
+        const content = comment.content || comment.body || ''
+        return {
+          id: comment._id.toString(),
+          postId: comment.postId,
+          postTitle: postDoc?.title || '삭제된 게시글',
+          contentPreview: content.slice(0, 80),
+          createdAt:
+            comment.createdAt instanceof Date
+              ? comment.createdAt.toISOString()
+              : comment.createdAt,
+        }
+      })
+    )
+
+    return NextResponse.json({ comments: result })
+  } catch (error) {
+    console.error('Error fetching user comments:', error)
+    return NextResponse.json(
+      { error: '댓글 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/completions/route.ts
+++ b/src/app/api/users/[id]/completions/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/completions - 유저의 코스 완주 기록
+ * Requirements: 9.3
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const completionsCollection = await getCollection(COLLECTIONS.ROUTE_COMPLETIONS)
+    const routesCollection = await getCollection(COLLECTIONS.ROUTES)
+
+    const completions = await completionsCollection
+      .find({ userId })
+      .sort({ completedAt: -1 })
+      .toArray()
+
+    const result = await Promise.all(
+      completions.map(async (completion) => {
+        let routeDoc = null
+        try {
+          routeDoc = await routesCollection.findOne({
+            _id: new ObjectId(completion.routeId),
+          })
+        } catch {
+          routeDoc = null
+        }
+
+        return {
+          id: completion._id.toString(),
+          routeId: completion.routeId,
+          routeName: routeDoc?.name || '삭제된 코스',
+          spotCount: routeDoc?.spots?.length ?? 0,
+          completedAt:
+            completion.completedAt instanceof Date
+              ? completion.completedAt.toISOString()
+              : completion.completedAt,
+        }
+      })
+    )
+
+    return NextResponse.json({ completions: result })
+  } catch (error) {
+    console.error('Error fetching user completions:', error)
+    return NextResponse.json(
+      { error: '완주 기록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/posts/route.ts
+++ b/src/app/api/users/[id]/posts/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/posts - 유저의 게시글 목록
+ * Requirements: 9.7
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const postsCollection = await getCollection(COLLECTIONS.POSTS)
+    const commentsCollection = await getCollection(COLLECTIONS.COMMENTS)
+
+    const posts = await postsCollection
+      .find({ userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = await Promise.all(
+      posts.map(async (post) => {
+        const commentCount = await commentsCollection.countDocuments({
+          postId: post._id.toString(),
+        })
+        const content = post.content || post.body || ''
+        return {
+          id: post._id.toString(),
+          title: post.title || '제목 없음',
+          contentPreview: content.slice(0, 100),
+          viewCount: post.viewCount || 0,
+          commentCount,
+          createdAt:
+            post.createdAt instanceof Date
+              ? post.createdAt.toISOString()
+              : post.createdAt,
+        }
+      })
+    )
+
+    return NextResponse.json({ posts: result })
+  } catch (error) {
+    console.error('Error fetching user posts:', error)
+    return NextResponse.json(
+      { error: '게시글 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/reports/route.ts
+++ b/src/app/api/users/[id]/reports/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/reports - 유저의 신규 스팟 제보 목록
+ * Requirements: 9.4
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const reportsCollection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+
+    const reports = await reportsCollection
+      .find({ reporterId: userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = reports.map((report) => ({
+      id: report._id.toString(),
+      spotName: report.spotName || report.name || '이름 없음',
+      status: report.status || 'pending',
+      createdAt:
+        report.createdAt instanceof Date
+          ? report.createdAt.toISOString()
+          : report.createdAt,
+    }))
+
+    return NextResponse.json({ reports: result })
+  } catch (error) {
+    console.error('Error fetching user reports:', error)
+    return NextResponse.json(
+      { error: '제보 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/routes/route.ts
+++ b/src/app/api/users/[id]/routes/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/routes - 유저가 만든 코스 목록
+ * Requirements: 9.1
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const routesCollection = await getCollection(COLLECTIONS.ROUTES)
+    const bookmarksCollection = await getCollection(COLLECTIONS.ROUTE_BOOKMARKS)
+
+    const routes = await routesCollection
+      .find({ authorId: userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = await Promise.all(
+      routes.map(async (route) => {
+        const bookmarkCount = await bookmarksCollection.countDocuments({
+          routeId: route._id.toString(),
+        })
+        return {
+          id: route._id.toString(),
+          name: route.name,
+          spotCount: route.spots?.length ?? 0,
+          bookmarkCount,
+          createdAt:
+            route.createdAt instanceof Date
+              ? route.createdAt.toISOString()
+              : route.createdAt,
+        }
+      })
+    )
+
+    return NextResponse.json({ routes: result })
+  } catch (error) {
+    console.error('Error fetching user routes:', error)
+    return NextResponse.json(
+      { error: '코스 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/status-reports/route.ts
+++ b/src/app/api/users/[id]/status-reports/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/status-reports - 유저의 상태신고 목록
+ * Requirements: 9.6
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const statusReportsCollection = await getCollection(COLLECTIONS.SPOT_STATUS_REPORTS)
+
+    const statusReports = await statusReportsCollection
+      .find({ reporterId: userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = statusReports.map((report) => ({
+      id: report._id.toString(),
+      spotName: report.spotName || '이름 없음',
+      reportedStatus: report.reportedStatus || report.status || '알 수 없음',
+      resolved: report.resolved || false,
+      createdAt:
+        report.createdAt instanceof Date
+          ? report.createdAt.toISOString()
+          : report.createdAt,
+    }))
+
+    return NextResponse.json({ statusReports: result })
+  } catch (error) {
+    console.error('Error fetching user status reports:', error)
+    return NextResponse.json(
+      { error: '상태신고 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/users/[id]/supplements/route.ts
+++ b/src/app/api/users/[id]/supplements/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCollection, COLLECTIONS } from '@/lib/db'
+
+/**
+ * GET /api/users/[id]/supplements - 유저의 정보보완 신청 목록
+ * Requirements: 9.5
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    const supplementsCollection = await getCollection(COLLECTIONS.SPOT_SUPPLEMENTS)
+
+    const supplements = await supplementsCollection
+      .find({ contributorId: userId })
+      .sort({ createdAt: -1 })
+      .toArray()
+
+    const result = supplements.map((supplement) => ({
+      id: supplement._id.toString(),
+      spotName: supplement.spotName || '이름 없음',
+      type: supplement.type || supplement.supplementType || '기타',
+      status: supplement.status || 'pending',
+      createdAt:
+        supplement.createdAt instanceof Date
+          ? supplement.createdAt.toISOString()
+          : supplement.createdAt,
+    }))
+
+    return NextResponse.json({ supplements: result })
+  } catch (error) {
+    console.error('Error fetching user supplements:', error)
+    return NextResponse.json(
+      { error: '정보보완 목록 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## 변경 사항

프로필 페이지 활동 허브 완성을 위한 유저 데이터 조회 GET API 8개를 구현합니다.

### 신규 엔드포인트

- `GET /api/users/[id]/routes` — 유저가 만든 코스 목록 (authorId 필터링, 북마크 수 포함)
- `GET /api/users/[id]/bookmarks` — 유저가 저장한 코스 목록 (userId 필터링, 코스 정보 조인)
- `GET /api/users/[id]/completions` — 유저의 코스 완주 기록 (userId 필터링, 코스명/스팟수 조인)
- `GET /api/users/[id]/reports` — 유저의 신규 스팟 제보 목록 (reporterId 필터링)
- `GET /api/users/[id]/supplements` — 유저의 정보보완 신청 목록 (contributorId 필터링)
- `GET /api/users/[id]/status-reports` — 유저의 상태신고 목록 (reporterId 필터링)
- `GET /api/users/[id]/posts` — 유저의 게시글 목록 (userId 필터링, 댓글 수 포함)
- `GET /api/users/[id]/comments` — 유저의 댓글 목록 (userId 필터링, 게시글 제목 조인)

## 테스트 방법

각 엔드포인트에 유효한 userId로 GET 요청 시 해당 유저의 데이터만 반환되는지 확인

## 관련 이슈

Closes #761

## 체크리스트

- [x] 코드 구현 완료
- [x] TypeScript 타입 체크 통과
- [x] 기존 API 패턴 준수 (NextRequest/NextResponse, getCollection, COLLECTIONS)
- [x] 에러 처리 (500 응답) 포함
- [x] 삭제된 연관 데이터 graceful 처리 (삭제된 코스/게시글 fallback 텍스트)