### PR TITLE
enhancement: reduce eager UI cost for gallery and profile routes

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,21 +1,45 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Suspense, useState, useCallback } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { GalleryContent } from '@/components/gallery/GalleryContent'
 import { FloatingActionButton } from '@/components/gallery/FloatingActionButton'
-import { SpotSearchModal } from '@/components/gallery/SpotSearchModal'
-import { CheckInModal } from '@/components/checkin/CheckInModal'
-import { BadgeEarnedModal } from '@/components/checkin/BadgeEarnedModal'
 import { Spot, UserBadge } from '@/types'
 import {
   GalleryPageSkeleton as GalleryPageSkeletonUI,
   SkeletonBlock,
   GalleryGridSkeleton,
 } from '@/components/common/SkeletonUI'
-import OnboardingTour from '@/components/common/OnboardingTour'
 import { useOnboarding } from '@/hooks/useOnboarding'
 import { GALLERY_PAGE_STEPS } from '@/lib/tour-config'
+
+const SpotSearchModal = dynamic(
+  () =>
+    import('@/components/gallery/SpotSearchModal').then(
+      (mod) => mod.SpotSearchModal
+    ),
+  { loading: () => null }
+)
+
+const CheckInModal = dynamic(
+  () =>
+    import('@/components/checkin/CheckInModal').then((mod) => mod.CheckInModal),
+  { loading: () => null }
+)
+
+const BadgeEarnedModal = dynamic(
+  () =>
+    import('@/components/checkin/BadgeEarnedModal').then(
+      (mod) => mod.BadgeEarnedModal
+    ),
+  { loading: () => null }
+)
+
+const OnboardingTour = dynamic(
+  () => import('@/components/common/OnboardingTour'),
+  { loading: () => null }
+)
 
 /**
  * 갤러리 탭 타입

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,14 +4,7 @@ import 'leaflet/dist/leaflet.css'
 import './globals.css'
 import { Providers } from '@/lib/providers'
 import { Header } from '@/components/layout'
-import {
-  SerwistRegistration,
-  InstallPromptListener,
-  InstallBottomSheet,
-  InstallToast,
-  IosPwaGuide,
-} from '@/components/pwa'
-import { CourseProgressBanner } from '@/components/course/CourseProgressBanner'
+import AppChromeDeferredHost from '@/components/app/AppChromeDeferredHost'
 import JsonLd from '@/components/seo/JsonLd'
 import GoogleAnalytics from '@/components/seo/GoogleAnalytics'
 import { generateWebSiteJsonLd } from '@/lib/seo/json-ld'
@@ -84,12 +77,7 @@ export default function RootLayout({
         <Providers>
           <Header />
           <main>{children}</main>
-          <CourseProgressBanner />
-          <InstallPromptListener />
-          <InstallBottomSheet />
-          <InstallToast />
-          <IosPwaGuide />
-          <SerwistRegistration />
+          <AppChromeDeferredHost />
         </Providers>
       </body>
     </html>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,18 +1,54 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { use } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { ProfileHeader } from '@/components/profile/ProfileHeader'
 import { SectionNavigation } from '@/components/profile/SectionNavigation'
-import { ActivitySection } from '@/components/profile/sections/ActivitySection'
-import { ContributionSection } from '@/components/profile/sections/ContributionSection'
-import { CommunitySection } from '@/components/profile/sections/CommunitySection'
-import { CollectionSection } from '@/components/profile/sections/CollectionSection'
-import { ManagementSection } from '@/components/profile/sections/ManagementSection'
 import { useUserInfo, useUserStats } from '@/hooks/useUserQueries'
 import type { ProfileSection, ExtendedUserStats } from '@/types/profile'
 import type { UserStats } from '@/types/checkin'
+
+const ActivitySection = dynamic(
+  () =>
+    import('@/components/profile/sections/ActivitySection').then(
+      (mod) => mod.ActivitySection
+    ),
+  { loading: () => <SectionLoadingPlaceholder /> }
+)
+
+const ContributionSection = dynamic(
+  () =>
+    import('@/components/profile/sections/ContributionSection').then(
+      (mod) => mod.ContributionSection
+    ),
+  { loading: () => <SectionLoadingPlaceholder /> }
+)
+
+const CommunitySection = dynamic(
+  () =>
+    import('@/components/profile/sections/CommunitySection').then(
+      (mod) => mod.CommunitySection
+    ),
+  { loading: () => <SectionLoadingPlaceholder /> }
+)
+
+const CollectionSection = dynamic(
+  () =>
+    import('@/components/profile/sections/CollectionSection').then(
+      (mod) => mod.CollectionSection
+    ),
+  { loading: () => <SectionLoadingPlaceholder /> }
+)
+
+const ManagementSection = dynamic(
+  () =>
+    import('@/components/profile/sections/ManagementSection').then(
+      (mod) => mod.ManagementSection
+    ),
+  { loading: () => <SectionLoadingPlaceholder /> }
+)
 
 interface UserProfilePageProps {
   params: Promise<{ id: string }>
@@ -176,6 +212,16 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+function SectionLoadingPlaceholder() {
+  return (
+    <div className="space-y-4">
+      <div className="h-5 w-40 animate-pulse rounded bg-neutral-200" />
+      <div className="h-24 animate-pulse rounded-xl bg-neutral-100" />
+      <div className="h-24 animate-pulse rounded-xl bg-neutral-100" />
     </div>
   )
 }

--- a/src/components/app/AppChromeDeferred.tsx
+++ b/src/components/app/AppChromeDeferred.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { CourseProgressBanner } from '@/components/course/CourseProgressBanner'
+import {
+  SerwistRegistration,
+  InstallPromptListener,
+  InstallBottomSheet,
+  InstallToast,
+  IosPwaGuide,
+} from '@/components/pwa'
+
+export default function AppChromeDeferred() {
+  return (
+    <>
+      <CourseProgressBanner />
+      <InstallPromptListener />
+      <InstallBottomSheet />
+      <InstallToast />
+      <IosPwaGuide />
+      <SerwistRegistration />
+    </>
+  )
+}

--- a/src/components/app/AppChromeDeferredHost.tsx
+++ b/src/components/app/AppChromeDeferredHost.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const AppChromeDeferred = dynamic(() => import('./AppChromeDeferred'), {
+  ssr: false,
+  loading: () => null,
+})
+
+export default function AppChromeDeferredHost() {
+  return <AppChromeDeferred />
+}

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { SessionProvider } from 'next-auth/react'
 import { ThemeProvider } from 'next-themes'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { SentryUserManager } from '@/components/common'
 
 interface ProvidersProps {
@@ -46,12 +45,31 @@ export function Providers({ children }: ProvidersProps) {
         <SentryUserManager />
         <QueryClientProvider client={queryClient}>
           {children}
-          {/* Show React Query DevTools in development */}
-          {process.env.NODE_ENV === 'development' && (
-            <ReactQueryDevtools initialIsOpen={false} />
-          )}
+          <DevOnlyReactQueryDevtools />
         </QueryClientProvider>
       </ThemeProvider>
     </SessionProvider>
   )
+}
+
+function DevOnlyReactQueryDevtools() {
+  const [Devtools, setDevtools] = useState<React.ComponentType<{
+    initialIsOpen?: boolean
+  }> | null>(null)
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') {
+      return
+    }
+
+    import('@tanstack/react-query-devtools').then((mod) => {
+      setDevtools(() => mod.ReactQueryDevtools)
+    })
+  }, [])
+
+  if (!Devtools) {
+    return null
+  }
+
+  return <Devtools initialIsOpen={false} />
 }


### PR DESCRIPTION
## ?? ??

- Closes #845

---

## PR ??
- [ ] ? **feat**: ??? ?? ??
- [ ] ?? **fix**: ?? ??
- [ ] ?? **ui**: UI/UX ??, ??? ??
- [x] ?? **enhancement**: ?? ?? ??, ?? ???
- [ ] ?? **chore**: ??, ??, ??? ??
- [ ] ?? **refactor**: ?? ???? (?? ?? ??)
- [ ] ?? **docs**: ?? ??

---

## ?? ??

> ?? client shell? ??? ? route?? ??? ? ???? ?? UI? ?? ??? gallery/profile? first-load JS? ????.

---

## ?? ??

- [x] root layout? ??? PWA/chrome UI? client host ?? ?? ??
- [x] react-query devtools? dev ?? ??? import? ??
- [x] /gallery? spot search / check-in / badge / onboarding UI? dynamic import? ??
- [x] /profile/[id]? section ?????? ?? lazy loading?? ??

---

## ?????
- [ ] 
pm run lint ??
- [x] 
pm run build ??
- [x] ?? ?? ?? ??

---

## ???? (??)

<!-- UI ??? ??? Before/After ?? -->

---

## ?? ?? (??)

<!-- ???? ??? ? ???? ???? -->
- verification:
  - 
pm test -- src/lib/deployment/performance-auditor.test.ts`n  - 
pm run build`n  - 
pm run type-check`n- build output deltas observed locally:
  - /gallery first-load JS: 273 kB -> 264 kB`n  - /profile/[id] first-load JS: 285 kB -> 250 kB`n- shared-by-all JS remains about 224 kB; a deeper provider/layout split is still separate follow-up work.
- existing repo-wide lint warnings remain out of scope for this PR.