### PR TITLE
chore(release): enforce route gates

### DIFF
--- a/.kiro/specs/53-route-performance-and-lint-release-gates/evidence.md
+++ b/.kiro/specs/53-route-performance-and-lint-release-gates/evidence.md
@@ -1,0 +1,52 @@
+# Spec 53 Evidence — Route Performance and Lint Release Gates
+
+## Build route evidence
+
+Command:
+
+```bash
+npm run build:route-budget
+```
+
+Budget file: `config/route-js-budgets.json`
+
+| Route | Code-review baseline | 2026-06-02 measured | Budget | Status |
+| --- | ---: | ---: | ---: | --- |
+| shared First Load JS | 224 kB | 224 kB | 230 kB | pass |
+| `/spots/[id]` | 299 kB | 302 kB | 310 kB | pass |
+| `/routes/[id]` | 277 kB | 277 kB | 285 kB | pass |
+| `/gallery` | 270 kB | 271 kB | 280 kB | pass |
+| `/map` | 267 kB | 267 kB | 275 kB | pass |
+
+Latest local build log is written to `.omx/release-gates/next-build-latest.log` by the budget script and is intentionally not a tracked release artifact.
+
+## Lint warning evidence
+
+Commands:
+
+```bash
+npm run lint
+npm run lint:release
+```
+
+Baseline file: `config/lint-release-warning-baseline.json`
+
+Current classified warning baseline:
+
+| Category | Count | Release policy |
+| --- | ---: | --- |
+| `react-hooks/exhaustive-deps` | 0 | must not regress |
+| `jsx-a11y/*` | 0 | must not regress |
+| production `console` | 59 | tracked baseline; must not increase |
+| `@typescript-eslint/no-explicit-any` | 0 | must not regress |
+| unused variables | 30 | tracked baseline; must not increase |
+| other warnings | 5 | tracked baseline; must not increase |
+
+`npm run lint` currently reports 94 warnings and 0 errors. `npm run lint:release` passes because no release-critical category exceeds the checked-in baseline.
+
+## Tooling migration notes
+
+- `package.json` now uses `eslint src` for `lint` and `eslint src --fix` for `lint:fix`, removing direct `next lint` usage.
+- The lint scope is deliberately `src`; raw `eslint .` currently sweeps `.omx`, `.kiro`, and generated `next-env.d.ts` artifacts and fails on files outside the previous `next lint` app scope. Expanding scope must be a separate cleanup with its own baseline.
+- `next build` still prints the Next plugin detection warning from Next's build-time lint integration even though ESLint CLI loads `next/core-web-vitals` through `FlatCompat`. The authoritative release lint gate is now `npm run lint:release`.
+- The route budget gate runs a production `next build`, parses the emitted route table, and fails if shared or core discovery route First Load JS exceeds the checked-in budget.

--- a/.kiro/specs/53-route-performance-and-lint-release-gates/tasks.md
+++ b/.kiro/specs/53-route-performance-and-lint-release-gates/tasks.md
@@ -1,0 +1,30 @@
+# Spec 53 Tasks — Route Performance and Lint Release Gates
+
+## Status: completed
+
+- [x] Capture current production build route First Load JS evidence.
+- [x] Define executable route JS budgets for core discovery routes.
+- [x] Add local route budget gate command.
+- [x] Migrate project lint script away from deprecated `next lint` to ESLint CLI without expanding scope into generated/runtime OMX artifacts.
+- [x] Add lint warning release gate that classifies release-critical categories separately from generic warning noise.
+- [x] Record current warning baseline and fail on category regressions.
+- [x] Document remaining lint/build tooling warnings and follow-up path.
+- [x] Verify lint, release lint gate, type-check, and route budget gate.
+
+## Commands
+
+```bash
+npm run lint
+npm run lint:release
+npm run type-check
+npm run build:route-budget
+npm run release:check
+```
+
+## Final classification
+
+- `Route_JS_Budget`: fixed
+- `Warning_Gate`: fixed
+- `Lint_Tooling_Migration`: partially-fixed
+  - `npm run lint` and `npm run lint:fix` now use ESLint CLI.
+  - `next build` still emits Next plugin detection text from Next's internal build-time lint integration. The release path no longer relies on that text as the lint authority; `npm run lint:release` is the release-warning gate.

--- a/config/lint-release-warning-baseline.json
+++ b/config/lint-release-warning-baseline.json
@@ -1,0 +1,48 @@
+{
+  "generatedAt": "2026-06-01T18:17:18.374Z",
+  "command": "npx eslint src --format json",
+  "scope": "src",
+  "policy": {
+    "errors": "must remain zero",
+    "warningCategories": "must not exceed baseline counts; react-hooks, jsx-a11y, no-explicit-any, production console, and unused variables are reported separately"
+  },
+  "summary": {
+    "errors": 0,
+    "warnings": 94,
+    "categories": {
+      "reactHooksExhaustiveDeps": 0,
+      "jsxA11y": 0,
+      "productionConsole": 59,
+      "noExplicitAny": 0,
+      "unusedVariables": 30,
+      "otherWarnings": 5
+    },
+    "rules": {
+      "no-console": 64,
+      "@typescript-eslint/no-unused-vars": 30
+    }
+  },
+  "examples": {
+    "productionConsole": [
+      "src\\app\\api\\admin\\content-images\\route.ts:88:5 no-console",
+      "src\\app\\api\\admin\\content-images\\route.ts:245:5 no-console",
+      "src\\app\\api\\admin\\content-images\\route.ts:304:5 no-console",
+      "src\\app\\api\\admin\\content-images\\sync\\route.ts:182:5 no-console",
+      "src\\app\\api\\auth\\register\\route.ts:98:5 no-console"
+    ],
+    "unusedVariables": [
+      "src\\app\\spots\\[id]\\__tests__\\spot-detail-required-info.test.tsx:198:5 @typescript-eslint/no-unused-vars",
+      "src\\app\\spots\\[id]\\__tests__\\spot-detail-required-info.test.tsx:199:5 @typescript-eslint/no-unused-vars",
+      "src\\app\\spots\\[id]\\__tests__\\spot-detail-required-info.test.tsx:200:5 @typescript-eslint/no-unused-vars",
+      "src\\app\\spots\\[id]\\__tests__\\spot-detail-required-info.test.tsx:201:5 @typescript-eslint/no-unused-vars",
+      "src\\app\\spots\\[id]\\__tests__\\spot-detail-required-info.test.tsx:202:5 @typescript-eslint/no-unused-vars"
+    ],
+    "otherWarnings": [
+      "src\\components\\landing\\data\\__tests__\\fetchProofImages.test.ts:301:31 no-console",
+      "src\\components\\landing\\data\\__tests__\\fetchProofImages.test.ts:305:5 no-console",
+      "src\\components\\landing\\data\\__tests__\\fetchProofImages.test.ts:310:5 no-console",
+      "src\\components\\landing\\data\\__tests__\\fetchProofImages.test.ts:381:12 no-console",
+      "src\\components\\landing\\data\\__tests__\\fetchProofImages.test.ts:402:12 no-console"
+    ]
+  }
+}

--- a/config/route-js-budgets.json
+++ b/config/route-js-budgets.json
@@ -1,0 +1,10 @@
+{
+  "description": "Spec 53 route-level First Load JS budgets. Values are kB from Next.js production build output with narrow launch headroom over the 2026-06-02 measured baseline.",
+  "sharedFirstLoadJsKb": 230,
+  "routes": {
+    "/spots/[id]": 310,
+    "/routes/[id]": 285,
+    "/gallery": 280,
+    "/map": 275
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "jest",
@@ -24,7 +24,10 @@
     "prepare": "husky install",
     "commit": "git-cz",
     "landing:photos:dry": "node scripts/seed-landing-spot-photos.mjs",
-    "landing:photos:apply": "node scripts/seed-landing-spot-photos.mjs --apply"
+    "landing:photos:apply": "node scripts/seed-landing-spot-photos.mjs --apply",
+    "lint:release": "node scripts/check-lint-release-warnings.mjs",
+    "build:route-budget": "node scripts/check-route-js-budget.mjs",
+    "release:check": "npm run lint && npm run lint:release && npm run type-check && npm run build:route-budget"
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.11.1",

--- a/scripts/check-lint-release-warnings.mjs
+++ b/scripts/check-lint-release-warnings.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+const baselinePath = resolve(
+  repoRoot,
+  'config/lint-release-warning-baseline.json'
+)
+const updateBaseline = process.argv.includes('--update-baseline')
+
+const lintResult = spawnSync('npx eslint src --format json', {
+  cwd: repoRoot,
+  encoding: 'utf8',
+  shell: true,
+  maxBuffer: 1024 * 1024 * 20,
+})
+
+if (lintResult.error) {
+  console.error(`Failed to run ESLint: ${lintResult.error.message}`)
+  process.exit(1)
+}
+
+let reports
+try {
+  reports = JSON.parse(lintResult.stdout || '[]')
+} catch (error) {
+  console.error('Failed to parse ESLint JSON output.')
+  console.error(error instanceof Error ? error.message : String(error))
+  if (lintResult.stdout) console.error(lintResult.stdout.slice(0, 4000))
+  if (lintResult.stderr) console.error(lintResult.stderr)
+  process.exit(1)
+}
+
+const emptySummary = () => ({
+  errors: 0,
+  warnings: 0,
+  categories: {
+    reactHooksExhaustiveDeps: 0,
+    jsxA11y: 0,
+    productionConsole: 0,
+    noExplicitAny: 0,
+    unusedVariables: 0,
+    otherWarnings: 0,
+  },
+  rules: {},
+})
+
+function isTestFile(filePath) {
+  const normalized = filePath.replaceAll('\\', '/')
+  return (
+    normalized.includes('/__tests__/') ||
+    normalized.endsWith('.test.ts') ||
+    normalized.endsWith('.test.tsx') ||
+    normalized.endsWith('.spec.ts') ||
+    normalized.endsWith('.spec.tsx')
+  )
+}
+
+function classify(ruleId, filePath) {
+  if (ruleId === 'react-hooks/exhaustive-deps')
+    return 'reactHooksExhaustiveDeps'
+  if (ruleId?.startsWith('jsx-a11y/')) return 'jsxA11y'
+  if (ruleId === '@typescript-eslint/no-explicit-any') return 'noExplicitAny'
+  if (ruleId === '@typescript-eslint/no-unused-vars') return 'unusedVariables'
+  if (ruleId === 'no-console' && !isTestFile(filePath))
+    return 'productionConsole'
+  return 'otherWarnings'
+}
+
+const summary = emptySummary()
+const examples = {}
+
+for (const report of reports) {
+  for (const message of report.messages) {
+    const ruleId = message.ruleId ?? 'unknown'
+    if (message.severity === 2) {
+      summary.errors += 1
+      summary.rules[ruleId] = (summary.rules[ruleId] ?? 0) + 1
+      examples[ruleId] ??= []
+      if (examples[ruleId].length < 5) {
+        examples[ruleId].push(
+          `${relative(repoRoot, report.filePath)}:${message.line}:${message.column}`
+        )
+      }
+      continue
+    }
+
+    summary.warnings += 1
+    summary.rules[ruleId] = (summary.rules[ruleId] ?? 0) + 1
+    const category = classify(ruleId, report.filePath)
+    summary.categories[category] += 1
+    examples[category] ??= []
+    if (examples[category].length < 5) {
+      examples[category].push(
+        `${relative(repoRoot, report.filePath)}:${message.line}:${message.column} ${ruleId}`
+      )
+    }
+  }
+}
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  command: 'npx eslint src --format json',
+  scope: 'src',
+  policy: {
+    errors: 'must remain zero',
+    warningCategories:
+      'must not exceed baseline counts; react-hooks, jsx-a11y, no-explicit-any, production console, and unused variables are reported separately',
+  },
+  summary,
+  examples,
+}
+
+if (updateBaseline) {
+  mkdirSync(dirname(baselinePath), { recursive: true })
+  writeFileSync(baselinePath, `${JSON.stringify(payload, null, 2)}\n`)
+  console.log(
+    `Updated lint warning baseline: ${relative(repoRoot, baselinePath)}`
+  )
+  console.log(JSON.stringify(summary, null, 2))
+  process.exit(summary.errors === 0 ? 0 : 1)
+}
+
+let baseline
+try {
+  baseline = JSON.parse(readFileSync(baselinePath, 'utf8'))
+} catch {
+  console.error(
+    `Missing lint warning baseline: ${relative(repoRoot, baselinePath)}`
+  )
+  console.error(
+    'Run: node scripts/check-lint-release-warnings.mjs --update-baseline'
+  )
+  process.exit(1)
+}
+
+const failures = []
+if (summary.errors > 0) failures.push(`ESLint errors: ${summary.errors}`)
+for (const [category, count] of Object.entries(summary.categories)) {
+  const allowed = baseline.summary?.categories?.[category]
+  if (typeof allowed !== 'number') {
+    failures.push(`Baseline missing category ${category}`)
+  } else if (count > allowed) {
+    failures.push(`${category}: ${count} > baseline ${allowed}`)
+  }
+}
+
+console.log('Lint release warning summary')
+console.log(JSON.stringify(summary, null, 2))
+
+if (failures.length > 0) {
+  console.error('Lint release gate failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(
+  'Lint release gate passed: no release-critical warning category regressed beyond baseline.'
+)

--- a/scripts/check-route-js-budget.mjs
+++ b/scripts/check-route-js-budget.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+const budgetPath = resolve(repoRoot, 'config/route-js-budgets.json')
+const latestLogPath = resolve(
+  repoRoot,
+  '.omx/release-gates/next-build-latest.log'
+)
+const parseOnlyIndex = process.argv.indexOf('--log')
+const parseOnlyPath =
+  parseOnlyIndex >= 0
+    ? resolve(repoRoot, process.argv[parseOnlyIndex + 1] ?? '')
+    : null
+
+const budgets = JSON.parse(
+  readFileSync(budgetPath, 'utf8').replace(/^\uFEFF/, '')
+)
+
+function runBuild() {
+  const result = spawnSync('npx next build', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    shell: true,
+    maxBuffer: 1024 * 1024 * 30,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: process.env.NODE_OPTIONS || '--max-old-space-size=4096',
+    },
+  })
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+  mkdirSync(dirname(latestLogPath), { recursive: true })
+  writeFileSync(latestLogPath, output)
+  if (result.error) {
+    throw new Error(`next build failed to start: ${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `next build exited with ${result.status}; log: ${relative(repoRoot, latestLogPath)}`
+    )
+  }
+  return output
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseKb(rawValue, unit) {
+  const value = Number(rawValue)
+  if (!Number.isFinite(value)) return null
+  if (unit === 'MB') return value * 1024
+  return value
+}
+
+function stripAnsi(value) {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+}
+
+function parseBuildOutput(output) {
+  const cleanOutput = stripAnsi(output)
+  const measurements = { routes: {} }
+  const sharedMatch = cleanOutput.match(
+    /^\+ First Load JS shared by all\s+([\d.]+)\s+(kB|MB)$/m
+  )
+  if (sharedMatch) {
+    measurements.sharedFirstLoadJsKb = parseKb(sharedMatch[1], sharedMatch[2])
+  }
+
+  for (const route of Object.keys(budgets.routes)) {
+    const routePattern = new RegExp(
+      `^.*\\s${escapeRegExp(route)}\\s+[\\d.]+\\s+(?:B|kB|MB)\\s+([\\d.]+)\\s+(kB|MB)$`,
+      'm'
+    )
+    const routeMatch = cleanOutput.match(routePattern)
+    if (routeMatch) {
+      measurements.routes[route] = parseKb(routeMatch[1], routeMatch[2])
+    }
+  }
+
+  return measurements
+}
+
+const output =
+  parseOnlyPath && existsSync(parseOnlyPath)
+    ? readFileSync(parseOnlyPath, 'utf8')
+    : runBuild()
+const measurements = parseBuildOutput(output)
+const failures = []
+
+if (typeof measurements.sharedFirstLoadJsKb !== 'number') {
+  failures.push('Missing shared First Load JS measurement')
+} else if (measurements.sharedFirstLoadJsKb > budgets.sharedFirstLoadJsKb) {
+  failures.push(
+    `shared First Load JS ${measurements.sharedFirstLoadJsKb} kB > budget ${budgets.sharedFirstLoadJsKb} kB`
+  )
+}
+
+for (const [route, budgetKb] of Object.entries(budgets.routes)) {
+  const measured = measurements.routes[route]
+  if (typeof measured !== 'number') {
+    failures.push(`Missing route measurement for ${route}`)
+  } else if (measured > budgetKb) {
+    failures.push(
+      `${route} First Load JS ${measured} kB > budget ${budgetKb} kB`
+    )
+  }
+}
+
+const report = {
+  command: parseOnlyPath
+    ? `node scripts/check-route-js-budget.mjs --log ${relative(repoRoot, parseOnlyPath)}`
+    : 'npx next build',
+  log: parseOnlyPath
+    ? relative(repoRoot, parseOnlyPath)
+    : relative(repoRoot, latestLogPath),
+  budgets,
+  measurements: {
+    sharedFirstLoadJsKb: measurements.sharedFirstLoadJsKb,
+    routes: Object.fromEntries(
+      Object.keys(budgets.routes).map((route) => [
+        route,
+        measurements.routes[route],
+      ])
+    ),
+  },
+}
+
+console.log('Route JS budget report')
+console.log(JSON.stringify(report, null, 2))
+
+if (failures.length > 0) {
+  console.error('Route JS budget gate failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Route JS budget gate passed.')


### PR DESCRIPTION
﻿## 관련 이슈

- Closes 없음

---

## PR 타입
- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] ui: UI/UX 개선, 스타일 수정
- [x] enhancement: 기존 기능 개선, 성능 최적화
- [x] chore: 빌드, 설정, 패키지 관리
- [ ] refactor: 코드 리팩토링 (기능 변경 없음)
- [x] docs: 문서 수정

---

## 작업 개요

Spec 53 릴리스 게이트를 완료합니다. 핵심 discovery route First Load JS budget을 실행 가능한 로컬 게이트로 만들고, deprecated `next lint` 직접 사용을 ESLint CLI 기반 명령으로 전환하며, release-critical warning category가 baseline을 초과하면 실패하도록 분리했습니다.

---

## 변경 사항

- [x] `npm run lint` / `lint:fix`를 `next lint`에서 `eslint src`로 전환
- [x] `lint:release`, `build:route-budget`, `release:check` 스크립트 추가
- [x] route First Load JS budget config 추가
- [x] lint warning category baseline config 추가
- [x] Spec 53 tasks/evidence 문서 추가

---

## 체크리스트
- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (`npm run build:route-budget`가 production build 실행)
- [x] 주요 기능 동작 확인 (`npm run release:check` 통과)

---

## 스크린샷 (선택)

N/A — tooling/release gate 변경입니다.

---

## 추가 정보 (선택)

Route budget evidence:
- shared First Load JS: 224 kB / budget 230 kB
- `/spots/[id]`: 302 kB / budget 310 kB
- `/routes/[id]`: 277 kB / budget 285 kB
- `/gallery`: 271 kB / budget 280 kB
- `/map`: 267 kB / budget 275 kB

Lint release baseline:
- `react-hooks/exhaustive-deps`: 0
- `jsx-a11y/*`: 0
- `no-explicit-any`: 0
- production console: 59
- unused variables: 30
