### PR TITLE
chore: 스팟 품질 MongoDB 컬렉션 초기화 스크립트 추가

### DIFF
--- a/scripts/init-spot-quality-collections.ts
+++ b/scripts/init-spot-quality-collections.ts
@@ -1,0 +1,184 @@
+/**
+ * 스팟 품질 워크플로 MongoDB 컬렉션 초기화 스크립트
+ * Spec: 40-spot-quality-workflow
+ *
+ * 실행: npx tsx scripts/init-spot-quality-collections.ts
+ *
+ * 수행 작업:
+ * 1. spot_quality_reports 컬렉션 인덱스 4개 생성
+ * 2. spot_lifecycle_history 컬렉션 인덱스 생성
+ * 3. supplement_requests 컬렉션 인덱스 2개 생성
+ * 4. spots 컬렉션에 lifecycleStatus, closureSuspected, urgentReviewRequired 필드 기본값 마이그레이션
+ *
+ * Requirements: 2.1, 2.6, 3.2, 4.1
+ */
+
+import { MongoClient } from 'mongodb'
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017'
+
+function extractDbNameFromUri(uri: string): string {
+  const match = uri.match(/\/([^/?]+)(\?|$)/)
+  return match ? match[1] : 'not-a-trip'
+}
+
+const MONGODB_DB = process.env.MONGODB_DB || extractDbNameFromUri(MONGODB_URI)
+
+async function initSpotQualityCollections(): Promise<void> {
+  const client = new MongoClient(MONGODB_URI)
+
+  try {
+    console.log('MongoDB에 연결 중...')
+    await client.connect()
+    console.log(`MongoDB 연결 성공! (DB: ${MONGODB_DB})`)
+
+    const db = client.db(MONGODB_DB)
+
+    // ─────────────────────────────────────────────────────────────
+    // 1. spot_quality_reports 컬렉션 인덱스 생성
+    // ─────────────────────────────────────────────────────────────
+    console.log('\n🔧 spot_quality_reports 인덱스 생성 시작...')
+    const qualityReports = db.collection('spot_quality_reports')
+
+    // 스팟별 신고 유형/상태 조회용
+    await qualityReports.createIndex(
+      { spotId: 1, reportType: 1, status: 1 },
+      { background: true }
+    )
+    console.log('  ✅ { spotId, reportType, status } 인덱스 생성 완료')
+
+    // 중복 신고 검증용 (24시간 이내 동일 사용자/스팟/유형)
+    await qualityReports.createIndex(
+      { reporterId: 1, spotId: 1, reportType: 1, createdAt: -1 },
+      { background: true }
+    )
+    console.log(
+      '  ✅ { reporterId, spotId, reportType, createdAt } 인덱스 생성 완료'
+    )
+
+    // SLA 기한 관리용 (상태별 기한 조회)
+    await qualityReports.createIndex(
+      { status: 1, deadline: 1 },
+      { background: true }
+    )
+    console.log('  ✅ { status, deadline } 인덱스 생성 완료')
+
+    // 누적 카운트용 (동일 스팟/유형 신고 집계)
+    await qualityReports.createIndex(
+      { spotId: 1, reportType: 1, createdAt: -1 },
+      { background: true }
+    )
+    console.log(
+      '  ✅ { spotId, reportType, createdAt } 인덱스 생성 완료 (누적 카운트용)'
+    )
+
+    console.log('✅ spot_quality_reports 인덱스 생성 완료 (4개)')
+
+    // ─────────────────────────────────────────────────────────────
+    // 2. spot_lifecycle_history 컬렉션 인덱스 생성
+    // ─────────────────────────────────────────────────────────────
+    console.log('\n🔧 spot_lifecycle_history 인덱스 생성 시작...')
+    const lifecycleHistory = db.collection('spot_lifecycle_history')
+
+    // 스팟별 이력 시간순 조회용
+    await lifecycleHistory.createIndex(
+      { spotId: 1, changedAt: -1 },
+      { background: true }
+    )
+    console.log('  ✅ { spotId, changedAt } 인덱스 생성 완료')
+
+    console.log('✅ spot_lifecycle_history 인덱스 생성 완료 (1개)')
+
+    // ─────────────────────────────────────────────────────────────
+    // 3. supplement_requests 컬렉션 인덱스 생성
+    // ─────────────────────────────────────────────────────────────
+    console.log('\n🔧 supplement_requests 인덱스 생성 시작...')
+    const supplementRequests = db.collection('supplement_requests')
+
+    // 스팟별 보완 요청 상태 조회용
+    await supplementRequests.createIndex(
+      { spotId: 1, status: 1 },
+      { background: true }
+    )
+    console.log('  ✅ { spotId, status } 인덱스 생성 완료')
+
+    // 만료 처리 배치용 (상태별 기한 조회)
+    await supplementRequests.createIndex(
+      { status: 1, deadline: 1 },
+      { background: true }
+    )
+    console.log('  ✅ { status, deadline } 인덱스 생성 완료')
+
+    console.log('✅ supplement_requests 인덱스 생성 완료 (2개)')
+
+    // ─────────────────────────────────────────────────────────────
+    // 4. spots 컬렉션 마이그레이션
+    //    기존 승인된 스팟에 품질 관련 필드 기본값 추가
+    // ─────────────────────────────────────────────────────────────
+    console.log('\n🔧 spots 컬렉션 마이그레이션 시작...')
+    const spots = db.collection('spots')
+
+    // lifecycleStatus 필드가 없는 스팟에 기본값 설정
+    // 기존 승인된 스팟(spotStatus: 'approved' 또는 필드 없음)은 'approved'로 설정
+    const lifecycleResult = await spots.updateMany(
+      { lifecycleStatus: { $exists: false } },
+      {
+        $set: {
+          lifecycleStatus: 'approved',
+          closureSuspected: false,
+          urgentReviewRequired: false,
+        },
+      }
+    )
+    console.log(
+      `  ✅ lifecycleStatus/closureSuspected/urgentReviewRequired 기본값 설정: ${lifecycleResult.modifiedCount}개 스팟 업데이트`
+    )
+
+    // closureSuspected 필드가 없는 스팟에 기본값 설정 (lifecycleStatus는 있지만 closureSuspected가 없는 경우)
+    const closureResult = await spots.updateMany(
+      { closureSuspected: { $exists: false } },
+      { $set: { closureSuspected: false } }
+    )
+    if (closureResult.modifiedCount > 0) {
+      console.log(
+        `  ✅ closureSuspected 기본값 설정: ${closureResult.modifiedCount}개 스팟 업데이트`
+      )
+    }
+
+    // urgentReviewRequired 필드가 없는 스팟에 기본값 설정
+    const urgentResult = await spots.updateMany(
+      { urgentReviewRequired: { $exists: false } },
+      { $set: { urgentReviewRequired: false } }
+    )
+    if (urgentResult.modifiedCount > 0) {
+      console.log(
+        `  ✅ urgentReviewRequired 기본값 설정: ${urgentResult.modifiedCount}개 스팟 업데이트`
+      )
+    }
+
+    console.log('✅ spots 컬렉션 마이그레이션 완료')
+
+    // ─────────────────────────────────────────────────────────────
+    // 완료 요약
+    // ─────────────────────────────────────────────────────────────
+    console.log('\n' + '='.repeat(60))
+    console.log('🎉 스팟 품질 컬렉션 초기화 완료!')
+    console.log('='.repeat(60))
+    console.log('  - spot_quality_reports: 인덱스 4개')
+    console.log('  - spot_lifecycle_history: 인덱스 1개')
+    console.log('  - supplement_requests: 인덱스 2개')
+    console.log(
+      `  - spots 마이그레이션: ${lifecycleResult.modifiedCount}개 문서 업데이트`
+    )
+  } finally {
+    await client.close()
+    console.log('\nMongoDB 연결 종료')
+  }
+}
+
+initSpotQualityCollections()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('❌ 초기화 실패:', error)
+    process.exit(1)
+  })

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -108,6 +108,10 @@ export const COLLECTIONS = {
   ACCOUNTS: 'accounts',
   // 스팟-작품 관계 컬렉션 (30-spot-content-relation)
   SPOT_CONTENT_RELATIONS: 'spot_content_relations',
+  // 스팟 품질 워크플로 컬렉션 (40-spot-quality-workflow)
+  SPOT_QUALITY_REPORTS: 'spot_quality_reports',
+  SPOT_LIFECYCLE_HISTORY: 'spot_lifecycle_history',
+  SUPPLEMENT_REQUESTS: 'supplement_requests',
 } as const
 
 /**

--- a/src/types/spot-quality.ts
+++ b/src/types/spot-quality.ts
@@ -1,0 +1,297 @@
+// ============================================
+// 스팟 품질 워크플로 TypeScript 타입/인터페이스 정의
+// Spec: 40-spot-quality-workflow
+// Requirements: 2.1, 3.1, 4.1, 5.1
+// ============================================
+
+// ============================================
+// 유니온 타입 정의
+// ============================================
+
+/**
+ * 스팟 라이프사이클 상태
+ * Requirements 2.1
+ */
+export type SpotLifecycleStatus =
+  | 'draft'
+  | 'pending'
+  | 'approved'
+  | 'archived'
+  | 'closed'
+
+/**
+ * 품질 신고 유형
+ * Requirements 3.1
+ */
+export type QualityReportType =
+  | 'inaccurate_info'
+  | 'closed_permanently'
+  | 'duplicate'
+  | 'inappropriate'
+  | 'other'
+
+/**
+ * 신고 처리 상태
+ * Requirements 3.2, 4.1
+ */
+export type ReportProcessingStatus =
+  | 'pending'
+  | 'in_review'
+  | 'resolved'
+  | 'rejected'
+  | 'sla_exceeded'
+
+/**
+ * 보완 요청 유형
+ * Requirements 5.1
+ */
+export type SupplementRequestType =
+  | 'photo_add'
+  | 'description_update'
+  | 'address_verify'
+  | 'operation_info'
+
+/**
+ * 보완 요청 상태
+ * Requirements 5.1, 5.5
+ */
+export type SupplementRequestStatus =
+  | 'pending'
+  | 'responded'
+  | 'approved'
+  | 'expired'
+
+// ============================================
+// 상수 정의
+// ============================================
+
+/**
+ * 허용된 상태 전이 맵
+ * Requirements 2.1, 2.7
+ *
+ * 참고: closure_suspected는 상태 머신 다이어그램의 가상 상태로,
+ * SpotLifecycleStatus에 포함되지 않으며 spots.closureSuspected 불리언 필드로 표현됨
+ */
+export const ALLOWED_TRANSITIONS: Record<
+  SpotLifecycleStatus,
+  SpotLifecycleStatus[]
+> = {
+  draft: ['pending'],
+  pending: ['approved'],
+  approved: ['archived', 'closed'],
+  archived: ['approved'],
+  closed: ['approved'],
+}
+
+/**
+ * SLA 기한 설정 (시간 단위)
+ * Requirements 4.1
+ */
+export const SLA_DEADLINES: Record<QualityReportType, number> = {
+  inappropriate: 24,
+  closed_permanently: 48,
+  duplicate: 72,
+  inaccurate_info: 120,
+  other: 120,
+}
+
+// ============================================
+// 인터페이스 정의
+// ============================================
+
+/**
+ * 스팟 품질 신고
+ * Requirements 3.1, 3.2, 4.1
+ */
+export interface SpotQualityReport {
+  id: string
+  spotId: string
+  reportType: QualityReportType
+  description: string
+  evidencePhotos?: string[]
+  reporterId: string
+  reporterName: string
+  status: ReportProcessingStatus
+  /** SLA 기한 */
+  deadline: Date
+  /** 긴급 검토 플래그 (동일 유형 3건+ 누적 시 true) */
+  isUrgent: boolean
+  /** 처리 결과 */
+  resolution?: {
+    action: 'approved' | 'rejected' | 'deferred'
+    reason: string
+    resolvedBy: string
+    resolvedAt: Date
+  }
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * 라이프사이클 상태 전이 이력
+ * Requirements 2.6
+ */
+export interface LifecycleTransition {
+  from: SpotLifecycleStatus
+  to: SpotLifecycleStatus
+  reason: string
+  changedBy: string
+  changedAt: Date
+}
+
+/**
+ * 상태 전이 결과
+ * Requirements 2.7
+ */
+export interface TransitionResult {
+  success: boolean
+  newStatus?: SpotLifecycleStatus
+  error?: string
+  allowedTransitions?: SpotLifecycleStatus[]
+}
+
+/**
+ * 근접 스팟/제보 항목 (200m 이내 조회 결과)
+ * Requirements 1.1, 1.3
+ */
+export interface NearbyItem {
+  id: string
+  name: string
+  coordinates: { lat: number; lng: number }
+  distance: number
+  type: 'spot' | 'report'
+  category?: string
+}
+
+/**
+ * 중복 후보 항목 (유사도 >= 0.7 AND 200m 이내)
+ * Requirements 1.2
+ */
+export interface DuplicateCandidate {
+  id: string
+  name: string
+  coordinates: { lat: number; lng: number }
+  distance: number
+  similarityScore: number
+  type: 'spot' | 'report'
+  category?: string
+}
+
+/**
+ * 중복 감지 결과
+ * Requirements 1.1, 1.2, 1.3
+ */
+export interface DuplicateCheckResult {
+  /** 200m 이내 근접 항목 */
+  nearbyItems: NearbyItem[]
+  /** 높은 중복 가능성 항목 (유사도 >= 0.7 AND 200m 이내) */
+  highDuplicates: DuplicateCandidate[]
+  /** 근접 스팟 항목 (50m 이내) */
+  proximityWarnings: NearbyItem[]
+}
+
+/**
+ * 보완 요청
+ * Requirements 5.1, 5.4, 5.5
+ */
+export interface SupplementRequest {
+  id: string
+  spotId: string
+  requestType: SupplementRequestType
+  content: string
+  deadline: Date
+  status: SupplementRequestStatus
+  createdBy: string
+  /** 응답 정보 */
+  response?: {
+    responderId: string
+    content: string
+    photos?: string[]
+    respondedAt: Date
+  }
+  createdAt: Date
+  updatedAt: Date
+}
+
+/**
+ * 폐쇄 감지 결과
+ * Requirements 6.1
+ */
+export interface ClosureDetectionResult {
+  shouldSuspect: boolean
+  reportCount: number
+  latestReportDate: Date
+}
+
+/**
+ * SLA 집계 통계
+ * Requirements 4.4
+ */
+export interface SlaStatistics {
+  /** SLA 준수율 (%) */
+  complianceRate: number
+  /** 평균 처리 시간 (밀리초) */
+  averageProcessingTime: number
+  /** SLA 초과 건수 */
+  exceededCount: number
+  /** 유형별 통계 (선택) */
+  byType?: Partial<Record<QualityReportType, SlaStatistics>>
+}
+
+/**
+ * spots 컬렉션 품질 확장 필드
+ * Requirements 2.1, 3.3, 5.3, 6.1, 6.2
+ */
+export interface SpotQualityExtension {
+  /** 라이프사이클 상태 */
+  lifecycleStatus: SpotLifecycleStatus
+  /** 폐쇄 의심 여부 (closed_permanently 신고 2건+ 시 true) */
+  closureSuspected: boolean
+  /** 폐쇄 확인 일자 */
+  closureConfirmedAt?: Date
+  /** 중복 의심 플래그 (제보 시 설정) */
+  duplicateSuspected: boolean
+  /** 미처리 보완 요청 수 */
+  pendingSupplementCount: number
+  /** 긴급 검토 필요 여부 (동일 유형 신고 3건+ 시 true) */
+  urgentReviewRequired: boolean
+}
+
+// ============================================
+// 입력 인터페이스 (API 요청용)
+// ============================================
+
+/**
+ * 품질 신고 생성 입력
+ * Requirements 3.2
+ */
+export interface CreateQualityReportInput {
+  spotId: string
+  reportType: QualityReportType
+  description: string
+  evidencePhotos?: string[]
+  reporterId: string
+  reporterName: string
+}
+
+/**
+ * 보완 요청 생성 입력
+ * Requirements 5.1
+ */
+export interface CreateSupplementRequestInput {
+  spotId: string
+  requestType: SupplementRequestType
+  content: string
+  deadline: Date
+  createdBy: string
+}
+
+/**
+ * 보완 응답 입력
+ * Requirements 5.4
+ */
+export interface SupplementResponseInput {
+  responderId: string
+  content: string
+  photos?: string[]
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #812

---

## 📋 PR 타입

- [x] 🧹 **chore**: 빌드, 설정, 패키지 관리

---

## ✨ 작업 개요

스팟 품질 워크플로(Spec 40) MongoDB 컬렉션 초기화 및 인덱스 생성 스크립트를 추가한다.

---

## 📋 변경 사항

- [x] `scripts/init-spot-quality-collections.ts` 생성
  - `spot_quality_reports` 컬렉션 인덱스 4개 생성
  - `spot_lifecycle_history` 컬렉션 인덱스 1개 생성
  - `supplement_requests` 컬렉션 인덱스 2개 생성
  - `spots` 컬렉션에 `lifecycleStatus`, `closureSuspected`, `urgentReviewRequired` 필드 기본값 마이그레이션
- [x] `src/lib/db.ts` COLLECTIONS 상수에 신규 컬렉션 3개 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run format` 통과

---

## 📝 추가 정보

- Requirements: 2.1, 2.6, 3.2, 4.1
- 실행 방법: `npx tsx scripts/init-spot-quality-collections.ts`
- 기존 스팟 문서에 `lifecycleStatus: 'approved'`, `closureSuspected: false`, `urgentReviewRequired: false` 기본값 설정
