### PR TITLE
feat: 헤더 프로필 링크를 마이페이지로 변경

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -117,7 +117,7 @@ export function Header() {
             ) : isAuthenticated && user ? (
               <div className="flex items-center gap-3">
                 <Link
-                  href="/settings/account"
+                  href={`/profile/${user.id}`}
                   className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-secondary-100"
                 >
                   {user.image ? (
@@ -266,14 +266,14 @@ export function Header() {
                   ⚙️ 관리자
                 </Link>
               )}
-              {isAuthenticated && (
+              {isAuthenticated && user && (
                 <Link
-                  href="/settings/account"
+                  href={`/profile/${user.id}`}
                   onClick={() => setIsMobileMenuOpen(false)}
                   className="text-text-secondary hover:text-text-primary flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition hover:bg-secondary-100"
                 >
                   <AppIcon name="profile" size="sm" />
-                  계정 설정
+                  마이페이지
                 </Link>
               )}
             </div>


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #770

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

헤더의 프로필 링크를 `/settings/account`에서 `/profile/{userId}`로 변경하고, 모바일 메뉴 텍스트를 "계정 설정"에서 "마이페이지"로 수정합니다.

---

## 📋 변경 사항

- [x] 데스크톱 프로필 링크: `href="/settings/account"` → `href={/profile/${user.id}}`
- [x] 모바일 메뉴 프로필 링크: `href="/settings/account"` → `href={/profile/${user.id}}`
- [x] 모바일 메뉴 텍스트: "계정 설정" → "마이페이지"
- [x] 모바일 메뉴 조건: `isAuthenticated` → `isAuthenticated && user` (user 객체 안전 접근)

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] 주요 기능 동작 확인

---

## 📝 추가 정보

- Requirements 1.2, 1.3, 1.4 대응
- spec: 45-profile-complete, Task 6.1