### PR TITLE
[ui] 라이트 대비와 튜토리얼 액션 위계 보강

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,7 +58,7 @@
   - Primary: Harbor Indigo for core actions, focus, route/navigation confidence.
   - Secondary: Sea Teal for discovery, map, category exploration, hover states.
   - Sunset: warm accent for admin/special states, passport/check-in warmth, subtle highlights.
-  - Background: warm off-white in light mode, deep slate/navy in dark mode.
+  - Background: restrained stone/off-white in light mode, deep slate/navy in dark mode; borders must stay visibly darker than warm surfaces.
   - Category/content colors: related but varied; use category tokens rather than ad hoc Tailwind colors.
 - Typography: Pretendard/system; prefer `font-semibold`, relaxed line height, and slight negative tracking on large display text.
 - Spacing/layout rhythm: mobile-first, generous card padding, section rhythm of 16–24 spacing units.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,13 +52,13 @@
   --color-neutral-900: 24 24 27;
 
   /* === 시맨틱 역할 토큰 (직접 RGB 값 저장 — 중첩 var() 회피) === */
-  --color-background: 255 252 247;
+  --color-background: 250 250 249;
   --color-surface: 255 255 255;
-  --color-accent-surface: 240 253 250;
+  --color-accent-surface: 241 245 249;
   --color-text: 15 23 42;
   --color-text-secondary: 71 85 105;
   --color-muted: 113 113 122;
-  --color-border: 226 232 240;
+  --color-border: 203 213 225;
   --color-danger: 239 68 68;
   --color-danger-surface: 254 242 242;
 

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -219,7 +219,7 @@ export default function OnboardingTour({
         className="fixed z-[10000] w-80 max-w-[calc(100vw-32px)] rounded-xl bg-white p-5 shadow-2xl dark:bg-gray-800"
         style={{ top: tooltipPos.top, left: tooltipPos.left }}
       >
-        <h3 className="mb-2 text-base font-bold text-gray-900 dark:text-gray-100">
+        <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-gray-100">
           {step.title}
         </h3>
         <p className="mb-5 text-sm leading-relaxed text-gray-600 dark:text-gray-300">
@@ -230,7 +230,7 @@ export default function OnboardingTour({
           <div className="flex items-center gap-2">
             <button
               onClick={onSkip}
-              className="text-sm text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+              className="text-sm text-gray-500 underline underline-offset-4 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
               type="button"
             >
               건너뛰기
@@ -239,7 +239,7 @@ export default function OnboardingTour({
             {onDismiss && (
               <button
                 onClick={onDismiss}
-                className="text-sm text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+                className="text-sm text-gray-500 underline underline-offset-4 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
                 type="button"
               >
                 다시 보지 않기

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -66,13 +66,13 @@ const NAV_ITEMS: NavItem[] = [
 
 function getNavLinkClass(isActive: boolean, mobile = false) {
   const base = mobile
-    ? 'flex items-center gap-2.5 rounded-xl px-3.5 py-3 text-base font-medium transition hover:bg-secondary-100'
-    : 'rounded-xl px-3 py-2 text-base font-medium transition hover:bg-secondary-100 hover:text-secondary-400'
+    ? 'flex items-center gap-2.5 rounded-xl px-3.5 py-3 text-base font-medium transition hover:bg-accent-surface hover:text-text-primary dark:hover:bg-secondary-500/15 dark:hover:text-secondary-600'
+    : 'rounded-xl px-3 py-2 text-base font-medium transition hover:bg-accent-surface hover:text-text-primary dark:hover:bg-secondary-500/15 dark:hover:text-secondary-600'
 
   return `${base} ${
     isActive
-      ? 'bg-secondary-100 text-secondary-400'
-      : 'text-text-secondary hover:text-text-primary'
+      ? 'bg-primary-50 text-primary-700 ring-1 ring-primary-200 dark:bg-secondary-500/15 dark:text-secondary-600 dark:ring-secondary-500/20'
+      : 'text-text-secondary'
   }`
 }
 
@@ -106,7 +106,7 @@ export function Header() {
               className="max-h-9"
               alt="Not a Trip"
             />
-            <span className="text-text-primary truncate text-xl font-bold sm:text-2xl">
+            <span className="truncate text-xl font-bold text-text-primary sm:text-2xl">
               Not a Trip
             </span>
           </Link>
@@ -136,7 +136,7 @@ export function Header() {
 
             <button
               onClick={() => setIsMobileMenuOpen((prev) => !prev)}
-              className="text-text-secondary hover:text-text-primary flex h-10 w-10 items-center justify-center rounded-xl transition hover:bg-secondary-100 lg:hidden"
+              className="flex h-10 w-10 items-center justify-center rounded-xl text-text-secondary transition hover:bg-secondary-100 hover:text-text-primary lg:hidden"
               aria-label={isMobileMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
               aria-expanded={isMobileMenuOpen}
               aria-controls="mobile-header-menu"

--- a/src/lib/color-system.test.ts
+++ b/src/lib/color-system.test.ts
@@ -38,4 +38,29 @@ describe('travel-inspired global color system', () => {
       "DEFAULT: 'rgb(var(--color-text-secondary) / <alpha-value>)'"
     )
   })
+  it('라이트 모드 표면은 노란 기를 낮추고 경계 대비를 확보한다', () => {
+    const globals = read('src/app/globals.css')
+
+    expect(globals).toContain('--color-background: 250 250 249')
+    expect(globals).toContain('--color-accent-surface: 241 245 249')
+    expect(globals).toContain('--color-border: 203 213 225')
+    expect(globals).not.toContain('--color-background: 255 252 247')
+  })
+
+  it('헤더 선택 상태는 라이트 모드에서 형광 보조색 대신 고대비 인디고를 쓴다', () => {
+    const header = read('src/components/layout/Header.tsx')
+
+    expect(header).toContain('bg-primary-50 text-primary-700')
+    expect(header).toContain('ring-primary-200')
+    expect(header).toContain('dark:bg-secondary-500/15 dark:text-secondary-600')
+    expect(header).not.toContain("? 'bg-secondary-100 text-secondary-400'")
+  })
+
+  it('튜토리얼 다이얼로그 제목과 보조 액션 위계를 고정한다', () => {
+    const onboardingTour = read('src/components/common/OnboardingTour.tsx')
+
+    expect(onboardingTour).toContain('mb-2 text-lg font-bold')
+    expect(onboardingTour).toContain('underline underline-offset-4')
+    expect(onboardingTour).toContain('text-gray-500')
+  })
 })


### PR DESCRIPTION
## 🔗 관련 이슈

- 관련 이슈 없음

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [x] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 라이트 모드의 밝은 배경/경계/헤더 선택 대비를 정리하고 튜토리얼 보조 액션 위계를 낮춥니다.

---

## 📋 변경 사항

- [x] 라이트 모드 배경을 덜 노란 stone 계열로 낮추고 기본 경계를 더 진하게 조정
- [x] 헤더 선택 상태를 라이트 모드에서 고대비 인디고 배경/텍스트/링으로 변경하고 다크 모드 상태는 유지
- [x] 온보딩 튜토리얼 제목을 `text-base`에서 `text-lg`로 올리고 건너뛰기/다시 보지 않기 버튼에 밑줄 적용
- [x] 디자인 문서와 색상 시스템 회귀 테스트에 새 대비 규칙 반영

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경이 있으면 Before/After 첨부 -->

---

## 📝 추가 정보 (선택)

- 추가 검증: `npx jest --runInBand --runTestsByPath src/lib/color-system.test.ts`, `npm run type-check`
- `npm run lint`와 `npm run build`는 기존 console/unused 경고를 출력하지만 성공했습니다.