### PR TITLE
fix: 프로필 변경 후 헤더 이름/이미지 미갱신 버그 수정

### DIFF
--- a/src/components/profile/sections/ManagementSection.tsx
+++ b/src/components/profile/sections/ManagementSection.tsx
@@ -223,6 +223,7 @@ const ALLOWED_TYPES_LABEL = 'JPG, PNG, GIF, WEBP'
 function ProfileEditTab({ userId }: { userId: string }) {
   const { data: userInfo } = useUserInfo(userId)
   const updateProfile = useUpdateProfile(userId)
+  const { update: updateSession } = useSession()
   const [name, setName] = useState(userInfo?.name ?? '')
   const [imageUrl, setImageUrl] = useState(userInfo?.image ?? '')
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
@@ -303,6 +304,8 @@ function ProfileEditTab({ userId }: { userId: string }) {
         name: trimmedName,
         image: imageUrl || undefined,
       })
+      // 세션 강제 갱신 — 헤더의 이름/이미지 즉시 반영
+      await updateSession()
       setSuccess(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : '저장에 실패했습니다')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -178,16 +178,20 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.provider = account?.provider || 'credentials'
       }
 
-      // 매번 DB에서 role 조회 (role 변경 즉시 반영)
+      // 매번 DB에서 role, name, image 조회 (프로필 변경 즉시 반영)
       if (token.email || token.id) {
         try {
           const db = await getDb()
           const query = token.email
             ? { email: token.email }
             : { _id: new ObjectId(token.id as string) }
-          const dbUser = await db.collection('users').findOne(query)
+          const dbUser = await db.collection('users').findOne(query, {
+            projection: { role: 1, name: 1, image: 1 },
+          })
           if (dbUser) {
             token.role = dbUser.role || 'user'
+            token.name = dbUser.name ?? token.name
+            token.picture = dbUser.image ?? token.picture
             // eslint-disable-next-line no-console
             console.log(
               `[Auth] User ${token.email || token.id} role: ${token.role}`
@@ -213,6 +217,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session.user.id = token.id as string
         session.user.provider = token.provider as string
         session.user.role = token.role as 'user' | 'admin'
+        // DB에서 갱신된 name/image를 세션에 반영
+        if (token.name) session.user.name = token.name as string
+        if (token.picture) session.user.image = token.picture as string
       }
       return session
     },


### PR DESCRIPTION
## 문제

프로필 편집에서 이름/이미지를 변경해도 헤더 우측 상단의 프로필 영역이 갱신되지 않음.

## 원인 분석

`Header`는 `useAuth` → `useSession`의 `session.user`를 표시하는데, NextAuth JWT 전략에서 `jwt` 콜백이 DB에서 `role`만 재조회하고 `name`/`image`는 재조회하지 않았음. 따라서 DB 업데이트 후에도 JWT 토큰에는 최초 로그인 시 구글에서 받아온 값이 유지됨.

## 수정 내용

**`src/lib/auth.ts`**
- `jwt` 콜백에서 DB 조회 시 `name`, `image` 필드도 함께 조회
- 조회된 값을 `token.name`, `token.picture`에 반영
- `session` 콜백에서 `token.name`/`token.picture`를 `session.user`에 반영

**`src/components/profile/sections/ManagementSection.tsx`**
- `useSession`의 `update` 함수 추가
- 프로필 저장 성공 후 `updateSession()` 호출 → 세션 재조회 트리거 → 헤더 즉시 갱신

## 동작 흐름

1. 저장 버튼 클릭 → `PUT /api/users/[id]` DB 업데이트
2. `updateSession()` 호출 → NextAuth가 `/api/auth/session` 재요청
3. `jwt` 콜백 재실행 → DB에서 최신 `name`/`image` 조회
4. 세션 갱신 → `useSession` 구독 컴포넌트(Header) 리렌더링

Closes #793