### PR TITLE
[ui] 랜딩 테마와 카드 톤 정리

### DIFF
--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -1,12 +1,14 @@
-﻿/**
+import { LandingThemeProvider } from '@/components/landing/LandingThemeProvider'
+
+/**
  * 랜딩 페이지 전용 레이아웃
- * - 항상 다크 모드로 고정
- * - 정적 랜딩 유지: 세션 provider를 주입하지 않음
+ * - 라이트/다크/시스템 테마를 랜딩에서도 동일하게 적용
+ * - 정적 랜딩 유지: 세션/쿼리 provider는 주입하지 않음
  */
 export default function LandingLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return <div className="dark">{children}</div>
+  return <LandingThemeProvider>{children}</LandingThemeProvider>
 }

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -85,7 +85,7 @@ export function ThemeSelector() {
     <div className="relative" ref={containerRef}>
       <button
         onClick={() => setIsOpen((prev) => !prev)}
-        className="flex h-10 w-10 items-center justify-center rounded-xl text-neutral-300 transition hover:bg-neutral-700 hover:text-white"
+        className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface/85 text-sub-text shadow-sm backdrop-blur-sm transition hover:border-primary-500/40 hover:bg-primary-50 hover:text-main-text dark:border-white/15 dark:bg-white/10 dark:text-white/80 dark:hover:bg-white/20 dark:hover:text-white"
         aria-expanded={isOpen}
         aria-haspopup="true"
         aria-label={`현재: ${currentLabel}. 클릭하여 테마 선택`}
@@ -98,7 +98,7 @@ export function ThemeSelector() {
 
       {isOpen && (
         <div
-          className="absolute right-0 top-full z-[9999] mt-1 w-44 overflow-hidden rounded-lg bg-surface shadow-lg ring-1 ring-black/5"
+          className="absolute right-0 top-full z-[9999] mt-2 w-44 overflow-hidden rounded-2xl border border-border bg-surface shadow-xl shadow-primary-500/10 ring-1 ring-black/5 dark:border-white/10"
           role="menu"
           aria-label="테마 선택"
         >
@@ -113,8 +113,8 @@ export function ThemeSelector() {
                 }}
                 className={`flex w-full items-center gap-2.5 px-3 py-2.5 text-sm transition-colors ${
                   isActive
-                    ? 'bg-primary-50 font-medium text-primary'
-                    : 'text-text-secondary hover:bg-secondary-100'
+                    ? 'bg-primary-50 font-medium text-primary dark:bg-white/10 dark:text-primary-300'
+                    : 'text-sub-text hover:bg-accent-surface hover:text-main-text'
                 }`}
                 role="menuitem"
               >

--- a/src/components/landing/CTAButton.tsx
+++ b/src/components/landing/CTAButton.tsx
@@ -17,9 +17,9 @@ interface CTAButtonProps {
 
 const variantStyles = {
   primary:
-    'bg-primary-500 text-white hover:bg-primary-600 focus-visible:ring-primary-500',
+    'bg-primary-500 text-white shadow-lg shadow-primary-500/25 hover:bg-primary-600 focus-visible:ring-primary-500',
   secondary:
-    'bg-secondary-100 text-secondary-700 hover:bg-secondary-200 focus-visible:ring-secondary-500',
+    'bg-secondary-100 text-secondary-700 shadow-sm hover:bg-secondary-200 focus-visible:ring-secondary-500',
 } as const
 
 const sizeStyles = {
@@ -36,7 +36,7 @@ export function CTAButton({
   return (
     <Link
       href={href}
-      className={`inline-flex items-center justify-center rounded-lg font-semibold transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${variantStyles[variant]} ${sizeStyles[size]} `}
+      className={`inline-flex items-center justify-center rounded-full font-semibold transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${variantStyles[variant]} ${sizeStyles[size]} `}
     >
       {label}
     </Link>

--- a/src/components/landing/CategoryCard.tsx
+++ b/src/components/landing/CategoryCard.tsx
@@ -39,8 +39,8 @@ interface CategoryCardProps {
  */
 function getCategoryStyles(colorToken: string) {
   return {
-    backgroundColor: `rgb(var(--${colorToken}-bg) / 0.3)`,
-    borderColor: `rgb(var(--${colorToken}-fg) / 0.3)`,
+    backgroundColor: `rgb(var(--${colorToken}-bg) / 0.22)`,
+    borderColor: `rgb(var(--${colorToken}-fg) / 0.24)`,
   }
 }
 
@@ -69,7 +69,7 @@ export function CategoryCard({
 
   return (
     <article
-      className={`category-card group relative flex flex-col overflow-hidden rounded-xl border backdrop-blur-sm transition-transform duration-300 ${
+      className={`category-card group relative flex flex-col overflow-hidden rounded-[1.5rem] border shadow-lg shadow-primary-500/5 backdrop-blur-sm transition-all duration-300 hover:shadow-xl hover:shadow-primary-500/10 ${
         !reducedMotion && isHighEnd ? 'hover:scale-[1.02]' : ''
       }`}
       style={{
@@ -104,10 +104,10 @@ export function CategoryCard({
       </div>
 
       {/* 카드 콘텐츠 */}
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-5">
+      <div className="flex flex-1 flex-col gap-3 bg-surface/70 p-5 dark:bg-black/10 md:p-6">
         {/* 마스코트 소품 + 제목 */}
         <div className="flex items-center gap-3">
-          <div className="relative flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg">
+          <div className="relative flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-background/60">
             {!mascotError ? (
               <Image
                 src={mascotProp}
@@ -127,7 +127,10 @@ export function CategoryCard({
               </span>
             )}
           </div>
-          <h3 className="text-lg font-bold md:text-xl" style={accentStyles}>
+          <h3
+            className="text-lg font-semibold tracking-[-0.01em] md:text-xl"
+            style={accentStyles}
+          >
             {title}
           </h3>
         </div>
@@ -140,10 +143,10 @@ export function CategoryCard({
         {/* 더 보기 링크 */}
         <Link
           href={`/map?category=${category}`}
-          className="mt-auto inline-flex items-center gap-1 self-start text-sm font-medium transition-colors hover:underline"
+          className="mt-auto inline-flex items-center gap-1 self-start rounded-full px-0 text-sm font-semibold transition-colors hover:underline"
           style={accentStyles}
         >
-          더 보기
+          지도에서 보기
           <svg
             className="h-4 w-4"
             fill="none"

--- a/src/components/landing/ConversionSection.tsx
+++ b/src/components/landing/ConversionSection.tsx
@@ -37,7 +37,7 @@ export const ConversionSection = forwardRef<
   return (
     <section
       ref={ref}
-      className="bg-background py-16 md:py-24"
+      className="bg-gradient-to-b from-background to-primary-50/50 py-16 dark:to-background md:py-24"
       aria-label="전환 영역"
     >
       <div className="mx-auto max-w-2xl px-4 text-center">
@@ -48,13 +48,13 @@ export const ConversionSection = forwardRef<
 
         {/* 설치 유도 카피 */}
         <header className="mb-10">
-          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl">
-            나만의 <span className="text-primary-500">여권</span>을 발급받고
+          <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl">
+            나만의 <span className="text-primary-500">여권</span>을 만들고
             <br />
-            성지순례를 시작하세요
+            다음 여행을 가볍게 시작해요
           </h2>
-          <p className="text-base text-sub-text md:text-lg">
-            전 세계 팬들이 찾는 특별한 장소를 탐험해보세요
+          <p className="text-base leading-7 text-sub-text md:text-lg">
+            저장한 장소와 방문 기록이 계속 이어지는 팬 여행 지도입니다
           </p>
         </header>
 
@@ -71,7 +71,7 @@ export const ConversionSection = forwardRef<
               <button
                 type="button"
                 onClick={handleInstall}
-                className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 bg-white/5 px-6 py-3 text-base font-medium text-white/70 backdrop-blur-sm transition hover:bg-white/10 hover:text-white"
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface/85 px-6 py-3 text-base font-medium text-sub-text shadow-sm backdrop-blur-sm transition hover:border-primary-500/40 hover:bg-background hover:text-main-text dark:border-white/15 dark:bg-white/10 dark:text-white/75 dark:hover:bg-white/20 dark:hover:text-white"
               >
                 <span>📲</span>
                 <span>앱으로 설치하기</span>
@@ -103,6 +103,21 @@ function PassportIllustration() {
       role="img"
       aria-label="마스코트가 여권을 들고 있는 일러스트"
     >
+      <defs>
+        <linearGradient
+          id="passportLightBody"
+          x1="20"
+          y1="40"
+          x2="140"
+          y2="190"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0%" stopColor="#faf5ff" />
+          <stop offset="48%" stopColor="#eef2ff" />
+          <stop offset="100%" stopColor="#f8fafc" />
+        </linearGradient>
+      </defs>
+
       {/* 여권 본체 */}
       <rect
         x="20"
@@ -110,7 +125,8 @@ function PassportIllustration() {
         width="120"
         height="150"
         rx="8"
-        className="fill-primary-600"
+        fill="url(#passportLightBody)"
+        className="dark:hidden"
       />
       <rect
         x="20"
@@ -118,7 +134,15 @@ function PassportIllustration() {
         width="120"
         height="150"
         rx="8"
-        className="stroke-primary-400"
+        className="hidden fill-primary-600 dark:block"
+      />
+      <rect
+        x="20"
+        y="40"
+        width="120"
+        height="150"
+        rx="8"
+        className="stroke-neutral-300 dark:stroke-primary-400"
         strokeWidth="2"
         fill="none"
       />
@@ -130,8 +154,8 @@ function PassportIllustration() {
         width="96"
         height="126"
         rx="4"
-        className="stroke-primary-300/40"
-        strokeWidth="1"
+        className="stroke-indigo-300/80 dark:stroke-primary-300/40"
+        strokeWidth="1.4"
         fill="none"
       />
 
@@ -140,7 +164,7 @@ function PassportIllustration() {
         x="80"
         y="72"
         textAnchor="middle"
-        className="fill-primary-200"
+        className="fill-violet-700 dark:fill-primary-200"
         fontSize="10"
         fontWeight="bold"
         letterSpacing="2"
@@ -149,27 +173,42 @@ function PassportIllustration() {
       </text>
 
       {/* 마스코트 얼굴 (원형 사진 영역) */}
-      <circle cx="80" cy="110" r="24" className="fill-primary-800/50" />
       <circle
         cx="80"
         cy="110"
         r="24"
-        className="stroke-primary-300"
-        strokeWidth="1.5"
+        className="fill-violet-50 dark:fill-primary-800/50"
+      />
+      <circle
+        cx="80"
+        cy="110"
+        r="24"
+        className="stroke-violet-400/80 dark:stroke-primary-300"
+        strokeWidth="1.8"
         fill="none"
       />
 
       {/* 마스코트 눈 */}
-      <circle cx="72" cy="106" r="3" className="fill-primary-200" />
-      <circle cx="88" cy="106" r="3" className="fill-primary-200" />
-      <circle cx="73" cy="105" r="1" className="fill-primary-800" />
-      <circle cx="89" cy="105" r="1" className="fill-primary-800" />
+      <circle cx="72" cy="106" r="3" className="fill-indigo-500" />
+      <circle cx="88" cy="106" r="3" className="fill-indigo-500" />
+      <circle
+        cx="73"
+        cy="105"
+        r="1"
+        className="fill-violet-950 dark:fill-primary-800"
+      />
+      <circle
+        cx="89"
+        cy="105"
+        r="1"
+        className="fill-violet-950 dark:fill-primary-800"
+      />
 
       {/* 마스코트 입 (미소) */}
       <path
         d="M74 116 Q80 122 86 116"
-        className="stroke-primary-200"
-        strokeWidth="1.5"
+        className="stroke-violet-600 dark:stroke-primary-200"
+        strokeWidth="1.8"
         fill="none"
         strokeLinecap="round"
       />
@@ -181,7 +220,7 @@ function PassportIllustration() {
         width="72"
         height="4"
         rx="2"
-        className="fill-primary-400/30"
+        className="fill-indigo-300/75 dark:fill-primary-400/30"
       />
       <rect
         x="52"
@@ -189,7 +228,7 @@ function PassportIllustration() {
         width="56"
         height="4"
         rx="2"
-        className="fill-primary-400/20"
+        className="fill-violet-300/65 dark:fill-primary-400/20"
       />
 
       {/* 여권 스탬프 (체크인 도장) */}
@@ -197,7 +236,7 @@ function PassportIllustration() {
         cx="120"
         cy="60"
         r="16"
-        className="stroke-secondary-400"
+        className="stroke-fuchsia-500/80 dark:stroke-secondary-400"
         strokeWidth="1.5"
         fill="none"
         strokeDasharray="3 2"
@@ -207,7 +246,7 @@ function PassportIllustration() {
         x="120"
         y="63"
         textAnchor="middle"
-        className="fill-secondary-400"
+        className="fill-fuchsia-600 dark:fill-secondary-400"
         fontSize="7"
         fontWeight="bold"
       >

--- a/src/components/landing/EntryPointSection.tsx
+++ b/src/components/landing/EntryPointSection.tsx
@@ -18,19 +18,19 @@ const ENTRY_POINTS: EntryPoint[] = [
   {
     icon: '🎬',
     title: '작품으로 찾기',
-    description: '좋아하는 작품의 성지를 탐색하세요',
+    description: '이름만 떠올라도 관련 스팟을 바로 모아볼 수 있어요',
     href: '/contents',
   },
   {
     icon: '🗺️',
     title: '코스로 따라가기',
-    description: '큐레이션된 순례 코스를 따라가세요',
+    description: '처음 가는 도시에서도 순서대로 따라가면 됩니다',
     href: '/routes',
   },
   {
     icon: '📸',
     title: '인증 둘러보기',
-    description: '다른 순례자들의 인증을 구경하세요',
+    description: '다른 팬들의 사진과 후기로 분위기를 먼저 확인해요',
     href: '/gallery',
   },
 ]
@@ -38,21 +38,20 @@ const ENTRY_POINTS: EntryPoint[] = [
 export function EntryPointSection() {
   return (
     <section
-      className="bg-background py-16 md:py-24"
+      className="bg-gradient-to-b from-background to-primary-50/40 py-16 dark:to-background md:py-24"
       aria-label="목적별 진입점"
     >
       <div className="mx-auto max-w-6xl px-4">
         {/* 헤더 */}
         <header className="mb-12 text-center">
-          <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl">
-            어떤 방식으로{' '}
-            <span className="bg-gradient-to-r from-primary-400 to-purple-400 bg-clip-text text-transparent">
-              탐색
+          <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl">
+            오늘은 어떻게{' '}
+            <span className="bg-gradient-to-r from-primary-600 to-secondary-500 bg-clip-text text-transparent dark:from-primary-300 dark:to-secondary-300">
+              떠나볼까요?
             </span>
-            할까요?
           </h2>
-          <p className="text-base text-white/50 md:text-lg">
-            목적에 맞는 경로를 선택하세요
+          <p className="text-base leading-7 text-sub-text md:text-lg">
+            원하는 시작점만 고르면 나머지는 자연스럽게 이어집니다
           </p>
         </header>
 
@@ -62,20 +61,20 @@ export function EntryPointSection() {
             <Link
               key={entry.href}
               href={entry.href}
-              className="group flex flex-col items-center rounded-xl border border-white/10 bg-white/5 p-8 text-center transition-all hover:border-primary-500/50 hover:bg-white/10 hover:shadow-lg hover:shadow-primary-500/10"
+              className="group flex flex-col items-center rounded-[1.5rem] border border-border bg-surface/85 p-8 text-center shadow-sm shadow-primary-500/5 backdrop-blur-sm transition-all hover:-translate-y-1 hover:border-primary-500/45 hover:bg-background hover:shadow-xl hover:shadow-primary-500/10 dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/10"
             >
               {/* 아이콘 */}
-              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-primary-500/30 bg-primary-500/10 text-3xl transition-transform group-hover:scale-110">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-primary-500/20 bg-primary-500/10 text-3xl transition-transform group-hover:scale-105">
                 {entry.icon}
               </div>
 
               {/* 제목 */}
-              <h3 className="mb-2 text-lg font-semibold text-white">
+              <h3 className="mb-2 text-lg font-semibold tracking-[-0.01em] text-main-text">
                 {entry.title}
               </h3>
 
               {/* 설명 */}
-              <p className="text-sm leading-relaxed text-white/50">
+              <p className="text-sm leading-relaxed text-sub-text">
                 {entry.description}
               </p>
             </Link>

--- a/src/components/landing/FloatingCard.tsx
+++ b/src/components/landing/FloatingCard.tsx
@@ -94,7 +94,7 @@ export function FloatingCard({
 
   return (
     <div
-      className="group relative rounded-lg border border-white/10 shadow-lg backdrop-blur-sm transition-all duration-300 will-change-transform hover:scale-105 hover:shadow-2xl hover:shadow-white/10"
+      className="group relative rounded-[1rem] border border-white/25 shadow-xl shadow-primary-500/10 backdrop-blur-sm transition-all duration-300 will-change-transform hover:scale-105 hover:shadow-2xl hover:shadow-primary-500/20 dark:border-white/10"
       style={{
         width,
         height,
@@ -107,14 +107,14 @@ export function FloatingCard({
       {card.additionalContentNames &&
         card.additionalContentNames.length > 0 && (
           <div
-            className="absolute -right-1 -top-1 z-20 flex items-center justify-center rounded-full border border-white/20 bg-white/90 shadow-md backdrop-blur-sm"
+            className="absolute -right-1 -top-1 z-20 flex items-center justify-center rounded-full border border-border bg-surface/95 shadow-md backdrop-blur-sm dark:border-white/20"
             style={{
               width: size === 'sm' ? 22 : size === 'md' ? 26 : 30,
               height: size === 'sm' ? 22 : size === 'md' ? 26 : 30,
             }}
           >
             <span
-              className={`font-bold text-gray-800 ${size === 'sm' ? 'text-[9px]' : size === 'md' ? 'text-[10px]' : 'text-xs'}`}
+              className={`font-bold text-main-text ${size === 'sm' ? 'text-[9px]' : size === 'md' ? 'text-[10px]' : 'text-xs'}`}
             >
               +{card.additionalContentNames.length}
             </span>
@@ -122,7 +122,7 @@ export function FloatingCard({
         )}
 
       {/* 카드 내부 콘텐츠 (overflow-hidden 적용) */}
-      <div className="absolute inset-0 overflow-hidden rounded-lg">
+      <div className="absolute inset-0 overflow-hidden rounded-[1rem]">
         {/* 배경 하이라이트 효과 */}
         <div
           className="absolute inset-0 opacity-15"
@@ -186,7 +186,7 @@ export function FloatingCard({
         <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 pb-1.5 pt-6">
           {/* 카테고리 태그 */}
           <div
-            className="mb-1 inline-flex items-center rounded px-1.5 py-0.5"
+            className="mb-1 inline-flex items-center rounded-full px-1.5 py-0.5"
             style={{ backgroundColor: `${accentColor}33` }}
           >
             <span

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -49,7 +49,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
     return (
       <section
         ref={ref}
-        className="relative flex min-h-screen flex-col overflow-hidden bg-background"
+        className="relative flex min-h-screen flex-col overflow-visible bg-gradient-to-b from-primary-50 via-background to-background dark:from-[#171321] dark:via-background dark:to-background"
         aria-label="히어로 섹션"
       >
         {/* 랜딩 전용 미니 헤더 */}
@@ -57,25 +57,32 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
 
         {/* 배경 글로우 블롭 */}
         <div
-          className="pointer-events-none absolute inset-0 overflow-hidden"
+          className="pointer-events-none absolute -inset-x-16 -bottom-56 -top-24 overflow-visible"
           aria-hidden="true"
         >
           <div
-            className="absolute -left-40 -top-40 h-[600px] w-[600px] rounded-full opacity-20 blur-[140px]"
+            className="absolute -left-40 -top-40 h-[600px] w-[600px] rounded-full opacity-25 blur-[140px] dark:opacity-20"
             style={{
               background:
                 'radial-gradient(circle, #7c3aed 0%, transparent 70%)',
             }}
           />
           <div
-            className="absolute -bottom-32 right-0 h-[500px] w-[500px] rounded-full opacity-15 blur-[120px]"
+            className="absolute -bottom-44 right-0 h-[560px] w-[560px] rounded-full opacity-20 blur-[120px] dark:opacity-15"
             style={{
               background:
                 'radial-gradient(circle, #1d4ed8 0%, transparent 70%)',
             }}
           />
           <div
-            className="opacity-8 absolute left-1/2 top-1/2 h-[400px] w-[800px] -translate-x-1/2 -translate-y-1/2 rounded-full blur-[100px]"
+            className="absolute -bottom-64 left-1/2 h-[420px] w-[760px] -translate-x-1/2 rounded-full opacity-10 blur-[120px] dark:opacity-[0.12]"
+            style={{
+              background:
+                'radial-gradient(ellipse, #7c3aed 0%, transparent 72%)',
+            }}
+          />
+          <div
+            className="absolute left-1/2 top-1/2 h-[400px] w-[800px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-10 blur-[100px] dark:opacity-[0.08]"
             style={{
               background:
                 'radial-gradient(ellipse, #6d28d9 0%, transparent 70%)',
@@ -88,36 +95,36 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
           {/* 좌측: 텍스트 + 검색 + 칩 */}
           <div className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
             {/* 상단 뱃지 */}
-            <div className="mb-5 inline-flex items-center gap-1.5 rounded-full border border-primary-500/30 bg-primary-500/10 px-3 py-1 text-xs font-medium text-primary-400">
+            <div className="mb-5 inline-flex items-center gap-1.5 rounded-full border border-primary-500/20 bg-surface/80 px-3 py-1 text-xs font-medium text-primary-700 shadow-sm backdrop-blur-sm dark:border-primary-400/25 dark:bg-white/10 dark:text-primary-300">
               <span>🗺️</span>
-              <span>팬들만 아는 특별한 여행지 플랫폼</span>
+              <span>팬들이 남긴 실제 장소를 모아봤어요</span>
             </div>
 
             {/* 헤드라인 */}
-            <h1 className="mb-4 text-4xl font-bold leading-tight text-white md:text-5xl lg:text-6xl">
-              관광지가 아닌
+            <h1 className="mb-5 text-4xl font-semibold leading-[1.08] tracking-[-0.045em] text-main-text md:text-5xl lg:text-6xl">
+              좋아하는 장면을
               <br />
-              <span className="bg-gradient-to-r from-primary-400 to-purple-400 bg-clip-text text-transparent">
-                성지
+              <span className="bg-gradient-to-r from-primary-600 via-primary-500 to-secondary-500 bg-clip-text text-transparent dark:from-primary-300 dark:via-primary-400 dark:to-secondary-300">
+                여행지
               </span>
-              를 탐험하세요
+              로 만나보세요
             </h1>
 
-            <p className="mb-8 max-w-md text-base text-white/60 md:text-lg">
-              애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등
+            <p className="mb-8 max-w-md text-base leading-7 text-sub-text md:text-lg md:leading-8">
+              애니메이션 성지, 촬영지, 콘서트 장소까지.
               <br className="hidden sm:block" />
-              팬들만 아는 특별한 여행지를 발견하세요.
+              지도에서 찾고 코스로 따라가며 방문 기록까지 남겨보세요.
             </p>
 
             {/* 검색창 */}
             <form onSubmit={handleSearch} className="mb-5 w-full max-w-md">
-              <div className="bg-white/8 focus-within:bg-white/12 flex overflow-hidden rounded-xl border border-white/15 backdrop-blur-md transition-all focus-within:border-primary-500/60">
+              <div className="flex overflow-hidden rounded-2xl border border-border bg-surface/90 shadow-xl shadow-primary-500/10 backdrop-blur-md transition-all focus-within:border-primary-500/60 focus-within:bg-background dark:border-white/15 dark:bg-white/10 dark:focus-within:bg-white/[0.14]">
                 <input
                   type="text"
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder="작품명, 장소명으로 검색..."
-                  className="flex-1 bg-transparent px-4 py-3 text-sm text-white placeholder-white/40 outline-none"
+                  className="flex-1 bg-transparent px-4 py-3 text-sm text-main-text placeholder-muted outline-none"
                   aria-label="성지 검색"
                 />
                 <button
@@ -126,7 +133,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
                   aria-label="검색"
                 >
                   <SearchIcon />
-                  <span className="hidden sm:inline">탐색</span>
+                  <span className="hidden sm:inline">찾기</span>
                 </button>
               </div>
             </form>
@@ -138,7 +145,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
                   key={chip.value}
                   type="button"
                   onClick={() => handleChip(chip.value)}
-                  className="bg-white/8 rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-white/70 backdrop-blur-sm transition hover:border-primary-500/50 hover:bg-primary-500/15 hover:text-white active:scale-95"
+                  className="rounded-full border border-border bg-surface/80 px-3 py-1.5 text-xs font-medium text-sub-text shadow-sm backdrop-blur-sm transition hover:border-primary-500/50 hover:bg-primary-50 hover:text-main-text active:scale-95 dark:border-white/15 dark:bg-white/10 dark:text-white/75 dark:hover:bg-primary-500/15 dark:hover:text-white"
                 >
                   {chip.label}
                 </button>
@@ -150,7 +157,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
           <div className="relative flex flex-1 items-center justify-center">
             {/* 콜라주 뒤 글로우 */}
             <div
-              className="pointer-events-none absolute inset-0 rounded-full opacity-25 blur-[70px]"
+              className="pointer-events-none absolute inset-0 rounded-full opacity-20 blur-[70px] dark:opacity-25"
               style={{
                 background:
                   'radial-gradient(circle, #7c3aed 0%, transparent 65%)',
@@ -170,8 +177,8 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
           className="relative z-10 flex justify-center pb-8"
           aria-hidden="true"
         >
-          <div className="flex flex-col items-center gap-1 text-white/30">
-            <span className="text-xs">스크롤하여 더 보기</span>
+          <div className="flex flex-col items-center gap-1 text-muted dark:text-white/35">
+            <span className="text-xs">아래에서 탐색 방법 보기</span>
             <ChevronDownIcon />
           </div>
         </div>

--- a/src/components/landing/HowItWorksSection.tsx
+++ b/src/components/landing/HowItWorksSection.tsx
@@ -8,26 +8,26 @@ const STEPS = [
   {
     step: '01',
     icon: '🔍',
-    title: '작품/아티스트 검색',
-    description: '좋아하는 애니메이션, 영화, 아티스트 이름으로 검색하세요',
+    title: '떠오른 이름 검색',
+    description: '작품, 아티스트, 장소 이름 중 기억나는 것만 입력하세요',
   },
   {
     step: '02',
     icon: '🗺️',
-    title: '지도에서 확인',
-    description: '전 세계 성지 스팟이 지도 위에 핀으로 표시됩니다',
+    title: '지도에서 거리감 확인',
+    description: '근처 스팟과 이동 흐름을 한눈에 확인합니다',
   },
   {
     step: '03',
     icon: '📸',
-    title: '현장 방문 & 인증',
-    description: '직접 방문하고 사진으로 순례 인증을 남기세요',
+    title: '현장에서 기록 남기기',
+    description: '방문 사진과 짧은 메모로 그 순간을 저장하세요',
   },
   {
     step: '04',
     icon: '🏅',
-    title: '뱃지 & 코스 완성',
-    description: '인증을 쌓아 뱃지를 모으고 나만의 순례 코스를 만드세요',
+    title: '나만의 코스 완성',
+    description: '방문 기록이 쌓이면 다음 여행 코스가 더 쉬워집니다',
   },
 ]
 
@@ -43,14 +43,14 @@ export function HowItWorksSection() {
       <div className="mx-auto max-w-6xl px-4">
         {/* 헤더 */}
         <header className="mb-12 text-center md:mb-16">
-          <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl lg:text-4xl">
-            이런 식으로{' '}
-            <span className="bg-gradient-to-r from-primary-400 to-purple-400 bg-clip-text text-transparent">
-              찾습니다
+          <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl lg:text-4xl">
+            복잡하게 말고,{' '}
+            <span className="bg-gradient-to-r from-primary-600 to-secondary-500 bg-clip-text text-transparent dark:from-primary-300 dark:to-secondary-300">
+              이렇게 찾습니다
             </span>
           </h2>
-          <p className="text-base text-white/50 md:text-lg">
-            4단계로 나만의 성지순례를 시작하세요
+          <p className="text-base leading-7 text-sub-text md:text-lg">
+            검색부터 기록까지 끊기지 않게 이어지는 흐름입니다
           </p>
         </header>
 
@@ -59,7 +59,7 @@ export function HowItWorksSection() {
           {STEPS.map((step, index) => (
             <div
               key={step.step}
-              className="relative flex flex-col items-center text-center"
+              className="relative flex flex-col items-center rounded-[1.5rem] border border-border bg-surface/80 p-6 text-center shadow-sm shadow-primary-500/5 dark:border-white/10 dark:bg-white/[0.05]"
             >
               {/* 연결선 (마지막 제외) */}
               {index < STEPS.length - 1 && (
@@ -70,7 +70,7 @@ export function HowItWorksSection() {
               )}
 
               {/* 아이콘 원 */}
-              <div className="relative mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-primary-500/30 bg-primary-500/10 text-2xl">
+              <div className="relative mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-primary-500/25 bg-primary-500/10 text-2xl">
                 {step.icon}
                 {/* 스텝 번호 */}
                 <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary-500 text-[10px] font-bold text-white">
@@ -78,10 +78,10 @@ export function HowItWorksSection() {
                 </span>
               </div>
 
-              <h3 className="mb-2 text-base font-semibold text-white">
+              <h3 className="mb-2 text-base font-semibold tracking-[-0.01em] text-main-text">
                 {step.title}
               </h3>
-              <p className="text-sm leading-relaxed text-white/50">
+              <p className="text-sm leading-relaxed text-sub-text">
                 {step.description}
               </p>
             </div>

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -1,28 +1,32 @@
-﻿import Link from 'next/link'
+import Link from 'next/link'
 import { AppIcon } from '@/components/common/AppIcon'
+import HeaderThemeSelectorHost from '@/components/layout/HeaderThemeSelectorHost'
 
 /**
  * 랜딩 페이지 전용 미니 헤더
- * 로고 / 지도 탐색 / 로그인 CTA만 정적으로 노출한다.
+ * 로고 / 테마 선택 / 지도 탐색 / 로그인 CTA를 노출한다.
  */
 export function LandingHeader() {
   return (
-    <header className="absolute inset-x-0 top-0 z-50 flex items-center justify-between px-6 py-4">
+    <header className="absolute inset-x-0 top-0 z-50 flex items-center justify-between px-5 py-4 md:px-6">
       <Link href="/" className="flex items-center gap-2">
         <AppIcon name="logo" size="2xl" className="max-h-8" />
-        <span className="text-lg font-bold text-white">Not a Trip</span>
+        <span className="text-lg font-semibold tracking-[-0.01em] text-main-text dark:text-white">
+          Not a Trip
+        </span>
       </Link>
 
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 sm:gap-3">
+        <HeaderThemeSelectorHost />
         <Link
           href="/map"
-          className="hidden rounded-lg border border-white/20 bg-white/10 px-4 py-1.5 text-sm font-medium text-white backdrop-blur-sm transition hover:bg-white/20 sm:block"
+          className="hidden rounded-full border border-border bg-surface/85 px-4 py-1.5 text-sm font-medium text-main-text shadow-sm backdrop-blur-sm transition hover:border-primary-500/40 hover:bg-primary-50 dark:border-white/15 dark:bg-white/10 dark:text-white dark:hover:bg-white/20 sm:block"
         >
           지도 탐색
         </Link>
         <Link
           href="/auth/signin"
-          className="rounded-lg bg-primary-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-primary-600"
+          className="rounded-full bg-primary-500 px-4 py-1.5 text-sm font-semibold text-white shadow-sm shadow-primary-500/20 transition hover:bg-primary-600"
         >
           로그인
         </Link>

--- a/src/components/landing/LandingThemeProvider.tsx
+++ b/src/components/landing/LandingThemeProvider.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { ThemeProvider } from 'next-themes'
+
+interface LandingThemeProviderProps {
+  children: React.ReactNode
+}
+
+/**
+ * 랜딩 전용 테마 공급자.
+ * 세션/쿼리 provider를 끌어오지 않고 라이트·다크·시스템 테마만 적용한다.
+ */
+export function LandingThemeProvider({ children }: LandingThemeProviderProps) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </ThemeProvider>
+  )
+}

--- a/src/components/landing/ProofCard.tsx
+++ b/src/components/landing/ProofCard.tsx
@@ -38,9 +38,9 @@ export function ProofCard({
   const hasScene = safeSceneImage && !sceneError
 
   return (
-    <article className="flex w-64 shrink-0 flex-col overflow-hidden rounded-lg border border-border bg-surface md:w-72">
+    <article className="flex w-64 shrink-0 flex-col overflow-hidden rounded-[1.35rem] border border-border bg-surface shadow-lg shadow-primary-500/5 dark:border-white/10 md:w-72">
       {/* 이미지 영역 */}
-      <div className="relative h-36 w-full bg-accent-surface">
+      <div className="relative h-40 w-full bg-accent-surface">
         {hasScene ? (
           /* 좌우 분할: 스팟 사진 | 작품 장면 */
           <div className="flex h-full">
@@ -58,7 +58,7 @@ export function ProofCard({
               ) : (
                 <ImageFallback />
               )}
-              <span className="absolute bottom-1 left-1 rounded-sm bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white">
+              <span className="absolute bottom-2 left-2 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">
                 실제
               </span>
             </div>
@@ -74,7 +74,7 @@ export function ProofCard({
                 sizes="(max-width: 768px) 128px, 144px"
                 onError={() => setSceneError(true)}
               />
-              <span className="absolute bottom-1 right-1 rounded-sm bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white">
+              <span className="absolute bottom-2 right-2 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">
                 작품
               </span>
             </div>
@@ -95,10 +95,10 @@ export function ProofCard({
       </div>
 
       {/* 콘텐츠 영역 */}
-      <div className="flex flex-1 flex-col gap-2 p-3">
+      <div className="flex flex-1 flex-col gap-2.5 p-4">
         {/* 카테고리 태그 */}
         <span
-          className="w-fit rounded-sm px-2 py-0.5 text-xs font-medium"
+          className="w-fit rounded-full px-2.5 py-1 text-xs font-medium"
           style={{
             backgroundColor: categoryConfig.bgColor,
             color: categoryConfig.fgColor,
@@ -108,7 +108,7 @@ export function ProofCard({
         </span>
 
         {/* 스팟 이름 + 작품명 */}
-        <h3 className="text-sm font-semibold text-main-text">
+        <h3 className="text-sm font-semibold leading-snug tracking-[-0.01em] text-main-text">
           {spotName}
           {contentName && (
             <span
@@ -122,7 +122,9 @@ export function ProofCard({
         </h3>
 
         {/* 코멘트 */}
-        <p className="line-clamp-2 text-xs text-sub-text">{comment}</p>
+        <p className="line-clamp-2 text-xs leading-relaxed text-sub-text">
+          {comment}
+        </p>
       </div>
     </article>
   )

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ProofCard } from './ProofCard'
@@ -235,11 +235,12 @@ export function SocialProofSection({
       <div className="mx-auto max-w-6xl px-4">
         {/* 섹션 헤더 */}
         <header className="mb-10 text-center md:mb-14">
-          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
-            함께 <span className="text-primary-500">덕질</span>하는 즐거움
+          <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl lg:text-4xl">
+            다른 팬들은{' '}
+            <span className="text-primary-500">이렇게 다녀왔어요</span>
           </h2>
-          <p className="text-base text-sub-text md:text-lg">
-            다른 팬들의 성지순례 경험을 만나보세요
+          <p className="text-base leading-7 text-sub-text md:text-lg">
+            인증 사진과 짧은 후기로 현장 분위기를 먼저 살펴보세요
           </p>
         </header>
 
@@ -249,7 +250,7 @@ export function SocialProofSection({
           <button
             type="button"
             onClick={goPrev}
-            className="hidden shrink-0 rounded-full border border-border bg-surface p-3 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
+            className="hidden shrink-0 rounded-full border border-border bg-surface/90 p-3 text-sub-text shadow-sm transition-colors hover:border-primary-500/40 hover:bg-background hover:text-main-text dark:border-white/10 md:block"
             aria-label="이전 카드"
           >
             <ChevronLeftIcon />
@@ -276,7 +277,7 @@ export function SocialProofSection({
               }}
               onTransitionEnd={handleTransitionEnd}
             >
-              {extended.map((proof, i) => (
+              {extended.map((proof) => (
                 <div
                   key={proof.id}
                   data-card
@@ -300,7 +301,7 @@ export function SocialProofSection({
           <button
             type="button"
             onClick={goNext}
-            className="hidden shrink-0 rounded-full border border-border bg-surface p-3 text-sub-text shadow-sm transition-colors hover:bg-background hover:text-main-text md:block"
+            className="hidden shrink-0 rounded-full border border-border bg-surface/90 p-3 text-sub-text shadow-sm transition-colors hover:border-primary-500/40 hover:bg-background hover:text-main-text dark:border-white/10 md:block"
             aria-label="다음 카드"
           >
             <ChevronRightIcon />

--- a/src/components/landing/StorytellingSection.tsx
+++ b/src/components/landing/StorytellingSection.tsx
@@ -76,11 +76,11 @@ function StorytellingSectionWithGSAP({
     >
       <div className="mx-auto max-w-6xl px-4">
         <header className="mb-12 text-center md:mb-16">
-          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
-            어떤 <span className="text-primary-500">덕질</span>을 하시나요?
+          <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl lg:text-4xl">
+            취향별로 <span className="text-primary-500">골라볼까요?</span>
           </h2>
-          <p className="text-base text-sub-text md:text-lg">
-            카테고리별 성지순례 스팟을 탐험해 보세요
+          <p className="text-base leading-7 text-sub-text md:text-lg">
+            장르마다 다른 분위기의 스팟을 카드로 먼저 살펴보세요
           </p>
         </header>
 
@@ -132,11 +132,11 @@ function StorytellingSectionFallback({
     >
       <div className="mx-auto max-w-6xl px-4">
         <header className="mb-12 text-center md:mb-16">
-          <h2 className="mb-3 text-2xl font-bold text-main-text md:text-3xl lg:text-4xl">
-            어떤 <span className="text-primary-500">덕질</span>을 하시나요?
+          <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl lg:text-4xl">
+            취향별로 <span className="text-primary-500">골라볼까요?</span>
           </h2>
-          <p className="text-base text-sub-text md:text-lg">
-            카테고리별 성지순례 스팟을 탐험해 보세요
+          <p className="text-base leading-7 text-sub-text md:text-lg">
+            장르마다 다른 분위기의 스팟을 카드로 먼저 살펴보세요
           </p>
         </header>
 
@@ -186,12 +186,11 @@ function useGSAPAnimation(
 
     async function loadAndAnimate() {
       try {
-        const [gsapModule, scrollTriggerModule, gsapReactModule] =
-          await Promise.all([
-            import('gsap'),
-            import('gsap/ScrollTrigger'),
-            import('@gsap/react'),
-          ])
+        const [gsapModule, scrollTriggerModule] = await Promise.all([
+          import('gsap'),
+          import('gsap/ScrollTrigger'),
+          import('@gsap/react'),
+        ])
 
         if (cancelled) return
 

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -107,7 +107,7 @@ export function WelcomePageClient({
 
       {/* SocialProofSection — 자동 스크롤 슬라이더 */}
       <div
-        className="h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
+        className="h-px bg-gradient-to-r from-transparent via-border to-transparent dark:via-white/10"
         aria-hidden="true"
       />
       <SocialProofSection proofImages={proofImages} />

--- a/src/components/landing/__tests__/landing-theme-softening.test.ts
+++ b/src/components/landing/__tests__/landing-theme-softening.test.ts
@@ -1,0 +1,71 @@
+/**
+ * 랜딩 테마/톤 정리 회귀 테스트
+ *
+ * Feature: landing-theme-softening
+ * Property 1: 랜딩은 다크 고정 레이아웃이 아니라 ThemeProvider를 통해 라이트/다크/시스템을 적용한다.
+ * Property 2: 핵심 랜딩 섹션은 하드코딩된 다크 텍스트 대신 시맨틱 텍스트 토큰을 사용한다.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const projectRoot = path.resolve(__dirname, '../../../../')
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+describe('landing theme and softer visual tone', () => {
+  it('랜딩 레이아웃은 ThemeProvider를 사용하고 dark 클래스를 강제하지 않는다', () => {
+    const layout = read('src/app/(landing)/layout.tsx')
+    const provider = read('src/components/landing/LandingThemeProvider.tsx')
+
+    expect(layout).toContain('LandingThemeProvider')
+    expect(layout).not.toContain('className="dark"')
+    expect(provider).toContain('ThemeProvider')
+    expect(provider).toContain('defaultTheme="system"')
+    expect(provider).toContain('enableSystem')
+  })
+
+  it('랜딩 헤더는 테마 선택기를 노출한다', () => {
+    const header = read('src/components/landing/LandingHeader.tsx')
+
+    expect(header).toContain('HeaderThemeSelectorHost')
+    expect(header).toContain('<HeaderThemeSelectorHost />')
+  })
+
+  it('핵심 카드/히어로 섹션은 시맨틱 텍스트 토큰과 부드러운 라운딩을 사용한다', () => {
+    const hero = read('src/components/landing/HeroSection.tsx')
+    const entry = read('src/components/landing/EntryPointSection.tsx')
+    const howItWorks = read('src/components/landing/HowItWorksSection.tsx')
+    const proofCard = read('src/components/landing/ProofCard.tsx')
+
+    expect(hero).toContain('text-main-text')
+    expect(hero).toContain('text-sub-text')
+    expect(entry).toContain('text-main-text')
+    expect(entry).toContain('rounded-[1.5rem]')
+    expect(howItWorks).toContain('text-main-text')
+    expect(howItWorks).toContain('rounded-[1.5rem]')
+    expect(proofCard).toContain('rounded-[1.35rem]')
+  })
+
+  it('히어로 배경 글로우는 화면 높이 경계에서 잘리지 않도록 아래로 이어진다', () => {
+    const hero = read('src/components/landing/HeroSection.tsx')
+
+    expect(hero).toContain('overflow-visible')
+    expect(hero).toContain('-bottom-56')
+    expect(hero).toContain('-bottom-64')
+  })
+
+  it('라이트 모드 여권 일러스트는 단색 보라 면을 피하고 내부 대비를 확보한다', () => {
+    const conversion = read('src/components/landing/ConversionSection.tsx')
+
+    expect(conversion).toContain('id="passportLightBody"')
+    expect(conversion).toContain('stopColor="#eef2ff"')
+    expect(conversion).toContain('stroke-neutral-300 dark:stroke-primary-400')
+    expect(conversion).toContain('stroke-indigo-300/80')
+    expect(conversion).toContain('stroke-violet-400/80')
+    expect(conversion).toContain('fill-indigo-300/75')
+    expect(conversion).toContain('fill-violet-300/65')
+  })
+})


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #이슈번호 없음

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 랜딩 페이지를 라이트/다크 테마에 맞게 적용하고 카드/타이포/여권 일러스트 톤을 부드럽게 정리합니다.

---

## 📋 변경 사항

- [x] 랜딩 레이아웃의 다크 모드 강제 적용을 제거하고 랜딩 전용 ThemeProvider를 추가
- [x] 랜딩 헤더에 테마 선택기를 노출하고 라이트/다크 대응 스타일을 적용
- [x] 히어로, 진입 카드, 이용 방법, 스토리, 소셜 프루프, 전환 영역의 하드코딩 다크 스타일을 시맨틱 토큰 기반으로 정리
- [x] 카드 라운딩/그림자/카피를 완화해 딱딱한 인상을 줄임
- [x] 라이트 모드 여권 일러스트를 보라 단색에서 라벤더/인디고/바이올렛 계열 혼합으로 조정하고 내부 대비를 강화
- [x] 히어로 원형 글로우가 첫 화면 경계에서 잘리는 문제를 완화
- [x] 랜딩 테마/시각 톤 회귀 테스트 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

- 미첨부: 로컬 코드/빌드 검증 중심으로 진행했습니다.

---

## 📝 추가 정보 (선택)

- `npm run lint`와 `npm run build`에서 기존 경고가 출력되지만 실패하지 않았습니다.
- 추가 검증: `npm run type-check`, `git diff --check`, 랜딩 회귀 Jest 테스트 통과.