### PR TITLE
[enhancement] map theme token migration

### DIFF
--- a/.kiro/specs/20-mascot-design-system/tasks.md
+++ b/.kiro/specs/20-mascot-design-system/tasks.md
@@ -169,7 +169,7 @@
     - WCAG AA 대비 기준 충족 확인
     - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5_
 
-  - [ ] 9.4 map.css 하드코딩 hex 값 새 팔레트에 맞게 교체
+  - [x] 9.4 map.css 하드코딩 hex 값 새 팔레트에 맞게 교체
     - Leaflet 줌 컨트롤, 팝업, 툴팁 등의 hex 값을 새 Primary 계열로 교체
     - _Requirements: 2.1_
 
@@ -199,9 +199,10 @@
     - `public/mascot/` 디렉토리 생성 및 플레이스홀더 에셋 경로 설정 (실제 에셋은 추후 추가)
     - _Requirements: 13.1, 13.2, 13.3, 13.4_
 
-  - [ ] 12.2 SpotPin 지도 마커 마스코트 테마 적용
+  - [-] 12.2 SpotPin 지도 마커 마스코트 테마 적용
     - 마스코트 테마 커스텀 마커 에셋 적용 (에셋 미존재 시 기존 SVG divIcon 폴백)
     - 카테고리별 마커 색상을 토큰(`--category-*-bg/fg`) 참조로 변경
+    - 2026-05-22: 에셋 미존재 상태에서 SpotPin/SpotMarkerLayer/SpotDetailMap 마커를 시맨틱 토큰 기반으로 우선 마이그레이션 완료
     - _Requirements: 12.1, 12.2, 12.4_
 
   - [ ] 12.3 CurrentLocationMarker 마스코트 에셋 적용

--- a/docs/2026-05-22-task20-followups.md
+++ b/docs/2026-05-22-task20-followups.md
@@ -1,0 +1,22 @@
+# Task 20 follow-ups
+
+## Completed in this branch
+- Map marker theming migrated to semantic design tokens
+- Leaflet `map.css` hardcoded palette values migrated to token-based colors
+- Spot detail map markers no longer depend on external colored marker assets
+
+## Scrum / decision needed
+1. **Mascot marker assets**
+   - `12.2`, `12.3` still need real mascot-specific marker assets.
+   - Current implementation keeps token-based divIcon markers as the fallback baseline.
+
+2. **Palette confirmation**
+   - `9.1`~`9.3` still need product confirmation on the final mascot-led palette direction.
+   - Current palette is internally consistent, but the spec still asks for user-facing confirmation and tuning.
+
+3. **Full legacy color sweep**
+   - `8.1` is still partial across the repo.
+   - This branch only closed the map-related legacy color path that was still functionally visible.
+
+4. **Lottie / mascot empty states**
+   - `11.x`, `12.1` remain blocked on asset choice and package adoption scope.

--- a/src/components/map/HoverTooltip.tsx
+++ b/src/components/map/HoverTooltip.tsx
@@ -34,8 +34,8 @@ const getCategoryLabel = (category?: SpotCategory): string => {
 
 // 카테고리별 색상 가져오기
 const getCategoryColor = (category?: SpotCategory): string => {
-  if (!category) return '#2d4a6f'
-  return CATEGORY_CONFIG[category]?.bgColor || '#2d4a6f'
+  if (!category) return 'rgb(var(--category-other-bg))'
+  return CATEGORY_CONFIG[category]?.bgColor || 'rgb(var(--category-other-bg))'
 }
 
 /**

--- a/src/components/map/PilgrimageMap.tsx
+++ b/src/components/map/PilgrimageMap.tsx
@@ -202,7 +202,7 @@ export default function PilgrimageMap({
       )}
 
       {/* Map attribution with navy theme */}
-      <div className="absolute bottom-2 left-2 z-[1000] rounded bg-primary-800/80 px-2 py-1 text-xs text-white">
+      <div className="text-text absolute bottom-2 left-2 z-[1000] rounded bg-surface/90 px-2 py-1 text-xs shadow-sm backdrop-blur-sm">
         Not a Trip
       </div>
 

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useCallback } from 'react'
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
-import { Map as LeafletMap, Icon } from 'leaflet'
+import { Map as LeafletMap, divIcon, DivIcon } from 'leaflet'
 import { SpotDetailData } from '@/hooks/useSpots'
 import { NearbyFacility, FacilityType } from '@/types'
 import { useResizeObserver } from '@/hooks/useResizeObserver'
@@ -14,118 +14,17 @@ interface SpotDetailMapProps {
   className?: string
 }
 
-const spotIcon = new Icon({
-  iconUrl:
-    'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
-  shadowUrl:
-    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41],
-})
-
-const facilityIcons: Record<FacilityType, Icon> = {
-  restaurant: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-orange.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  convenience_store: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  cafe: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  station: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-violet.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  other: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-grey.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  coin_locker: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-violet.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  solo_dining: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  charging_cafe: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  public_restroom: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
-  goods_shop: new Icon({
-    iconUrl:
-      'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-gold.png',
-    shadowUrl:
-      'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [20, 33],
-    iconAnchor: [10, 33],
-    popupAnchor: [1, -28],
-    shadowSize: [33, 33],
-  }),
+const FACILITY_THEME_COLORS: Record<FacilityType, string> = {
+  restaurant: 'rgb(var(--link-schedule))',
+  convenience_store: 'rgb(var(--color-primary-500))',
+  cafe: 'rgb(var(--link-ticket))',
+  station: 'rgb(var(--color-secondary-500))',
+  other: 'rgb(var(--color-muted))',
+  coin_locker: 'rgb(var(--color-secondary-600))',
+  solo_dining: 'rgb(var(--color-danger))',
+  charging_cafe: 'rgb(var(--link-official))',
+  public_restroom: 'rgb(var(--link-ticket))',
+  goods_shop: 'rgb(var(--content-game-fg))',
 }
 
 const facilityTypeLabels: Record<FacilityType, string> = {
@@ -138,7 +37,49 @@ const facilityTypeLabels: Record<FacilityType, string> = {
   solo_dining: '혼밥 식당',
   charging_cafe: '충전/와이파이',
   public_restroom: '화장실',
-  goods_shop: '굿즈/잡화',
+  goods_shop: '굿즈/상점',
+}
+
+function createMapPin(color: string, size: 'spot' | 'facility'): DivIcon {
+  const pinSize = size === 'spot' ? 26 : 20
+  const tailWidth = size === 'spot' ? 9 : 7
+  const tailHeight = size === 'spot' ? 14 : 11
+
+  return divIcon({
+    className: `detail-map-pin detail-map-pin--${size}`,
+    html: `<div style="width:${pinSize}px;height:${pinSize + tailHeight}px;display:flex;flex-direction:column;align-items:center;">
+      <div style="width:${pinSize}px;height:${pinSize}px;border-radius:9999px;background:${color};border:2px solid rgb(var(--color-surface));box-shadow:0 4px 12px rgb(var(--color-text) / 0.22);"></div>
+      <div style="width:0;height:0;border-left:${tailWidth}px solid transparent;border-right:${tailWidth}px solid transparent;border-top:${tailHeight}px solid ${color};margin-top:-2px;"></div>
+    </div>`,
+    iconSize: [pinSize, pinSize + tailHeight],
+    iconAnchor: [pinSize / 2, pinSize + tailHeight],
+    popupAnchor: [0, -(pinSize + tailHeight - 8)],
+  })
+}
+
+const spotIcon = createMapPin('rgb(var(--color-danger))', 'spot')
+
+const facilityIcons: Record<FacilityType, DivIcon> = {
+  restaurant: createMapPin(FACILITY_THEME_COLORS.restaurant, 'facility'),
+  convenience_store: createMapPin(
+    FACILITY_THEME_COLORS.convenience_store,
+    'facility'
+  ),
+  cafe: createMapPin(FACILITY_THEME_COLORS.cafe, 'facility'),
+  station: createMapPin(FACILITY_THEME_COLORS.station, 'facility'),
+  other: createMapPin(FACILITY_THEME_COLORS.other, 'facility'),
+  coin_locker: createMapPin(FACILITY_THEME_COLORS.coin_locker, 'facility'),
+  solo_dining: createMapPin(FACILITY_THEME_COLORS.solo_dining, 'facility'),
+  charging_cafe: createMapPin(FACILITY_THEME_COLORS.charging_cafe, 'facility'),
+  public_restroom: createMapPin(
+    FACILITY_THEME_COLORS.public_restroom,
+    'facility'
+  ),
+  goods_shop: createMapPin(FACILITY_THEME_COLORS.goods_shop, 'facility'),
+}
+
+function getFacilityColor(type: FacilityType): string {
+  return FACILITY_THEME_COLORS[type] || 'rgb(var(--color-muted))'
 }
 
 export default function SpotDetailMap({
@@ -268,8 +209,11 @@ export default function SpotDetailMap({
           <h4 className="mb-2 text-sm font-semibold text-main-text">범례</h4>
           <div className="space-y-1">
             <div className="flex items-center text-xs text-sub-text">
-              <div className="mr-2 h-3 w-3 rounded-full bg-red-500"></div>
-              <span>특별한 여행지</span>
+              <div
+                className="mr-2 h-3 w-3 rounded-full"
+                style={{ backgroundColor: 'rgb(var(--color-danger))' }}
+              ></div>
+              <span>성지 본체</span>
             </div>
             {Array.from(new Set(facilities.map((f) => f.type))).map((type) => (
               <div
@@ -277,7 +221,8 @@ export default function SpotDetailMap({
                 className="flex items-center text-xs text-sub-text"
               >
                 <div
-                  className={`mr-2 h-3 w-3 rounded-full ${getFacilityColor(type)}`}
+                  className="mr-2 h-3 w-3 rounded-full"
+                  style={{ backgroundColor: getFacilityColor(type) }}
                 ></div>
                 <span>{facilityTypeLabels[type]}</span>
               </div>
@@ -286,26 +231,9 @@ export default function SpotDetailMap({
         </div>
       )}
 
-      <div className="absolute bottom-2 right-2 z-[1000] rounded bg-primary-800/80 px-2 py-1 text-xs text-white">
+      <div className="text-text absolute bottom-2 right-2 z-[1000] rounded bg-surface/90 px-2 py-1 text-xs shadow-sm backdrop-blur-sm">
         Not a Trip
       </div>
     </div>
   )
-}
-
-function getFacilityColor(type: FacilityType): string {
-  const colors: Record<FacilityType, string> = {
-    restaurant: 'bg-orange-500',
-    convenience_store: 'bg-primary',
-    cafe: 'bg-green-500',
-    station: 'bg-purple-500',
-    other: 'bg-neutral-500',
-    coin_locker: 'bg-violet-500',
-    solo_dining: 'bg-rose-500',
-    charging_cafe: 'bg-cyan-500',
-    public_restroom: 'bg-teal-500',
-    goods_shop: 'bg-pink-500',
-  }
-
-  return colors[type] || 'bg-neutral-500'
 }

--- a/src/components/map/SpotMarkerLayer.tsx
+++ b/src/components/map/SpotMarkerLayer.tsx
@@ -58,9 +58,23 @@ const CATEGORY_EMOJI: Record<SpotCategory, string> = {
   other: '📍',
 }
 
+const MAP_THEME_COLORS = {
+  defaultCategory: 'rgb(var(--category-other-bg))',
+  markerSurface: 'rgb(var(--color-surface))',
+  markerText: 'rgb(var(--color-text))',
+  markerPlaceholder: 'rgb(var(--color-accent-surface))',
+  hoveredAccent: 'rgb(var(--color-secondary-500))',
+  markerBorder: 'rgb(var(--color-surface))',
+  clusterText: 'rgb(var(--color-background))',
+  clusterBase: 'rgb(var(--color-primary-600))',
+  clusterWarn: 'rgb(var(--color-primary-700))',
+  clusterHot: 'rgb(var(--color-secondary-500))',
+  clusterCritical: 'rgb(var(--color-danger))',
+}
+
 const getCategoryColor = (category?: SpotCategory): string => {
-  if (!category) return '#4164a5'
-  return CATEGORY_CONFIG[category]?.bgColor || '#4164a5'
+  if (!category) return MAP_THEME_COLORS.defaultCategory
+  return CATEGORY_CONFIG[category]?.bgColor || MAP_THEME_COLORS.defaultCategory
 }
 
 const getCategoryEmoji = (category?: SpotCategory): string => {
@@ -89,7 +103,7 @@ function createDotIcon(category?: SpotCategory): L.DivIcon {
   const emoji = getCategoryEmoji(category)
   return L.divIcon({
     className: 'spot-dot-pin',
-    html: `<div style="width:22px;height:22px;border-radius:50%;background:${color};border:2px solid white;display:flex;align-items:center;justify-content:center;font-size:11px;cursor:pointer;">${emoji}</div>`,
+    html: `<div style="width:22px;height:22px;border-radius:50%;background:${color};border:2px solid ${MAP_THEME_COLORS.markerBorder};display:flex;align-items:center;justify-content:center;font-size:11px;cursor:pointer;">${emoji}</div>`,
     iconSize: [22, 22],
     iconAnchor: [11, 11],
   })
@@ -104,8 +118,8 @@ function createLabelIcon(name: string, category?: SpotCategory): L.DivIcon {
   return L.divIcon({
     className: 'spot-label-pin',
     html: `<div style="display:flex;flex-direction:column;align-items:center;cursor:pointer;">
-      <div style="width:32px;height:32px;border-radius:50%;background:${color};border:2.5px solid white;display:flex;align-items:center;justify-content:center;font-size:14px;box-shadow:0 1px 3px rgba(0,0,0,0.2);">${emoji}</div>
-      <div style="margin-top:2px;padding:1px 4px;border-radius:4px;background:rgba(255,255,255,0.92);font-size:10px;font-weight:600;color:#1f2937;white-space:nowrap;max-width:80px;overflow:hidden;text-overflow:ellipsis;box-shadow:0 1px 2px rgba(0,0,0,0.1);">${displayName}</div>
+      <div style="width:32px;height:32px;border-radius:50%;background:${color};border:2.5px solid ${MAP_THEME_COLORS.markerBorder};display:flex;align-items:center;justify-content:center;font-size:14px;box-shadow:0 1px 3px rgb(var(--color-text) / 0.2);">${emoji}</div>
+      <div style="margin-top:2px;padding:1px 4px;border-radius:4px;background:rgb(var(--color-surface) / 0.92);font-size:10px;font-weight:600;color:${MAP_THEME_COLORS.markerText};white-space:nowrap;max-width:80px;overflow:hidden;text-overflow:ellipsis;box-shadow:0 1px 2px rgb(var(--color-text) / 0.1);">${displayName}</div>
     </div>`,
     iconSize: [80, 50],
     iconAnchor: [40, 20],
@@ -129,7 +143,7 @@ function createImageIcon(
   return L.divIcon({
     className: 'spot-image-pin',
     html: `<div style="width:48px;height:58px;position:relative;cursor:pointer;">
-      <div style="width:48px;height:48px;border-radius:50%;border:3px solid ${color};overflow:hidden;background:#e5e7eb;">${imageHtml}</div>
+      <div style="width:48px;height:48px;border-radius:50%;border:3px solid ${color};overflow:hidden;background:${MAP_THEME_COLORS.markerPlaceholder};">${imageHtml}</div>
       <div style="position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:0;height:0;border-left:7px solid transparent;border-right:7px solid transparent;border-top:10px solid ${color};"></div>
     </div>`,
     iconSize: [48, 58],
@@ -154,8 +168,8 @@ function createHoveredIcon(
   return L.divIcon({
     className: 'spot-image-pin is-hovered',
     html: `<div style="width:56px;height:66px;position:relative;cursor:pointer;">
-      <div style="width:56px;height:56px;border-radius:50%;border:4px solid #fbbf24;overflow:hidden;background:#e5e7eb;box-shadow:0 0 10px 2px rgba(251,191,36,0.4);">${imageHtml}</div>
-      <div style="position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:0;height:0;border-left:8px solid transparent;border-right:8px solid transparent;border-top:10px solid #fbbf24;"></div>
+      <div style="width:56px;height:56px;border-radius:50%;border:4px solid ${MAP_THEME_COLORS.hoveredAccent};overflow:hidden;background:${MAP_THEME_COLORS.markerPlaceholder};box-shadow:0 0 10px 2px rgb(var(--color-secondary-500) / 0.4);">${imageHtml}</div>
+      <div style="position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:0;height:0;border-left:8px solid transparent;border-right:8px solid transparent;border-top:10px solid ${MAP_THEME_COLORS.hoveredAccent};"></div>
     </div>`,
     iconSize: [56, 66],
     iconAnchor: [28, 66],
@@ -177,25 +191,25 @@ function getIconForZoom(spot: SpotPinType, tier: ZoomTier): L.DivIcon {
 // ─── 클러스터 아이콘 ─────────────────────────────────────────────────────────
 function createClusterIcon(cluster: L.MarkerCluster): L.DivIcon {
   const count = cluster.getChildCount()
-  let size = 36,
-    bgColor = '#4164a5',
-    fontSize = '12px'
+  let size = 36
+  let bgColor = MAP_THEME_COLORS.clusterBase
+  let fontSize = '12px'
   if (count >= 50) {
     size = 48
-    bgColor = '#dc2626'
+    bgColor = MAP_THEME_COLORS.clusterCritical
     fontSize = '14px'
   } else if (count >= 20) {
     size = 44
-    bgColor = '#ea580c'
+    bgColor = MAP_THEME_COLORS.clusterHot
     fontSize = '13px'
   } else if (count >= 10) {
     size = 40
-    bgColor = '#ca8a04'
+    bgColor = MAP_THEME_COLORS.clusterWarn
     fontSize = '13px'
   }
 
   return L.divIcon({
-    html: `<div style="width:${size}px;height:${size}px;border-radius:50%;background:${bgColor};color:white;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:${fontSize};border:3px solid white;box-shadow:0 2px 4px rgba(0,0,0,0.25);">${count}</div>`,
+    html: `<div style="width:${size}px;height:${size}px;border-radius:50%;background:${bgColor};color:${MAP_THEME_COLORS.clusterText};display:flex;align-items:center;justify-content:center;font-weight:700;font-size:${fontSize};border:3px solid ${MAP_THEME_COLORS.markerBorder};box-shadow:0 2px 4px rgb(var(--color-text) / 0.25);">${count}</div>`,
     className: 'marker-cluster-custom',
     iconSize: L.point(size, size),
   })
@@ -235,6 +249,7 @@ export default function SpotMarkerLayer({
       iconCreateFunction: createClusterIcon,
     })
     clusterGroupRef.current = clusterGroup
+    const currentMarkers = markersRef.current
     map.addLayer(clusterGroup)
 
     // 줌 변경 시 아이콘 일괄 교체
@@ -258,7 +273,7 @@ export default function SpotMarkerLayer({
       map.off('zoomend', onZoomEnd)
       map.removeLayer(clusterGroup)
       clusterGroupRef.current = null
-      markersRef.current.clear()
+      currentMarkers.clear()
     }
   }, [map])
 

--- a/src/components/map/SpotPin.tsx
+++ b/src/components/map/SpotPin.tsx
@@ -74,10 +74,18 @@ const Z_INDEX = { base: 0, hovered: 10000 }
 // 핀 크기 상수
 const PIN_SIZES = { base: 48, hovered: 54 }
 
+const MAP_THEME_COLORS = {
+  defaultCategory: 'rgb(var(--category-other-bg))',
+  hoveredAccent: 'rgb(var(--color-secondary-500))',
+  popularStart: 'rgb(var(--color-secondary-500))',
+  popularEnd: 'rgb(var(--color-danger))',
+  markerPlaceholder: 'rgb(var(--color-accent-surface))',
+} as const
+
 // 카테고리별 색상
 const getCategoryColor = (category?: SpotCategory): string => {
-  if (!category) return '#2d4a6f'
-  return CATEGORY_CONFIG[category]?.bgColor || '#2d4a6f'
+  if (!category) return MAP_THEME_COLORS.defaultCategory
+  return CATEGORY_CONFIG[category]?.bgColor || MAP_THEME_COLORS.defaultCategory
 }
 
 // 카테고리별 아이콘
@@ -109,16 +117,16 @@ const createImagePinIcon = (
   const size = isHovered ? PIN_SIZES.hovered : PIN_SIZES.base
   const categoryColor = getCategoryColor(category)
   const categoryIconData = getCategoryIcon(category)
-  const borderColor = isHovered ? '#fbbf24' : categoryColor
+  const borderColor = isHovered ? MAP_THEME_COLORS.hoveredAccent : categoryColor
   const borderWidth = isHovered ? 4 : 3
   const shadowIntensity = isHovered ? 0.5 : 0.3
   const glowEffect = isHovered
-    ? 'box-shadow: 0 0 12px 2px rgba(251, 191, 36, 0.4);'
+    ? 'box-shadow: 0 0 12px 2px rgb(var(--color-secondary-500) / 0.4);'
     : ''
 
   const isPopular = checkInCount && checkInCount >= 10
   const popularBadge = isPopular
-    ? `<div style="position:absolute;top:-4px;right:-4px;background:linear-gradient(135deg,#f59e0b,#ef4444);color:white;font-size:10px;font-weight:bold;padding:2px 4px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.2);z-index:10;">🔥${checkInCount}</div>`
+    ? `<div style="position:absolute;top:-4px;right:-4px;background:linear-gradient(135deg,${MAP_THEME_COLORS.popularStart},${MAP_THEME_COLORS.popularEnd});color:white;font-size:10px;font-weight:bold;padding:2px 4px;border-radius:8px;box-shadow:0 2px 4px rgb(var(--color-text) / 0.2);z-index:10;">🔥${checkInCount}</div>`
     : ''
 
   const hasImage = thumbnailUrl && thumbnailUrl.length > 0
@@ -137,7 +145,7 @@ const createImagePinIcon = (
     className: `custom-image-spot-pin ${hoverClass}`,
     html: `
       <div class="image-pin-container ${hoverClass}" style="width:${size}px;height:${size + 12}px;position:relative;cursor:pointer;filter:drop-shadow(0 4px 8px rgba(0,0,0,${shadowIntensity}));transition:all 0.25s cubic-bezier(0.34,1.56,0.64,1);">
-        <div class="image-circle" style="width:${size}px;height:${size}px;border-radius:50%;border:${borderWidth}px solid ${borderColor};overflow:hidden;background:#e5e7eb;box-shadow:0 2px 8px rgba(0,0,0,0.2);transition:all 0.25s cubic-bezier(0.34,1.56,0.64,1);${glowEffect}">
+        <div class="image-circle" style="width:${size}px;height:${size}px;border-radius:50%;border:${borderWidth}px solid ${borderColor};overflow:hidden;background:${MAP_THEME_COLORS.markerPlaceholder};box-shadow:0 2px 8px rgb(var(--color-text) / 0.2);transition:all 0.25s cubic-bezier(0.34,1.56,0.64,1);${glowEffect}">
           ${imageContent}
         </div>
         <div class="pin-tail" style="position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:0;height:0;border-left:8px solid transparent;border-right:8px solid transparent;border-top:12px solid ${borderColor};transition:border-color 0.25s ease;"></div>
@@ -165,8 +173,6 @@ export default memo(function SpotPin({ spot, onSelect }: SpotPinProps) {
   )
   // previewSpotId, isPreviewHovered는 구독하지 않고 ref로만 읽음
   // → store 변경 시 SpotPin 리렌더 없음
-  const isPreviewHovered = useUIStore.getState().isPreviewHovered
-  const previewSpotId = useUIStore.getState().previewSpotId
   const { open: openBottomSheet } = useBottomSheetStore(
     useShallow((s) => ({ open: s.open }))
   )

--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -3,14 +3,14 @@
 
 /* 지도 컨테이너 기본 스타일 */
 .leaflet-container {
-  background: #f4f4f5; /* neutral-100 */
+  background: rgb(var(--color-neutral-100));
   font-family: inherit;
   z-index: 0 !important;
 }
 
 /* 다크 모드 지도 컨테이너 배경 */
 .dark .leaflet-container {
-  background: #27272a; /* neutral-800 */
+  background: rgb(var(--color-neutral-800));
 }
 
 /* 지도 내부 요소들의 z-index 제한 */
@@ -53,41 +53,41 @@
 
 /* 줌 컨트롤 스타일 - primary 테마 */
 .leaflet-control-zoom a {
-  background-color: #4c40a8 !important; /* primary-600 */
-  border-color: #5f52c8 !important; /* primary-500 */
-  color: white !important;
+  background-color: rgb(var(--color-primary-600)) !important;
+  border-color: rgb(var(--color-primary-500)) !important;
+  color: rgb(var(--color-background)) !important;
 }
 
 .leaflet-control-zoom a:hover {
-  background-color: #3c328a !important; /* primary-700 */
+  background-color: rgb(var(--color-primary-700)) !important;
 }
 
 /* 팝업 스타일 */
 .leaflet-popup-content-wrapper {
-  background: white;
-  border: 1px solid #bdb7f2; /* primary-200 */
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-primary-200));
   border-radius: 0.5rem;
   box-shadow:
-    0 10px 15px -3px rgba(0, 0, 0, 0.1),
-    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    0 10px 15px -3px rgb(var(--color-text) / 0.1),
+    0 4px 6px -2px rgb(var(--color-text) / 0.05);
 }
 
 .leaflet-popup-tip {
-  background: white;
+  background: rgb(var(--color-surface));
 }
 
 .dark .leaflet-popup-content-wrapper {
-  background: #111827;
-  border-color: #374151;
-  color: #f5f5f5;
+  background: rgb(var(--color-surface));
+  border-color: rgb(var(--color-border));
+  color: rgb(var(--color-text));
 }
 
 .dark .leaflet-popup-tip {
-  background: #111827;
+  background: rgb(var(--color-surface));
 }
 
 .dark .leaflet-popup-content {
-  color: #f5f5f5 !important;
+  color: rgb(var(--color-text)) !important;
 }
 
 .spot-detail-popup-content {
@@ -113,13 +113,15 @@
 
 /* Attribution 스타일 */
 .leaflet-control-attribution {
-  background: rgba(30, 24, 72, 0.8) !important; /* primary-900/80 */
-  color: white !important;
+  background: rgb(var(--color-surface) / 0.88) !important;
+  color: rgb(var(--color-text)) !important;
   font-size: 0.75rem !important;
+  border: 1px solid rgb(var(--color-border)) !important;
+  backdrop-filter: blur(8px);
 }
 
 .leaflet-control-attribution a {
-  color: #bdb7f2 !important; /* primary-200 */
+  color: rgb(var(--color-primary-600)) !important;
 }
 
 /* SpotPin 커스텀 마커 스타일 */
@@ -145,7 +147,7 @@
 /* 이미지 핀 호버 효과 */
 .image-pin-container:hover .image-circle {
   transform: scale(1.08);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px rgb(var(--color-text) / 0.3);
 }
 
 /* 호버 상태 핀 스타일 */
@@ -178,13 +180,13 @@
 /* 핀 호버 시 글로우 확산 애니메이션 (노란색) */
 @keyframes pin-glow-spread {
   0% {
-    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.5);
+    box-shadow: 0 0 0 0 rgb(var(--color-secondary-500) / 0.5);
   }
   60% {
-    box-shadow: 0 0 14px 4px rgba(251, 191, 36, 0.35);
+    box-shadow: 0 0 14px 4px rgb(var(--color-secondary-500) / 0.35);
   }
   100% {
-    box-shadow: 0 0 12px 2px rgba(251, 191, 36, 0.4);
+    box-shadow: 0 0 12px 2px rgb(var(--color-secondary-500) / 0.4);
   }
 }
 
@@ -192,10 +194,10 @@
 
 /* 스팟 팝업 스타일 */
 .spot-popup .leaflet-popup-content-wrapper {
-  background: white !important;
-  border: 2px solid #5f52c8 !important; /* primary-500 */
+  background: rgb(var(--color-surface)) !important;
+  border: 2px solid rgb(var(--color-primary-500)) !important;
   border-radius: 0.75rem !important;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
+  box-shadow: 0 25px 50px -12px rgb(var(--color-text) / 0.25) !important;
   max-width: 350px !important;
   min-width: 320px !important;
   padding: 0 !important;
@@ -207,16 +209,16 @@
 }
 
 .spot-popup .leaflet-popup-tip {
-  background: white !important;
+  background: rgb(var(--color-surface)) !important;
 }
 
 .dark .spot-popup .leaflet-popup-content-wrapper {
-  background: #111827 !important;
-  border-color: #5f52c8 !important;
+  background: rgb(var(--color-surface)) !important;
+  border-color: rgb(var(--color-primary-500)) !important;
 }
 
 .dark .spot-popup .leaflet-popup-tip {
-  background: #111827 !important;
+  background: rgb(var(--color-surface)) !important;
 }
 
 /* 마커 애니메이션 */
@@ -236,20 +238,20 @@
 .spot-pin-container:hover .spot-pin-marker {
   transform: rotate(-45deg) scale(1.1) !important;
   box-shadow:
-    0 6px 16px rgba(0, 0, 0, 0.4),
-    0 3px 6px rgba(0, 0, 0, 0.15) !important;
+    0 6px 16px rgb(var(--color-text) / 0.4),
+    0 3px 6px rgb(var(--color-text) / 0.15) !important;
 }
 
 /* 선택된 마커 애니메이션 */
 @keyframes pulse-marker {
   0% {
-    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.7);
+    box-shadow: 0 0 0 0 rgb(var(--color-secondary-500) / 0.7);
   }
   70% {
-    box-shadow: 0 0 0 10px rgba(251, 191, 36, 0);
+    box-shadow: 0 0 0 10px rgb(var(--color-secondary-500) / 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0);
+    box-shadow: 0 0 0 0 rgb(var(--color-secondary-500) / 0);
   }
 }
 
@@ -294,11 +296,11 @@
 
 /* Leaflet Tooltip 기본 스타일 오버라이드 */
 .leaflet-tooltip.hover-tooltip {
-  background: #1e1848; /* primary-900 */
-  border: 1px solid #4c40a8; /* primary-600 */
+  background: rgb(var(--color-surface));
+  border: 1px solid rgb(var(--color-primary-500));
   border-radius: 8px;
   padding: 0;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 12px rgb(var(--color-text) / 0.3);
   z-index: 1000 !important;
 
   /* 페이드인/아웃 애니메이션 (150ms) */
@@ -327,7 +329,7 @@
   transform: translateX(-50%);
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid #1e1848; /* primary-900 */
+  border-top: 8px solid rgb(var(--color-surface));
 }
 
 /* 화살표 테두리 효과 */
@@ -339,7 +341,7 @@
   transform: translateX(-50%);
   border-left: 9px solid transparent;
   border-right: 9px solid transparent;
-  border-top: 9px solid #4c40a8; /* primary-600 */
+  border-top: 9px solid rgb(var(--color-primary-500));
   z-index: -1;
 }
 
@@ -360,7 +362,7 @@
   height: 44px;
   border-radius: 6px;
   overflow: hidden;
-  background: #3c328a; /* primary-700 */
+  background: rgb(var(--color-primary-700));
 }
 
 /* 썸네일 이미지 */
@@ -395,7 +397,7 @@
   margin: 0 0 4px 0;
   font-size: 13px;
   font-weight: 600;
-  color: #ffffff;
+  color: rgb(var(--color-text));
   line-height: 1.3;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -415,7 +417,7 @@
 
 .hover-tooltip-category-label {
   font-size: 11px;
-  color: #bdb7f2; /* primary-200 */
+  color: rgb(var(--color-text-secondary));
 }
 
 /* 반응형 조정 */


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #823

---

## 📋 PR 타입
- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] 🚀 **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🛠 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📝 **docs**: 문서 수정

---

## ✨ 작업 개요

지도 관련 하드코딩 색상과 외부 colored marker 의존성을 시맨틱 디자인 토큰 기반으로 정리해 task 20의 map/theme 마이그레이션 경로를 마무리합니다.

---

## 📋 변경 사항

- [x] SpotPin / SpotMarkerLayer / HoverTooltip의 marker, hover, cluster 색상을 시맨틱 토큰 기반으로 마이그레이션
- [x] SpotDetailMap의 외부 Leaflet colored marker asset 의존성을 제거하고 divIcon 기반 토큰 마커로 교체
- [x] map.css의 zoom control, popup, tooltip, attribution 등 Leaflet UI 하드코딩 hex 색상을 토큰 참조로 교체
- [x] task 20 진행 상황과 후속 스크럼 필요 항목을 spec/tasks 및 docs 문서에 동기화

---

## ✅ 체크리스트
- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

- 검증: `npm run type-check`, 대상 map 파일 대상 `npx eslint`
- follow-up: `docs/2026-05-22-task20-followups.md`
- mascot 전용 마커 에셋은 아직 없어 토큰 기반 divIcon fallback을 유지했습니다.