### PR TITLE
[enhancement] add facility status filtering support

### DIFF
--- a/.kiro/specs/11-otaku-facilities/tasks.md
+++ b/.kiro/specs/11-otaku-facilities/tasks.md
@@ -1,186 +1,152 @@
-# Implementation Plan: 덕후 친화적 편의시설 (Otaku-Friendly Facilities)
+﻿# Implementation Plan: ?뺥썑 移쒗솕???몄쓽?쒖꽕 (Otaku-Friendly Facilities)
 
 ## Overview
 
-기존 편의시설 시스템(5개 Legacy_Category)을 확장하여 덕후 특화 5개 카테고리를 추가하고, 유저 제보 및 마이크로 투표 기반 데이터 검증 시스템을 구축합니다. 기존 타입/컴포넌트/API를 하위 호환성을 유지하며 확장하고, 신규 컴포넌트와 API를 추가합니다.
+湲곗〈 ?몄쓽?쒖꽕 ?쒖뒪??5媛?Legacy_Category)???뺤옣?섏뿬 ?뺥썑 ?뱁솕 5媛?移댄뀒怨좊━瑜?異붽??섍퀬, ?좎? ?쒕낫 諛?留덉씠?щ줈 ?ы몴 湲곕컲 ?곗씠??寃利??쒖뒪?쒖쓣 援ъ텞?⑸땲?? 湲곗〈 ???而댄룷?뚰듃/API瑜??섏쐞 ?명솚?깆쓣 ?좎??섎ŉ ?뺤옣?섍퀬, ?좉퇋 而댄룷?뚰듃? API瑜?異붽??⑸땲??
 
 ## Tasks
 
-- [-] 1. 데이터 모델 및 타입 정의
-  - [x] 1.1 `src/types/facility.ts` 신규 생성 — 카테고리별 상세 인터페이스 정의
-    - `CoinLockerDetails`, `SoloDiningDetails`, `ChargingCafeDetails`, `PublicRestroomDetails`, `GoodsShopDetails` 인터페이스 작성
-    - `OtakuFacilityDetails` 판별 유니온 타입 정의
-    - `LockerSize`, `GoodsShopSubtype`, `FacilityStatus` 타입 정의
-    - `FacilityVoteDocument` 인터페이스 정의 (facility_votes 컬렉션용)
+- [-] 1. ?곗씠??紐⑤뜽 諛?????뺤쓽
+  - [x] 1.1 `src/types/facility.ts` ?좉퇋 ?앹꽦 ??移댄뀒怨좊━蹂??곸꽭 ?명꽣?섏씠???뺤쓽
+    - `CoinLockerDetails`, `SoloDiningDetails`, `ChargingCafeDetails`, `PublicRestroomDetails`, `GoodsShopDetails` ?명꽣?섏씠???묒꽦
+    - `OtakuFacilityDetails` ?먮퀎 ?좊땲??????뺤쓽
+    - `LockerSize`, `GoodsShopSubtype`, `FacilityStatus` ????뺤쓽
+    - `FacilityVoteDocument` ?명꽣?섏씠???뺤쓽 (facility_votes 而щ젆?섏슜)
     - _Requirements: 6.2, 6.3, 6.4, 6.5, 6.6, 6.8, 6.9_
 
-  - [x] 1.2 `src/types/spot.ts` 확장 — FacilityType 및 NearbyFacility 인터페이스 확장
-    - `LegacyFacilityType`, `OtakuFacilityType` 타입 분리 후 `FacilityType` 유니온으로 통합
-    - `NearbyFacility` 인터페이스에 `status`, `verificationScore`, `upvotes`, `downvotes`, `googlePlaceId`, `otakuDetails`, `reportedBy`, `createdAt`, `updatedAt` 필드 추가
-    - 기존 `Facility` 인터페이스도 동일하게 확장
-    - 기존 Legacy_Category 코드와의 하위 호환성 유지
+  - [x] 1.2 `src/types/spot.ts` ?뺤옣 ??FacilityType 諛?NearbyFacility ?명꽣?섏씠???뺤옣
+    - `LegacyFacilityType`, `OtakuFacilityType` ???遺꾨━ ??`FacilityType` ?좊땲?⑥쑝濡??듯빀
+    - `NearbyFacility` ?명꽣?섏씠?ㅼ뿉 `status`, `verificationScore`, `upvotes`, `downvotes`, `googlePlaceId`, `otakuDetails`, `reportedBy`, `createdAt`, `updatedAt` ?꾨뱶 異붽?
+    - 湲곗〈 `Facility` ?명꽣?섏씠?ㅻ룄 ?숈씪?섍쾶 ?뺤옣
+    - 湲곗〈 Legacy_Category 肄붾뱶????섏쐞 ?명솚???좎?
     - _Requirements: 1.1, 6.1, 6.7, 6.8, 6.9, 6.10_
 
-  - [-] 1.3 `src/lib/facility-utils.ts` 확장 — 유틸리티 함수 업데이트
-    - `groupFacilitiesByType` 함수에 Otaku_Category 5개 추가
-    - `VALID_FACILITY_TYPES` 배열에 신규 카테고리 추가
-    - 기존 Legacy_Category 분류 로직 유지
+  - [-] 1.3 `src/lib/facility-utils.ts` ?뺤옣 ???좏떥由ы떚 ?⑥닔 ?낅뜲?댄듃
+    - `groupFacilitiesByType` ?⑥닔??Otaku_Category 5媛?異붽?
+    - `VALID_FACILITY_TYPES` 諛곗뿴???좉퇋 移댄뀒怨좊━ 異붽?
+    - 湲곗〈 Legacy_Category 遺꾨쪟 濡쒖쭅 ?좎?
     - _Requirements: 1.1, 6.7_
 
-  - [ ]* 1.4 Property 테스트 — 카테고리 분류 무결성
-    - **Property 1: 카테고리 분류 무결성**
-    - `groupFacilitiesByType` 함수가 모든 시설을 누락 없이 분류하는지 검증
-    - **Validates: Requirements 1.1, 6.7**
+  - [ ]* 1.4 Property ?뚯뒪????移댄뀒怨좊━ 遺꾨쪟 臾닿껐??    - **Property 1: 移댄뀒怨좊━ 遺꾨쪟 臾닿껐??*
+    - `groupFacilitiesByType` ?⑥닔媛 紐⑤뱺 ?쒖꽕???꾨씫 ?놁씠 遺꾨쪟?섎뒗吏 寃利?    - **Validates: Requirements 1.1, 6.7**
 
-  - [ ]* 1.5 Property 테스트 — 하위 호환성
-    - **Property 2: 하위 호환성**
-    - Legacy_Category 편의시설이 `otakuDetails` 없이도 정상 처리되는지 검증
-    - **Validates: Requirements 6.7**
+  - [ ]* 1.5 Property ?뚯뒪?????섏쐞 ?명솚??    - **Property 2: ?섏쐞 ?명솚??*
+    - Legacy_Category ?몄쓽?쒖꽕??`otakuDetails` ?놁씠???뺤긽 泥섎━?섎뒗吏 寃利?    - **Validates: Requirements 6.7**
 
-- [ ] 2. Checkpoint — 데이터 모델 검증
-  - Ensure all tests pass, ask the user if questions arise.
+- [ ] 2. Checkpoint ???곗씠??紐⑤뜽 寃利?  - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 3. 편의시설 API 확장
-  - [ ] 3.1 `src/app/api/spots/[id]/facilities/route.ts` 확장 — GET API에 type/status 필터 추가
-    - `type` 쿼리 파라미터로 특정 카테고리 필터링 지원
-    - `status`가 `hidden`인 시설 자동 제외
-    - 응답에 `otakuDetails`, `status`, `verificationScore`, `upvotes`, `downvotes` 포함
-    - _Requirements: 7.1, 7.2, 7.5_
+- [ ] 3. ?몄쓽?쒖꽕 API ?뺤옣
+  - [ ] 3.1 `src/app/api/spots/[id]/facilities/route.ts` ?뺤옣 ??GET API??type/status ?꾪꽣 異붽?
+    - `type` 荑쇰━ ?뚮씪誘명꽣濡??뱀젙 移댄뀒怨좊━ ?꾪꽣留?吏??    - `status`媛 `hidden`???쒖꽕 ?먮룞 ?쒖쇅
+    - ?묐떟??`otakuDetails`, `status`, `verificationScore`, `upvotes`, `downvotes` ?ы븿
+    - 2026-05-22: `status=active|needs_verification` 필터 지원 추가, `hidden`은 계속 자동 제외`r`n    - _Requirements: 7.1, 7.2, 7.5_
 
-  - [ ] 3.2 `src/app/api/facilities/report/route.ts` 신규 생성 — 편의시설 제보 API
-    - POST 핸들러: 필수 필드(`name`, `type`, `coordinates`) 검증
-    - 카테고리별 `otakuDetails` 저장 처리
-    - 기본값 설정: `status: 'active'`, `verificationScore: 50`, `upvotes: 0`, `downvotes: 0`
-    - 성공 시 201, 필수 필드 누락 시 400 + 누락 필드 목록 반환
+  - [ ] 3.2 `src/app/api/facilities/report/route.ts` ?좉퇋 ?앹꽦 ???몄쓽?쒖꽕 ?쒕낫 API
+    - POST ?몃뱾?? ?꾩닔 ?꾨뱶(`name`, `type`, `coordinates`) 寃利?    - 移댄뀒怨좊━蹂?`otakuDetails` ???泥섎━
+    - 湲곕낯媛??ㅼ젙: `status: 'active'`, `verificationScore: 50`, `upvotes: 0`, `downvotes: 0`
+    - ?깃났 ??201, ?꾩닔 ?꾨뱶 ?꾨씫 ??400 + ?꾨씫 ?꾨뱶 紐⑸줉 諛섑솚
     - _Requirements: 7.3, 7.4_
 
-  - [ ] 3.3 `src/app/api/facilities/[id]/vote/route.ts` 신규 생성 — 마이크로 투표 API
-    - POST 핸들러: `value`(boolean) 필드 검증
-    - `facility_votes` 컬렉션에서 `{ facilityId, userId }` 복합 유니크 인덱스 활용
-    - 기존 투표 존재 시 값 업데이트, 신규 시 삽입
-    - `upvotes`/`downvotes` 재계산 및 `verificationScore` 산출
-    - `downvotes - upvotes >= 5` 시 `needs_verification` 상태 전이
-    - `verificationScore < 20` 시 `hidden` 상태 전이
-    - 투표 값 또는 인증 누락 시 400 반환
+  - [ ] 3.3 `src/app/api/facilities/[id]/vote/route.ts` ?좉퇋 ?앹꽦 ??留덉씠?щ줈 ?ы몴 API
+    - POST ?몃뱾?? `value`(boolean) ?꾨뱶 寃利?    - `facility_votes` 而щ젆?섏뿉??`{ facilityId, userId }` 蹂듯빀 ?좊땲???몃뜳???쒖슜
+    - 湲곗〈 ?ы몴 議댁옱 ??媛??낅뜲?댄듃, ?좉퇋 ???쎌엯
+    - `upvotes`/`downvotes` ?ш퀎??諛?`verificationScore` ?곗텧
+    - `downvotes - upvotes >= 5` ??`needs_verification` ?곹깭 ?꾩씠
+    - `verificationScore < 20` ??`hidden` ?곹깭 ?꾩씠
+    - ?ы몴 媛??먮뒗 ?몄쬆 ?꾨씫 ??400 諛섑솚
     - _Requirements: 7.6, 7.7, 7.8, 5.11_
 
-  - [ ]* 3.4 Property 테스트 — Verification Score 범위 불변식
-    - **Property 4: Verification Score 범위 불변식**
-    - `verificationScore`가 항상 0~100 범위이며, 투표 0건이면 50인지 검증
-    - **Validates: Requirements 6.8, 5.11**
+  - [ ]* 3.4 Property ?뚯뒪????Verification Score 踰붿쐞 遺덈???    - **Property 4: Verification Score 踰붿쐞 遺덈???*
+    - `verificationScore`媛 ??긽 0~100 踰붿쐞?대ŉ, ?ы몴 0嫄댁씠硫?50?몄? 寃利?    - **Validates: Requirements 6.8, 5.11**
 
-  - [ ]* 3.5 Property 테스트 — 제보 필수 필드 검증
-    - **Property 6: 제보 필수 필드 검증**
-    - `name`, `type`, `coordinates` 중 하나라도 누락 시 400 에러 반환 검증
-    - **Validates: Requirements 7.3, 7.4**
+  - [ ]* 3.5 Property ?뚯뒪?????쒕낫 ?꾩닔 ?꾨뱶 寃利?    - **Property 6: ?쒕낫 ?꾩닔 ?꾨뱶 寃利?*
+    - `name`, `type`, `coordinates` 以??섎굹?쇰룄 ?꾨씫 ??400 ?먮윭 諛섑솚 寃利?    - **Validates: Requirements 7.3, 7.4**
 
-  - [ ]* 3.6 Property 테스트 — Status 필터링 일관성
-    - **Property 5: Status 필터링 일관성**
-    - GET API 응답에 `status: 'hidden'`인 시설이 포함되지 않는지 검증
-    - **Validates: Requirements 7.1, 7.2**
+  - [ ]* 3.6 Property ?뚯뒪????Status ?꾪꽣留??쇨???    - **Property 5: Status ?꾪꽣留??쇨???*
+    - GET API ?묐떟??`status: 'hidden'`???쒖꽕???ы븿?섏? ?딅뒗吏 寃利?    - **Validates: Requirements 7.1, 7.2**
 
-- [ ] 4. Checkpoint — API 검증
-  - Ensure all tests pass, ask the user if questions arise.
+- [ ] 4. Checkpoint ??API 寃利?  - Ensure all tests pass, ask the user if questions arise.
 
-- [x] 5. FacilityFilter 컴포넌트 구현
-  - [x] 5.1 `src/components/spot/FacilityFilter.tsx` 신규 생성 — 카테고리 필터 칩 UI
-    - Legacy_Category + Otaku_Category 전체 카테고리 필터 칩 렌더링
-    - "전체" 칩 포함, 복수 선택 지원
-    - 칩 클릭 시 해당 카테고리 토글, 전체 해제 시 모든 카테고리 표시
-    - 각 카테고리별 아이콘/라벨 표시 (FACILITY_CONFIG 활용)
+- [x] 5. FacilityFilter 而댄룷?뚰듃 援ы쁽
+  - [x] 5.1 `src/components/spot/FacilityFilter.tsx` ?좉퇋 ?앹꽦 ??移댄뀒怨좊━ ?꾪꽣 移?UI
+    - Legacy_Category + Otaku_Category ?꾩껜 移댄뀒怨좊━ ?꾪꽣 移??뚮뜑留?    - "?꾩껜" 移??ы븿, 蹂듭닔 ?좏깮 吏??    - 移??대┃ ???대떦 移댄뀒怨좊━ ?좉?, ?꾩껜 ?댁젣 ??紐⑤뱺 移댄뀒怨좊━ ?쒖떆
+    - 媛?移댄뀒怨좊━蹂??꾩씠肄??쇰꺼 ?쒖떆 (FACILITY_CONFIG ?쒖슜)
     - _Requirements: 1.4, 1.5_
 
-  - [x] 5.2 `src/components/spot/NearbyFacilities.tsx` 확장 — FACILITY_CONFIG 및 필터 통합
-    - `FACILITY_CONFIG`에 Otaku_Category 5개 추가 (아이콘, 라벨, 색상)
-    - `FacilityFilter` 컴포넌트를 목록 상단에 통합
-    - 선택된 카테고리에 따라 편의시설 목록 필터링 로직 추가
+  - [x] 5.2 `src/components/spot/NearbyFacilities.tsx` ?뺤옣 ??FACILITY_CONFIG 諛??꾪꽣 ?듯빀
+    - `FACILITY_CONFIG`??Otaku_Category 5媛?異붽? (?꾩씠肄? ?쇰꺼, ?됱긽)
+    - `FacilityFilter` 而댄룷?뚰듃瑜?紐⑸줉 ?곷떒???듯빀
+    - ?좏깮??移댄뀒怨좊━???곕씪 ?몄쓽?쒖꽕 紐⑸줉 ?꾪꽣留?濡쒖쭅 異붽?
     - _Requirements: 1.2, 1.3, 1.4, 1.5_
 
-- [x] 6. FacilityCard 카테고리별 상세 렌더링 확장
-  - [x] 6.1 `src/components/spot/FacilityCard.tsx` 확장 — 카테고리별 상세 정보 렌더링
-    - `coin_locker`: 크기별 가격 테이블, 대형 로커 유무 배지, 이용 시간 표시, 미등록 시 "정보 미등록" 텍스트
-    - `solo_dining`: "1인 OK" 태그, 카운터석/1인 메뉴 유무, 빠른 식사/심야 배지, 미등록 시 "정보 미등록" 텍스트
-    - `charging_cafe`: 충전/와이파이 유무 아이콘 표시
-    - `public_restroom`: 접근성/24시간 유무 아이콘 표시
-    - `goods_shop`: 매장 유형 배지(서브컬처/잡화), 영업시간 표시
-    - 신뢰도 점수(`verificationScore`) 및 투표 수(`upvotes`/`downvotes`) 표시
+- [x] 6. FacilityCard 移댄뀒怨좊━蹂??곸꽭 ?뚮뜑留??뺤옣
+  - [x] 6.1 `src/components/spot/FacilityCard.tsx` ?뺤옣 ??移댄뀒怨좊━蹂??곸꽭 ?뺣낫 ?뚮뜑留?    - `coin_locker`: ?ш린蹂?媛寃??뚯씠釉? ???濡쒖빱 ?좊Т 諛곗?, ?댁슜 ?쒓컙 ?쒖떆, 誘몃벑濡???"?뺣낫 誘몃벑濡? ?띿뒪??    - `solo_dining`: "1??OK" ?쒓렇, 移댁슫?곗꽍/1??硫붾돱 ?좊Т, 鍮좊Ⅸ ?앹궗/?ъ빞 諛곗?, 誘몃벑濡???"?뺣낫 誘몃벑濡? ?띿뒪??    - `charging_cafe`: 異⑹쟾/??댄뙆???좊Т ?꾩씠肄??쒖떆
+    - `public_restroom`: ?묎렐??24?쒓컙 ?좊Т ?꾩씠肄??쒖떆
+    - `goods_shop`: 留ㅼ옣 ?좏삎 諛곗?(?쒕툕而ъ쿂/?≫솕), ?곸뾽?쒓컙 ?쒖떆
+    - ?좊ː???먯닔(`verificationScore`) 諛??ы몴 ??`upvotes`/`downvotes`) ?쒖떆
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3_
 
-  - [ ]* 6.2 단위 테스트 — FacilityCard 카테고리별 렌더링
-    - Legacy_Category 시설이 기존과 동일하게 렌더링되는지 확인
-    - 각 Otaku_Category 시설의 상세 정보가 올바르게 표시되는지 확인
-    - 미등록 필드에 "정보 미등록" 텍스트가 표시되는지 확인
+  - [ ]* 6.2 ?⑥쐞 ?뚯뒪????FacilityCard 移댄뀒怨좊━蹂??뚮뜑留?    - Legacy_Category ?쒖꽕??湲곗〈怨??숈씪?섍쾶 ?뚮뜑留곷릺?붿? ?뺤씤
+    - 媛?Otaku_Category ?쒖꽕???곸꽭 ?뺣낫媛 ?щ컮瑜닿쾶 ?쒖떆?섎뒗吏 ?뺤씤
+    - 誘몃벑濡??꾨뱶??"?뺣낫 誘몃벑濡? ?띿뒪?멸? ?쒖떆?섎뒗吏 ?뺤씤
     - _Requirements: 2.4, 3.3, 6.7_
 
-- [x] 7. MicroVoteButton 컴포넌트 구현
-  - [x] 7.1 `src/components/spot/MicroVoteButton.tsx` 신규 생성 — 마이크로 투표 UI
-    - "이 정보가 정확한가요?" 텍스트와 👍/👎 버튼 렌더링
-    - `POST /api/facilities/[id]/vote` API 호출 연동
-    - 이미 투표한 경우 선택 상태 하이라이트 표시
-    - 투표 후 `verificationScore` 실시간 업데이트
-    - 비로그인 유저에게 로그인 유도 메시지 표시
+- [x] 7. MicroVoteButton 而댄룷?뚰듃 援ы쁽
+  - [x] 7.1 `src/components/spot/MicroVoteButton.tsx` ?좉퇋 ?앹꽦 ??留덉씠?щ줈 ?ы몴 UI
+    - "???뺣낫媛 ?뺥솗?쒓???" ?띿뒪?몄? ?몟/?몠 踰꾪듉 ?뚮뜑留?    - `POST /api/facilities/[id]/vote` API ?몄텧 ?곕룞
+    - ?대? ?ы몴??寃쎌슦 ?좏깮 ?곹깭 ?섏씠?쇱씠???쒖떆
+    - ?ы몴 ??`verificationScore` ?ㅼ떆媛??낅뜲?댄듃
+    - 鍮꾨줈洹몄씤 ?좎??먭쾶 濡쒓렇???좊룄 硫붿떆吏 ?쒖떆
     - _Requirements: 5.10, 7.6_
 
-  - [x] 7.2 `src/components/spot/FacilityCard.tsx`에 MicroVoteButton 통합
-    - FacilityCard 하단에 MicroVoteButton 배치
+  - [x] 7.2 `src/components/spot/FacilityCard.tsx`??MicroVoteButton ?듯빀
+    - FacilityCard ?섎떒??MicroVoteButton 諛곗튂
     - _Requirements: 5.10_
 
-  - [ ]* 7.3 Property 테스트 — 투표 중복 방지 불변식
-    - **Property 3: 투표 중복 방지 불변식**
-    - 동일 유저가 동일 시설에 투표 시 `facility_votes`에 최대 1개 문서만 존재하는지 검증
-    - **Validates: Requirements 7.8**
+  - [ ]* 7.3 Property ?뚯뒪?????ы몴 以묐났 諛⑹? 遺덈???    - **Property 3: ?ы몴 以묐났 諛⑹? 遺덈???*
+    - ?숈씪 ?좎?媛 ?숈씪 ?쒖꽕???ы몴 ??`facility_votes`??理쒕? 1媛?臾몄꽌留?議댁옱?섎뒗吏 寃利?    - **Validates: Requirements 7.8**
 
-- [x] 8. Checkpoint — UI 컴포넌트 검증
-  - Ensure all tests pass, ask the user if questions arise.
+- [x] 8. Checkpoint ??UI 而댄룷?뚰듃 寃利?  - Ensure all tests pass, ask the user if questions arise.
 
-- [x] 9. FacilityReportForm 제보 폼 구현
-  - [x] 9.1 `src/components/spot/FacilityReportForm.tsx` 신규 생성 — 제보 폼 모달 기본 구조
-    - 모달 형태의 제보 폼 레이아웃
-    - 장소 입력 방식 선택 UI (구글맵 검색 / 직접 핀 꽂기 투트랙)
-    - 공통 필수 필드: 이름, 카테고리 선택 드롭다운, 위치(좌표)
-    - 필수 필드 미입력 시 오류 메시지 표시
+- [x] 9. FacilityReportForm ?쒕낫 ??援ы쁽
+  - [x] 9.1 `src/components/spot/FacilityReportForm.tsx` ?좉퇋 ?앹꽦 ???쒕낫 ??紐⑤떖 湲곕낯 援ъ“
+    - 紐⑤떖 ?뺥깭???쒕낫 ???덉씠?꾩썐
+    - ?μ냼 ?낅젰 諛⑹떇 ?좏깮 UI (援ш?留?寃??/ 吏곸젒 ? 苑귢린 ?ы듃??
+    - 怨듯넻 ?꾩닔 ?꾨뱶: ?대쫫, 移댄뀒怨좊━ ?좏깮 ?쒕∼?ㅼ슫, ?꾩튂(醫뚰몴)
+    - ?꾩닔 ?꾨뱶 誘몄엯?????ㅻ쪟 硫붿떆吏 ?쒖떆
     - _Requirements: 5.1, 5.2, 5.8, 5.9_
 
-  - [x] 9.2 FacilityReportForm 카테고리별 동적 필드 구현
-    - `coin_locker` 선택 시: 크기, 가격, 이용 시간, 대형 로커 유무 필드 표시
-    - `solo_dining` 선택 시: 카운터석 유무, 1인 메뉴 유무, 빠른 식사 가능 여부, 심야 영업 여부 필드 표시
-    - `goods_shop` 선택 시: 매장 유형(서브컬처/잡화), 영업시간 필드 표시
-    - `charging_cafe` 선택 시: 충전 콘센트 유무, 무료 와이파이 유무 필드 표시
-    - `public_restroom` 선택 시: 장애인 접근 가능 여부, 24시간 이용 가능 여부 필드 표시
+  - [x] 9.2 FacilityReportForm 移댄뀒怨좊━蹂??숈쟻 ?꾨뱶 援ы쁽
+    - `coin_locker` ?좏깮 ?? ?ш린, 媛寃? ?댁슜 ?쒓컙, ???濡쒖빱 ?좊Т ?꾨뱶 ?쒖떆
+    - `solo_dining` ?좏깮 ?? 移댁슫?곗꽍 ?좊Т, 1??硫붾돱 ?좊Т, 鍮좊Ⅸ ?앹궗 媛???щ?, ?ъ빞 ?곸뾽 ?щ? ?꾨뱶 ?쒖떆
+    - `goods_shop` ?좏깮 ?? 留ㅼ옣 ?좏삎(?쒕툕而ъ쿂/?≫솕), ?곸뾽?쒓컙 ?꾨뱶 ?쒖떆
+    - `charging_cafe` ?좏깮 ?? 異⑹쟾 肄섏꽱???좊Т, 臾대즺 ??댄뙆???좊Т ?꾨뱶 ?쒖떆
+    - `public_restroom` ?좏깮 ?? ?μ븷???묎렐 媛???щ?, 24?쒓컙 ?댁슜 媛???щ? ?꾨뱶 ?쒖떆
     - _Requirements: 5.3, 5.4, 5.5, 5.6, 5.7_
 
-  - [x] 9.3 FacilityReportForm API 연동 및 제출 처리
-    - `POST /api/facilities/report` API 호출 연동
-    - 성공 시 성공 메시지 표시 및 폼 초기화
-    - 에러 시 서버 응답 기반 오류 메시지 표시
+  - [x] 9.3 FacilityReportForm API ?곕룞 諛??쒖텧 泥섎━
+    - `POST /api/facilities/report` API ?몄텧 ?곕룞
+    - ?깃났 ???깃났 硫붿떆吏 ?쒖떆 諛???珥덇린??    - ?먮윭 ???쒕쾭 ?묐떟 湲곕컲 ?ㅻ쪟 硫붿떆吏 ?쒖떆
     - _Requirements: 5.8, 5.9, 7.3_
 
-- [x] 10. 통합 및 와이어링
-  - [x] 10.1 `src/hooks/useSpotDetail.ts` 확장 — useFacilities 훅에 필터/투표 기능 추가
-    - `type` 파라미터를 활용한 카테고리별 조회 지원
-    - 투표 API 호출 함수 추가
-    - 제보 후 목록 갱신 로직 추가
+- [x] 10. ?듯빀 諛???댁뼱留?  - [x] 10.1 `src/hooks/useSpotDetail.ts` ?뺤옣 ??useFacilities ?낆뿉 ?꾪꽣/?ы몴 湲곕뒫 異붽?
+    - `type` ?뚮씪誘명꽣瑜??쒖슜??移댄뀒怨좊━蹂?議고쉶 吏??    - ?ы몴 API ?몄텧 ?⑥닔 異붽?
+    - ?쒕낫 ??紐⑸줉 媛깆떊 濡쒖쭅 異붽?
     - _Requirements: 1.3, 1.4, 7.1_
 
-  - [x] 10.2 Spot Detail 페이지에 "편의시설 제보" 버튼 및 FacilityReportForm 연결
-    - NearbyFacilities 영역에 "편의시설 제보" 버튼 추가
-    - 버튼 클릭 시 FacilityReportForm 모달 열기
-    - 제보 완료 후 편의시설 목록 자동 갱신
+  - [x] 10.2 Spot Detail ?섏씠吏??"?몄쓽?쒖꽕 ?쒕낫" 踰꾪듉 諛?FacilityReportForm ?곌껐
+    - NearbyFacilities ?곸뿭??"?몄쓽?쒖꽕 ?쒕낫" 踰꾪듉 異붽?
+    - 踰꾪듉 ?대┃ ??FacilityReportForm 紐⑤떖 ?닿린
+    - ?쒕낫 ?꾨즺 ???몄쓽?쒖꽕 紐⑸줉 ?먮룞 媛깆떊
     - _Requirements: 5.1_
 
-  - [ ]* 10.3 통합 테스트 — 편의시설 조회/제보/투표 플로우
-    - 편의시설 목록 조회 → 카테고리 필터링 → 상세 정보 표시 플로우 검증
-    - 제보 폼 제출 → API 저장 → 목록 갱신 플로우 검증
-    - 투표 → 점수 업데이트 → 상태 전이 플로우 검증
-    - _Requirements: 1.3, 5.8, 5.10, 5.11_
+  - [ ]* 10.3 ?듯빀 ?뚯뒪?????몄쓽?쒖꽕 議고쉶/?쒕낫/?ы몴 ?뚮줈??    - ?몄쓽?쒖꽕 紐⑸줉 議고쉶 ??移댄뀒怨좊━ ?꾪꽣留????곸꽭 ?뺣낫 ?쒖떆 ?뚮줈??寃利?    - ?쒕낫 ???쒖텧 ??API ?????紐⑸줉 媛깆떊 ?뚮줈??寃利?    - ?ы몴 ???먯닔 ?낅뜲?댄듃 ???곹깭 ?꾩씠 ?뚮줈??寃利?    - _Requirements: 1.3, 5.8, 5.10, 5.11_
 
-- [ ] 11. Final Checkpoint — 전체 검증
-  - Ensure all tests pass, ask the user if questions arise.
+- [ ] 11. Final Checkpoint ???꾩껜 寃利?  - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes
 
 - Tasks marked with `*` are optional and can be skipped for faster MVP
-- 기존 Legacy_Category 편의시설과의 하위 호환성을 최우선으로 유지합니다
-- 구글맵 Places Autocomplete 연동은 FacilityReportForm 내에서 구현하되, API 키 설정은 환경 변수로 관리합니다
-- `facility_votes` 컬렉션의 `{ facilityId, userId }` 복합 유니크 인덱스는 API 초기화 시 생성합니다
-- Property 테스트는 구현 직후 배치하여 조기 오류 감지를 지원합니다
+- 湲곗〈 Legacy_Category ?몄쓽?쒖꽕怨쇱쓽 ?섏쐞 ?명솚?깆쓣 理쒖슦?좎쑝濡??좎??⑸땲??- 援ш?留?Places Autocomplete ?곕룞? FacilityReportForm ?댁뿉??援ы쁽?섎릺, API ???ㅼ젙? ?섍꼍 蹂?섎줈 愿由ы빀?덈떎
+- `facility_votes` 而щ젆?섏쓽 `{ facilityId, userId }` 蹂듯빀 ?좊땲???몃뜳?ㅻ뒗 API 珥덇린?????앹꽦?⑸땲??- Property ?뚯뒪?몃뒗 援ы쁽 吏곹썑 諛곗튂?섏뿬 議곌린 ?ㅻ쪟 媛먯?瑜?吏?먰빀?덈떎
+

--- a/src/app/api/spots/[id]/facilities/route.ts
+++ b/src/app/api/spots/[id]/facilities/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+﻿import { NextRequest, NextResponse } from 'next/server'
 import { ObjectId } from 'mongodb'
 import { getCollection } from '@/lib/db'
 import {
@@ -37,6 +37,8 @@ interface FacilityDocument {
 }
 
 type MappedFacility = NearbyFacility | null
+
+const FILTERABLE_STATUSES: FacilityStatus[] = ['active', 'needs_verification']
 
 function calculateDistance(
   lat1: number,
@@ -94,6 +96,7 @@ export async function GET(
     const radiusKm = parseFloat(searchParams.get('radius') || '2')
     const maxResults = parseInt(searchParams.get('limit') || '50')
     const typeFilter = searchParams.get('type')
+    const statusFilter = searchParams.get('status')
 
     const spotsCollection = await getCollection<SpotDocument>('spots')
     const spot = await spotsCollection.findOne(
@@ -114,6 +117,13 @@ export async function GET(
       VALID_FACILITY_TYPES.includes(typeFilter as FacilityType)
     ) {
       query.type = typeFilter
+    }
+
+    if (
+      statusFilter &&
+      FILTERABLE_STATUSES.includes(statusFilter as FacilityStatus)
+    ) {
+      query.status = statusFilter
     }
 
     const facilitiesCollection =


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #835

---

## 🧩 PR 유형
- [ ] **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] 🚀 **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🛠 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📝 **docs**: 문서 수정

---

## ✨ 작업 개요

> task 11의 편의시설 API에서 빠져 있던 status 쿼리 필터를 추가하고, hidden 자동 제외 규칙은 유지했습니다.

---

## 🔧 변경 사항

- [x] /api/spots/[id]/facilities에 status=active|needs_verification 필터 지원 추가
- [x] hidden 시설 자동 제외 규칙 유지
- [x] task 11 문서의 3.1 진행 상태 반영

---

## ✅ 체크리스트
- [x] 
pm run lint 통과
- [ ] 
pm run build 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📋 추가 정보 (선택)

<!-- 리뷰어가 알아야 할 맥락이나 특이사항 -->
- 현재 구현은 사용자 노출 API 기준으로 hidden 상태를 계속 차단합니다.