### PR TITLE
feat: PUT 프로필 업데이트 API 및 stats 확장

### DIFF
--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { ObjectId } from 'mongodb'
 import { getCollection, COLLECTIONS } from '@/lib/db'
+import { auth } from '@/lib/auth'
 
 /**
  * GET /api/users/[id] - 유저 기본 정보 조회
@@ -38,14 +39,103 @@ export async function GET(
       id: user._id.toString(),
       name: user.name,
       image: user.image || null,
-      createdAt: user.createdAt instanceof Date
-        ? user.createdAt.toISOString()
-        : user.createdAt,
+      createdAt:
+        user.createdAt instanceof Date
+          ? user.createdAt.toISOString()
+          : user.createdAt,
     })
   } catch (error) {
     console.error('Error fetching user info:', error)
     return NextResponse.json(
       { error: '유저 정보 조회에 실패했습니다' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * PUT /api/users/[id] - 유저 프로필 업데이트
+ * Requirements: 9.9, 9.10, 9.11
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id: userId } = await params
+
+    // 세션 검증
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: '로그인이 필요합니다' },
+        { status: 401 }
+      )
+    }
+
+    // 권한 확인
+    if (session.user.id !== userId) {
+      return NextResponse.json(
+        { error: '본인의 프로필만 수정할 수 있습니다' },
+        { status: 403 }
+      )
+    }
+
+    const body = await request.json()
+    const { name, image } = body
+
+    // 이름 유효성 검사
+    if (name !== undefined) {
+      if (typeof name !== 'string' || name.trim() === '') {
+        return NextResponse.json(
+          { error: '이름을 입력해주세요' },
+          { status: 400 }
+        )
+      }
+      if (name.trim().length > 50) {
+        return NextResponse.json(
+          { error: '이름은 50자 이내로 입력해주세요' },
+          { status: 400 }
+        )
+      }
+    }
+
+    const usersCollection = await getCollection(COLLECTIONS.USERS)
+
+    const user = await usersCollection.findOne({ _id: new ObjectId(userId) })
+    if (!user) {
+      return NextResponse.json(
+        { error: '유저를 찾을 수 없습니다' },
+        { status: 404 }
+      )
+    }
+
+    const updateData: Record<string, unknown> = { updatedAt: new Date() }
+    if (name !== undefined) updateData.name = name.trim()
+    if (image !== undefined) updateData.image = image
+
+    await usersCollection.updateOne(
+      { _id: new ObjectId(userId) },
+      { $set: updateData }
+    )
+
+    const updatedUser = await usersCollection.findOne({
+      _id: new ObjectId(userId),
+    })
+
+    return NextResponse.json({
+      id: updatedUser!._id.toString(),
+      name: updatedUser!.name,
+      image: updatedUser!.image || null,
+      updatedAt:
+        updatedUser!.updatedAt instanceof Date
+          ? updatedUser!.updatedAt.toISOString()
+          : updatedUser!.updatedAt,
+    })
+  } catch (error) {
+    console.error('Error updating user profile:', error)
+    return NextResponse.json(
+      { error: '프로필 업데이트에 실패했습니다' },
       { status: 500 }
     )
   }

--- a/src/app/api/users/[id]/stats/route.ts
+++ b/src/app/api/users/[id]/stats/route.ts
@@ -3,8 +3,8 @@ import { getCollection, COLLECTIONS } from '@/lib/db'
 import { UserStats } from '@/types'
 
 /**
- * GET /api/users/[id]/stats - 유저 통계 조회
- * Requirements: 3.3
+ * GET /api/users/[id]/stats - 유저 통계 조회 (확장)
+ * Requirements: 3.3, 8.4, 8.5
  */
 export async function GET(
   request: NextRequest,
@@ -13,25 +13,39 @@ export async function GET(
   try {
     const { id: userId } = await params
 
-    const statsCollection = await getCollection<UserStats>(
-      COLLECTIONS.USER_STATS
-    )
+    const statsCollection = await getCollection<UserStats>(COLLECTIONS.USER_STATS)
+    const completionsCollection = await getCollection(COLLECTIONS.ROUTE_COMPLETIONS)
+    const spotsCollection = await getCollection(COLLECTIONS.SPOTS)
+    const reportsCollection = await getCollection(COLLECTIONS.SPOT_REPORTS)
+    const postsCollection = await getCollection(COLLECTIONS.POSTS)
 
     const stats = await statsCollection.findOne({ userId })
 
-    // 통계가 없으면 기본값 반환
-    if (!stats) {
-      return NextResponse.json({
-        userId,
-        totalCheckIns: 0,
-        uniqueSpots: 0,
-        badgeCount: 0,
-        contentProgress: [],
-        updatedAt: new Date(),
-      })
+    // 추가 통계 집계
+    const [completedRoutes, registeredSpots, reportCount, postCount] =
+      await Promise.all([
+        completionsCollection.countDocuments({ userId }),
+        spotsCollection.countDocuments({ authorId: userId }),
+        reportsCollection.countDocuments({ reporterId: userId }),
+        postsCollection.countDocuments({ userId }),
+      ])
+
+    const baseStats = stats || {
+      userId,
+      totalCheckIns: 0,
+      uniqueSpots: 0,
+      badgeCount: 0,
+      contentProgress: [],
+      updatedAt: new Date(),
     }
 
-    return NextResponse.json(stats)
+    return NextResponse.json({
+      ...baseStats,
+      completedRoutes,
+      registeredSpots,
+      reportCount,
+      postCount,
+    })
   } catch (error) {
     console.error('Error fetching user stats:', error)
     return NextResponse.json(


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #763

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

PUT /api/users/[id] 프로필 업데이트 엔드포인트 구현 및 GET /api/users/[id]/stats 확장 통계 필드 추가

---

## 📋 변경 사항

- [x] PUT /api/users/[id] 핸들러 추가 (세션 검증, 권한 확인, 이름 유효성 검사, DB 업데이트)
- [x] GET /api/users/[id]/stats에 completedRoutes, registeredSpots, reportCount, postCount 필드 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

### Task 3.1 - PUT /api/users/[id]
- auth() 함수로 세션 검증 (미인증 시 401)
- session.user.id !== userId 이면 403 반환
- 이름 빈 문자열/공백만이면 400 ("이름을 입력해주세요")
- 이름 50자 초과이면 400 ("이름은 50자 이내로 입력해주세요")
- $set으로 name, image, updatedAt 업데이트 후 업데이트된 유저 반환

### Task 3.2 - GET /api/users/[id]/stats 확장
- route_completions에서 userId로 completedRoutes count
- spots에서 authorId로 registeredSpots count
- spot_reports에서 reporterId로 reportCount count
- posts에서 userId로 postCount count
- Promise.all로 병렬 집계