### PR TITLE
[chore] UI 버그 수정 및 spec 문서 추가

### DIFF
--- a/.kiro/specs/45-profile-complete/.config.kiro
+++ b/.kiro/specs/45-profile-complete/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "dddc9f24-f6dd-4f3f-ae6a-c32311afaac7", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/45-profile-complete/design.md
+++ b/.kiro/specs/45-profile-complete/design.md
@@ -1,0 +1,841 @@
+# Design Document
+
+## 45-profile-complete: 프로필 페이지 활동 허브 완성
+
+## Overview
+
+프로필 페이지(`/profile/[id]`)를 기존 4탭 구조에서 **활동 / 기여 / 커뮤니티 / 보관함 / 관리** 5개 섹션 허브로 재설계한다. `/settings/account` 페이지를 관리 섹션에 통합하고, 헤더 프로필 링크를 수정하며, 프로필 편집 기능을 구현한다.
+
+### 핵심 변경 범위
+
+1. **프로필 페이지 재구조화**: 5개 섹션 + 각 섹션별 하위 탭
+2. **API 확장**: 8개 신규 GET 엔드포인트 + PUT 프로필 업데이트
+3. **헤더 링크 변경**: `/settings/account` → `/profile/{userId}`
+4. **리다이렉트 설정**: `/settings/account` → `/profile/{userId}?section=management`
+5. **프로필 편집**: 이름/이미지 변경 폼 + 유효성 검사
+6. **계정 설정 통합**: OAuth 연동, 비밀번호 설정을 관리 섹션으로 이동
+
+---
+
+## Architecture
+
+### 전체 구조
+
+```mermaid
+graph TD
+    subgraph "Profile Page /profile/[id]"
+        PH[ProfileHeader]
+        SN[SectionNavigation]
+        
+        subgraph "Sections"
+            AS[ActivitySection]
+            CS[ContributionSection]
+            CMS[CommunitySection]
+            CLS[CollectionSection]
+            MS[ManagementSection]
+        end
+    end
+    
+    PH --> SN
+    SN --> AS
+    SN --> CS
+    SN --> CMS
+    SN --> CLS
+    SN --> MS
+    
+    subgraph "API Layer"
+        A1[GET /api/users/id]
+        A2[GET /api/users/id/stats]
+        A3[GET /api/users/id/routes]
+        A4[GET /api/users/id/bookmarks]
+        A5[GET /api/users/id/completions]
+        A6[GET /api/users/id/reports]
+        A7[GET /api/users/id/supplements]
+        A8[GET /api/users/id/status-reports]
+        A9[GET /api/users/id/posts]
+        A10[GET /api/users/id/comments]
+        A11[PUT /api/users/id]
+    end
+    
+    AS --> A2
+    AS --> A5
+    CS --> A6
+    CS --> A7
+    CS --> A8
+    CMS --> A9
+    CMS --> A10
+    CLS --> A3
+    CLS --> A4
+    MS --> A11
+```
+
+### 데이터 흐름
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Page as ProfilePage
+    participant Hook as React Query Hooks
+    participant API as API Routes
+    participant DB as MongoDB
+
+    User->>Page: /profile/[id] 접근
+    Page->>Hook: useUserInfo(id)
+    Page->>Hook: useUserStats(id)
+    Hook->>API: GET /api/users/[id]
+    Hook->>API: GET /api/users/[id]/stats
+    API->>DB: users.findOne / aggregation
+    DB-->>API: 유저 데이터
+    API-->>Hook: JSON 응답
+    Hook-->>Page: 데이터 렌더링
+    
+    User->>Page: 섹션 탭 클릭 (예: 기여)
+    Page->>Hook: useUserReports(id) [lazy load]
+    Hook->>API: GET /api/users/[id]/reports
+    API->>DB: spot_reports.find({reporterId})
+    DB-->>API: 제보 목록
+    API-->>Hook: JSON 응답
+    Hook-->>Page: 탭 콘텐츠 렌더링
+```
+
+### 섹션 구조
+
+| 섹션 | 하위 탭 | 데이터 소스 |
+|------|---------|------------|
+| 활동 | 인증 갤러리, 코스 완주, 트로피 룸, 진행 현황 | checkins, route_completions, user_badges, user_stats |
+| 기여 | 등록한 스팟, 신규 제보, 정보보완, 상태신고 | spots, spot_reports, spot_supplements, spot_status_reports |
+| 커뮤니티 | 내 게시글, 내 댓글 | posts, comments |
+| 보관함 | 내가 만든 코스, 저장한 코스 | routes, route_bookmarks |
+| 관리 | 프로필 편집, 계정 연동, 알림 설정 | users, accounts, push_subscriptions |
+
+### 리다이렉트 전략
+
+```
+/settings/account (로그인) → /profile/{userId}?section=management
+/settings/account (비로그인) → /auth/signin?callbackUrl=/settings/account
+```
+
+Next.js 페이지 레벨에서 `redirect()` 사용 (서버 컴포넌트) 또는 클라이언트 `useRouter().replace()` 사용.
+
+---
+
+## Components and Interfaces
+
+### 1. ProfileHeader 컴포넌트
+
+**파일**: `src/components/profile/ProfileHeader.tsx`
+
+```typescript
+interface ProfileHeaderProps {
+  userInfo: UserInfo
+  stats: ExtendedUserStats
+  isOwner: boolean
+  onEditClick: () => void
+}
+```
+
+표시 항목:
+- 유저 이름, 프로필 이미지, 가입일
+- 통계: 총 인증 수, 방문 스팟 수, 획득 배지 수, 완주 코스 수, 등록 스팟 수, 제보 수, 게시글 수
+- Owner일 때만 "편집" 버튼 표시
+
+### 2. SectionNavigation 컴포넌트
+
+**파일**: `src/components/profile/SectionNavigation.tsx`
+
+```typescript
+type ProfileSection = 'activity' | 'contribution' | 'community' | 'collection' | 'management'
+
+interface SectionNavigationProps {
+  activeSection: ProfileSection
+  onSectionChange: (section: ProfileSection) => void
+  isOwner: boolean  // 관리 섹션 표시 여부
+}
+```
+
+- 가로 스크롤 지원 (`overflow-x-auto`)
+- 활성 섹션 시각적 구분 (하단 보더 또는 배경색)
+- `isOwner === false`일 때 "관리" 탭 미표시
+
+### 3. SubTabNavigation 컴포넌트
+
+**파일**: `src/components/profile/SubTabNavigation.tsx`
+
+```typescript
+interface SubTabNavigationProps {
+  tabs: { key: string; label: string }[]
+  activeTab: string
+  onTabChange: (tab: string) => void
+}
+```
+
+### 4. 섹션 컴포넌트
+
+#### ActivitySection
+
+**파일**: `src/components/profile/sections/ActivitySection.tsx`
+
+```typescript
+interface ActivitySectionProps {
+  userId: string
+  isOwner: boolean
+}
+```
+
+하위 탭: 인증 갤러리 | 코스 완주 | 트로피 룸 | 진행 현황
+
+#### ContributionSection
+
+**파일**: `src/components/profile/sections/ContributionSection.tsx`
+
+```typescript
+interface ContributionSectionProps {
+  userId: string
+}
+```
+
+하위 탭: 등록한 스팟 | 신규 제보 | 정보보완 | 상태신고
+
+#### CommunitySection
+
+**파일**: `src/components/profile/sections/CommunitySection.tsx`
+
+```typescript
+interface CommunitySectionProps {
+  userId: string
+}
+```
+
+하위 탭: 내 게시글 | 내 댓글
+
+#### CollectionSection
+
+**파일**: `src/components/profile/sections/CollectionSection.tsx`
+
+```typescript
+interface CollectionSectionProps {
+  userId: string
+  isOwner: boolean
+}
+```
+
+하위 탭: 내가 만든 코스 | 저장한 코스
+
+#### ManagementSection
+
+**파일**: `src/components/profile/sections/ManagementSection.tsx`
+
+```typescript
+interface ManagementSectionProps {
+  userId: string
+}
+```
+
+하위 탭: 프로필 편집 | 계정 연동 | 알림 설정
+
+기존 `/settings/account` 페이지의 `AccountSettingsContent` 로직을 재사용.
+
+### 5. API 엔드포인트
+
+#### GET /api/users/[id]/routes
+
+```typescript
+// 응답 (200 OK)
+{
+  routes: Array<{
+    id: string
+    name: string
+    spotCount: number
+    bookmarkCount: number
+    createdAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/bookmarks
+
+```typescript
+// 응답 (200 OK)
+{
+  bookmarks: Array<{
+    id: string          // route ID
+    name: string        // route name
+    authorName: string
+    spotCount: number
+    bookmarkedAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/completions
+
+```typescript
+// 응답 (200 OK)
+{
+  completions: Array<{
+    id: string
+    routeId: string
+    routeName: string
+    spotCount: number
+    completedAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/reports
+
+```typescript
+// 응답 (200 OK)
+{
+  reports: Array<{
+    id: string
+    spotName: string
+    status: 'pending' | 'approved' | 'rejected'
+    createdAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/supplements
+
+```typescript
+// 응답 (200 OK)
+{
+  supplements: Array<{
+    id: string
+    spotName: string
+    type: string        // 보완 유형
+    status: 'pending' | 'approved' | 'rejected'
+    createdAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/status-reports
+
+```typescript
+// 응답 (200 OK)
+{
+  statusReports: Array<{
+    id: string
+    spotName: string
+    reportedStatus: string
+    resolved: boolean
+    createdAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/posts
+
+```typescript
+// 응답 (200 OK)
+{
+  posts: Array<{
+    id: string
+    title: string
+    contentPreview: string  // 내용 앞 100자
+    viewCount: number
+    commentCount: number
+    createdAt: string
+  }>
+}
+```
+
+#### GET /api/users/[id]/comments
+
+```typescript
+// 응답 (200 OK)
+{
+  comments: Array<{
+    id: string
+    postId: string
+    postTitle: string
+    contentPreview: string  // 댓글 내용 앞 80자
+    createdAt: string
+  }>
+}
+```
+
+#### PUT /api/users/[id]
+
+```typescript
+// 요청 Body
+{
+  name?: string
+  image?: string
+}
+
+// 응답 (200 OK)
+{
+  id: string
+  name: string
+  image: string | null
+  updatedAt: string
+}
+
+// 응답 (400 Bad Request)
+{ error: '이름을 입력해주세요' }
+
+// 응답 (403 Forbidden)
+{ error: '본인의 프로필만 수정할 수 있습니다' }
+
+// 응답 (404 Not Found)
+{ error: '유저를 찾을 수 없습니다' }
+```
+
+### 6. API 상수 확장
+
+**파일**: `src/lib/api-routes.ts`
+
+```typescript
+USERS: {
+  INFO: (id: string) => `/api/users/${id}`,
+  STATS: (id: string) => `/api/users/${id}/stats`,
+  BADGES: (id: string) => `/api/users/${id}/badges`,
+  PROGRESS: (id: string) => `/api/users/${id}/progress`,
+  // 신규 추가
+  ROUTES: (id: string) => `/api/users/${id}/routes`,
+  BOOKMARKS: (id: string) => `/api/users/${id}/bookmarks`,
+  COMPLETIONS: (id: string) => `/api/users/${id}/completions`,
+  REPORTS: (id: string) => `/api/users/${id}/reports`,
+  SUPPLEMENTS: (id: string) => `/api/users/${id}/supplements`,
+  STATUS_REPORTS: (id: string) => `/api/users/${id}/status-reports`,
+  POSTS: (id: string) => `/api/users/${id}/posts`,
+  COMMENTS: (id: string) => `/api/users/${id}/comments`,
+  UPDATE: (id: string) => `/api/users/${id}`,
+}
+```
+
+### 7. React Query 훅 확장
+
+**파일**: `src/hooks/useUserQueries.ts`
+
+```typescript
+// 쿼리 키 팩토리 확장
+export const userKeys = {
+  all: ['users'] as const,
+  info: (userId: string) => [...userKeys.all, 'info', userId] as const,
+  stats: (userId: string) => [...userKeys.all, 'stats', userId] as const,
+  badges: (userId: string) => [...userKeys.all, 'badges', userId] as const,
+  progress: (userId: string) => [...userKeys.all, 'progress', userId] as const,
+  reportedSpots: (userId: string) => [...userKeys.all, 'reportedSpots', userId] as const,
+  // 신규 추가
+  routes: (userId: string) => [...userKeys.all, 'routes', userId] as const,
+  bookmarks: (userId: string) => [...userKeys.all, 'bookmarks', userId] as const,
+  completions: (userId: string) => [...userKeys.all, 'completions', userId] as const,
+  reports: (userId: string) => [...userKeys.all, 'reports', userId] as const,
+  supplements: (userId: string) => [...userKeys.all, 'supplements', userId] as const,
+  statusReports: (userId: string) => [...userKeys.all, 'statusReports', userId] as const,
+  posts: (userId: string) => [...userKeys.all, 'posts', userId] as const,
+  comments: (userId: string) => [...userKeys.all, 'comments', userId] as const,
+}
+
+// 신규 훅들
+export function useUserRoutes(userId: string, enabled?: boolean)
+export function useUserBookmarks(userId: string, enabled?: boolean)
+export function useUserCompletions(userId: string, enabled?: boolean)
+export function useUserReports(userId: string, enabled?: boolean)
+export function useUserSupplements(userId: string, enabled?: boolean)
+export function useUserStatusReports(userId: string, enabled?: boolean)
+export function useUserPosts(userId: string, enabled?: boolean)
+export function useUserComments(userId: string, enabled?: boolean)
+export function useUpdateProfile(userId: string)  // useMutation
+```
+
+각 훅은 `enabled` 파라미터로 lazy loading을 지원한다. 해당 섹션/탭이 활성화될 때만 `enabled: true`로 전환.
+
+### 8. 헤더 수정
+
+**파일**: `src/components/layout/Header.tsx`
+
+변경 사항:
+- 데스크톱 프로필 링크: `href="/settings/account"` → `href={`/profile/${user.id}`}`
+- 모바일 메뉴 "계정 설정" 링크: `href="/settings/account"` → `href={`/profile/${user.id}`}`
+- 모바일 메뉴 텍스트: "계정 설정" → "마이페이지"
+
+---
+
+## Data Models
+
+### ExtendedUserStats (확장 통계)
+
+기존 `UserStats`를 확장하여 추가 통계를 포함한다.
+
+```typescript
+interface ExtendedUserStats extends UserStats {
+  /** 완주한 코스 수 */
+  completedRoutes: number
+  /** 등록한 스팟 수 */
+  registeredSpots: number
+  /** 제보 수 (spot_reports) */
+  reportCount: number
+  /** 게시글 수 */
+  postCount: number
+}
+```
+
+기존 `GET /api/users/[id]/stats` 엔드포인트를 확장하여 추가 필드를 반환한다.
+
+### UserRoute (유저 코스)
+
+```typescript
+interface UserRoute {
+  id: string
+  name: string
+  spotCount: number
+  bookmarkCount: number
+  createdAt: string
+}
+```
+
+### UserBookmark (저장한 코스)
+
+```typescript
+interface UserBookmark {
+  id: string          // route ID
+  name: string
+  authorName: string
+  spotCount: number
+  bookmarkedAt: string
+}
+```
+
+### UserCompletion (코스 완주)
+
+```typescript
+interface UserCompletion {
+  id: string
+  routeId: string
+  routeName: string
+  spotCount: number
+  completedAt: string
+}
+```
+
+### UserReport (신규 제보)
+
+```typescript
+interface UserReport {
+  id: string
+  spotName: string
+  status: 'pending' | 'approved' | 'rejected'
+  createdAt: string
+}
+```
+
+### UserSupplement (정보보완)
+
+```typescript
+interface UserSupplement {
+  id: string
+  spotName: string
+  type: string
+  status: 'pending' | 'approved' | 'rejected'
+  createdAt: string
+}
+```
+
+### UserStatusReport (상태신고)
+
+```typescript
+interface UserStatusReport {
+  id: string
+  spotName: string
+  reportedStatus: string
+  resolved: boolean
+  createdAt: string
+}
+```
+
+### UserPost (게시글)
+
+```typescript
+interface UserPost {
+  id: string
+  title: string
+  contentPreview: string
+  viewCount: number
+  commentCount: number
+  createdAt: string
+}
+```
+
+### UserComment (댓글)
+
+```typescript
+interface UserComment {
+  id: string
+  postId: string
+  postTitle: string
+  contentPreview: string
+  createdAt: string
+}
+```
+
+### MongoDB 컬렉션 매핑
+
+| 데이터 타입 | 컬렉션 | 필터 필드 |
+|------------|--------|-----------|
+| 유저 코스 | `routes` | `authorId` |
+| 저장한 코스 | `route_bookmarks` | `userId` |
+| 코스 완주 | `route_completions` | `userId` |
+| 신규 제보 | `spot_reports` | `reporterId` |
+| 정보보완 | `spot_supplements` | `contributorId` |
+| 상태신고 | `spot_status_reports` | `reporterId` |
+| 게시글 | `posts` | `userId` |
+| 댓글 | `comments` | `userId` |
+| 등록 스팟 | `spots` | `authorId` |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: 헤더 프로필 링크 정확성
+
+*For any* 로그인된 유저 세션에 대해, 헤더의 모든 프로필 관련 링크(데스크톱 및 모바일)의 href는 `/profile/{session.user.id}` 형식이어야 하며, `/settings/account`를 가리키는 링크가 존재하지 않아야 한다.
+
+**Validates: Requirements 1.2, 1.3, 1.4**
+
+### Property 2: Owner 전용 UI 가시성
+
+*For any* `sessionUserId`와 `urlUserId` 조합에 대해, "관리" 섹션과 "편집" 버튼은 `sessionUserId === urlUserId`인 경우에만 표시되고, 그 외(불일치 또는 세션 없음)에는 표시되지 않아야 한다.
+
+**Validates: Requirements 2.4, 2.5, 2.6, 3.4, 8.2, 8.3**
+
+### Property 3: 섹션 네비게이션 상태 일관성
+
+*For any* 프로필 섹션 탭 클릭에 대해, 클릭된 섹션이 활성 상태로 전환되고 해당 섹션의 콘텐츠가 렌더링되어야 한다.
+
+**Validates: Requirements 2.2**
+
+### Property 4: 목록 항목 필드 완전성
+
+*For any* 유효한 데이터 레코드에 대해, 각 목록 항목의 렌더링 결과는 해당 타입에 정의된 모든 필수 필드를 포함해야 한다:
+- 코스 완주: 코스 이름, 완주일, 스팟 수
+- 등록 스팟: 이름, 주소, 카테고리, 등록일
+- 신규 제보: 스팟 이름, 제보일, 처리 상태
+- 게시글: 제목/미리보기, 작성일, 조회수, 댓글 수
+- 댓글: 내용 미리보기, 작성일, 원문 게시글 링크
+- 코스: 이름, 스팟 수, 생성일, 북마크 수
+
+**Validates: Requirements 3.3, 3.6, 4.3, 4.5, 4.7, 4.9, 5.3, 5.6, 6.3, 6.5**
+
+### Property 5: 상세 페이지 네비게이션 정확성
+
+*For any* 목록 항목(게시글, 댓글, 코스)에 대해, 해당 항목의 링크 href는 올바른 상세 페이지 경로를 가리켜야 한다:
+- 게시글 → `/community/posts/{postId}`
+- 댓글 → `/community/posts/{comment.postId}`
+- 코스 → `/routes/{routeId}`
+
+**Validates: Requirements 5.4, 5.7, 6.6**
+
+### Property 6: 프로필 이름 유효성 검사
+
+*For any* 빈 문자열 또는 공백만으로 구성된 문자열을 프로필 이름으로 제출하면, 시스템은 이를 거부하고 "이름을 입력해주세요" 에러를 표시해야 한다.
+
+**Validates: Requirements 7.5**
+
+### Property 7: 프로필 헤더 데이터 완전성
+
+*For any* 유효한 `UserInfo`와 `ExtendedUserStats` 데이터에 대해, 프로필 헤더는 유저 이름, 프로필 이미지(또는 기본 아이콘), 가입일, 그리고 모든 통계 항목(총 인증 수, 방문 스팟 수, 획득 배지 수, 완주 코스 수, 등록 스팟 수, 제보 수, 게시글 수)을 표시해야 한다.
+
+**Validates: Requirements 8.1, 8.4, 8.5**
+
+### Property 8: API 유저 데이터 필터링 정확성
+
+*For any* 유저 ID와 데이터 컬렉션에 대해, `GET /api/users/[id]/{resource}` 엔드포인트는 해당 유저의 데이터만 반환해야 한다. 즉, 반환된 모든 레코드의 소유자 필드(authorId, userId, reporterId, contributorId)가 요청된 유저 ID와 일치해야 한다.
+
+**Validates: Requirements 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8**
+
+### Property 9: 프로필 업데이트 라운드트립
+
+*For any* 유효한 이름과 이미지 URL에 대해, `PUT /api/users/[id]`로 업데이트한 후 `GET /api/users/[id]`로 조회하면 업데이트된 이름과 이미지가 반환되어야 한다.
+
+**Validates: Requirements 9.9**
+
+### Property 10: 프로필 업데이트 권한 검증
+
+*For any* 두 개의 서로 다른 유저 ID(세션 유저 ID ≠ URL 파라미터 ID)에 대해, `PUT /api/users/[id]` 요청은 HTTP 403 응답을 반환해야 한다.
+
+**Validates: Requirements 9.10**
+
+### Property 11: /settings/account 리다이렉트
+
+*For any* 로그인된 유저가 `/settings/account` 경로에 접근하면, `/profile/{session.user.id}` 경로로 리다이렉트되어야 한다.
+
+**Validates: Requirements 10.1**
+
+### Property 12: 빈 상태 Owner 액션 링크
+
+*For any* 섹션/탭 조합에서 데이터가 비어있고 `isOwner === true`인 경우, 빈 상태 UI에는 관련 기능으로 이동하는 액션 링크가 포함되어야 한다.
+
+**Validates: Requirements 11.2, 11.3**
+
+---
+
+## Error Handling
+
+### API Route 에러 처리
+
+| 상황 | HTTP 상태 | 응답 본문 |
+|------|-----------|-----------|
+| 유저 없음 | 404 | `{ error: '유저를 찾을 수 없습니다' }` |
+| 권한 없음 (PUT) | 403 | `{ error: '본인의 프로필만 수정할 수 있습니다' }` |
+| 유효성 검사 실패 | 400 | `{ error: '이름을 입력해주세요' }` |
+| DB 오류 | 500 | `{ error: '데이터 조회에 실패했습니다' }` |
+| 잘못된 ObjectId | 400 | `{ error: '잘못된 유저 ID입니다' }` |
+
+### 클라이언트 에러 처리
+
+- **React Query `isError` 상태**: 각 섹션별로 에러 메시지 + 재시도 버튼 표시
+- **네트워크 오류**: "네트워크 연결을 확인해주세요" 메시지
+- **인증 만료**: 로그인 페이지로 리다이렉트
+
+### 프로필 편집 유효성 검사
+
+| 필드 | 검증 규칙 | 에러 메시지 |
+|------|-----------|------------|
+| name | 빈 문자열 또는 공백만 | "이름을 입력해주세요" |
+| name | 50자 초과 | "이름은 50자 이내로 입력해주세요" |
+| image | 유효하지 않은 URL | "올바른 이미지 URL이 아닙니다" |
+
+### 빈 상태 처리
+
+각 탭별 빈 상태 메시지:
+
+| 탭 | 빈 상태 메시지 | Owner 액션 링크 |
+|----|---------------|----------------|
+| 인증 갤러리 | "아직 인증 기록이 없습니다" | "성지 탐색하러 가기" → `/` |
+| 코스 완주 | "아직 완주한 코스가 없습니다" | "코스 탐색하기" → `/routes` |
+| 트로피 룸 | "아직 획득한 배지가 없습니다" | — |
+| 등록한 스팟 | "아직 등록한 스팟이 없습니다" | "스팟 등록하기" → `/spots/register` |
+| 신규 제보 | "아직 제보한 스팟이 없습니다" | "스팟 제보하기" → `/reports/new` |
+| 내 게시글 | "아직 작성한 게시글이 없습니다" | "커뮤니티 가기" → `/community` |
+| 내가 만든 코스 | "아직 만든 코스가 없습니다" | "코스 만들기" → `/routes/create` |
+| 저장한 코스 | "아직 저장한 코스가 없습니다" | "코스 탐색하기" → `/routes` |
+
+---
+
+## Testing Strategy
+
+### 단위 테스트 (Unit Tests)
+
+**API Route 테스트**:
+- 각 GET 엔드포인트: 정상 응답, 유저 없음 404, DB 오류 500
+- PUT 엔드포인트: 정상 업데이트, 권한 없음 403, 유효성 실패 400, 유저 없음 404
+
+**컴포넌트 테스트**:
+- `SectionNavigation`: 탭 클릭 시 콜백 호출 확인
+- `ProfileHeader`: 통계 데이터 렌더링 확인
+- 각 섹션 컴포넌트: 로딩/빈 상태/데이터 상태 렌더링
+
+**유틸 함수 테스트**:
+- `formatJoinDate`: 다양한 날짜 입력에 대한 포맷 확인
+- 프로필 이름 유효성 검사 함수
+
+### 속성 기반 테스트 (Property-Based Tests)
+
+**라이브러리**: `fast-check` (프로젝트 기존 사용)
+
+**Property 2 — Owner 전용 UI 가시성**:
+```typescript
+// Feature: 45-profile-complete, Property 2: Owner 전용 UI 가시성
+fc.assert(fc.property(
+  fc.string({ minLength: 1 }),
+  fc.string({ minLength: 1 }),
+  (sessionUserId, urlUserId) => {
+    const isOwner = sessionUserId === urlUserId
+    // isOwner일 때만 관리 섹션과 편집 버튼이 표시되어야 함
+    const managementVisible = isOwner
+    const editButtonVisible = isOwner
+    return managementVisible === isOwner && editButtonVisible === isOwner
+  }
+), { numRuns: 100 })
+```
+
+**Property 6 — 프로필 이름 유효성 검사**:
+```typescript
+// Feature: 45-profile-complete, Property 6: 프로필 이름 유효성 검사
+fc.assert(fc.property(
+  fc.stringOf(fc.constantFrom(' ', '\t', '\n', '\r', '')),
+  (whitespaceOnlyName) => {
+    const result = validateProfileName(whitespaceOnlyName)
+    return result.valid === false && result.error === '이름을 입력해주세요'
+  }
+), { numRuns: 100 })
+```
+
+**Property 8 — API 유저 데이터 필터링 정확성**:
+```typescript
+// Feature: 45-profile-complete, Property 8: API 유저 데이터 필터링 정확성
+fc.assert(fc.asyncProperty(
+  fc.string({ minLength: 1 }),
+  fc.array(fc.record({ authorId: fc.string(), name: fc.string() })),
+  async (targetUserId, routes) => {
+    // mock DB에 routes 삽입 후 API 호출
+    const response = await callRoutesApi(targetUserId)
+    const body = await response.json()
+    // 반환된 모든 route의 authorId가 targetUserId와 일치해야 함
+    return body.routes.every((r: { authorId: string }) => r.authorId === targetUserId)
+  }
+), { numRuns: 100 })
+```
+
+**Property 9 — 프로필 업데이트 라운드트립**:
+```typescript
+// Feature: 45-profile-complete, Property 9: 프로필 업데이트 라운드트립
+fc.assert(fc.asyncProperty(
+  fc.string({ minLength: 1, maxLength: 50 }),
+  fc.webUrl(),
+  async (newName, newImage) => {
+    // PUT으로 업데이트 후 GET으로 조회
+    await callPutApi(userId, { name: newName, image: newImage })
+    const response = await callGetApi(userId)
+    const body = await response.json()
+    return body.name === newName && body.image === newImage
+  }
+), { numRuns: 100 })
+```
+
+**Property 10 — 프로필 업데이트 권한 검증**:
+```typescript
+// Feature: 45-profile-complete, Property 10: 프로필 업데이트 권한 검증
+fc.assert(fc.asyncProperty(
+  fc.string({ minLength: 1 }),
+  fc.string({ minLength: 1 }),
+  fc.string({ minLength: 1 }),
+  async (sessionUserId, urlUserId, newName) => {
+    fc.pre(sessionUserId !== urlUserId)  // 서로 다른 ID만 테스트
+    const response = await callPutApiWithSession(sessionUserId, urlUserId, { name: newName })
+    return response.status === 403
+  }
+), { numRuns: 100 })
+```
+
+**Property 11 — /settings/account 리다이렉트**:
+```typescript
+// Feature: 45-profile-complete, Property 11: /settings/account 리다이렉트
+fc.assert(fc.property(
+  fc.string({ minLength: 1 }),
+  (userId) => {
+    const redirectUrl = getSettingsRedirectUrl(userId)
+    return redirectUrl === `/profile/${userId}`
+  }
+), { numRuns: 100 })
+```
+
+### 테스트 구성
+
+- 각 속성 테스트는 최소 **100회 반복** 실행
+- 각 테스트에 **Feature: 45-profile-complete, Property N: {title}** 태그 포함
+- `fast-check` 라이브러리 사용 (프로젝트 기존 의존성)
+
+### 통합 테스트
+
+- 프로필 페이지 전체 렌더링 (로그인/비로그인 상태)
+- 섹션 전환 및 데이터 로딩 확인
+- `/settings/account` 리다이렉트 동작 확인
+- 프로필 편집 폼 제출 → API 호출 → UI 업데이트 흐름

--- a/.kiro/specs/45-profile-complete/requirements.md
+++ b/.kiro/specs/45-profile-complete/requirements.md
@@ -1,0 +1,184 @@
+# Requirements Document
+
+## Introduction
+
+개인 프로필 페이지(`/profile/[id]`)를 "내 활동 허브"로 완성한다. 현재 프로필 페이지는 인증 갤러리/배지/진행 현황/최초 제보 스팟 4개 탭만 제공하지만, 실제 서비스에서 유저가 생성·참여하는 데이터는 훨씬 다양하다.
+
+본 spec은 서비스 전체 인벤토리를 기반으로 마이페이지를 **활동 / 기여 / 커뮤니티 / 보관함 / 관리** 5개 섹션으로 재편하고, `/settings/account` 페이지를 프로필에 통합하며, 헤더 프로필 링크를 수정하고, 프로필 편집 기능을 구현한다. 또한 현재 `/profile/[id]` 접근 시 발생하는 에러를 함께 수정한다.
+
+## Glossary
+
+- **Profile_Page**: `/profile/[id]` 경로의 유저 프로필 페이지
+- **Activity_Hub**: 프로필 페이지의 전체 구조 — 활동/기여/커뮤니티/보관함/관리 섹션으로 구성
+- **Header**: 전역 네비게이션 헤더 컴포넌트 (`src/components/layout/Header.tsx`)
+- **Owner**: URL 파라미터 `id`와 현재 로그인 유저의 Session `user.id`가 일치하는 경우 (본인 프로필)
+- **Visitor**: Owner가 아닌 프로필 페이지 방문자 (비로그인 포함)
+- **Section_Navigation**: 프로필 페이지의 섹션/탭 전환 UI
+- **Route_Bookmark**: `route_bookmarks` 컬렉션의 코스 북마크 데이터
+- **Route_Completion**: `route_completions` 컬렉션의 코스 완주 기록 데이터
+- **Spot_Report**: `spot_reports` 컬렉션의 신규 스팟 제보 데이터 (reporterId 기반)
+- **Supplement**: `supplements` 컬렉션의 정보보완 신청 데이터 (contributorId 기반)
+- **Status_Report**: `status_reports` 컬렉션의 현재 상태 신고 데이터 (reporterId 기반)
+
+## Requirements
+
+### Requirement 1: 프로필 페이지 에러 수정 및 헤더 링크 변경
+
+**User Story:** As a 로그인한 유저, I want 헤더의 프로필 아이콘을 클릭하면 에러 없이 내 프로필 페이지로 이동하기를, so that 내 활동과 정보를 바로 확인할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Profile_Page SHALL `/profile/[id]` 경로 접근 시 에러 없이 정상적으로 렌더링된다.
+2. WHEN 로그인한 유저가 Header의 프로필 아이콘/이름 영역을 클릭하면, THE Header SHALL `/profile/{현재 로그인 유저의 ID}` 경로로 이동한다.
+3. WHEN 로그인한 유저가 모바일 메뉴에서 프로필 관련 링크를 클릭하면, THE Header SHALL `/profile/{현재 로그인 유저의 ID}` 경로로 이동한다.
+4. THE Header SHALL 기존 `/settings/account` 링크를 모두 `/profile/{현재 로그인 유저의 ID}` 링크로 대체한다.
+
+### Requirement 2: 섹션 구조 재설계 — 활동 허브
+
+**User Story:** As a 프로필 페이지 방문자, I want 유저의 다양한 활동을 체계적으로 구분하여 탐색하기를, so that 원하는 정보를 빠르게 찾을 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Profile_Page SHALL 다음 5개 섹션을 제공한다: **활동**, **기여**, **커뮤니티**, **보관함**, **관리**.
+2. THE Section_Navigation SHALL 섹션 간 전환을 지원하며, 현재 활성 섹션을 시각적으로 구분한다.
+3. THE Section_Navigation SHALL 화면 너비가 좁을 경우 가로 스크롤 또는 드롭다운으로 접근성을 유지한다.
+4. WHEN Owner가 본인 프로필을 방문하면, THE Profile_Page SHALL 5개 섹션 모두를 표시한다.
+5. WHEN Visitor가 타인 프로필을 방문하면, THE Profile_Page SHALL "관리" 섹션을 표시하지 않는다.
+6. WHEN 비로그인 상태에서 프로필 페이지를 방문하면, THE Profile_Page SHALL Visitor와 동일하게 "관리" 섹션을 표시하지 않는다.
+
+### Requirement 3: 활동 섹션 — 인증, 코스 완주, 배지, 진행도
+
+**User Story:** As a 프로필 페이지 방문자, I want 유저의 순례 활동 기록을 한눈에 보기를, so that 유저의 순례 성과를 확인할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE 활동 섹션 SHALL 다음 하위 탭을 포함한다: 인증 갤러리, 코스 완주, 트로피 룸, 진행 현황.
+2. WHEN "인증 갤러리" 탭이 활성화되면, THE Profile_Page SHALL 유저의 체크인 기록을 사진 그리드로 표시한다.
+3. THE 인증 갤러리 SHALL 각 인증에 사진, 스팟 이름, 방문일, 코멘트를 포함한다.
+4. WHEN Owner가 본인 인증 갤러리를 볼 때, THE Profile_Page SHALL 각 인증에 삭제 버튼을 표시한다.
+5. WHEN "코스 완주" 탭이 활성화되면, THE Profile_Page SHALL 유저의 Route_Completion 목록을 표시한다.
+6. THE 코스 완주 목록 SHALL 각 완주 기록에 코스 이름, 완주일, 스팟 수를 포함한다.
+7. WHEN "트로피 룸" 탭이 활성화되면, THE Profile_Page SHALL 유저의 획득 배지 목록을 표시한다.
+8. WHEN "진행 현황" 탭이 활성화되면, THE Profile_Page SHALL 유저의 작품별 스팟 방문 진행률을 표시한다.
+
+### Requirement 4: 기여 섹션 — 등록 스팟, 제보, 정보보완, 상태신고
+
+**User Story:** As a 프로필 페이지 방문자, I want 유저가 서비스에 기여한 내역을 보기를, so that 유저의 기여도를 확인할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE 기여 섹션 SHALL 다음 하위 탭을 포함한다: 등록한 스팟, 신규 제보, 정보보완, 상태신고.
+2. WHEN "등록한 스팟" 탭이 활성화되면, THE Profile_Page SHALL `authorId`가 해당 유저인 스팟 목록을 표시한다.
+3. THE 등록한 스팟 목록 SHALL 각 스팟에 이름, 주소, 카테고리, 등록일을 포함한다.
+4. WHEN "신규 제보" 탭이 활성화되면, THE Profile_Page SHALL 유저의 Spot_Report 목록을 상태(대기/승인/반려)와 함께 표시한다.
+5. THE 신규 제보 목록 SHALL 각 제보에 스팟 이름, 제보일, 처리 상태를 포함한다.
+6. WHEN "정보보완" 탭이 활성화되면, THE Profile_Page SHALL 유저의 Supplement 목록을 상태와 함께 표시한다.
+7. THE 정보보완 목록 SHALL 각 신청에 대상 스팟, 보완 유형, 신청일, 처리 상태를 포함한다.
+8. WHEN "상태신고" 탭이 활성화되면, THE Profile_Page SHALL 유저의 Status_Report 목록을 표시한다.
+9. THE 상태신고 목록 SHALL 각 신고에 대상 스팟, 신고 상태, 신고일, 처리 여부를 포함한다.
+
+### Requirement 5: 커뮤니티 섹션 — 게시글, 댓글
+
+**User Story:** As a 프로필 페이지 방문자, I want 유저의 커뮤니티 활동을 보기를, so that 유저가 작성한 글과 댓글을 확인할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE 커뮤니티 섹션 SHALL 다음 하위 탭을 포함한다: 내 게시글, 내 댓글.
+2. WHEN "내 게시글" 탭이 활성화되면, THE Profile_Page SHALL `userId`가 해당 유저인 게시글 목록을 표시한다.
+3. THE 게시글 목록 SHALL 각 게시글에 제목(또는 내용 미리보기), 작성일, 조회수, 댓글 수를 포함한다.
+4. WHEN 유저가 게시글을 클릭하면, THE Profile_Page SHALL 해당 게시글 상세 페이지로 이동한다.
+5. WHEN "내 댓글" 탭이 활성화되면, THE Profile_Page SHALL `userId`가 해당 유저인 댓글 목록을 표시한다.
+6. THE 댓글 목록 SHALL 각 댓글에 내용 미리보기, 작성일, 원문 게시글 링크를 포함한다.
+7. WHEN 유저가 댓글 항목을 클릭하면, THE Profile_Page SHALL 해당 댓글이 달린 게시글로 이동한다.
+
+### Requirement 6: 보관함 섹션 — 저장한 코스, 내가 만든 코스
+
+**User Story:** As a 프로필 페이지 방문자, I want 유저의 코스 관련 데이터를 보기를, so that 유저가 만들거나 저장한 코스를 참고할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE 보관함 섹션 SHALL 다음 하위 탭을 포함한다: 내가 만든 코스, 저장한 코스.
+2. WHEN "내가 만든 코스" 탭이 활성화되면, THE Profile_Page SHALL 해당 유저가 생성한 코스 목록을 표시한다.
+3. THE 코스 목록 SHALL 각 코스에 이름, 스팟 수, 생성일, 북마크 수를 포함한다.
+4. WHEN "저장한 코스" 탭이 활성화되면, THE Profile_Page SHALL 해당 유저의 Route_Bookmark 목록을 표시한다.
+5. THE 저장한 코스 목록 SHALL 각 코스에 이름, 작성자, 스팟 수를 포함한다.
+6. WHEN 유저가 코스 카드를 클릭하면, THE Profile_Page SHALL 해당 코스 상세 페이지(`/routes/[id]`)로 이동한다.
+7. WHEN 해당 목록이 비어있으면, THE Profile_Page SHALL 적절한 빈 상태 메시지와 관련 페이지 링크를 표시한다.
+8. WHEN Owner가 본인 프로필의 빈 상태를 볼 때, THE Profile_Page SHALL "코스 만들기" 또는 "코스 탐색하기" 액션 링크를 포함한다.
+
+### Requirement 7: 관리 섹션 — 계정 설정, 프로필 편집, 푸시 알림
+
+**User Story:** As a 로그인한 유저, I want 프로필 페이지에서 계정과 알림을 관리하기를, so that 별도 페이지로 이동하지 않고 한 곳에서 모든 설정을 처리할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE 관리 섹션 SHALL Owner에게만 표시되며, 다음 하위 탭을 포함한다: 프로필 편집, 계정 연동, 알림 설정.
+2. WHEN "프로필 편집" 탭이 활성화되면, THE Profile_Page SHALL 이름과 프로필 이미지 변경 폼을 표시한다.
+3. WHEN Owner가 이름을 변경하고 저장하면, THE Profile_Page SHALL `PUT /api/users/[id]` 엔드포인트를 호출하여 이름을 업데이트한다.
+4. WHEN Owner가 프로필 이미지를 변경하고 저장하면, THE Profile_Page SHALL 이미지를 업로드하고 유저 정보를 업데이트한다.
+5. IF 이름이 빈 문자열이면, THEN THE Profile_Page SHALL "이름을 입력해주세요" 유효성 검사 에러를 표시한다.
+6. WHEN "계정 연동" 탭이 활성화되면, THE Profile_Page SHALL 각 OAuth 프로바이더(Google, 카카오, 네이버, X)의 연결 상태와 연결/해제 버튼을 표시한다.
+7. WHILE 유저에게 비밀번호가 설정되어 있지 않으면, THE 계정 연동 탭 SHALL 이메일/비밀번호 설정 폼을 표시한다.
+8. WHEN "알림 설정" 탭이 활성화되면, THE Profile_Page SHALL 푸시 알림 구독/해제 토글을 표시한다.
+9. THE 관리 섹션 SHALL 기존 `/settings/account` 페이지의 모든 기능을 동일하게 제공한다.
+
+### Requirement 8: 프로필 헤더 및 통계 영역
+
+**User Story:** As a 프로필 페이지 방문자, I want 유저의 기본 정보와 핵심 통계를 프로필 상단에서 바로 보기를, so that 유저의 전반적인 활동 수준을 빠르게 파악할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE Profile_Page SHALL 프로필 헤더에 유저 이름, 프로필 이미지, 가입일을 표시한다.
+2. WHEN Owner가 본인 프로필을 방문하면, THE Profile_Page SHALL 프로필 헤더에 "편집" 버튼을 표시한다.
+3. WHEN Visitor가 타인 프로필을 방문하면, THE Profile_Page SHALL "편집" 버튼을 표시하지 않는다.
+4. THE Profile_Page SHALL 통계 영역에 총 인증 수, 방문 스팟 수, 획득 배지 수, 완주 코스 수를 표시한다.
+5. THE Profile_Page SHALL 통계 영역에 등록한 스팟 수, 제보 수, 게시글 수를 추가로 표시한다.
+
+### Requirement 9: 프로필 API 확장
+
+**User Story:** As a 프론트엔드 개발자, I want 유저의 활동 데이터를 조회하는 API를 사용하기를, so that 프로필 페이지에서 필요한 데이터를 효율적으로 가져올 수 있다.
+
+#### Acceptance Criteria
+
+1. WHEN `GET /api/users/[id]/routes` 요청이 수신되면, THE API SHALL 해당 유저가 생성한 코스 목록을 반환한다.
+2. WHEN `GET /api/users/[id]/bookmarks` 요청이 수신되면, THE API SHALL 해당 유저가 북마크한 코스 목록을 반환한다.
+3. WHEN `GET /api/users/[id]/completions` 요청이 수신되면, THE API SHALL 해당 유저의 코스 완주 기록을 반환한다.
+4. WHEN `GET /api/users/[id]/reports` 요청이 수신되면, THE API SHALL 해당 유저의 신규 스팟 제보 목록을 반환한다.
+5. WHEN `GET /api/users/[id]/supplements` 요청이 수신되면, THE API SHALL 해당 유저의 정보보완 신청 목록을 반환한다.
+6. WHEN `GET /api/users/[id]/status-reports` 요청이 수신되면, THE API SHALL 해당 유저의 상태신고 목록을 반환한다.
+7. WHEN `GET /api/users/[id]/posts` 요청이 수신되면, THE API SHALL 해당 유저의 게시글 목록을 반환한다.
+8. WHEN `GET /api/users/[id]/comments` 요청이 수신되면, THE API SHALL 해당 유저의 댓글 목록을 반환한다.
+9. WHEN `PUT /api/users/[id]` 요청이 수신되면, THE API SHALL 유저의 이름과 이미지를 업데이트한다.
+10. IF `PUT /api/users/[id]` 요청의 Session 유저 ID와 URL 파라미터 `id`가 일치하지 않으면, THEN THE API SHALL HTTP 403 응답을 반환한다.
+11. IF 요청된 `id`에 해당하는 유저가 존재하지 않으면, THEN THE API SHALL HTTP 404 응답을 반환한다.
+
+### Requirement 10: `/settings/account` 경로 리다이렉트
+
+**User Story:** As a 기존 유저, I want `/settings/account` URL로 접근해도 프로필 페이지로 안내받기를, so that 기존 북마크나 링크가 깨지지 않는다.
+
+#### Acceptance Criteria
+
+1. WHEN 로그인한 유저가 `/settings/account` 경로에 접근하면, THE System SHALL `/profile/{현재 로그인 유저의 ID}` 경로로 리다이렉트한다 (관리 섹션 활성 상태).
+2. WHEN 비로그인 유저가 `/settings/account` 경로에 접근하면, THE System SHALL 로그인 페이지로 리다이렉트한다.
+
+### Requirement 11: 빈 상태 및 로딩 UX
+
+**User Story:** As a 프로필 페이지 방문자, I want 데이터가 없거나 로딩 중일 때 적절한 피드백을 받기를, so that 페이지 상태를 명확히 인지할 수 있다.
+
+#### Acceptance Criteria
+
+1. WHILE 각 섹션의 데이터를 로딩 중이면, THE Profile_Page SHALL 해당 영역에 스켈레톤 UI를 표시한다.
+2. WHEN 특정 탭의 데이터가 비어있으면, THE Profile_Page SHALL 해당 탭에 맞는 빈 상태 메시지를 표시한다.
+3. WHEN Owner가 본인 프로필의 빈 상태를 볼 때, THE Profile_Page SHALL 관련 기능으로 이동하는 액션 링크를 포함한다.
+4. IF API 요청이 실패하면, THEN THE Profile_Page SHALL 에러 메시지를 표시하고 재시도 버튼을 제공한다.
+
+### Requirement 12: 우선순위 보류 항목 (설계 보완 후 추가)
+
+**User Story:** As a 서비스 운영자, I want 현재 데이터 모델이 부족한 기능을 식별하기를, so that 향후 마이페이지 확장 시 필요한 스키마 변경을 계획할 수 있다.
+
+#### Acceptance Criteria
+
+1. THE System SHALL 현재 scene 스키마에 작성자 ID가 없어 "내가 추가한 작품 속 장면" 기능은 본 spec 범위에서 제외한다.
+2. THE System SHALL 현재 장면 좋아요 조회 API가 없어 "내가 좋아요한 장면" 기능은 본 spec 범위에서 제외한다.
+3. THE System SHALL 현재 시설 제보의 reportedBy가 세션 기반이 아니어서 "내가 제보한 시설" 기능은 본 spec 범위에서 제외한다.
+4. THE System SHALL 위 3개 항목을 향후 스키마 보완 후 마이페이지에 추가할 수 있도록 확장 가능한 구조로 설계한다.

--- a/.kiro/specs/45-profile-complete/tasks.md
+++ b/.kiro/specs/45-profile-complete/tasks.md
@@ -1,0 +1,218 @@
+# Implementation Plan: 프로필 페이지 활동 허브 완성
+
+## Overview
+
+프로필 페이지를 5개 섹션(활동/기여/커뮤니티/보관함/관리) 허브로 재설계한다. 8개 신규 GET API + 1개 PUT API를 구현하고, React Query 훅을 확장하며, 기존 `/settings/account` 페이지를 관리 섹션에 통합한다. 헤더 프로필 링크를 수정하고 리다이렉트를 설정한다.
+
+## Tasks
+
+- [x] 1. API 상수 등록 및 타입 정의
+  - [x] 1.1 API_ROUTES.USERS 확장
+    - `src/lib/api-routes.ts`의 USERS 객체에 ROUTES, BOOKMARKS, COMPLETIONS, REPORTS, SUPPLEMENTS, STATUS_REPORTS, POSTS, COMMENTS, UPDATE 추가
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9_
+  - [x] 1.2 프로필 관련 타입 정의
+    - `src/types/index.ts`에 ExtendedUserStats, UserRoute, UserBookmark, UserCompletion, UserReport, UserSupplement, UserStatusReport, UserPost, UserComment 인터페이스 추가
+    - ProfileSection 타입 정의: `'activity' | 'contribution' | 'community' | 'collection' | 'management'`
+    - _Requirements: 2.1, 8.4, 8.5, 9.1~9.8_
+
+- [x] 2. API Routes 구현 — GET 엔드포인트
+  - [x] 2.1 GET /api/users/[id]/routes 구현
+    - `src/app/api/users/[id]/routes/route.ts` 생성
+    - `routes` 컬렉션에서 `authorId`로 필터링, 이름/스팟수/북마크수/생성일 반환
+    - _Requirements: 9.1_
+  - [x] 2.2 GET /api/users/[id]/bookmarks 구현
+    - `src/app/api/users/[id]/bookmarks/route.ts` 생성
+    - `route_bookmarks` 컬렉션에서 `userId`로 필터링, routes와 조인하여 코스 정보 반환
+    - _Requirements: 9.2_
+  - [x] 2.3 GET /api/users/[id]/completions 구현
+    - `src/app/api/users/[id]/completions/route.ts` 생성
+    - `route_completions` 컬렉션에서 `userId`로 필터링, routes와 조인하여 코스명/스팟수/완주일 반환
+    - _Requirements: 9.3_
+  - [x] 2.4 GET /api/users/[id]/reports 구현
+    - `src/app/api/users/[id]/reports/route.ts` 생성
+    - `spot_reports` 컬렉션에서 `reporterId`로 필터링, 스팟명/상태/제보일 반환
+    - _Requirements: 9.4_
+  - [x] 2.5 GET /api/users/[id]/supplements 구현
+    - `src/app/api/users/[id]/supplements/route.ts` 생성
+    - `spot_supplements` 컬렉션에서 `contributorId`로 필터링, 스팟명/유형/상태/신청일 반환
+    - _Requirements: 9.5_
+  - [x] 2.6 GET /api/users/[id]/status-reports 구현
+    - `src/app/api/users/[id]/status-reports/route.ts` 생성
+    - `spot_status_reports` 컬렉션에서 `reporterId`로 필터링, 스팟명/신고상태/처리여부/신고일 반환
+    - _Requirements: 9.6_
+  - [x] 2.7 GET /api/users/[id]/posts 구현
+    - `src/app/api/users/[id]/posts/route.ts` 생성
+    - `posts` 컬렉션에서 `userId`로 필터링, 제목/내용미리보기(100자)/조회수/댓글수/작성일 반환
+    - _Requirements: 9.7_
+  - [x] 2.8 GET /api/users/[id]/comments 구현
+    - `src/app/api/users/[id]/comments/route.ts` 생성
+    - `comments` 컬렉션에서 `userId`로 필터링, posts와 조인하여 게시글제목/내용미리보기(80자)/작성일 반환
+    - _Requirements: 9.8_
+  - [ ]* 2.9 GET 엔드포인트 속성 테스트
+    - **Property 8: API 유저 데이터 필터링 정확성**
+    - **Validates: Requirements 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8**
+
+- [x] 3. API Routes 구현 — PUT 엔드포인트 및 통계 확장
+  - [x] 3.1 PUT /api/users/[id] 구현
+    - `src/app/api/users/[id]/route.ts` 수정 (기존 GET에 PUT 핸들러 추가)
+    - 세션 검증 → 권한 확인(403) → 유효성 검사(400) → 업데이트 → 응답
+    - 이름: 빈 문자열/공백만 거부, 50자 제한
+    - _Requirements: 9.9, 9.10, 9.11_
+  - [x] 3.2 GET /api/users/[id]/stats 확장
+    - 기존 stats 엔드포인트에 completedRoutes, registeredSpots, reportCount, postCount 필드 추가
+    - route_completions, spots, spot_reports, posts 컬렉션에서 각각 count 집계
+    - _Requirements: 8.4, 8.5_
+  - [ ]* 3.3 PUT 엔드포인트 속성 테스트 — 이름 유효성
+    - **Property 6: 프로필 이름 유효성 검사**
+    - **Validates: Requirements 7.5**
+  - [ ]* 3.4 PUT 엔드포인트 속성 테스트 — 권한 검증
+    - **Property 10: 프로필 업데이트 권한 검증**
+    - **Validates: Requirements 9.10**
+  - [ ]* 3.5 PUT 엔드포인트 속성 테스트 — 라운드트립
+    - **Property 9: 프로필 업데이트 라운드트립**
+    - **Validates: Requirements 9.9**
+
+- [x] 4. Checkpoint — API 레이어 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. React Query 훅 확장
+  - [x] 5.1 쿼리 키 팩토리 및 신규 훅 추가
+    - `src/hooks/useUserQueries.ts`에 userKeys 확장 (routes, bookmarks, completions, reports, supplements, statusReports, posts, comments)
+    - useUserRoutes, useUserBookmarks, useUserCompletions, useUserReports, useUserSupplements, useUserStatusReports, useUserPosts, useUserComments 훅 구현
+    - 각 훅에 `enabled` 파라미터로 lazy loading 지원
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8_
+  - [x] 5.2 useUpdateProfile mutation 훅 추가
+    - `src/hooks/useUserQueries.ts`에 useMutation 기반 useUpdateProfile 훅 구현
+    - 성공 시 userKeys.info 쿼리 무효화
+    - _Requirements: 9.9_
+
+- [x] 6. 프로필 페이지 에러 수정 및 헤더 링크 변경
+  - [x] 6.1 Header 프로필 링크 수정
+    - `src/components/layout/Header.tsx` 수정
+    - 데스크톱: `href="/settings/account"` → `href={`/profile/${user.id}`}`
+    - 모바일 메뉴: `href="/settings/account"` → `href={`/profile/${user.id}`}`, 텍스트 "계정 설정" → "마이페이지"
+    - _Requirements: 1.2, 1.3, 1.4_
+  - [x] 6.2 프로필 페이지 기존 에러 수정
+    - `src/app/profile/[id]/page.tsx`의 기존 렌더링 에러 확인 및 수정
+    - _Requirements: 1.1_
+  - [ ]* 6.3 헤더 링크 속성 테스트
+    - **Property 1: 헤더 프로필 링크 정확성**
+    - **Validates: Requirements 1.2, 1.3, 1.4**
+
+- [x] 7. 프로필 페이지 재구조화 — 네비게이션 컴포넌트
+  - [x] 7.1 SectionNavigation 컴포넌트 구현
+    - `src/components/profile/SectionNavigation.tsx` 생성
+    - 5개 섹션 탭 (활동/기여/커뮤니티/보관함/관리), 가로 스크롤 지원
+    - `isOwner === false`일 때 "관리" 탭 미표시
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+  - [x] 7.2 SubTabNavigation 컴포넌트 구현
+    - `src/components/profile/SubTabNavigation.tsx` 생성
+    - 각 섹션 내 하위 탭 전환 UI (재사용 가능한 범용 컴포넌트)
+    - _Requirements: 2.2_
+  - [x] 7.3 ProfileHeader 컴포넌트 리팩토링
+    - `src/components/profile/ProfileHeader.tsx` 수정 또는 신규 생성
+    - ExtendedUserStats 기반 통계 표시 (총 인증, 방문 스팟, 배지, 완주 코스, 등록 스팟, 제보, 게시글)
+    - Owner일 때만 "편집" 버튼 표시
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+  - [x] 7.4 프로필 페이지 메인 레이아웃 재구성
+    - `src/app/profile/[id]/page.tsx` 전면 리팩토링
+    - URL 쿼리 파라미터 `?section=` 지원, 기본값 'activity'
+    - ProfileHeader + SectionNavigation + 섹션 콘텐츠 구조
+    - _Requirements: 2.1, 2.2, 2.4, 2.5, 2.6_
+  - [ ]* 7.5 Owner 전용 UI 가시성 속성 테스트
+    - **Property 2: Owner 전용 UI 가시성**
+    - **Validates: Requirements 2.4, 2.5, 2.6, 3.4, 8.2, 8.3**
+  - [ ]* 7.6 섹션 네비게이션 상태 일관성 속성 테스트
+    - **Property 3: 섹션 네비게이션 상태 일관성**
+    - **Validates: Requirements 2.2**
+
+- [x] 8. 활동 섹션 구현
+  - [x] 8.1 ActivitySection 컴포넌트 구현
+    - `src/components/profile/sections/ActivitySection.tsx` 생성
+    - 하위 탭: 인증 갤러리 | 코스 완주 | 트로피 룸 | 진행 현황
+    - 인증 갤러리: 기존 `CheckInGallery` 컴포넌트 재사용
+    - 코스 완주: useUserCompletions 훅으로 완주 목록 표시 (코스명, 완주일, 스팟수)
+    - 트로피 룸: 기존 `TrophyRoom` 컴포넌트 재사용
+    - 진행 현황: 기존 `ContentProgressCard` 컴포넌트 재사용
+    - Owner일 때 인증 갤러리에 삭제 버튼 표시
+    - 각 탭 빈 상태 메시지 및 Owner 액션 링크 포함
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 11.1, 11.2, 11.3_
+
+- [x] 9. 기여 섹션 구현
+  - [x] 9.1 ContributionSection 컴포넌트 구현
+    - `src/components/profile/sections/ContributionSection.tsx` 생성
+    - 하위 탭: 등록한 스팟 | 신규 제보 | 정보보완 | 상태신고
+    - 등록한 스팟: 기존 useUserReportedSpots 훅 활용 (이름, 주소, 카테고리, 등록일)
+    - 신규 제보: useUserReports 훅 (스팟명, 제보일, 처리상태 뱃지)
+    - 정보보완: useUserSupplements 훅 (스팟명, 보완유형, 신청일, 처리상태)
+    - 상태신고: useUserStatusReports 훅 (스팟명, 신고상태, 신고일, 처리여부)
+    - 각 탭 빈 상태 메시지 및 Owner 액션 링크 포함
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 11.2, 11.3_
+
+- [x] 10. 커뮤니티 섹션 구현
+  - [x] 10.1 CommunitySection 컴포넌트 구현
+    - `src/components/profile/sections/CommunitySection.tsx` 생성
+    - 하위 탭: 내 게시글 | 내 댓글
+    - 내 게시글: useUserPosts 훅 (제목/미리보기, 작성일, 조회수, 댓글수), 클릭 시 `/community/posts/{postId}` 이동
+    - 내 댓글: useUserComments 훅 (내용 미리보기, 작성일, 원문 게시글 링크), 클릭 시 `/community/posts/{postId}` 이동
+    - 각 탭 빈 상태 메시지 및 Owner 액션 링크 포함
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 11.2, 11.3_
+  - [ ]* 10.2 상세 페이지 네비게이션 속성 테스트
+    - **Property 5: 상세 페이지 네비게이션 정확성**
+    - **Validates: Requirements 5.4, 5.7, 6.6**
+
+- [x] 11. 보관함 섹션 구현
+  - [x] 11.1 CollectionSection 컴포넌트 구현
+    - `src/components/profile/sections/CollectionSection.tsx` 생성
+    - 하위 탭: 내가 만든 코스 | 저장한 코스
+    - 내가 만든 코스: useUserRoutes 훅 (이름, 스팟수, 생성일, 북마크수), 클릭 시 `/routes/{routeId}` 이동
+    - 저장한 코스: useUserBookmarks 훅 (이름, 작성자, 스팟수), 클릭 시 `/routes/{routeId}` 이동
+    - 각 탭 빈 상태 메시지 및 Owner 액션 링크 ("코스 만들기" → `/routes/create`, "코스 탐색하기" → `/routes`)
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 11.2, 11.3_
+  - [ ]* 11.2 목록 항목 필드 완전성 속성 테스트
+    - **Property 4: 목록 항목 필드 완전성**
+    - **Validates: Requirements 3.3, 3.6, 4.3, 4.5, 4.7, 4.9, 5.3, 5.6, 6.3, 6.5**
+
+- [x] 12. Checkpoint — UI 섹션 검증
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 13. 관리 섹션 구현
+  - [x] 13.1 ManagementSection 컴포넌트 구현
+    - `src/components/profile/sections/ManagementSection.tsx` 생성
+    - 하위 탭: 프로필 편집 | 계정 연동 | 알림 설정
+    - 프로필 편집: 이름/이미지 변경 폼, useUpdateProfile mutation 사용, 유효성 검사 (빈 이름 거부, 50자 제한)
+    - 계정 연동: 기존 `AccountSettingsContent` 로직 재사용 (useLinkedAccounts 훅, OAuth 프로바이더 연결/해제, 비밀번호 설정)
+    - 알림 설정: 푸시 알림 구독/해제 토글
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9_
+  - [ ]* 13.2 프로필 헤더 데이터 완전성 속성 테스트
+    - **Property 7: 프로필 헤더 데이터 완전성**
+    - **Validates: Requirements 8.1, 8.4, 8.5**
+
+- [x] 14. /settings/account 리다이렉트 구현
+  - [x] 14.1 리다이렉트 페이지 구현
+    - `src/app/settings/account/page.tsx` 수정
+    - 로그인 상태: `/profile/{session.user.id}?section=management`로 리다이렉트
+    - 비로그인 상태: `/auth/signin?callbackUrl=/settings/account`로 리다이렉트
+    - _Requirements: 10.1, 10.2_
+  - [ ]* 14.2 리다이렉트 속성 테스트
+    - **Property 11: /settings/account 리다이렉트**
+    - **Validates: Requirements 10.1**
+  - [ ]* 14.3 빈 상태 Owner 액션 링크 속성 테스트
+    - **Property 12: 빈 상태 Owner 액션 링크**
+    - **Validates: Requirements 11.2, 11.3**
+
+- [x] 15. 최종 Checkpoint — 전체 기능 검증
+  - Ensure all tests pass, ask the user if questions arise.
+  - 프로필 페이지 전체 렌더링 확인 (로그인/비로그인)
+  - 5개 섹션 전환 및 데이터 로딩 확인
+  - 헤더 프로필 링크 동작 확인
+  - `/settings/account` 리다이렉트 동작 확인
+  - 프로필 편집 폼 제출 → API 호출 → UI 업데이트 흐름 확인
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- 각 Task는 독립적으로 커밋 가능한 단위로 구성됨
+- Property 테스트는 `fast-check` 라이브러리 사용 (프로젝트 기존 의존성)
+- 기존 컴포넌트 재사용: CheckInGallery, TrophyRoom, ContentProgressCard, useLinkedAccounts
+- 확장 가능 구조: 향후 "내가 추가한 장면", "좋아요한 장면", "제보한 시설" 탭 추가 가능 (Requirement 12)

--- a/.kiro/specs/checkin-detail-interaction/.config.kiro
+++ b/.kiro/specs/checkin-detail-interaction/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "0d670d42-85e4-4472-93cd-99ce14e9dbd7", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/checkin-detail-interaction/requirements.md
+++ b/.kiro/specs/checkin-detail-interaction/requirements.md
@@ -1,0 +1,104 @@
+# Requirements Document
+
+## Introduction
+
+사이트 전반에서 순례 인증 게시글(사진 카드)을 클릭했을 때 일관되게 "인증 상세 보기" 모달(`CheckInDetailModal`)이 열리도록 UX를 통일한다. 현재 스팟 상세의 `CheckInGallery`에서만 상세 모달이 동작하며, 갤러리 메인 피드·명예의 전당·콘텐츠별 피드·프로필 인증 갤러리에서는 클릭 시 아무 반응이 없거나 핸들러가 연결되지 않은 상태이다.
+
+## Glossary
+
+- **CheckIn_Card**: 인증 사진을 표시하는 클릭 가능한 UI 요소 (FeedGridItem, RankingList 인증 카드, CheckInGallery 카드 등)
+- **CheckInDetailModal**: 인증 상세 정보를 표시하는 공통 모달 컴포넌트
+- **Gallery_Page**: `/gallery` 라우트의 갤러리 메인 페이지 (실시간 피드, 명예의 전당, 콘텐츠별 탭 포함)
+- **Feed_Tab**: 갤러리 페이지의 실시간 피드 탭
+- **HallOfFame_Tab**: 갤러리 페이지의 명예의 전당 탭
+- **Content_Tab**: 갤러리 페이지의 콘텐츠별 인증 피드 탭
+- **Profile_Gallery**: 프로필 페이지의 인증 갤러리 섹션
+- **Spot_Detail_Gallery**: 스팟 상세 페이지의 인증 갤러리 (기존 기준점)
+- **CheckIn_API**: `/api/checkins/[id]` 엔드포인트로 단일 인증 데이터를 조회하는 API
+
+## Requirements
+
+### Requirement 1: checkInId 기반 단일 인증 조회 API
+
+**User Story:** As a developer, I want to fetch a single check-in by its ID, so that screens with only checkInId can display the full detail modal.
+
+#### Acceptance Criteria
+
+1. WHEN a GET request is made to `/api/checkins/[id]` with a valid checkInId, THE CheckIn_API SHALL return the full CheckIn object including photoUrl, sceneImageUrl, userName, userImage, visitedAt, comment, likeCount, spotId, contentName, and relationId
+2. WHEN a GET request is made to `/api/checkins/[id]` with a non-existent checkInId, THE CheckIn_API SHALL return a 404 status with an error message
+3. WHEN a GET request is made to `/api/checkins/[id]` with an invalid format, THE CheckIn_API SHALL return a 400 status with a validation error message
+
+### Requirement 2: CheckInDetailModal의 checkInId 기반 로딩 지원
+
+**User Story:** As a developer, I want CheckInDetailModal to accept either a full CheckIn object or just a checkInId, so that all screens can open the modal regardless of available data.
+
+#### Acceptance Criteria
+
+1. WHEN a full CheckIn object is provided, THE CheckInDetailModal SHALL render immediately without additional API calls
+2. WHEN only a checkInId is provided, THE CheckInDetailModal SHALL fetch the CheckIn data from CheckIn_API and display a loading state during the request
+3. IF the fetch fails when loading by checkInId, THEN THE CheckInDetailModal SHALL display an error message with a retry option
+4. THE CheckInDetailModal SHALL display the check-in photo, author info, visit date, comment, like count, related spot link, related content link, and related course links
+
+### Requirement 3: 갤러리 실시간 피드 탭 클릭 인터랙션
+
+**User Story:** As a user, I want to click a check-in photo in the gallery feed to see its details, so that I can view full information without navigating away.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks a CheckIn_Card in Feed_Tab, THE Gallery_Page SHALL open CheckInDetailModal with the selected CheckIn data
+2. WHEN a user presses Enter or Space on a focused CheckIn_Card in Feed_Tab, THE Gallery_Page SHALL open CheckInDetailModal with the selected CheckIn data
+3. WHILE CheckInDetailModal is open, THE Gallery_Page SHALL close the modal when the user clicks the backdrop or the close button
+4. THE Feed_Tab SHALL display cursor-pointer and a visual hover effect on each CheckIn_Card
+
+### Requirement 4: 갤러리 콘텐츠별 피드 탭 클릭 인터랙션
+
+**User Story:** As a user, I want to click a check-in photo in the content-specific feed to see its details, so that I can view full information about content-related check-ins.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks a CheckIn_Card in Content_Tab filtered feed, THE Gallery_Page SHALL open CheckInDetailModal with the selected CheckIn data
+2. WHEN a user presses Enter or Space on a focused CheckIn_Card in Content_Tab, THE Gallery_Page SHALL open CheckInDetailModal with the selected CheckIn data
+3. WHILE CheckInDetailModal is open, THE Gallery_Page SHALL close the modal when the user clicks the backdrop or the close button
+
+### Requirement 5: 명예의 전당 인기 인증 클릭 인터랙션
+
+**User Story:** As a user, I want to click a popular check-in photo in the Hall of Fame to see its details, so that I can learn more about trending check-ins.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks a CheckIn_Card in HallOfFame_Tab check-in ranking section, THE Gallery_Page SHALL open CheckInDetailModal using the checkInId
+2. WHEN a user presses Enter or Space on a focused CheckIn_Card in HallOfFame_Tab, THE Gallery_Page SHALL open CheckInDetailModal using the checkInId
+3. WHILE CheckInDetailModal is open, THE Gallery_Page SHALL close the modal when the user clicks the backdrop or the close button
+4. THE HallOfFame_Tab SHALL display cursor-pointer and a scale hover effect on each check-in ranking card
+
+### Requirement 6: 프로필 인증 갤러리 클릭 인터랙션
+
+**User Story:** As a user, I want to click a check-in photo in my profile gallery to see its details, so that I can review my past check-ins.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks a CheckIn_Card in Profile_Gallery, THE Profile_Gallery SHALL open CheckInDetailModal with the selected CheckIn data
+2. WHEN a user presses Enter or Space on a focused CheckIn_Card in Profile_Gallery, THE Profile_Gallery SHALL open CheckInDetailModal with the selected CheckIn data
+3. WHILE CheckInDetailModal is open, THE Profile_Gallery SHALL close the modal when the user clicks the backdrop or the close button
+
+### Requirement 7: 모달 접근성 및 키보드 지원
+
+**User Story:** As a user with accessibility needs, I want the detail modal to be fully keyboard-navigable, so that I can use the feature without a mouse.
+
+#### Acceptance Criteria
+
+1. WHEN CheckInDetailModal opens, THE CheckInDetailModal SHALL trap focus within the modal content
+2. WHEN a user presses Escape while CheckInDetailModal is open, THE CheckInDetailModal SHALL close the modal
+3. WHEN CheckInDetailModal closes, THE CheckInDetailModal SHALL return focus to the CheckIn_Card that triggered the modal
+4. THE CheckInDetailModal SHALL have role="dialog" and aria-modal="true" attributes
+5. THE CheckInDetailModal SHALL have an aria-label describing the modal content
+
+### Requirement 8: 기존 스팟 상세 갤러리와의 일관성 유지
+
+**User Story:** As a user, I want the check-in detail experience to be consistent across all screens, so that I have a predictable interaction pattern.
+
+#### Acceptance Criteria
+
+1. THE Spot_Detail_Gallery SHALL continue to open CheckInDetailModal on CheckIn_Card click without regression
+2. THE CheckInDetailModal SHALL display identical information layout regardless of which screen triggered it
+3. THE CheckInDetailModal SHALL display the same hover and focus visual cues on CheckIn_Cards across all screens

--- a/scripts/migrate-multi-content-descriptions.mjs
+++ b/scripts/migrate-multi-content-descriptions.mjs
@@ -1,0 +1,298 @@
+/**
+ * Multi-content spot description / relation summary migration
+ *
+ * Usage:
+ * - Dry run: node scripts/migrate-multi-content-descriptions.mjs
+ * - Apply:   node scripts/migrate-multi-content-descriptions.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb'
+import { readFileSync } from 'fs'
+
+function loadEnvLocal() {
+  try {
+    const envContent = readFileSync('.env.local', 'utf-8')
+    for (const line of envContent.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const idx = trimmed.indexOf('=')
+      if (idx === -1) continue
+      const key = trimmed.slice(0, idx).trim()
+      const value = trimmed.slice(idx + 1).trim()
+      if (!(key in process.env)) process.env[key] = value
+    }
+  } catch {
+    // ignore missing .env.local
+  }
+}
+
+const SPOT_UPDATES = [
+  {
+    id: 'REAL-ANI-002',
+    description:
+      '에노덴 가마쿠라코코마에역 앞에 위치한 유명한 건널목으로, 바다와 철길이 함께 보이는 가마쿠라 대표 풍경입니다. 애니메이션과 극장판을 포함해 여러 작품에서 인상적인 장면의 배경으로 활용되며, 팬들이 사진을 남기기 위해 자주 찾는 성지입니다.',
+    relations: {
+      '슬램덩크 (スラムダンク)':
+        '애니메이션 오프닝과 작품 이미지로 널리 알려진 대표 성지입니다. 바다를 배경으로 한 건널목 풍경이 슬램덩크 특유의 청춘 분위기를 떠올리게 합니다.',
+      '더 퍼스트 슬램덩크':
+        '극장판 개봉 이후 다시 주목받은 장소로, 슬램덩크 팬들이 작품의 여운을 느끼기 위해 찾는 대표 코스입니다.',
+    },
+  },
+  {
+    id: 'REAL-ANI-008',
+    description:
+      '도쿄를 상징하는 랜드마크로, 전망대와 야경, 주변 도시 풍경 덕분에 다양한 작품에서 배경으로 자주 등장하는 장소입니다. 특정 한 작품보다도 “도쿄다움”을 보여주는 아이콘으로 소비되어 여러 장르의 팬들이 함께 찾는 스팟입니다.',
+    relations: {
+      '도쿄 구울 (東京喰種)':
+        '도쿄의 음울하고 비현실적인 분위기를 강조하는 배경으로 자주 언급되는 랜드마크입니다.',
+      '원피스 (ONE PIECE)':
+        '도쿄를 상징하는 장소로서 각종 협업, 이벤트, 도시 배경 연상 포인트로 함께 회자되는 스팟입니다.',
+      '미소녀 전사 세일러문 (美少女戦士セーラームーン)':
+        '도쿄의 상징적인 스카이라인을 보여주는 요소로, 세일러문이 그리는 도시적 감성과 잘 어울리는 장소입니다.',
+      '명탐정 코난 (名探偵コナン)':
+        '도쿄를 배경으로 한 사건과 추격, 야경 장면을 연상시키는 대표 랜드마크 중 하나입니다.',
+    },
+  },
+  {
+    id: 'REAL-ANI-009',
+    description:
+      '바다와 언덕, 전망대, 에노덴 풍경이 어우러진 쇼난 대표 관광지로 여러 청춘물과 일상물의 배경이 되는 지역입니다. 작품마다 다른 정서를 담아내지만, 산책과 해변, 섬 풍경을 함께 즐길 수 있다는 점에서 공통된 성지 경험을 제공합니다.',
+    relations: {
+      '청춘 돼지는 바니걸 선배의 꿈을 꾸지 않는다':
+        '주요 배경 지역으로, 해변과 전망대, 에노덴을 따라 이어지는 장면들이 작품의 청춘 멜로 분위기를 형성합니다.',
+      '슬램덩크 (スラムダンク)':
+        '가마쿠라 일대 성지 코스를 함께 묶어 방문하는 경우가 많으며, 쇼난 해안 특유의 풍경이 작품의 감성과 잘 맞닿아 있습니다.',
+      '츠리타마 (つり球)':
+        '에노시마와 바다 풍경이 작품의 밝고 개성적인 분위기를 만드는 핵심 배경 중 하나로 기억됩니다.',
+    },
+  },
+  {
+    id: 'REAL-ANI-010',
+    description:
+      '도쿄 치요다구의 전자상가이자 서브컬처 중심지로, 애니메이션·게임·피규어·메이드 카페 문화가 밀집한 대표 성지입니다. 라디오회관과 전기상가 거리, 각종 굿즈 숍과 카페가 모여 있어 여러 작품의 배경과 팬 문화가 겹쳐지는 스팟입니다.',
+    relations: {
+      '슈타인즈 게이트 (STEINS;GATE)':
+        '라디오회관과 골목 풍경, 메이드 카페 거리 등 작품에서 익숙한 배경을 직접 떠올릴 수 있는 대표 성지입니다.',
+      '러브라이브! (ラブライブ!)':
+        '오토노키자카 일대와 함께 팬들이 자주 묶어 방문하는 지역으로, 아이돌 문화와 서브컬처 분위기를 함께 체감할 수 있습니다.',
+      '소드 아트 온라인 (Sword Art Online)':
+        '게임과 전자기기, 서브컬처 상점이 밀집한 공간이라는 점에서 작품 속 오프라인 배경 감성을 떠올리게 하는 장소입니다.',
+    },
+  },
+  {
+    id: 'REAL-ANI-017',
+    description:
+      '도쿄 신주쿠의 대표 번화가로, 네온사인과 유흥가, 뒷골목 분위기가 강한 지역입니다. 코믹한 패러디부터 하드보일드한 범죄 서사까지 다양한 작품이 이 거리의 복합적인 이미지를 각자 다른 방식으로 활용합니다.',
+    relations: {
+      '은혼 (銀魂)':
+        '작중 가부키쵸의 모델로 자주 거론되는 지역으로, 난장판 같은 활기와 코믹한 에너지를 떠올리게 합니다.',
+      '용과 같이 (龍が如く)':
+        '가무로초의 모티프로 잘 알려진 공간으로, 화려한 번화가와 뒷골목의 대비가 게임 분위기와 맞닿아 있습니다.',
+      '가부키초 셜록 (歌舞伎町シャーロック)':
+        '제목 그대로 가부키초를 전면에 내세운 작품으로, 지역의 혼잡하고 독특한 분위기를 배경으로 삼습니다.',
+    },
+  },
+  {
+    id: 'REAL-ANI-020',
+    description:
+      '수많은 보행자가 한 번에 오가는 세계적인 교차로로, 시부야를 상징하는 대표 장면을 만들어내는 장소입니다. 군중, 네온, 대형 전광판이 한 화면에 들어와 현대 도쿄의 속도감과 혼잡함을 표현하기 좋은 배경으로 자주 등장합니다.',
+    relations: {
+      '주술회전 (呪術廻戦)':
+        '시부야 사변을 떠올리게 하는 핵심 배경으로, 대규모 전투와 긴장감 있는 도시 연출의 중심 장소입니다.',
+      '최애의 아이 (【推しの子】)':
+        '연예 산업과 도심 이미지를 상징하는 시부야의 풍경을 떠올리게 하는 대표 배경 포인트입니다.',
+      '듀라라라!! (デュラララ!!)':
+        '도쿄 도심의 복잡한 흐름과 군중성을 보여주는 장면과 잘 어울리는 장소로, 도시 군상극의 분위기를 강화합니다.',
+    },
+  },
+  {
+    id: 'REAL-SPO-005',
+    description:
+      '서울 잠실에 위치한 대표 야구장으로, 두 구단이 홈구장으로 함께 사용하는 국내 야구 성지입니다. 같은 장소라도 응원 문화와 팀 분위기가 달라 경기일마다 전혀 다른 현장감을 체험할 수 있습니다.',
+    relations: {
+      'LG 트윈스':
+        'LG 트윈스의 홈경기를 직관할 수 있는 구장으로, 응원석 분위기와 팀 상징 요소를 현장에서 함께 체험할 수 있습니다.',
+      '두산 베어스':
+        '두산 베어스의 홈구장으로도 사용되며, 같은 구장 안에서도 팀에 따라 다른 응원 문화와 팬 분위기를 느낄 수 있습니다.',
+    },
+  },
+  {
+    id: 'REAL-MOV-003',
+    description:
+      '뉴질랜드 마타마타 지역에 조성된 실물 영화 세트장으로, 중간계의 샤이어를 현실에서 가장 생생하게 체험할 수 있는 장소입니다. 반지의 제왕과 호빗 시리즈 모두와 깊게 연결되어 있어 판타지 영화 팬들에게 상징적인 성지입니다.',
+    relations: {
+      '반지의 제왕 시리즈':
+        '샤이어와 호빗 마을의 정서를 직접 체험할 수 있는 대표 촬영지로, 영화 팬들의 필수 방문 코스입니다.',
+      '호빗 시리즈':
+        '호빗 시리즈에서도 같은 세트장이 적극 활용되어, 비주얼적으로 더 확장된 샤이어의 분위기를 떠올리게 합니다.',
+    },
+  },
+  {
+    id: 'REAL-MUS-002',
+    description:
+      '일본을 대표하는 대형 공연장으로, 해외 아티스트와 K-POP 팀들에게도 상징적인 투어 무대입니다. 공연장 자체가 목표 지점이 되는 만큼 특정 한 팀보다 “도쿄돔 입성”이라는 상징성을 체험하려는 팬들의 방문이 이어지는 장소입니다.',
+    relations: {
+      BTS: '일본 공연과 투어의 상징적 무대 중 하나로, 대규모 콘서트의 현장감을 떠올리게 하는 장소입니다.',
+      블랙핑크:
+        '대형 해외 투어 무대의 상징으로, 블랙핑크의 공연 스케일과 팬덤 열기를 함께 연상시키는 장소입니다.',
+    },
+  },
+  {
+    id: 'REAL-MUS-004',
+    description:
+      'HYBE 아티스트 관련 전시와 체험 요소를 중심으로 운영되던 복합 문화 공간으로, 소속 아티스트 팬들이 함께 찾는 장소였습니다. 특정 팀 하나만의 성지라기보다 레이블 전체의 세계관과 아카이브를 경험하는 성격이 강한 스팟입니다.',
+    relations: {
+      BTS: 'BTS 관련 전시와 아카이브, 음악 세계관을 체험하려는 팬들이 가장 먼저 떠올리는 공간 중 하나였습니다.',
+      세븐틴:
+        'HYBE 레이블 소속 아티스트로서 세븐틴 관련 전시, 콘텐츠, 팬 경험과 함께 연결되는 공간입니다.',
+    },
+  },
+  {
+    id: 'REAL-MUS-005',
+    description:
+      'SM엔터테인먼트 소속 아티스트의 굿즈, 전시, 팬 체험 요소가 모인 복합 문화 공간입니다. 한 팀 전용 공간이 아니라 여러 팀 팬층이 동시에 방문하는 허브 역할을 하며, 세대별 SM 아티스트 팬 문화가 겹쳐지는 장소입니다.',
+    relations: {
+      EXO: 'EXO 굿즈와 전시, 팬 체험 요소를 찾는 방문자들이 자주 들르는 대표 SM 관련 스팟입니다.',
+      NCT: 'NCT 관련 상품과 전시 콘텐츠를 현장에서 확인할 수 있어 팬들이 자주 찾는 장소입니다.',
+      에스파:
+        '에스파 관련 굿즈와 전시, 팬 경험 요소를 한 자리에서 만날 수 있는 SM 팬 허브 공간입니다.',
+    },
+  },
+  {
+    id: 'REAL-GAM-001',
+    description:
+      'LCK 경기가 열리는 대표 e스포츠 경기장으로, 게임 팬과 팀 팬이 함께 모이는 현장형 성지입니다. 리그 전체의 상징성과 특정 팀 응원 경험이 동시에 겹쳐지는 장소라서 여러 층위의 팬 경험을 제공합니다.',
+    relations: {
+      '리그 오브 레전드 (League of Legends)':
+        'LCK를 통해 리그 오브 레전드 e스포츠를 현장에서 체감할 수 있는 대표 무대입니다.',
+      T1: 'T1 경기를 직접 관람하거나 팀 팬덤 문화를 현장에서 느끼려는 방문자에게 상징적인 장소입니다.',
+    },
+  },
+  {
+    id: 'REAL-GAM-002',
+    description:
+      '시부야 PARCO에 위치한 닌텐도 공식 스토어로, 대표 프랜차이즈 굿즈와 전시 연출이 한데 모여 있는 공간입니다. 특정 게임 하나보다 닌텐도 브랜드 전체를 체험하는 성격이 강해 여러 시리즈 팬들이 함께 찾는 스팟입니다.',
+    relations: {
+      '슈퍼 마리오':
+        '마리오 시리즈 굿즈와 캐릭터 상품을 가장 쉽게 만날 수 있는 대표 닌텐도 오프라인 공간입니다.',
+      '젤다의 전설':
+        '젤다 시리즈 관련 상품과 아트워크를 현장에서 접할 수 있어 팬들이 자주 방문하는 장소입니다.',
+      포켓몬스터:
+        '포켓몬 굿즈와 캐릭터 상품을 포함해 닌텐도 대표 IP를 함께 체험할 수 있는 스토어형 성지입니다.',
+    },
+  },
+  {
+    id: 'REAL-GAM-004',
+    description:
+      '유니버설 스튜디오 재팬 내 닌텐도 테마 구역으로, 실내외 어트랙션과 공간 연출을 통해 게임 세계를 몸으로 체험할 수 있는 장소입니다. 마리오 시리즈 전반의 이미지와 마리오 카트 같은 개별 타이틀 경험이 함께 겹쳐지는 대표 스팟입니다.',
+    relations: {
+      '슈퍼 마리오':
+        '버섯왕국과 캐릭터 세계관을 현실 공간으로 옮긴 구역으로, 마리오 팬들에게 가장 직관적인 체험형 성지입니다.',
+      '마리오 카트':
+        '마리오 카트 테마 어트랙션을 통해 게임 특유의 경쟁과 코스 체험을 오프라인에서 재현하는 장소입니다.',
+    },
+  },
+]
+
+async function main() {
+  loadEnvLocal()
+
+  const isApply = process.argv.includes('--apply')
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/not-a-trip'
+  const dbName =
+    process.env.MONGODB_DB || uri.match(/\/([^/?]+)(\?|$)/)?.[1] || 'not-a-trip'
+
+  console.log(
+    `Starting multi-content description migration (${isApply ? 'apply' : 'dry-run'})`
+  )
+  console.log(`DB: ${dbName}`)
+  console.log(`URI: ${uri}\n`)
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 5000 })
+  await client.connect()
+
+  try {
+    const db = client.db(dbName)
+    const spotsCollection = db.collection('spots')
+    const relationsCollection = db.collection('spot_content_relations')
+
+    let spotUpdates = 0
+    let relationUpdates = 0
+    let relationMisses = 0
+
+    for (const update of SPOT_UPDATES) {
+      const currentSpot = await spotsCollection.findOne(
+        { id: update.id },
+        { projection: { _id: 0, id: 1, name: 1, description: 1 } }
+      )
+
+      if (!currentSpot) {
+        console.log(`[missing spot] ${update.id}`)
+        continue
+      }
+
+      const needsSpotUpdate = currentSpot.description !== update.description
+      console.log(`[${update.id}] ${currentSpot.name}`)
+      if (needsSpotUpdate) {
+        console.log(`  description:`)
+        console.log(`  - before: ${currentSpot.description}`)
+        console.log(`  - after : ${update.description}`)
+      } else {
+        console.log(`  description already up to date`)
+      }
+
+      if (isApply && needsSpotUpdate) {
+        await spotsCollection.updateOne(
+          { id: update.id },
+          { $set: { description: update.description } }
+        )
+        spotUpdates++
+      }
+
+      for (const [contentName, summary] of Object.entries(update.relations)) {
+        const currentRelation = await relationsCollection.findOne(
+          { spotId: update.id, contentName, status: 'active' },
+          { projection: { _id: 0, summary: 1 } }
+        )
+
+        if (!currentRelation) {
+          relationMisses++
+          console.log(`  [missing relation] ${contentName}`)
+          continue
+        }
+
+        const needsRelationUpdate = currentRelation.summary !== summary
+        if (needsRelationUpdate) {
+          console.log(`  summary -> ${contentName}`)
+        }
+
+        if (isApply && needsRelationUpdate) {
+          await relationsCollection.updateOne(
+            { spotId: update.id, contentName, status: 'active' },
+            { $set: { summary } }
+          )
+          relationUpdates++
+        }
+      }
+
+      console.log('')
+    }
+
+    if (!isApply) {
+      console.log('Dry run complete. Re-run with --apply to update the database.')
+      return
+    }
+
+    console.log('Applied changes:')
+    console.log(`- spot descriptions updated: ${spotUpdates}`)
+    console.log(`- relation summaries updated: ${relationUpdates}`)
+    console.log(`- missing relations skipped: ${relationMisses}`)
+  } finally {
+    await client.close()
+  }
+}
+
+main().catch((error) => {
+  console.error('Migration failed:', error)
+  process.exit(1)
+})

--- a/scripts/migrate-spot-display-names.mjs
+++ b/scripts/migrate-spot-display-names.mjs
@@ -1,0 +1,289 @@
+/**
+ * Spot display name / related content cleanup migration
+ *
+ * Usage:
+ * - Dry run: node scripts/migrate-spot-display-names.mjs
+ * - Apply:   node scripts/migrate-spot-display-names.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb'
+import { readFileSync } from 'fs'
+
+function loadEnvLocal() {
+  try {
+    const envContent = readFileSync('.env.local', 'utf-8')
+    for (const line of envContent.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const idx = trimmed.indexOf('=')
+      if (idx === -1) continue
+      const key = trimmed.slice(0, idx).trim()
+      const value = trimmed.slice(idx + 1).trim()
+      if (!(key in process.env)) process.env[key] = value
+    }
+  } catch {
+    // ignore missing .env.local
+  }
+}
+
+function normalizeContentName(name) {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9가-힣ａ-ｚＡ-Ｚぁ-ゔァ-ヴー一-龠-]/g, '')
+}
+
+function getContentAliases(contentName) {
+  const trimmed = contentName.trim()
+  const beforeParen = trimmed.replace(/\s*\([^)]*\)\s*$/, '').trim()
+  const aliases = [trimmed]
+  if (beforeParen && beforeParen !== trimmed) aliases.push(beforeParen)
+  return [...new Set(aliases.map((value) => value.toLowerCase()))]
+}
+
+function dedupeRelatedContent(contents) {
+  if (!Array.isArray(contents) || contents.length === 0) {
+    return { deduped: [], duplicateNames: [] }
+  }
+
+  const seen = new Set()
+  const deduped = []
+  const duplicateNames = []
+
+  for (const content of contents) {
+    const key = normalizeContentName(content.name)
+    if (seen.has(key)) {
+      duplicateNames.push(content.name)
+      continue
+    }
+    seen.add(key)
+    deduped.push(content)
+  }
+
+  return { deduped, duplicateNames }
+}
+
+function dedupeRelations(relations) {
+  const sorted = [...relations].sort(
+    (a, b) => a.displayPriority - b.displayPriority
+  )
+  const seen = new Set()
+  const keep = []
+  const remove = []
+  const duplicateNames = []
+
+  for (const relation of sorted) {
+    const key = normalizeContentName(relation.contentName)
+    if (seen.has(key)) {
+      remove.push(relation)
+      duplicateNames.push(relation.contentName)
+      continue
+    }
+    seen.add(key)
+    keep.push(relation)
+  }
+
+  return { keep, remove, duplicateNames }
+}
+
+function getRenamedSpotName(spotName, dedupedRelatedContent) {
+  if (dedupedRelatedContent.length < 2) return spotName
+
+  const explicitNameOverrides = {
+    '\uC5D0\uB178\uC2DC\uB9C8 (\uCCAD\uCD98 \uB3FC\uC9C0 \uC2DC\uB9AC\uC988)':
+      '\uC5D0\uB178\uC2DC\uB9C8',
+    '\uC288\uD37C \uB2CC\uD150\uB3C4 \uC6D4\uB4DC (\uC720\uB2C8\uBC84\uC124 \uC2A4\uD29C\uB514\uC624 \uC7AC\uD32C)':
+      '\uC720\uB2C8\uBC84\uC124 \uC2A4\uD29C\uB514\uC624 \uC7AC\uD32C - \uC288\uD37C \uB2CC\uD150\uB3C4 \uC6D4\uB4DC',
+  }
+  if (explicitNameOverrides[spotName]) {
+    return explicitNameOverrides[spotName]
+  }
+
+  const match = spotName.match(/^(.*)\s+\(([^()]+)\)\s*$/)
+  if (!match) return spotName
+
+  const baseName = match[1].trim()
+  const suffix = match[2].trim().toLowerCase()
+  if (!baseName || !suffix) return spotName
+
+  const aliases = dedupedRelatedContent.flatMap((content) =>
+    getContentAliases(content.name)
+  )
+
+  return aliases.includes(suffix) ? baseName : spotName
+}
+
+async function main() {
+  loadEnvLocal()
+
+  const isApply = process.argv.includes('--apply')
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/not-a-trip'
+  const dbName =
+    process.env.MONGODB_DB || uri.match(/\/([^/?]+)(\?|$)/)?.[1] || 'not-a-trip'
+
+  console.log(
+    `Starting spot display-name migration (${isApply ? 'apply' : 'dry-run'})`
+  )
+  console.log(`DB: ${dbName}`)
+  console.log(`URI: ${uri}\n`)
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 5000 })
+  await client.connect()
+
+  try {
+    const db = client.db(dbName)
+    const spotsCollection = db.collection('spots')
+    const relationsCollection = db.collection('spot_content_relations')
+
+    const spots = await spotsCollection.find({}).toArray()
+    const stats = {
+      scanned: spots.length,
+      candidates: 0,
+      namesChanged: 0,
+      relatedDeduped: 0,
+      relationsDeleted: 0,
+      relationPrioritiesUpdated: 0,
+    }
+    const candidates = []
+
+    for (const spot of spots) {
+      const originalRelated = Array.isArray(spot.relatedContent)
+        ? spot.relatedContent
+        : []
+      const {
+        deduped: dedupedRelated,
+        duplicateNames: duplicateRelatedNames,
+      } = dedupeRelatedContent(originalRelated)
+
+      const activeRelations = await relationsCollection
+        .find({ spotId: spot.id, status: 'active' })
+        .toArray()
+      const {
+        keep: dedupedRelations,
+        remove: duplicateRelations,
+        duplicateNames: duplicateRelationNames,
+      } = dedupeRelations(activeRelations)
+
+      const renamed = getRenamedSpotName(spot.name, dedupedRelated)
+      const needsNameUpdate = renamed !== spot.name
+      const needsRelatedDedup = dedupedRelated.length !== originalRelated.length
+      const needsRelationDedup = duplicateRelations.length > 0
+      const needsRelationPriorityFix = dedupedRelations.some(
+        (relation, index) => relation.displayPriority !== index
+      )
+
+      if (
+        !needsNameUpdate &&
+        !needsRelatedDedup &&
+        !needsRelationDedup &&
+        !needsRelationPriorityFix
+      ) {
+        continue
+      }
+
+      stats.candidates++
+      candidates.push({
+        id: spot.id,
+        beforeName: spot.name,
+        afterName: renamed,
+        originalRelatedCount: originalRelated.length,
+        dedupedRelatedCount: dedupedRelated.length,
+        originalRelationCount: activeRelations.length,
+        dedupedRelationCount: dedupedRelations.length,
+        relatedNames: dedupedRelated.map((content) => content.name),
+        duplicateRelatedNames,
+        duplicateRelationNames,
+      })
+
+      if (!isApply) continue
+
+      if (needsNameUpdate || needsRelatedDedup) {
+        const setFields = {}
+        if (needsNameUpdate) setFields.name = renamed
+        if (needsRelatedDedup) setFields.relatedContent = dedupedRelated
+        await spotsCollection.updateOne({ id: spot.id }, { $set: setFields })
+        if (needsNameUpdate) stats.namesChanged++
+        if (needsRelatedDedup) {
+          stats.relatedDeduped += originalRelated.length - dedupedRelated.length
+        }
+      }
+
+      if (needsRelationDedup) {
+        await relationsCollection.deleteMany({
+          id: { $in: duplicateRelations.map((relation) => relation.id) },
+        })
+        stats.relationsDeleted += duplicateRelations.length
+      }
+
+      if (needsRelationDedup || needsRelationPriorityFix) {
+        for (const [index, relation] of dedupedRelations.entries()) {
+          if (relation.displayPriority === index) continue
+          await relationsCollection.updateOne(
+            { id: relation.id },
+            { $set: { displayPriority: index } }
+          )
+          stats.relationPrioritiesUpdated++
+        }
+      }
+    }
+
+    const preview = candidates.slice(0, 20)
+    console.log(`Scanned spots: ${stats.scanned}`)
+    console.log(`Migration candidates: ${stats.candidates}\n`)
+
+    for (const candidate of preview) {
+      console.log(`[${candidate.id}] ${candidate.beforeName}`)
+      if (candidate.beforeName !== candidate.afterName) {
+        console.log(`  -> ${candidate.afterName}`)
+      }
+      if (candidate.originalRelatedCount !== candidate.dedupedRelatedCount) {
+        console.log(
+          `  relatedContent: ${candidate.originalRelatedCount} -> ${candidate.dedupedRelatedCount}`
+        )
+      }
+      if (candidate.originalRelationCount !== candidate.dedupedRelationCount) {
+        console.log(
+          `  relations: ${candidate.originalRelationCount} -> ${candidate.dedupedRelationCount}`
+        )
+      }
+      if (candidate.duplicateRelatedNames.length > 0) {
+        console.log(
+          `  duplicate relatedContent: ${candidate.duplicateRelatedNames.join(', ')}`
+        )
+      }
+      if (candidate.duplicateRelationNames.length > 0) {
+        console.log(
+          `  duplicate relations: ${candidate.duplicateRelationNames.join(', ')}`
+        )
+      }
+      console.log(`  contents: ${candidate.relatedNames.join(' | ')}`)
+    }
+
+    if (candidates.length > preview.length) {
+      console.log(
+        `\n... ${candidates.length - preview.length} more candidate(s) omitted`
+      )
+    }
+
+    if (!isApply) {
+      console.log('\nDry run complete. Re-run with --apply to update the database.')
+      return
+    }
+
+    console.log('\nApplied changes:')
+    console.log(`- spot names changed: ${stats.namesChanged}`)
+    console.log(`- duplicate relatedContent removed: ${stats.relatedDeduped}`)
+    console.log(`- duplicate relations deleted: ${stats.relationsDeleted}`)
+    console.log(
+      `- relation displayPriority updates: ${stats.relationPrioritiesUpdated}`
+    )
+  } finally {
+    await client.close()
+  }
+}
+
+main().catch((error) => {
+  console.error('Migration failed:', error)
+  process.exit(1)
+})

--- a/scripts/migrate-spot-display-names.ts
+++ b/scripts/migrate-spot-display-names.ts
@@ -1,0 +1,187 @@
+/**
+ * related display-name migration source version
+ *
+ * Runtime uses the `.mjs` file so this file is kept mainly as a typed reference.
+ */
+
+import { connectToDatabase, COLLECTIONS } from '../src/lib/db'
+import { normalizeContentName } from '../src/lib/relation-utils'
+import type { RelatedContent, SpotContentRelation } from '../src/types/spot'
+
+interface SpotDocument {
+  id: string
+  name: string
+  relatedContent?: RelatedContent[]
+}
+
+interface MigrationCandidate {
+  id: string
+  beforeName: string
+  afterName: string
+  originalRelatedCount: number
+  dedupedRelatedCount: number
+  originalRelationCount: number
+  dedupedRelationCount: number
+  relatedNames: string[]
+  duplicateRelatedNames: string[]
+  duplicateRelationNames: string[]
+}
+
+function getContentAliases(contentName: string): string[] {
+  const trimmed = contentName.trim()
+  const beforeParen = trimmed.replace(/\s*\([^)]*\)\s*$/, '').trim()
+  const aliases = [trimmed]
+  if (beforeParen && beforeParen !== trimmed) aliases.push(beforeParen)
+  return [...new Set(aliases.map((value) => value.toLowerCase()))]
+}
+
+function dedupeRelatedContent(contents: RelatedContent[] | undefined): {
+  deduped: RelatedContent[]
+  duplicateNames: string[]
+} {
+  if (!contents || contents.length === 0) {
+    return { deduped: [], duplicateNames: [] }
+  }
+
+  const seen = new Set<string>()
+  const deduped: RelatedContent[] = []
+  const duplicateNames: string[] = []
+
+  for (const content of contents) {
+    const key = normalizeContentName(content.name)
+    if (seen.has(key)) {
+      duplicateNames.push(content.name)
+      continue
+    }
+    seen.add(key)
+    deduped.push(content)
+  }
+
+  return { deduped, duplicateNames }
+}
+
+function dedupeRelations(relations: SpotContentRelation[]): {
+  keep: SpotContentRelation[]
+  remove: SpotContentRelation[]
+  duplicateNames: string[]
+} {
+  const sorted = [...relations].sort(
+    (a, b) => a.displayPriority - b.displayPriority
+  )
+  const seen = new Set<string>()
+  const keep: SpotContentRelation[] = []
+  const remove: SpotContentRelation[] = []
+  const duplicateNames: string[] = []
+
+  for (const relation of sorted) {
+    const key = normalizeContentName(relation.contentName)
+    if (seen.has(key)) {
+      remove.push(relation)
+      duplicateNames.push(relation.contentName)
+      continue
+    }
+    seen.add(key)
+    keep.push(relation)
+  }
+
+  return { keep, remove, duplicateNames }
+}
+
+function getRenamedSpotName(
+  spotName: string,
+  dedupedRelatedContent: RelatedContent[]
+): string {
+  if (dedupedRelatedContent.length < 2) return spotName
+
+  const explicitNameOverrides: Record<string, string> = {
+    '\uC5D0\uB178\uC2DC\uB9C8 (\uCCAD\uCD98 \uB3FC\uC9C0 \uC2DC\uB9AC\uC988)':
+      '\uC5D0\uB178\uC2DC\uB9C8',
+    '\uC288\uD37C \uB2CC\uD150\uB3C4 \uC6D4\uB4DC (\uC720\uB2C8\uBC84\uC124 \uC2A4\uD29C\uB514\uC624 \uC7AC\uD32C)':
+      '\uC720\uB2C8\uBC84\uC124 \uC2A4\uD29C\uB514\uC624 \uC7AC\uD32C - \uC288\uD37C \uB2CC\uD150\uB3C4 \uC6D4\uB4DC',
+  }
+  if (explicitNameOverrides[spotName]) {
+    return explicitNameOverrides[spotName]
+  }
+
+  const match = spotName.match(/^(.*)\s+\(([^()]+)\)\s*$/)
+  if (!match) return spotName
+
+  const baseName = match[1].trim()
+  const suffix = match[2].trim().toLowerCase()
+  if (!baseName || !suffix) return spotName
+
+  const aliases = dedupedRelatedContent.flatMap((content) =>
+    getContentAliases(content.name)
+  )
+
+  return aliases.includes(suffix) ? baseName : spotName
+}
+
+async function migrateSpotDisplayNames() {
+  const isApply = process.argv.includes('--apply')
+  console.log(
+    `Starting spot display-name migration (${isApply ? 'apply' : 'dry-run'})...\n`
+  )
+
+  const { db } = await connectToDatabase()
+  const spotsCollection = db.collection<SpotDocument>(COLLECTIONS.SPOTS)
+  const relationsCollection = db.collection<SpotContentRelation>(
+    COLLECTIONS.SPOT_CONTENT_RELATIONS
+  )
+
+  const spots = await spotsCollection.find({}).toArray()
+  const candidates: MigrationCandidate[] = []
+
+  for (const spot of spots) {
+    const originalRelated = spot.relatedContent ?? []
+    const { deduped: dedupedRelated, duplicateNames: duplicateRelatedNames } =
+      dedupeRelatedContent(originalRelated)
+
+    const activeRelations = await relationsCollection
+      .find({ spotId: spot.id, status: 'active' })
+      .toArray()
+    const {
+      keep: dedupedRelations,
+      remove: duplicateRelations,
+      duplicateNames: duplicateRelationNames,
+    } = dedupeRelations(activeRelations)
+
+    const renamed = getRenamedSpotName(spot.name, dedupedRelated)
+    const needsNameUpdate = renamed !== spot.name
+    const needsRelatedDedup = dedupedRelated.length !== originalRelated.length
+    const needsRelationDedup = duplicateRelations.length > 0
+    const needsRelationPriorityFix = dedupedRelations.some(
+      (relation, index) => relation.displayPriority !== index
+    )
+
+    if (
+      !needsNameUpdate &&
+      !needsRelatedDedup &&
+      !needsRelationDedup &&
+      !needsRelationPriorityFix
+    ) {
+      continue
+    }
+
+    candidates.push({
+      id: spot.id,
+      beforeName: spot.name,
+      afterName: renamed,
+      originalRelatedCount: originalRelated.length,
+      dedupedRelatedCount: dedupedRelated.length,
+      originalRelationCount: activeRelations.length,
+      dedupedRelationCount: dedupedRelations.length,
+      relatedNames: dedupedRelated.map((content) => content.name),
+      duplicateRelatedNames,
+      duplicateRelationNames,
+    })
+  }
+
+  console.log(`Scanned spots: ${spots.length}`)
+  console.log(`Migration candidates: ${candidates.length}`)
+}
+
+migrateSpotDisplayNames().catch((error) => {
+  console.error('Migration failed:', error)
+  process.exit(1)
+})

--- a/src/components/profile/SubTabNavigation.tsx
+++ b/src/components/profile/SubTabNavigation.tsx
@@ -22,7 +22,7 @@ export function SubTabNavigation({
 }: SubTabNavigationProps) {
   return (
     <div
-      className="flex gap-2 overflow-x-auto whitespace-nowrap pb-1"
+      className="flex gap-2 overflow-x-auto whitespace-nowrap py-1"
       role="tablist"
       aria-label="하위 탭 네비게이션"
     >

--- a/src/components/route/RecommendedRoutes.tsx
+++ b/src/components/route/RecommendedRoutes.tsx
@@ -14,7 +14,7 @@ interface RecommendedData {
 /** 추천 코스 카드 스켈레톤 */
 function RecommendedSkeleton() {
   return (
-    <div className="flex gap-4 overflow-x-auto pb-2">
+    <div className="flex gap-4 overflow-x-auto pb-2 pt-1">
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
@@ -76,7 +76,7 @@ export function RecommendedRoutes() {
         {isLoading ? (
           <RecommendedSkeleton />
         ) : data && data.official.length > 0 ? (
-          <div className="flex gap-4 overflow-x-auto pb-2">
+          <div className="flex gap-4 overflow-x-auto px-1 pb-2 pt-1">
             {data.official.map((route) => (
               <div key={route.id} className="w-72 flex-shrink-0">
                 <RouteCard route={route} />
@@ -97,7 +97,7 @@ export function RecommendedRoutes() {
         {isLoading ? (
           <RecommendedSkeleton />
         ) : data && data.popular.length > 0 ? (
-          <div className="flex gap-4 overflow-x-auto pb-2">
+          <div className="flex gap-4 overflow-x-auto px-1 pb-2 pt-1">
             {data.popular.map((route) => (
               <div key={route.id} className="w-72 flex-shrink-0">
                 <RouteCard route={route} />

--- a/src/components/route/RelatedRoutes.tsx
+++ b/src/components/route/RelatedRoutes.tsx
@@ -26,7 +26,7 @@ export function RelatedRoutes({ contentNames }: RelatedRoutesProps) {
             <AppIcon name="map" size={24} />
             관련 순례 코스
           </h2>
-          <div className="flex gap-4 overflow-x-auto pb-2">
+          <div className="flex gap-4 overflow-x-auto pb-2 pt-1">
             {Array.from({ length: 2 }, (_, i) => (
               <div
                 key={i}
@@ -57,7 +57,7 @@ export function RelatedRoutes({ contentNames }: RelatedRoutesProps) {
         <p className="mb-3 text-sm text-sub-text">
           「{contentNames[0]}」 관련 코스를 따라가보세요
         </p>
-        <div className="flex gap-4 overflow-x-auto pb-2">
+        <div className="flex gap-4 overflow-x-auto pb-2 pt-1">
           {routes.map((route) => (
             <div key={route.id} className="w-64 flex-shrink-0">
               <RouteCard route={route} />

--- a/src/components/spot/SameContentSpots.tsx
+++ b/src/components/spot/SameContentSpots.tsx
@@ -66,7 +66,7 @@ export function SameContentSpots({
           <h2 className="mb-4 text-lg font-bold text-main-text md:text-xl">
             같은 작품의 다른 스팟
           </h2>
-          <div className="flex gap-3 overflow-x-auto pb-2">
+          <div className="flex gap-3 overflow-x-auto pb-2 pt-1">
             {[1, 2, 3].map((i) => (
               <div
                 key={i}
@@ -93,7 +93,7 @@ export function SameContentSpots({
         <h2 className="mb-4 text-lg font-bold text-main-text md:text-xl">
           같은 작품의 다른 스팟
         </h2>
-        <div className="flex gap-3 overflow-x-auto pb-2">
+        <div className="flex gap-3 overflow-x-auto pb-2 pt-1">
           {otherSpots.map((spot) => (
             <SameContentSpotCard
               key={spot.id}

--- a/src/lib/tour-config.ts
+++ b/src/lib/tour-config.ts
@@ -47,7 +47,7 @@ export const ROUTE_DETAIL_STEPS: TourStep[] = [
     title: '🚀 코스 시작하기',
     description:
       '이 버튼을 누르면 가이드 모드가 시작됩니다! 각 스팟을 순서대로 방문하며 GPS 기반 인증을 할 수 있어요.',
-    placement: 'bottom',
+    placement: 'top',
   },
   {
     target: '[data-tour="route-spot-list"]',


### PR DESCRIPTION
## 개요

UI 버그 수정, Kiro spec 문서 추가, 마이그레이션 스크립트 추가를 포함한 변경사항입니다.

Closes #786

## 변경 사항

### 🐛 UI 버그 수정

- **SubTabNavigation**: `pb-1` → `py-1` 변경으로 선택된 탭 버튼 상단 잘림 수정
  - `overflow-x-auto`가 `overflow-y: hidden`을 유발해 버튼 상단이 클리핑되던 문제
- **RecommendedRoutes**: 공식 추천/인기 코스 가로 스크롤 컨테이너에 `px-1` 추가
  - 첫 번째 카드의 border/shadow가 잘리던 문제 수정
- **RelatedRoutes, SameContentSpots**: 동일한 카드 잘림 수정
- **tour-config**: 코스 상세 가이드 팝업 `placement: 'bottom'` → `'top'` 변경
  - "코스 시작" 버튼 클릭 시 가이드 팝업이 버튼을 가리던 문제 수정

### 📄 Kiro Spec 문서 추가

- **45-profile-complete**: 프로필 페이지 활동 허브 완성 spec (requirements, design, tasks)
- **checkin-detail-interaction**: 순례 인증 게시글 클릭 인터랙션 통일 spec (requirements)

### 🔧 마이그레이션 스크립트 추가

- **migrate-spot-display-names**: 스팟 이름에서 작품명 괄호 제거 (`아키하바라 (슈타인즈 게이트)` → `아키하바라`)
- **migrate-multi-content-descriptions**: 다중 작품 스팟 설명 마이그레이션

## 테스트

- `npm run type-check` 통과
- UI 변경사항은 로컬에서 시각적으로 확인 필요