### PR TITLE
[ui] mascot-themed empty states

### DIFF
--- a/.kiro/specs/20-mascot-design-system/tasks.md
+++ b/.kiro/specs/20-mascot-design-system/tasks.md
@@ -190,13 +190,14 @@
     - _Requirements: 13.3_
 
 - [ ] 12. 마스코트 에셋 기반 상태 화면 및 지도 마커 개편
-  - [ ] 12.1 상태 화면 컴포넌트 마스코트 일러스트 적용
+  - [-] 12.1 상태 화면 컴포넌트 마스코트 일러스트 적용
     - `EmptySearchOverlay`: 마스코트 일러스트 + 폴백 (기존 SearchIcon)
     - `EmptyFilterOverlay`: 마스코트 일러스트 + 폴백 (기존 FilterIcon)
     - `SpotErrorDisplay`: 마스코트 일러스트 + `accent-surface` 배경 + 폴백 (기존 AlertTriangleIcon)
     - `ErrorBoundary`: 마스코트 일러스트 + `primary` 버튼 + 폴백
     - 로딩 스피너: LottieLoader 컴포넌트 적용 + 폴백 체인
     - `public/mascot/` 디렉토리 생성 및 플레이스홀더 에셋 경로 설정 (실제 에셋은 추후 추가)
+    - 2026-05-22: 공용 `MascotIllustration` 추가 및 Empty/Error/Loading 상태 UI를 기존 로컬 마스코트 에셋 기반으로 우선 개편 완료
     - _Requirements: 13.1, 13.2, 13.3, 13.4_
 
   - [-] 12.2 SpotPin 지도 마커 마스코트 테마 적용

--- a/docs/2026-05-22-task20-followups.md
+++ b/docs/2026-05-22-task20-followups.md
@@ -4,6 +4,7 @@
 - Map marker theming migrated to semantic design tokens
 - Leaflet `map.css` hardcoded palette values migrated to token-based colors
 - Spot detail map markers no longer depend on external colored marker assets
+- Mascot-themed empty/error/loading fallback UI applied using existing local mascot assets
 
 ## Scrum / decision needed
 1. **Mascot marker assets**
@@ -18,5 +19,6 @@
    - `8.1` is still partial across the repo.
    - This branch only closed the map-related legacy color path that was still functionally visible.
 
-4. **Lottie / mascot empty states**
-   - `11.x`, `12.1` remain blocked on asset choice and package adoption scope.
+4. **Lottie / mascot loading upgrade**
+   - `11.x` still needs a package decision because new dependencies are currently out of scope.
+   - `12.1` is partially closed with static mascot assets, but the Lottie-specific loading path is still open.

--- a/src/components/common/EmptyFilterOverlay.tsx
+++ b/src/components/common/EmptyFilterOverlay.tsx
@@ -1,4 +1,5 @@
 import { FilterIcon } from '@/components/icons'
+import { MascotIllustration } from './MascotIllustration'
 
 /**
  * 카테고리 필터 전체 해제 시 빈 상태 오버레이 컴포넌트
@@ -7,18 +8,29 @@ import { FilterIcon } from '@/components/icons'
 export function EmptyFilterOverlay() {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="backdrop-blur-sm/95 pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
-          <FilterIcon size="lg" className="text-muted" />
+      <div className="pointer-events-auto w-full max-w-sm rounded-2xl border border-border bg-surface/95 px-8 py-7 text-center shadow-xl backdrop-blur-md">
+        <div className="text-text-secondary mb-3 inline-flex items-center gap-2 rounded-full bg-accent-surface px-3 py-1 text-xs font-medium">
+          <FilterIcon size="sm" className="text-primary" />
+          필터 선택 필요
         </div>
+
+        <MascotIllustration
+          variant="greeting"
+          size="md"
+          className="mx-auto mb-3"
+        />
+
         <p className="text-lg font-semibold text-primary-800 dark:text-primary-300">
-          카테고리를 선택해주세요
+          카테고리를 선택해 주세요
         </p>
+
         <p className="mt-2 text-sm text-secondary dark:text-neutral-400">
-          표시할 스팟 카테고리가 선택되지 않았습니다
+          표시할 스팟 카테고리가 아직 선택되지 않았습니다.
         </p>
-        <p className="mt-1 text-xs text-muted dark:text-neutral-500">
-          필터에서 원하는 카테고리를 선택하세요
+
+        <p className="mt-2 rounded-xl bg-accent-surface px-4 py-3 text-xs leading-5 text-muted dark:text-neutral-400">
+          관심 있는 장르를 고르면 마스코트가 그 분위기에 맞는 장소를 바로
+          보여드릴게요.
         </p>
       </div>
     </div>

--- a/src/components/common/EmptySearchOverlay.tsx
+++ b/src/components/common/EmptySearchOverlay.tsx
@@ -1,4 +1,5 @@
 import { SearchIcon } from '@/components/icons'
+import { MascotIllustration } from './MascotIllustration'
 
 interface EmptySearchOverlayProps {
   searchQuery: string
@@ -11,18 +12,29 @@ interface EmptySearchOverlayProps {
 export function EmptySearchOverlay({ searchQuery }: EmptySearchOverlayProps) {
   return (
     <div className="pointer-events-none absolute inset-0 z-[999] flex items-center justify-center">
-      <div className="backdrop-blur-sm/95 pointer-events-auto rounded-xl bg-surface/95 px-8 py-6 text-center shadow-xl">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
-          <SearchIcon size="lg" className="text-muted" />
+      <div className="pointer-events-auto w-full max-w-sm rounded-2xl border border-border bg-surface/95 px-8 py-7 text-center shadow-xl backdrop-blur-md">
+        <div className="text-text-secondary mb-3 inline-flex items-center gap-2 rounded-full bg-accent-surface px-3 py-1 text-xs font-medium">
+          <SearchIcon size="sm" className="text-primary" />
+          검색 결과 없음
         </div>
+
+        <MascotIllustration
+          variant="confirm"
+          size="md"
+          className="mx-auto mb-3"
+        />
+
         <p className="text-lg font-semibold text-primary-800 dark:text-primary-300">
           검색 결과가 없습니다
         </p>
+
         <p className="mt-2 text-sm text-secondary dark:text-neutral-400">
           &quot;{searchQuery}&quot;에 해당하는 스팟을 찾을 수 없습니다
         </p>
-        <p className="mt-1 text-xs text-muted dark:text-neutral-500">
-          다른 검색어를 입력하거나 필터를 조정해 보세요
+
+        <p className="mt-2 rounded-xl bg-accent-surface px-4 py-3 text-xs leading-5 text-muted dark:text-neutral-400">
+          마스코트가 아직 단서를 못 찾았어요. 다른 검색어를 입력하거나 필터를
+          조금 넓혀보세요.
         </p>
       </div>
     </div>

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import * as Sentry from '@sentry/nextjs'
 import { AlertTriangleIcon } from '@/components/icons'
+import { MascotIllustration } from './MascotIllustration'
 
 interface ErrorBoundaryProps {
   children: React.ReactNode
@@ -75,20 +76,36 @@ class ErrorBoundary extends React.Component<
 
       // 우선순위 3: 기본 에러 UI
       return (
-        <div className="flex h-full w-full items-center justify-center p-8">
-          <div className="text-center">
-            <div className="mx-auto h-12 w-12 rounded-full bg-red-100 p-3">
-              <AlertTriangleIcon size={24} color="#dc2626" />
+        <div className="flex h-full w-full items-center justify-center bg-neutral-100 p-8 dark:bg-background">
+          <div className="w-full max-w-sm rounded-2xl border border-border bg-surface p-6 text-center shadow-lg">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-danger-surface px-3 py-1 text-xs font-medium text-danger">
+              <AlertTriangleIcon size={16} color="currentColor" />
+              화면 오류
             </div>
-            <p className="mt-4 text-sm text-neutral-700">문제가 발생했습니다</p>
-            <p className="mt-1 text-xs text-neutral-500">
+
+            <MascotIllustration
+              variant="confirm"
+              size="md"
+              className="mx-auto mb-3"
+            />
+
+            <p className="text-text text-lg font-semibold">
+              문제가 발생했습니다
+            </p>
+
+            <p className="text-text-secondary mt-2 text-sm">
+              잠시 후 다시 시도하면 대부분 정상적으로 복구됩니다.
+            </p>
+
+            <p className="mt-3 rounded-xl bg-accent-surface px-4 py-3 text-xs leading-5 text-muted">
               {this.state.error.message}
             </p>
+
             <button
               onClick={this.handleReset}
-              className="mt-3 rounded bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-primary-500"
+              className="mt-4 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-500"
             >
-              다시 시도
+              다시 열기
             </button>
           </div>
         </div>

--- a/src/components/common/MascotIllustration.tsx
+++ b/src/components/common/MascotIllustration.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image'
+
+type MascotVariant = 'main' | 'greeting' | 'confirm' | 'cheer'
+
+interface MascotIllustrationProps {
+  variant?: MascotVariant
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+  priority?: boolean
+}
+
+const MASCOT_ASSETS: Record<MascotVariant, string> = {
+  main: '/icons/raw/0329/캐릭터_메인_최종.webp',
+  greeting: '/icons/raw/0329/캐릭터-인사.webp',
+  confirm: '/icons/raw/0329/캐릭터-확인.webp',
+  cheer: '/icons/raw/0329/캐릭터-환호.webp',
+}
+
+const SIZE_CLASSES: Record<
+  NonNullable<MascotIllustrationProps['size']>,
+  string
+> = {
+  sm: 'h-20 w-20',
+  md: 'h-28 w-28',
+  lg: 'h-36 w-36',
+}
+
+export function MascotIllustration({
+  variant = 'main',
+  size = 'md',
+  className = '',
+  priority = false,
+}: MascotIllustrationProps) {
+  return (
+    <div
+      className={`relative ${SIZE_CLASSES[size]} ${className}`}
+      aria-hidden="true"
+    >
+      <Image
+        src={MASCOT_ASSETS[variant]}
+        alt=""
+        fill
+        priority={priority}
+        sizes="(max-width: 768px) 80px, 144px"
+        className="object-contain drop-shadow-lg"
+      />
+    </div>
+  )
+}

--- a/src/components/common/SpotErrorDisplay.tsx
+++ b/src/components/common/SpotErrorDisplay.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangleIcon } from '@/components/icons'
+import { MascotIllustration } from './MascotIllustration'
 
 interface SpotErrorDisplayProps {
   error: Error
@@ -11,20 +12,34 @@ interface SpotErrorDisplayProps {
  */
 export function SpotErrorDisplay({ error, onRetry }: SpotErrorDisplayProps) {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-neutral-100">
-      <div className="text-center">
-        <div className="mx-auto h-12 w-12 rounded-full bg-danger-surface p-3 dark:bg-red-900/30">
-          <AlertTriangleIcon size={24} color="#dc2626" />
+    <div className="flex h-full w-full items-center justify-center bg-neutral-100 px-6 dark:bg-background">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-surface p-6 text-center shadow-lg">
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-danger-surface px-3 py-1 text-xs font-medium text-danger">
+          <AlertTriangleIcon size={16} color="currentColor" />
+          불러오기 실패
         </div>
-        <p className="mt-4 text-neutral-700 dark:text-neutral-200">
-          스팟 데이터를 불러올 수 없습니다
+
+        <MascotIllustration
+          variant="confirm"
+          size="md"
+          className="mx-auto mb-3"
+        />
+
+        <p className="text-text text-lg font-semibold">
+          스팟 데이터를 불러오지 못했습니다
         </p>
-        <p className="mt-1 text-xs text-muted dark:text-neutral-500">
+
+        <p className="text-text-secondary mt-2 text-sm">
+          잠시 후 다시 시도하거나 네트워크 상태를 확인해 주세요.
+        </p>
+
+        <p className="mt-3 rounded-xl bg-accent-surface px-4 py-3 text-xs leading-5 text-muted">
           {error.message}
         </p>
+
         <button
           onClick={onRetry}
-          className="mt-3 rounded bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-primary-400"
+          className="mt-4 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-400"
         >
           다시 시도
         </button>

--- a/src/components/common/SpotLoadingSkeleton.tsx
+++ b/src/components/common/SpotLoadingSkeleton.tsx
@@ -1,4 +1,5 @@
 import { SpinnerIcon } from '@/components/icons'
+import { MascotIllustration } from './MascotIllustration'
 
 /**
  * 스팟 데이터 로딩 중 표시되는 컴포넌트
@@ -6,13 +7,30 @@ import { SpinnerIcon } from '@/components/icons'
  */
 export function SpotLoadingSkeleton() {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-neutral-100">
-      <div className="text-center">
-        <SpinnerIcon
-          size="lg"
-          className="mx-auto animate-spin text-neutral-400 dark:text-neutral-200"
+    <div className="flex h-full w-full items-center justify-center bg-neutral-100 px-6 dark:bg-background">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-surface p-6 text-center shadow-lg">
+        <div className="text-text-secondary mb-3 inline-flex items-center gap-2 rounded-full bg-accent-surface px-3 py-1 text-xs font-medium">
+          <SpinnerIcon size="sm" className="animate-spin text-primary" />
+          스팟 탐색 중
+        </div>
+
+        <MascotIllustration
+          variant="main"
+          size="md"
+          className="mx-auto mb-3 animate-pulse"
         />
-        <p className="mt-2 text-sm text-neutral-500">스팟 데이터 로딩 중...</p>
+
+        <p className="text-text text-lg font-semibold">
+          특별한 장소를 찾고 있어요
+        </p>
+
+        <p className="text-text-secondary mt-2 text-sm">
+          주변 스팟과 관련 정보를 정리하는 중입니다.
+        </p>
+
+        <div className="mt-4 overflow-hidden rounded-full bg-accent-surface">
+          <div className="animate-loading-bar h-1.5 w-1/4 rounded-full bg-primary" />
+        </div>
       </div>
     </div>
   )

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -21,6 +21,7 @@ export { SentryUserManager } from './SentryUserManager'
 export type { ErrorBoundaryProps } from './ErrorBoundary'
 export { AsyncBoundary } from './AsyncBoundary'
 export type { AsyncBoundaryProps } from './AsyncBoundary'
+export { MascotIllustration } from './MascotIllustration'
 
 export { ThemeSelector } from './ThemeToggle'
 export { default as ShareButton } from './ShareButton'


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #825

---

## 📋 PR 타입
- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] 🚀 **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🛠 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📝 **docs**: 문서 수정

---

## ✨ 작업 개요

Task 20 후속으로 generic 상태 UI를 기존 로컬 마스코트 에셋 기반 fallback UI로 교체해 브랜드 일관성을 높입니다.

---

## 📋 변경 사항

- [x] 공용 `MascotIllustration` 컴포넌트 추가
- [x] `EmptySearchOverlay`, `EmptyFilterOverlay`를 mascot-themed 상태 카드로 개편
- [x] `SpotErrorDisplay`, `ErrorBoundary`, `SpotLoadingSkeleton`의 기본 fallback UI를 mascot-themed로 개편
- [x] task 20 문서와 follow-up 문서에 부분 완료 상태 반영

---

## ✅ 체크리스트
- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

- 검증: `npm run type-check`, 대상 common 파일 `npx eslint`
- 새 dependency 없이 기존 로컬 마스코트 에셋만 재사용했습니다.
- Lottie 로딩 경로는 별도 scope 결정 후 진행 필요합니다.