### PR TITLE
feat: updateUserStats 내 contentProgress 계산 로직 교체

### DIFF
--- a/src/app/api/checkins/route.ts
+++ b/src/app/api/checkins/route.ts
@@ -11,6 +11,11 @@ import {
   RelationType,
 } from '@/types'
 import { checkAndAwardBadges } from '@/lib/badge-utils'
+import {
+  fetchTotalSpotsMap,
+  fetchCheckedSpotsMap,
+  mergeProgressMaps,
+} from '@/lib/progress-utils'
 
 /**
  * CheckIn MongoDB Document
@@ -80,6 +85,13 @@ async function updateUserStats(userId: string): Promise<void> {
   const badgesCollection = await getCollection(COLLECTIONS.USER_BADGES)
   const badgeCount = await badgesCollection.countDocuments({ userId })
 
+  // 콘텐츠별 진행률 계산 (Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 1.6)
+  const [totalSpotsMap, checkedSpotsMap] = await Promise.all([
+    fetchTotalSpotsMap(),
+    fetchCheckedSpotsMap(userId),
+  ])
+  const contentProgress = mergeProgressMaps(totalSpotsMap, checkedSpotsMap)
+
   // 통계 업데이트 (upsert)
   await statsCollection.updateOne(
     { userId },
@@ -89,7 +101,7 @@ async function updateUserStats(userId: string): Promise<void> {
         totalCheckIns,
         uniqueSpots,
         badgeCount,
-        contentProgress: [], // TODO: 콘텐츠별 진행률 계산
+        contentProgress,
         updatedAt: new Date(),
       },
     },


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #801

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가

---

## ✨ 작업 개요

`POST /api/checkins`의 `updateUserStats` 함수에서 `contentProgress: []` TODO를 `spot_content_relations` 기반 실제 계산 로직으로 교체한다.

---

## 📋 변경 사항

- [x] `src/app/api/checkins/route.ts`에 `fetchTotalSpotsMap`, `fetchCheckedSpotsMap`, `mergeProgressMaps` import 추가
- [x] `updateUserStats` 내 `contentProgress: []` TODO를 `Promise.all` 병렬 실행 + `mergeProgressMaps` 호출로 교체

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run format` 통과

---

## 📝 추가 정보 (선택)

- `fetchTotalSpotsMap()`과 `fetchCheckedSpotsMap(userId)`를 `Promise.all`로 병렬 실행하여 성능 최적화
- Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 1.6 대응
- Spec: 38-checkin-content-progress, Task 3