### PR TITLE
fix: 헤더 프로필 이미지 미표시 및 포커스 링 남발 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,8 +220,12 @@ html {
   background: rgb(var(--color-primary-500));
 }
 
-/* Focus styles */
+/* Focus styles — 키보드 탐색 시에만 표시 */
 *:focus {
+  outline: none;
+}
+
+*:focus-visible {
   outline: 2px solid rgb(var(--color-primary-500));
   outline-offset: 2px;
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -127,7 +127,12 @@ export function Header() {
                       width={28}
                       height={28}
                       className="h-7 w-7 rounded-full object-cover"
-                      referrerPolicy="no-referrer"
+                      referrerPolicy={
+                        user.image.startsWith('http')
+                          ? 'no-referrer'
+                          : undefined
+                      }
+                      unoptimized={!user.image.startsWith('http')}
                     />
                   ) : (
                     <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-secondary-100">


### PR DESCRIPTION
## 수정 내용

### 1. 포커스 링 남발 제거 (`globals.css`)

기존 `*:focus` 전역 스타일이 마우스 클릭 시에도 모든 요소에 보라색 테두리를 표시했음.

- `*:focus { outline: none }` — 클릭 시 기본 포커스 링 제거
- `*:focus-visible { outline: 2px solid ... }` — 키보드 탐색(Tab) 시에만 포커스 링 표시

로고, 링크, 버튼 클릭 시 사각형 테두리가 사라지고, 키보드 접근성은 유지됨.

### 2. 헤더 프로필 이미지 미표시 수정 (`Header.tsx`)

로컬 업로드 이미지(`/uploads/...`)를 프로필로 설정하면 헤더에서 이미지가 표시되지 않던 문제.

- 외부 URL(`http`/`https` 시작)일 때만 `referrerPolicy="no-referrer"` 적용
- 로컬 경로(`/uploads/...`)는 `unoptimized` 추가하여 Next.js Image Optimization 우회

Closes #795