### PR TITLE
[fix] clear stale dev service worker precache

### DIFF
--- a/src/components/pwa/SerwistRegistration.tsx
+++ b/src/components/pwa/SerwistRegistration.tsx
@@ -2,18 +2,55 @@
 
 import { useEffect } from 'react'
 
+const DEV_SW_RESET_KEY = 'not-a-trip-dev-sw-reset'
+
+async function resetDevelopmentServiceWorkers() {
+  const registrations = await navigator.serviceWorker.getRegistrations()
+
+  if (registrations.length === 0) {
+    sessionStorage.removeItem(DEV_SW_RESET_KEY)
+    return
+  }
+
+  await Promise.all(
+    registrations.map((registration) => registration.unregister())
+  )
+
+  if ('caches' in window) {
+    const cacheNames = await caches.keys()
+    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)))
+  }
+
+  if (
+    navigator.serviceWorker.controller &&
+    sessionStorage.getItem(DEV_SW_RESET_KEY) !== 'done'
+  ) {
+    sessionStorage.setItem(DEV_SW_RESET_KEY, 'done')
+    window.location.reload()
+    return
+  }
+
+  sessionStorage.removeItem(DEV_SW_RESET_KEY)
+}
+
 /**
  * Serwist Service Worker 등록 컴포넌트
- * 클라이언트 사이드에서 SW를 자동 등록합니다.
+ * - production: service worker 등록
+ * - development: stale service worker 등록 해제 + cache 정리
  * @requirements 1.4, 1.6
  */
 export function SerwistRegistration() {
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').catch((error) => {
-        console.error('Service Worker 등록 실패:', error)
-      })
+    if (!('serviceWorker' in navigator)) {
+      return
     }
+
+    if (process.env.NODE_ENV !== 'production') {
+      resetDevelopmentServiceWorkers().catch(() => undefined)
+      return
+    }
+
+    navigator.serviceWorker.register('/sw.js').catch(() => undefined)
   }, [])
 
   return null


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #827

---

## 📋 PR 타입
- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] 🚀 **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🛠 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📝 **docs**: 문서 수정

---

## ✨ 작업 개요

개발 모드에서 stale service worker가 예전 hashed CSS를 계속 precache 요청해 `bad-precaching-response` 404를 발생시키는 문제를 제거합니다.

---

## 📋 변경 사항

- [x] production에서만 service worker를 등록하도록 제한
- [x] development에서는 기존 service worker 등록 해제 + cache 정리 수행
- [x] controller가 남아 있는 개발 세션에서는 한 번만 reload하여 stale precache 루프 차단

---

## ✅ 체크리스트
- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

- 검증: `npm run type-check`, `npx eslint src/components/pwa/SerwistRegistration.tsx`
- production PWA 등록 경로는 유지하고 dev cleanup만 분기했습니다.