### PR TITLE
[feat] Task 5.1~5.2 - React Query 훅 확장

### DIFF
--- a/src/hooks/useUserQueries.ts
+++ b/src/hooks/useUserQueries.ts
@@ -1,6 +1,18 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { API_ROUTES, buildUrl } from '@/lib/api-routes'
-import type { UserStats, UserBadge, ContentProgress } from '@/types'
+import type {
+  UserStats,
+  UserBadge,
+  ContentProgress,
+  UserRoute,
+  UserBookmark,
+  UserCompletion,
+  UserReport,
+  UserSupplement,
+  UserStatusReport,
+  UserPost,
+  UserComment,
+} from '@/types'
 
 // ── Response Types ──────────────────────────────────────────
 
@@ -35,6 +47,18 @@ export const userKeys = {
   progress: (userId: string) => [...userKeys.all, 'progress', userId] as const,
   reportedSpots: (userId: string) =>
     [...userKeys.all, 'reportedSpots', userId] as const,
+  routes: (userId: string) => [...userKeys.all, 'routes', userId] as const,
+  bookmarks: (userId: string) =>
+    [...userKeys.all, 'bookmarks', userId] as const,
+  completions: (userId: string) =>
+    [...userKeys.all, 'completions', userId] as const,
+  reports: (userId: string) => [...userKeys.all, 'reports', userId] as const,
+  supplements: (userId: string) =>
+    [...userKeys.all, 'supplements', userId] as const,
+  statusReports: (userId: string) =>
+    [...userKeys.all, 'statusReports', userId] as const,
+  posts: (userId: string) => [...userKeys.all, 'posts', userId] as const,
+  comments: (userId: string) => [...userKeys.all, 'comments', userId] as const,
 }
 
 // ── Hooks ───────────────────────────────────────────────────
@@ -128,5 +152,141 @@ export function useUserReportedSpots(userId: string) {
       )
     },
     enabled: !!userId,
+  })
+}
+
+/**
+ * 유저가 만든 코스 목록 조회 훅
+ * Requirements: 9.1
+ */
+export function useUserRoutes(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.routes(userId),
+    queryFn: async (): Promise<UserRoute[]> => {
+      const res = await fetch(API_ROUTES.USERS.ROUTES(userId))
+      if (!res.ok) throw new Error('코스 목록 조회 실패')
+      const data = await res.json()
+      return data.routes
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저가 저장한 코스 목록 조회 훅
+ * Requirements: 9.2
+ */
+export function useUserBookmarks(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.bookmarks(userId),
+    queryFn: async (): Promise<UserBookmark[]> => {
+      const res = await fetch(API_ROUTES.USERS.BOOKMARKS(userId))
+      if (!res.ok) throw new Error('저장한 코스 조회 실패')
+      const data = await res.json()
+      return data.bookmarks
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저의 코스 완주 기록 조회 훅
+ * Requirements: 9.3
+ */
+export function useUserCompletions(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.completions(userId),
+    queryFn: async (): Promise<UserCompletion[]> => {
+      const res = await fetch(API_ROUTES.USERS.COMPLETIONS(userId))
+      if (!res.ok) throw new Error('완주 기록 조회 실패')
+      const data = await res.json()
+      return data.completions
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저의 신규 스팟 제보 목록 조회 훅
+ * Requirements: 9.4
+ */
+export function useUserReports(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.reports(userId),
+    queryFn: async (): Promise<UserReport[]> => {
+      const res = await fetch(API_ROUTES.USERS.REPORTS(userId))
+      if (!res.ok) throw new Error('제보 목록 조회 실패')
+      const data = await res.json()
+      return data.reports
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저의 정보보완 신청 목록 조회 훅
+ * Requirements: 9.5
+ */
+export function useUserSupplements(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.supplements(userId),
+    queryFn: async (): Promise<UserSupplement[]> => {
+      const res = await fetch(API_ROUTES.USERS.SUPPLEMENTS(userId))
+      if (!res.ok) throw new Error('정보보완 목록 조회 실패')
+      const data = await res.json()
+      return data.supplements
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저의 상태신고 목록 조회 훅
+ * Requirements: 9.6
+ */
+export function useUserStatusReports(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.statusReports(userId),
+    queryFn: async (): Promise<UserStatusReport[]> => {
+      const res = await fetch(API_ROUTES.USERS.STATUS_REPORTS(userId))
+      if (!res.ok) throw new Error('상태신고 목록 조회 실패')
+      const data = await res.json()
+      return data.statusReports
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저의 게시글 목록 조회 훅
+ * Requirements: 9.7
+ */
+export function useUserPosts(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.posts(userId),
+    queryFn: async (): Promise<UserPost[]> => {
+      const res = await fetch(API_ROUTES.USERS.POSTS(userId))
+      if (!res.ok) throw new Error('게시글 목록 조회 실패')
+      const data = await res.json()
+      return data.posts
+    },
+    enabled: !!userId && enabled,
+  })
+}
+
+/**
+ * 유저의 댓글 목록 조회 훅
+ * Requirements: 9.8
+ */
+export function useUserComments(userId: string, enabled = true) {
+  return useQuery({
+    queryKey: userKeys.comments(userId),
+    queryFn: async (): Promise<UserComment[]> => {
+      const res = await fetch(API_ROUTES.USERS.COMMENTS(userId))
+      if (!res.ok) throw new Error('댓글 목록 조회 실패')
+      const data = await res.json()
+      return data.comments
+    },
+    enabled: !!userId && enabled,
   })
 }

--- a/src/hooks/useUserQueries.ts
+++ b/src/hooks/useUserQueries.ts
@@ -290,3 +290,30 @@ export function useUserComments(userId: string, enabled = true) {
     enabled: !!userId && enabled,
   })
 }
+
+/**
+ * 프로필 업데이트 mutation 훅
+ * Requirements: 9.9
+ */
+export function useUpdateProfile(userId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: { name?: string; image?: string }) => {
+      const res = await fetch(API_ROUTES.USERS.UPDATE(userId), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) {
+        const error = await res.json()
+        throw new Error(error.error || '프로필 업데이트 실패')
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      // 유저 정보 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: userKeys.info(userId) })
+    },
+  })
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #767

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

프로필 페이지(45-profile-complete spec)에 필요한 React Query 훅들을 `useUserQueries.ts`에 추가한다.

---

## 📋 변경 사항

- [x] `useMutation`, `useQueryClient` import 추가
- [x] 프로필 관련 타입 import 추가 (UserRoute, UserBookmark, UserCompletion, UserReport, UserSupplement, UserStatusReport, UserPost, UserComment)
- [x] `userKeys` 쿼리 키 팩토리 확장 (routes, bookmarks, completions, reports, supplements, statusReports, posts, comments)
- [x] 신규 훅 8개 추가 (각 훅에 `enabled` 파라미터로 lazy loading 지원):
  - `useUserRoutes` — 유저가 만든 코스 목록 (Requirements 9.1)
  - `useUserBookmarks` — 유저가 저장한 코스 목록 (Requirements 9.2)
  - `useUserCompletions` — 유저의 코스 완주 기록 (Requirements 9.3)
  - `useUserReports` — 유저의 신규 스팟 제보 목록 (Requirements 9.4)
  - `useUserSupplements` — 유저의 정보보완 신청 목록 (Requirements 9.5)
  - `useUserStatusReports` — 유저의 상태신고 목록 (Requirements 9.6)
  - `useUserPosts` — 유저의 게시글 목록 (Requirements 9.7)
  - `useUserComments` — 유저의 댓글 목록 (Requirements 9.8)
- [x] `useUpdateProfile` mutation 훅 추가 — 성공 시 `userKeys.info` 쿼리 무효화 (Requirements 9.9)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보 (선택)

- Spec: `.kiro/specs/45-profile-complete`
- Task 5.1, 5.2 구현
- 기존 API_ROUTES.USERS 상수는 Task 1.1에서 이미 추가되어 있음