### PR TITLE
[feat] add spec 43 observability and ops tooling

### DIFF
--- a/docs/2026-05-24-specs-41-44-task-plan.md
+++ b/docs/2026-05-24-specs-41-44-task-plan.md
@@ -24,7 +24,7 @@
 - [x] 8. Add full image conversion + thumbnail pipeline (`41 - Requirements 2, 3, 6`)
 - [x] 9. Add storage migration tooling for legacy uploads (`41 - Requirement 7`)
 - [x] 10. Add API rate limiting, spam guard, input sanitization (`42 - Requirements 1, 2, 6`)
-- [ ] 11. Add alerting, ops dashboard, backup/migration runbook (`43 - Requirements 1, 3, 4, 5`)
+- [x] 11. Add alerting, ops dashboard, backup/migration runbook (`43 - Requirements 1, 3, 4, 5`)
 - [ ] 12. Add broader deployment validators for images, PWA, SEO, performance, error pages (`44 - Requirements 1-6, 8`)
 
 ## Detailed tasks
@@ -132,5 +132,27 @@
   - verification:
     - `npm test -- src/lib/security/rate-limit.test.ts src/lib/security/input-sanitizer.test.ts`
     - `npm test -- src/app/api/upload/__tests__/route.test.ts`
+    - `npm run type-check`
+    - `npm run build`
+- 2026-05-25 spec 43 checkpoint:
+  - added `src/lib/ops/alerting.ts` with Slack/Discord webhook delivery, 3 retries, and repeated-error escalation tracking
+  - added `POST /api/ops/sentry-alert` for Sentry webhook forwarding into configured alert channels
+  - expanded admin dashboard summary with:
+    - today DAU
+    - today check-in count
+    - tracked 24h 5xx ratio
+    - today new users
+    - today new spots
+    - 7-day DAU trend
+    - 7-day check-in trend
+  - updated admin page UI to display the expanded operations metrics
+  - added middleware-driven request metric ingestion via `/api/internal/ops/request`
+  - added MongoDB operations tooling:
+    - `scripts/backup-mongodb.mjs`
+    - `scripts/restore-mongodb.mjs`
+    - upgraded `scripts/run-migration.mjs` with dry-run/history support
+    - `docs/2026-05-25-spec43-ops-runbook.md`
+  - verification:
+    - `npm test -- src/lib/ops/alerting.test.ts src/lib/security/rate-limit.test.ts src/lib/security/input-sanitizer.test.ts`
     - `npm run type-check`
     - `npm run build`

--- a/docs/2026-05-25-spec43-ops-runbook.md
+++ b/docs/2026-05-25-spec43-ops-runbook.md
@@ -1,0 +1,80 @@
+# Spec 43 Ops Runbook
+
+## Scope
+- alert webhook foundation
+- admin ops dashboard metrics
+- MongoDB backup / restore
+- migration runner with history and dry-run
+
+## Backup
+### Create backup
+```bash
+npm run backup:db
+```
+
+- Uses `mongodump --archive --gzip`
+- Output directory defaults to `backups/`
+- Keeps the most recent 7 days of archives
+- Fails if the archive is missing or empty
+
+## Restore
+### Restore into a target database
+```bash
+npm run restore:db -- backups/mongodb-backup-2026-05-25T00-00-00-000Z.archive.gz not-a-trip-restore
+```
+
+- Requires an archive path and target database name
+- Uses `mongorestore --archive --gzip`
+
+## Migration runner
+### Run a migration
+```bash
+node scripts/run-migration.mjs scripts/migrate-user-roles.ts
+```
+
+### Dry-run a migration
+```bash
+node scripts/run-migration.mjs scripts/migrate-user-roles.ts --dry-run --collection users
+```
+
+### Behavior
+- derives database name from `.env.local`
+- skips already successful migrations unless dry-run is used
+- stores history in MongoDB `migrations` collection
+- records:
+  - script name
+  - target collection
+  - dry-run flag
+  - start/end timestamps
+  - success/failure
+  - before/after document counts when `--collection` is supplied
+
+## Alert webhook foundation
+- `src/lib/ops/alerting.ts` supports:
+  - Slack webhook delivery
+  - Discord webhook delivery
+  - 3 retry attempts
+  - escalation when the same fingerprint is delivered 10+ times within 1 hour
+- Sentry can POST into:
+  - `POST /api/ops/sentry-alert`
+- optional secret validation:
+  - set `SENTRY_WEBHOOK_SECRET`
+  - send the same value in `x-sentry-webhook-secret`
+- required env for delivery:
+  - `SLACK_WEBHOOK_URL`
+  - `DISCORD_WEBHOOK_URL`
+
+## Dashboard metrics
+- admin summary route now includes:
+  - pending review counts
+  - today DAU
+  - today check-ins
+  - tracked 24h 5xx rate
+  - today new users
+  - today new spots
+  - 7-day DAU trend
+  - 7-day check-in trend
+
+## Notes
+- tracked 24h 5xx rate is based on request metrics ingested by middleware and explicit 5xx metric writes from key write endpoints.
+- if webhook env values are unset, alert delivery is skipped but dashboard/backup tooling still works.

--- a/docs/agent-session-handoff.md
+++ b/docs/agent-session-handoff.md
@@ -78,3 +78,10 @@
       - sanitized input handling for register/checkin/post/comment/report payloads
       - upload abuse protections layered onto `POST /api/upload`
       - credentials login normalization, failed-attempt lockout, successful-login security logs, and 24h token/session max age
+    - spec 43 ops tooling slice:
+      - `src/lib/ops/*` helpers for alert delivery, request/error metrics, and dashboard aggregation
+      - `POST /api/ops/sentry-alert` webhook ingestion path for Slack/Discord notifications
+      - middleware-fed request metric ingestion route `/api/internal/ops/request`
+      - expanded admin dashboard metrics/trend UI
+      - MongoDB backup/restore scripts and migration runner history/dry-run support
+      - runbook: `docs/2026-05-25-spec43-ops-runbook.md`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "type-check": "tsc --noEmit",
+    "backup:db": "node scripts/backup-mongodb.mjs",
+    "restore:db": "node scripts/restore-mongodb.mjs",
     "prepare": "husky install",
     "commit": "git-cz"
   },

--- a/scripts/backup-mongodb.mjs
+++ b/scripts/backup-mongodb.mjs
@@ -1,0 +1,39 @@
+import { spawnSync } from 'child_process'
+import { mkdirSync, readdirSync, rmSync, statSync } from 'fs'
+import { join } from 'path'
+
+const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/not-a-trip'
+const backupRoot = process.env.BACKUP_DIR || 'backups'
+const now = new Date()
+const timestamp = now.toISOString().replace(/[:.]/g, '-')
+const archivePath = join(backupRoot, `mongodb-backup-${timestamp}.archive.gz`)
+
+mkdirSync(backupRoot, { recursive: true })
+
+const result = spawnSync(
+  'mongodump',
+  [`--uri=${uri}`, `--archive=${archivePath}`, '--gzip'],
+  { stdio: 'inherit' }
+)
+
+if (result.status !== 0) {
+  console.error('Backup failed.')
+  process.exit(result.status || 1)
+}
+
+const stats = statSync(archivePath)
+if (!stats.isFile() || stats.size <= 0) {
+  console.error('Backup integrity check failed: archive missing or empty.')
+  process.exit(1)
+}
+
+const retentionThreshold = Date.now() - 7 * 24 * 60 * 60 * 1000
+for (const fileName of readdirSync(backupRoot)) {
+  const fullPath = join(backupRoot, fileName)
+  const fileStats = statSync(fullPath)
+  if (fileStats.mtimeMs < retentionThreshold) {
+    rmSync(fullPath, { force: true })
+  }
+}
+
+console.log(`Backup created: ${archivePath}`)

--- a/scripts/restore-mongodb.mjs
+++ b/scripts/restore-mongodb.mjs
@@ -1,0 +1,25 @@
+import { spawnSync } from 'child_process'
+
+const archivePath = process.argv[2]
+const targetDb = process.argv[3]
+const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/not-a-trip'
+
+if (!archivePath || !targetDb) {
+  console.error(
+    'Usage: node scripts/restore-mongodb.mjs <archive-path> <target-db>'
+  )
+  process.exit(1)
+}
+
+const result = spawnSync(
+  'mongorestore',
+  [`--uri=${uri}`, `--nsFrom=*`, `--nsTo=${targetDb}.*`, `--archive=${archivePath}`, '--gzip'],
+  { stdio: 'inherit' }
+)
+
+if (result.status !== 0) {
+  console.error('Restore failed.')
+  process.exit(result.status || 1)
+}
+
+console.log(`Restore completed into database: ${targetDb}`)

--- a/scripts/run-migration.mjs
+++ b/scripts/run-migration.mjs
@@ -1,11 +1,14 @@
 /**
- * 마이그레이션 실행 래퍼
- * MONGODB_DB 환경변수를 명시적으로 설정하고 마이그레이션 스크립트를 실행
+ * Migration runner with dry-run/history support.
+ *
+ * Usage:
+ *   node scripts/run-migration.mjs <script-path> [--dry-run] [--collection <name>]
  */
 import { execSync } from 'child_process'
+import { basename } from 'path'
+import { MongoClient } from 'mongodb'
 import { readFileSync } from 'fs'
 
-// .env.local 파싱
 const envContent = readFileSync('.env.local', 'utf-8')
 const envVars = {}
 for (const line of envContent.split('\n')) {
@@ -18,25 +21,101 @@ for (const line of envContent.split('\n')) {
   envVars[key] = value
 }
 
-// MONGODB_URI에서 DB 이름 추출
-const uri = envVars['MONGODB_URI'] || 'mongodb://localhost:27017/not-a-trip'
+const uri = envVars.MONGODB_URI || 'mongodb://localhost:27017/not-a-trip'
 const dbMatch = uri.match(/\/([^/?]+)(\?|$)/)
-const dbName = dbMatch ? dbMatch[1] : 'not-a-trip'
+const dbName = envVars.MONGODB_DB || (dbMatch ? dbMatch[1] : 'not-a-trip')
 
-console.log(`📦 DB: ${dbName}`)
-console.log(`🔗 URI: ${uri}\n`)
+const args = process.argv.slice(2)
+const script = args[0]
 
-const script = process.argv[2]
 if (!script) {
-  console.error('Usage: node scripts/run-migration.mjs <script-path>')
+  console.error(
+    'Usage: node scripts/run-migration.mjs <script-path> [--dry-run] [--collection <name>]'
+  )
   process.exit(1)
 }
 
-execSync(`npx tsx ${script}`, {
-  stdio: 'inherit',
-  env: {
-    ...process.env,
-    ...envVars,
-    MONGODB_DB: dbName,
-  },
+const dryRun = args.includes('--dry-run')
+const collectionIndex = args.indexOf('--collection')
+const collectionName =
+  collectionIndex >= 0 ? args[collectionIndex + 1] || undefined : undefined
+const migrationName = basename(script)
+const startedAt = new Date()
+
+const client = new MongoClient(uri)
+await client.connect()
+const db = client.db(dbName)
+const migrations = db.collection('migrations')
+
+const existing = await migrations.findOne({
+  name: migrationName,
+  success: true,
 })
+
+if (existing && !dryRun) {
+  console.log(`Skipping already applied migration: ${migrationName}`)
+  await client.close()
+  process.exit(0)
+}
+
+const beforeCount = collectionName
+  ? await db.collection(collectionName).countDocuments()
+  : null
+
+try {
+  console.log(`DB: ${dbName}`)
+  console.log(`URI: ${uri}`)
+  console.log(`Migration: ${migrationName}`)
+  console.log(`Dry-run: ${dryRun ? 'yes' : 'no'}`)
+  if (collectionName) {
+    console.log(`Target collection: ${collectionName}`)
+    console.log(`Documents before: ${beforeCount}`)
+  }
+  console.log('')
+
+  execSync(`npx tsx ${script}`, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...envVars,
+      MONGODB_DB: dbName,
+      MIGRATION_DRY_RUN: dryRun ? '1' : '0',
+      MIGRATION_COLLECTION: collectionName || '',
+    },
+  })
+
+  const afterCount = collectionName
+    ? await db.collection(collectionName).countDocuments()
+    : null
+  const affectedCount =
+    beforeCount !== null && afterCount !== null ? afterCount - beforeCount : null
+
+  await migrations.insertOne({
+    name: migrationName,
+    scriptPath: script,
+    collectionName: collectionName || null,
+    dryRun,
+    startedAt,
+    finishedAt: new Date(),
+    success: true,
+    beforeCount,
+    afterCount,
+    affectedCount,
+  })
+} catch (error) {
+  await migrations.insertOne({
+    name: migrationName,
+    scriptPath: script,
+    collectionName: collectionName || null,
+    dryRun,
+    startedAt,
+    finishedAt: new Date(),
+    success: false,
+    errorMessage: error instanceof Error ? error.message : String(error),
+    beforeCount,
+  })
+  await client.close()
+  throw error
+}
+
+await client.close()

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,13 +5,10 @@ import { useAdminDashboardSummary } from '@/hooks/useAdminQueries'
 import { AdminDashboardCard } from '@/components/admin/AdminDashboardCard'
 import { AppIcon } from '@/components/common/AppIcon'
 
-/**
- * 관리자 대시보드 랜딩 페이지
- * Requirements: 4.5, 5.1
- * - useAdminAuth 훅으로 권한 검사 (미인증/비관리자 → 메인 페이지 리다이렉트)
- * - useAdminDashboardSummary 훅으로 대기 항목 수 로드
- * - 4개 AdminDashboardCard 렌더링
- */
+function formatTrendLabel(date: string): string {
+  return date.slice(5)
+}
+
 export default function AdminDashboardPage() {
   const { isLoading: authLoading, isAuthorized } = useAdminAuth()
   const {
@@ -28,70 +25,182 @@ export default function AdminDashboardPage() {
     )
   }
 
-  // 비관리자는 useAdminAuth가 자동 리다이렉트 — 리다이렉트 완료까지 빈 화면 유지
   if (!isAuthorized) {
     return null
   }
 
   return (
     <div className="min-h-screen bg-neutral-50">
-      {/* 헤더 */}
       <div className="border-b border-neutral-200 bg-surface px-6 py-4">
         <h1 className="text-xl font-bold text-neutral-800">관리자 대시보드</h1>
         <p className="mt-0.5 text-sm text-neutral-500">
-          모든 관리 기능의 현황을 확인하고 빠르게 이동할 수 있습니다
+          운영 지표와 검토 대기 현황을 한 번에 확인합니다.
         </p>
       </div>
 
-      {/* 카드 그리드 */}
-      <div className="mx-auto max-w-4xl px-6 py-8">
+      <div className="mx-auto max-w-6xl px-6 py-8">
         {error && (
           <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
             {error instanceof Error
               ? error.message
-              : '서버 오류가 발생했습니다'}
+              : '서버 오류가 발생했습니다.'}
           </div>
         )}
 
         {dataLoading ? (
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-            {[...Array(4)].map((_, i) => (
-              <div
-                key={i}
-                className="h-40 animate-pulse rounded-xl border border-neutral-200 bg-surface"
-              />
-            ))}
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
+              {[...Array(4)].map((_, i) => (
+                <div
+                  key={i}
+                  className="h-40 animate-pulse rounded-xl border border-neutral-200 bg-surface"
+                />
+              ))}
+            </div>
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+              {[...Array(2)].map((_, i) => (
+                <div
+                  key={i}
+                  className="h-72 animate-pulse rounded-xl border border-neutral-200 bg-surface"
+                />
+              ))}
+            </div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-            <AdminDashboardCard
-              title="제보 관리"
-              description="사용자가 제출한 성지 제보를 검토하고 승인/반려합니다"
-              icon="📋"
-              pendingCount={summary?.pendingReports ?? 0}
-              href="/admin/reports"
-            />
-            <AdminDashboardCard
-              title="정보 보완 검토"
-              description="사용자가 제출한 정보 보완을 검토하고 승인/반려합니다"
-              icon="📝"
-              pendingCount={summary?.pendingSupplements ?? 0}
-              href="/admin/supplements"
-            />
-            <AdminDashboardCard
-              title="상태 신고 검토"
-              description="사용자가 신고한 스팟 상태를 검토하고 확인 처리합니다"
-              icon="🚨"
-              pendingCount={summary?.pendingStatusReports ?? 0}
-              href="/admin/status-reports"
-            />
-            <AdminDashboardCard
-              title="콘텐츠 이미지 관리"
-              description="콘텐츠 마스터 이미지를 관리합니다"
-              icon={<AppIcon name="gallery" size={24} />}
-              pendingCount={0}
-              href="/admin/content-images"
-            />
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-4">
+              <AdminDashboardCard
+                title="제보 관리"
+                description="사용자 제출 신규 제보를 검토하고 승인/반려합니다."
+                icon="📥"
+                pendingCount={summary?.pendingReports ?? 0}
+                href="/admin/reports"
+              />
+              <AdminDashboardCard
+                title="정보 보완 검토"
+                description="사용자 제안 보완 정보를 검토하고 승인/반려합니다."
+                icon="🧩"
+                pendingCount={summary?.pendingSupplements ?? 0}
+                href="/admin/supplements"
+              />
+              <AdminDashboardCard
+                title="상태 제보 검토"
+                description="현장 상태 제보를 검토하고 처리합니다."
+                icon="🛠️"
+                pendingCount={summary?.pendingStatusReports ?? 0}
+                href="/admin/status-reports"
+              />
+              <AdminDashboardCard
+                title="콘텐츠 이미지 관리"
+                description="콘텐츠 마스터 이미지를 관리합니다."
+                icon={<AppIcon name="gallery" size={24} />}
+                pendingCount={0}
+                href="/admin/content-images"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
+              {[
+                ['오늘 DAU', summary?.dauToday ?? 0],
+                ['오늘 체크인', summary?.totalCheckInsToday ?? 0],
+                ['24시간 5xx 비율', `${summary?.errorRate24h ?? 0}%`],
+                ['오늘 신규 사용자', summary?.newUsersToday ?? 0],
+                ['오늘 신규 스팟', summary?.newSpotsToday ?? 0],
+              ].map(([label, value]) => (
+                <div
+                  key={String(label)}
+                  className="rounded-xl border border-neutral-200 bg-surface p-5 shadow-sm"
+                >
+                  <p className="text-sm text-neutral-500">{label}</p>
+                  <p className="mt-2 text-2xl font-bold text-neutral-800">
+                    {value}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+              <section className="rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold text-neutral-800">
+                    최근 7일 DAU
+                  </h2>
+                  <span className="text-xs text-neutral-500">
+                    {summary?.generatedAt
+                      ? new Date(summary.generatedAt).toLocaleString('ko-KR')
+                      : ''}
+                  </span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  {summary?.dauTrend.map((point) => (
+                    <div key={point.date}>
+                      <div className="mb-1 flex items-center justify-between text-sm">
+                        <span className="text-neutral-500">
+                          {formatTrendLabel(point.date)}
+                        </span>
+                        <span className="font-medium text-neutral-800">
+                          {point.count}
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-neutral-100">
+                        <div
+                          className="h-2 rounded-full bg-primary"
+                          style={{
+                            width: `${Math.max(
+                              8,
+                              ((point.count || 0) /
+                                Math.max(
+                                  ...((summary?.dauTrend ?? []).map(
+                                    (item) => item.count
+                                  ) || [1])
+                                )) *
+                                100
+                            )}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              <section className="rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm">
+                <h2 className="text-lg font-semibold text-neutral-800">
+                  최근 7일 체크인 추이
+                </h2>
+                <div className="mt-4 space-y-3">
+                  {summary?.checkInTrend.map((point) => (
+                    <div key={point.date}>
+                      <div className="mb-1 flex items-center justify-between text-sm">
+                        <span className="text-neutral-500">
+                          {formatTrendLabel(point.date)}
+                        </span>
+                        <span className="font-medium text-neutral-800">
+                          {point.count}
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-neutral-100">
+                        <div
+                          className="h-2 rounded-full bg-secondary"
+                          style={{
+                            width: `${Math.max(
+                              8,
+                              ((point.count || 0) /
+                                Math.max(
+                                  ...((summary?.checkInTrend ?? []).map(
+                                    (item) => item.count
+                                  ) || [1])
+                                )) *
+                                100
+                            )}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            </div>
           </div>
         )}
       </div>

--- a/src/app/api/admin/dashboard/summary/route.ts
+++ b/src/app/api/admin/dashboard/summary/route.ts
@@ -1,62 +1,33 @@
 import { NextResponse } from 'next/server'
-import { getCollection, COLLECTIONS } from '@/lib/db'
 import { auth } from '@/lib/auth'
-import type { DashboardSummaryResponse } from '@/types/report'
+import { buildDashboardSummary } from '@/lib/ops/dashboard'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
 
-/**
- * GET /api/admin/dashboard/summary - 대시보드 요약 (대기 항목 count)
- * Requirements: 6.1, 6.2, 6.3, 6.4
- */
 export async function GET(): Promise<NextResponse> {
   try {
     const session = await auth()
     if (!session?.user) {
       return NextResponse.json(
-        { error: '로그인이 필요합니다' },
+        { error: '로그인이 필요합니다.' },
         { status: 401 }
       )
     }
 
     if (session.user.role !== 'admin') {
       return NextResponse.json(
-        { error: '관리자 권한이 필요합니다' },
+        { error: '관리자 권한이 필요합니다.' },
         { status: 403 }
       )
     }
 
-    const [reportsCol, supplementsCol, statusReportsCol] = await Promise.all([
-      getCollection(COLLECTIONS.SPOT_REPORTS),
-      getCollection(COLLECTIONS.SPOT_SUPPLEMENTS),
-      getCollection(COLLECTIONS.SPOT_STATUS_REPORTS),
-    ])
-
-    const [pendingReports, pendingSupplements, pendingStatusReports] =
-      await Promise.all([
-        reportsCol.countDocuments({ status: 'pending' }),
-        supplementsCol.countDocuments({
-          $or: [
-            { status: 'pending' },
-            { status: { $exists: false }, approved: { $ne: true } },
-          ],
-        }),
-        statusReportsCol.countDocuments({
-          $or: [
-            { reviewStatus: 'pending' },
-            { reviewStatus: { $exists: false } },
-          ],
-        }),
-      ])
-
-    const response: DashboardSummaryResponse = {
-      pendingReports,
-      pendingSupplements,
-      pendingStatusReports,
-    }
-
-    return NextResponse.json(response)
+    return NextResponse.json(await buildDashboardSummary())
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Error fetching dashboard summary:', error)
+    await recordApiErrorMetric({
+      path: '/api/admin/dashboard/summary',
+      statusCode: 500,
+    })
     return NextResponse.json(
       { error: '서버 오류가 발생했습니다' },
       { status: 500 }

--- a/src/app/api/checkins/route.ts
+++ b/src/app/api/checkins/route.ts
@@ -25,6 +25,7 @@ import {
   sanitizeOptionalPlainText,
   SpamGuardError,
 } from '@/lib/security'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
 
 /**
  * CheckIn MongoDB Document
@@ -422,6 +423,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     console.error('Error creating checkin:', error)
+    await recordApiErrorMetric({ path: '/api/checkins', statusCode: 500 })
     return NextResponse.json(
       { error: '인증 생성에 실패했습니다' },
       { status: 500 }

--- a/src/app/api/internal/ops/request/route.ts
+++ b/src/app/api/internal/ops/request/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { recordApiRequestMetric } from '@/lib/ops/metrics'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    if (request.headers.get('x-ops-ingest') !== '1') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = (await request.json()) as { path?: string }
+    if (!body.path) {
+      return NextResponse.json({ error: 'Missing path' }, { status: 400 })
+    }
+
+    await recordApiRequestMetric(body.path)
+    return NextResponse.json({ ok: true })
+  } catch {
+    return NextResponse.json(
+      { error: 'Metric ingestion failed' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/ops/sentry-alert/route.ts
+++ b/src/app/api/ops/sentry-alert/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { sendConfiguredAlert } from '@/lib/ops/alerting'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
+
+interface SentryWebhookPayload {
+  title?: string
+  url?: string
+  culprit?: string
+  fingerprint?: string[]
+  metadata?: {
+    title?: string
+    value?: string
+  }
+  event?: {
+    title?: string
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const expectedSecret = process.env.SENTRY_WEBHOOK_SECRET?.trim()
+    if (expectedSecret) {
+      const providedSecret = request.headers.get('x-sentry-webhook-secret')
+      if (providedSecret !== expectedSecret) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+      }
+    }
+
+    const payload = (await request.json()) as SentryWebhookPayload
+    const title =
+      payload.title ||
+      payload.event?.title ||
+      payload.metadata?.title ||
+      payload.culprit ||
+      'Sentry alert'
+    const fingerprint =
+      payload.fingerprint?.join(':') ||
+      payload.metadata?.value ||
+      title.toLowerCase().replace(/\s+/g, '-')
+
+    const result = await sendConfiguredAlert({
+      title,
+      occurredAt: new Date().toISOString(),
+      sentryUrl: payload.url,
+      fingerprint,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      deliveredTo: result.deliveredTo,
+      escalated: result.escalated,
+    })
+  } catch (error) {
+    await recordApiErrorMetric({
+      path: '/api/ops/sentry-alert',
+      statusCode: 500,
+    })
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to process Sentry alert',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/posts/[id]/comments/route.ts
+++ b/src/app/api/posts/[id]/comments/route.ts
@@ -13,6 +13,7 @@ import {
   sanitizePlainText,
   SpamGuardError,
 } from '@/lib/security'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
 
 interface CommentDocument {
   _id?: ObjectId
@@ -248,6 +249,10 @@ export async function POST(
     }
 
     console.error('Error creating comment:', error)
+    await recordApiErrorMetric({
+      path: '/api/posts/[id]/comments',
+      statusCode: 500,
+    })
     return NextResponse.json(
       { error: 'Failed to create comment' },
       { status: 500 }

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -14,6 +14,7 @@ import {
   sanitizePlainText,
   SpamGuardError,
 } from '@/lib/security'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
 
 interface PostDocument {
   _id?: ObjectId
@@ -278,6 +279,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     console.error('Error creating post:', error)
+    await recordApiErrorMetric({ path: '/api/posts', statusCode: 500 })
     return NextResponse.json(
       { error: 'Failed to create post' },
       { status: 500 }

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -14,6 +14,7 @@ import {
   sanitizeUrl,
   SpamGuardError,
 } from '@/lib/security'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
 
 interface SpotReportDocument {
   id: string
@@ -244,6 +245,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     console.error('Error creating report:', error)
+    await recordApiErrorMetric({ path: '/api/reports', statusCode: 500 })
     return NextResponse.json(
       { error: '제보 생성에 실패했습니다' },
       { status: 500 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -20,6 +20,7 @@ import {
 import { UploadQuotaError } from '@/lib/upload/quota'
 import { UploadValidationError } from '@/lib/upload/validation'
 import { StorageConfigError } from '@/lib/storage/r2'
+import { recordApiErrorMetric } from '@/lib/ops/metrics'
 import type { UploadApiSuccess } from '@/types/upload'
 
 /**
@@ -138,6 +139,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // eslint-disable-next-line no-console
     console.error('Error uploading file:', error)
+    await recordApiErrorMetric({ path: '/api/upload', statusCode: 500 })
     return NextResponse.json(
       { error: '파일 업로드에 실패했습니다.' },
       { status: 500 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -117,6 +117,9 @@ export const COLLECTIONS = {
   SECURITY_LOGS: 'security_logs',
   UPLOAD_FINGERPRINTS: 'upload_fingerprints',
   AUTH_LOGIN_ATTEMPTS: 'auth_login_attempts',
+  OPS_METRICS: 'ops_metrics',
+  ALERT_EVENTS: 'alert_events',
+  MIGRATIONS: 'migrations',
 } as const
 
 /**

--- a/src/lib/ops/alerting.test.ts
+++ b/src/lib/ops/alerting.test.ts
@@ -1,0 +1,70 @@
+import {
+  createAlertMessage,
+  sendConfiguredAlert,
+  shouldEscalateRepeatedError,
+} from './alerting'
+import { getCollection } from '@/lib/db'
+
+jest.mock('@/lib/db', () => ({
+  COLLECTIONS: {
+    ALERT_EVENTS: 'alert_events',
+  },
+  getCollection: jest.fn(),
+}))
+
+const mockGetCollection = getCollection as jest.MockedFunction<
+  typeof getCollection
+>
+
+describe('ops alerting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.test'
+    process.env.DISCORD_WEBHOOK_URL = 'https://discord.test/webhook'
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as never
+  })
+
+  afterEach(() => {
+    delete process.env.SLACK_WEBHOOK_URL
+    delete process.env.DISCORD_WEBHOOK_URL
+  })
+
+  test('creates a readable alert message', () => {
+    expect(
+      createAlertMessage({
+        title: 'Database unavailable',
+        occurredAt: '2026-05-25T00:00:00.000Z',
+        affectedUsers: 12,
+        sentryUrl: 'https://sentry.example.com/issue/1',
+        fingerprint: 'db-unavailable',
+      })
+    ).toContain('Database unavailable')
+  })
+
+  test('sends webhook alerts to configured channels', async () => {
+    const insertOne = jest.fn()
+    const countDocuments = jest.fn().mockResolvedValue(0)
+    mockGetCollection.mockResolvedValue({
+      insertOne,
+      countDocuments,
+    } as never)
+
+    const result = await sendConfiguredAlert({
+      title: 'Repeated 500 errors',
+      occurredAt: '2026-05-25T00:00:00.000Z',
+      affectedUsers: 3,
+      fingerprint: '500-errors',
+    })
+
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(result.deliveredTo).toEqual(['slack', 'discord'])
+  })
+
+  test('flags escalation after repeated alerts', async () => {
+    mockGetCollection.mockResolvedValue({
+      countDocuments: jest.fn().mockResolvedValue(10),
+    } as never)
+
+    await expect(shouldEscalateRepeatedError('same-error')).resolves.toBe(true)
+  })
+})

--- a/src/lib/ops/alerting.ts
+++ b/src/lib/ops/alerting.ts
@@ -1,0 +1,139 @@
+import { COLLECTIONS, getCollection } from '@/lib/db'
+
+const RETRY_LIMIT = 3
+const ESCALATION_THRESHOLD = 10
+const ESCALATION_WINDOW_MS = 60 * 60 * 1000
+
+export interface AlertEventRecord {
+  fingerprint: string
+  title: string
+  createdAt: Date
+  channel: 'slack' | 'discord'
+  delivered: boolean
+}
+
+export interface AlertNotificationInput {
+  title: string
+  occurredAt: string
+  affectedUsers?: number
+  sentryUrl?: string
+  fingerprint: string
+}
+
+export function createAlertMessage(input: AlertNotificationInput): string {
+  const parts = [
+    `Error: ${input.title}`,
+    `Occurred at: ${input.occurredAt}`,
+    `Affected users: ${input.affectedUsers ?? 0}`,
+  ]
+
+  if (input.sentryUrl) {
+    parts.push(`Sentry: ${input.sentryUrl}`)
+  }
+
+  return parts.join('\n')
+}
+
+async function deliverWebhook(url: string, payload: unknown): Promise<void> {
+  let lastError: Error | null = null
+
+  for (let attempt = 1; attempt <= RETRY_LIMIT; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        throw new Error(`Webhook returned ${response.status}`)
+      }
+
+      return
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+    }
+  }
+
+  throw lastError ?? new Error('Unknown webhook delivery failure')
+}
+
+async function recordAlertEvent(params: {
+  fingerprint: string
+  title: string
+  channel: 'slack' | 'discord'
+  delivered: boolean
+}): Promise<void> {
+  const collection = await getCollection<AlertEventRecord>(
+    COLLECTIONS.ALERT_EVENTS
+  )
+  await collection.insertOne({
+    fingerprint: params.fingerprint,
+    title: params.title,
+    channel: params.channel,
+    delivered: params.delivered,
+    createdAt: new Date(),
+  })
+}
+
+export async function shouldEscalateRepeatedError(
+  fingerprint: string
+): Promise<boolean> {
+  const collection = await getCollection<AlertEventRecord>(
+    COLLECTIONS.ALERT_EVENTS
+  )
+  const threshold = new Date(Date.now() - ESCALATION_WINDOW_MS)
+  const count = await collection.countDocuments({
+    fingerprint,
+    createdAt: { $gte: threshold },
+    delivered: true,
+  })
+
+  return count >= ESCALATION_THRESHOLD
+}
+
+export async function sendConfiguredAlert(
+  input: AlertNotificationInput
+): Promise<{ deliveredTo: Array<'slack' | 'discord'>; escalated: boolean }> {
+  const slackUrl = process.env.SLACK_WEBHOOK_URL?.trim()
+  const discordUrl = process.env.DISCORD_WEBHOOK_URL?.trim()
+  const message = createAlertMessage(input)
+  const deliveredTo: Array<'slack' | 'discord'> = []
+
+  if (slackUrl) {
+    await deliverWebhook(slackUrl, { text: message })
+    await recordAlertEvent({
+      fingerprint: input.fingerprint,
+      title: input.title,
+      channel: 'slack',
+      delivered: true,
+    })
+    deliveredTo.push('slack')
+  }
+
+  if (discordUrl) {
+    await deliverWebhook(discordUrl, { content: message })
+    await recordAlertEvent({
+      fingerprint: input.fingerprint,
+      title: input.title,
+      channel: 'discord',
+      delivered: true,
+    })
+    deliveredTo.push('discord')
+  }
+
+  const escalated = await shouldEscalateRepeatedError(input.fingerprint)
+  if (escalated) {
+    const escalationMessage = `${message}\nEscalation: repeated 10+ times in the last hour.`
+
+    if (slackUrl) {
+      await deliverWebhook(slackUrl, { text: escalationMessage })
+    }
+
+    if (discordUrl) {
+      await deliverWebhook(discordUrl, { content: escalationMessage })
+    }
+  }
+
+  return { deliveredTo, escalated }
+}

--- a/src/lib/ops/dashboard.ts
+++ b/src/lib/ops/dashboard.ts
@@ -1,0 +1,188 @@
+import { COLLECTIONS, getCollection } from '@/lib/db'
+import type { DashboardSummaryResponse } from '@/types/report'
+import { getTrackedApiErrorRate24h } from './metrics'
+
+interface ActivityDocument {
+  userId?: string
+  createdAt: Date
+}
+
+function startOfDay(date = new Date()): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000)
+}
+
+function formatDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+async function getPendingReviewCounts() {
+  const [reportsCol, supplementsCol, statusReportsCol] = await Promise.all([
+    getCollection(COLLECTIONS.SPOT_REPORTS),
+    getCollection(COLLECTIONS.SPOT_SUPPLEMENTS),
+    getCollection(COLLECTIONS.SPOT_STATUS_REPORTS),
+  ])
+
+  const [pendingReports, pendingSupplements, pendingStatusReports] =
+    await Promise.all([
+      reportsCol.countDocuments({ status: 'pending' }),
+      supplementsCol.countDocuments({
+        $or: [
+          { status: 'pending' },
+          { status: { $exists: false }, approved: { $ne: true } },
+        ],
+      }),
+      statusReportsCol.countDocuments({
+        $or: [
+          { reviewStatus: 'pending' },
+          { reviewStatus: { $exists: false } },
+        ],
+      }),
+    ])
+
+  return { pendingReports, pendingSupplements, pendingStatusReports }
+}
+
+async function getDistinctUserIdsSince(
+  collectionName: string,
+  since: Date
+): Promise<string[]> {
+  const collection = await getCollection<ActivityDocument>(collectionName)
+  const values = await collection.distinct('userId', {
+    createdAt: { $gte: since },
+    userId: { $exists: true },
+  })
+  return values.filter((value): value is string => typeof value === 'string')
+}
+
+async function getDauToday(): Promise<number> {
+  const today = startOfDay()
+  const [checkinUsers, postUsers, commentUsers, reportUsers] =
+    await Promise.all([
+      getDistinctUserIdsSince(COLLECTIONS.CHECKINS, today),
+      getDistinctUserIdsSince(COLLECTIONS.POSTS, today),
+      getDistinctUserIdsSince(COLLECTIONS.COMMENTS, today),
+      getDistinctUserIdsSince(COLLECTIONS.SPOT_REPORTS, today),
+    ])
+
+  return new Set([
+    ...checkinUsers,
+    ...postUsers,
+    ...commentUsers,
+    ...reportUsers,
+  ]).size
+}
+
+async function getCheckInTrend(days = 7) {
+  const collection = await getCollection<ActivityDocument>(COLLECTIONS.CHECKINS)
+  const points: Array<{ date: string; count: number }> = []
+
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    const dayStart = startOfDay(addDays(new Date(), -offset))
+    const nextDay = addDays(dayStart, 1)
+    const count = await collection.countDocuments({
+      createdAt: { $gte: dayStart, $lt: nextDay },
+    })
+    points.push({ date: formatDayKey(dayStart), count })
+  }
+
+  return points
+}
+
+async function getDauTrend(days = 7) {
+  const checkins = await getCollection<ActivityDocument>(COLLECTIONS.CHECKINS)
+  const posts = await getCollection<ActivityDocument>(COLLECTIONS.POSTS)
+  const comments = await getCollection<ActivityDocument>(COLLECTIONS.COMMENTS)
+  const reports = await getCollection<ActivityDocument>(
+    COLLECTIONS.SPOT_REPORTS
+  )
+  const points: Array<{ date: string; count: number }> = []
+
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    const dayStart = startOfDay(addDays(new Date(), -offset))
+    const nextDay = addDays(dayStart, 1)
+    const [checkinUsers, postUsers, commentUsers, reportUsers] =
+      await Promise.all([
+        checkins.distinct('userId', {
+          createdAt: { $gte: dayStart, $lt: nextDay },
+          userId: { $exists: true },
+        }),
+        posts.distinct('userId', {
+          createdAt: { $gte: dayStart, $lt: nextDay },
+          userId: { $exists: true },
+        }),
+        comments.distinct('userId', {
+          createdAt: { $gte: dayStart, $lt: nextDay },
+          userId: { $exists: true },
+        }),
+        reports.distinct('userId', {
+          createdAt: { $gte: dayStart, $lt: nextDay },
+          userId: { $exists: true },
+        }),
+      ])
+
+    points.push({
+      date: formatDayKey(dayStart),
+      count: new Set([
+        ...checkinUsers.filter(
+          (value): value is string => typeof value === 'string'
+        ),
+        ...postUsers.filter(
+          (value): value is string => typeof value === 'string'
+        ),
+        ...commentUsers.filter(
+          (value): value is string => typeof value === 'string'
+        ),
+        ...reportUsers.filter(
+          (value): value is string => typeof value === 'string'
+        ),
+      ]).size,
+    })
+  }
+
+  return points
+}
+
+export async function buildDashboardSummary(): Promise<DashboardSummaryResponse> {
+  const today = startOfDay()
+  const usersCollection = await getCollection(COLLECTIONS.USERS)
+  const spotsCollection = await getCollection(COLLECTIONS.SPOTS)
+  const checkinsCollection = await getCollection<ActivityDocument>(
+    COLLECTIONS.CHECKINS
+  )
+
+  const [
+    pendingCounts,
+    dauToday,
+    totalCheckInsToday,
+    errorRate24h,
+    newUsersToday,
+    newSpotsToday,
+    dauTrend,
+    checkInTrend,
+  ] = await Promise.all([
+    getPendingReviewCounts(),
+    getDauToday(),
+    checkinsCollection.countDocuments({ createdAt: { $gte: today } }),
+    getTrackedApiErrorRate24h(),
+    usersCollection.countDocuments({ createdAt: { $gte: today } }),
+    spotsCollection.countDocuments({ createdAt: { $gte: today } }),
+    getDauTrend(),
+    getCheckInTrend(),
+  ])
+
+  return {
+    ...pendingCounts,
+    dauToday,
+    totalCheckInsToday,
+    errorRate24h,
+    newUsersToday,
+    newSpotsToday,
+    dauTrend,
+    checkInTrend,
+    generatedAt: new Date().toISOString(),
+  }
+}

--- a/src/lib/ops/metrics.ts
+++ b/src/lib/ops/metrics.ts
@@ -1,0 +1,58 @@
+import { COLLECTIONS, getCollection } from '@/lib/db'
+
+export interface OpsMetricRecord {
+  kind: 'api_request' | 'api_error'
+  path: string
+  statusCode?: number
+  createdAt: Date
+}
+
+export async function recordApiRequestMetric(path: string): Promise<void> {
+  const collection = await getCollection<OpsMetricRecord>(
+    COLLECTIONS.OPS_METRICS
+  )
+  await collection.insertOne({
+    kind: 'api_request',
+    path,
+    createdAt: new Date(),
+  })
+}
+
+export async function recordApiErrorMetric(params: {
+  path: string
+  statusCode?: number
+}): Promise<void> {
+  const collection = await getCollection<OpsMetricRecord>(
+    COLLECTIONS.OPS_METRICS
+  )
+  await collection.insertOne({
+    kind: 'api_error',
+    path: params.path,
+    statusCode: params.statusCode ?? 500,
+    createdAt: new Date(),
+  })
+}
+
+export async function getTrackedApiErrorRate24h(): Promise<number> {
+  const collection = await getCollection<OpsMetricRecord>(
+    COLLECTIONS.OPS_METRICS
+  )
+  const threshold = new Date(Date.now() - 24 * 60 * 60 * 1000)
+
+  const [requestCount, errorCount] = await Promise.all([
+    collection.countDocuments({
+      kind: 'api_request',
+      createdAt: { $gte: threshold },
+    }),
+    collection.countDocuments({
+      kind: 'api_error',
+      createdAt: { $gte: threshold },
+    }),
+  ])
+
+  if (requestCount === 0) {
+    return 0
+  }
+
+  return Number(((errorCount / requestCount) * 100).toFixed(2))
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,30 @@
 import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
 import {
   createRateLimitHeaders,
   evaluateSlidingWindowLimit,
   getClientIp,
 } from '@/lib/security/rate-limit'
 
-export function middleware(request: NextRequest) {
+export function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl
 
   if (pathname.startsWith('/api/')) {
+    if (pathname === '/api/internal/ops/request') {
+      return NextResponse.next()
+    }
+
+    event.waitUntil(
+      fetch(new URL('/api/internal/ops/request', request.url), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-ops-ingest': '1',
+        },
+        body: JSON.stringify({ path: pathname }),
+      }).catch(() => undefined)
+    )
+
     const ip = getClientIp(request)
     const result = evaluateSlidingWindowLimit({
       key: `api-ip:${ip}`,

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -212,6 +212,14 @@ export interface DashboardSummaryResponse {
   pendingReports: number
   pendingSupplements: number
   pendingStatusReports: number
+  dauToday: number
+  totalCheckInsToday: number
+  errorRate24h: number
+  newUsersToday: number
+  newSpotsToday: number
+  dauTrend: Array<{ date: string; count: number }>
+  checkInTrend: Array<{ date: string; count: number }>
+  generatedAt: string
 }
 
 /** GET /api/admin/supplements 응답 */


### PR DESCRIPTION
## Related issue
- Closes #841

---

## PR type
- [x] feat
- [ ] fix
- [ ] ui
- [ ] enhancement
- [ ] chore
- [ ] refactor
- [ ] docs

---

## Work summary

> Added the remaining spec 43 observability and operations tooling slice.

---

## Changes

- [x] Added ops alerting helpers with Slack/Discord delivery, retries, and repeated-error escalation
- [x] Added POST /api/ops/sentry-alert webhook ingestion for Sentry-driven alerts
- [x] Expanded the admin dashboard summary API and UI with DAU, check-in, user, spot, and tracked 5xx metrics
- [x] Added middleware-fed request metric ingestion via /api/internal/ops/request
- [x] Added MongoDB backup/restore scripts and upgraded migration runner with dry-run/history support
- [x] Added the spec 43 ops runbook and updated handoff/task docs

---

## Checklist
- [x] 
pm run lint passed via pre-commit
- [x] 
pm run build passed
- [x] Core behavior checked

---

## Screenshot (optional)

<!-- Add Before/After when UI changes exist -->

---

## Additional notes (optional)

- Validation run:
  - 
pm test -- src/lib/ops/alerting.test.ts src/lib/security/rate-limit.test.ts src/lib/security/input-sanitizer.test.ts
  - 
pm run type-check
  - 
pm run build
- Existing repo-wide lint warnings remain out of scope for this PR.