### PR TITLE
chore(release): harden launch logging hygiene

### DIFF
--- a/.kiro/specs/54-launch-content-and-runtime-logging-hygiene/evidence.md
+++ b/.kiro/specs/54-launch-content-and-runtime-logging-hygiene/evidence.md
@@ -1,0 +1,46 @@
+# Spec 54 Evidence - Launch Content and Runtime Logging Hygiene
+
+## Launch-facing content naming
+
+- Renamed `PROOF_DUMMY_DATA` to `LANDING_PROOF_CARDS` in:
+  - `src/components/landing/data/proofData.ts`
+  - `src/components/landing/SocialProofSection.tsx`
+  - `src/components/landing/__tests__/SocialProofSection.test.ts`
+- Displayed content is intentionally unchanged; only the production-facing symbol name changed.
+
+## Fixture naming scan
+
+Command used:
+
+```bash
+rg -n "PROOF_DUMMY_DATA|dummy|Dummy|placeholder" src/components/landing src/lib scripts -S
+```
+
+Classification:
+
+- Public-facing changed proof data: fixed; no `PROOF_DUMMY_DATA` references remain.
+- Internal-only landing fetch guard: `url.includes('dummy')` remains as validation logic for rejecting placeholder URLs.
+- Test-only/script-only dummy terms remain isolated to tests, seed scripts, validation scripts, and migration diagnostics.
+
+## Runtime logger strategy
+
+Added `src/lib/runtime-logger.ts`:
+
+- supports `debug`, `info`, `warn`, and `error`
+- uses `RUNTIME_LOG_LEVEL` when configured
+- defaults to `warn` in production and `info` outside production
+- writes structured payloads with normalized `Error` metadata
+
+Initial migration scope:
+
+- `src/lib/db.ts`
+- `src/lib/ops/alerting.ts`
+- `src/lib/security/security-log.ts`
+- `src/lib/spot-quality/lifecycle-manager.ts`
+- `src/components/landing/data/fetchShowcaseSpots.ts`
+
+## no-console classification
+
+The lint release warning baseline was regenerated after this migration. Production console warnings decreased from the Spec 53 baseline. Remaining runtime console usage is still tracked by `npm run lint:release` and must not regress.
+
+Logging hygiene status: `partially-fixed` because the logger exists and high-signal migration has started, but API route-wide migration remains deliberate follow-up work.

--- a/.kiro/specs/54-launch-content-and-runtime-logging-hygiene/tasks.md
+++ b/.kiro/specs/54-launch-content-and-runtime-logging-hygiene/tasks.md
@@ -1,0 +1,20 @@
+# Spec 54 Tasks - Launch Content and Runtime Logging Hygiene
+
+## Status: completed
+
+- [x] Rename launch-facing proof data from fixture-oriented naming to production-oriented naming.
+- [x] Update all imports, exports, and tests from `PROOF_DUMMY_DATA` to `LANDING_PROOF_CARDS`.
+- [x] Scan nearby landing proof/showcase content for remaining fixture wording.
+- [x] Introduce a runtime logger wrapper with environment-aware levels and structured metadata.
+- [x] Start migration in high-signal runtime paths: database connection, alert delivery, security log fallback, spot lifecycle transitions, and landing showcase fetch fallback logging.
+- [x] Preserve test/script console exceptions.
+- [x] Update lint release warning baseline after reducing production console warnings.
+- [x] Verify targeted tests, lint release gate, type-check, and formatting.
+
+## Final classification
+
+- Launch_Facing_Content naming: fixed
+- Fixture_Naming scan: fixed for changed landing proof/showcase surface; remaining dummy terms are test/script/internal data-validation only
+- Runtime_Logger: partially-fixed
+- no-console warning handling: partially-fixed
+- Logging hygiene: partially-fixed

--- a/config/lint-release-warning-baseline.json
+++ b/config/lint-release-warning-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T18:17:18.374Z",
+  "generatedAt": "2026-06-01T18:44:01.354Z",
   "command": "npx eslint src --format json",
   "scope": "src",
   "policy": {
@@ -8,17 +8,17 @@
   },
   "summary": {
     "errors": 0,
-    "warnings": 94,
+    "warnings": 86,
     "categories": {
       "reactHooksExhaustiveDeps": 0,
       "jsxA11y": 0,
-      "productionConsole": 59,
+      "productionConsole": 51,
       "noExplicitAny": 0,
       "unusedVariables": 30,
       "otherWarnings": 5
     },
     "rules": {
-      "no-console": 64,
+      "no-console": 56,
       "@typescript-eslint/no-unused-vars": 30
     }
   },

--- a/src/components/landing/SocialProofSection.tsx
+++ b/src/components/landing/SocialProofSection.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ProofCard } from './ProofCard'
-import { PROOF_DUMMY_DATA } from './data/proofData'
+import { LANDING_PROOF_CARDS } from './data/proofData'
 import type { ProofData } from './data/proofData'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import type { SpotCategory } from '@/types/spot'
@@ -84,9 +84,9 @@ export function getExtendedData(
     })
 
     // 서버 데이터 + 더미 데이터 결합 (서버 데이터 우선)
-    baseData = [...checkinProofData, ...PROOF_DUMMY_DATA]
+    baseData = [...checkinProofData, ...LANDING_PROOF_CARDS]
   } else {
-    baseData = [...PROOF_DUMMY_DATA]
+    baseData = [...LANDING_PROOF_CARDS]
   }
 
   const data: ProofData[] = baseData.map((item) => ({

--- a/src/components/landing/__tests__/SocialProofSection.test.ts
+++ b/src/components/landing/__tests__/SocialProofSection.test.ts
@@ -1,5 +1,5 @@
 import { getExtendedData } from '../SocialProofSection'
-import { PROOF_DUMMY_DATA } from '../data/proofData'
+import { LANDING_PROOF_CARDS } from '../data/proofData'
 import type { SpotCategory } from '@/types/spot'
 
 const CLONE_COUNT = 4
@@ -21,9 +21,9 @@ describe('SocialProofSection spot-specific images', () => {
       extended.length - CLONE_COUNT
     )
 
-    expect(originalCards).toHaveLength(PROOF_DUMMY_DATA.length)
+    expect(originalCards).toHaveLength(LANDING_PROOF_CARDS.length)
 
-    for (const sourceCard of PROOF_DUMMY_DATA) {
+    for (const sourceCard of LANDING_PROOF_CARDS) {
       const renderedCard = originalCards.find(
         (card) => card.id === sourceCard.id
       )
@@ -56,7 +56,7 @@ describe('SocialProofSection spot-specific images', () => {
   })
 
   it('does not ship category icons as proof-card photos', () => {
-    for (const card of PROOF_DUMMY_DATA) {
+    for (const card of LANDING_PROOF_CARDS) {
       expect(card.image).not.toContain('/icons/categories/')
       expect(card.sceneImage).toBeUndefined()
     }
@@ -86,6 +86,6 @@ describe('SocialProofSection spot-specific images', () => {
       contentName: '체크인 작품',
       image: 'https://example.com/checkin.jpg',
     })
-    expect(originalCards[1].id).toBe(PROOF_DUMMY_DATA[0].id)
+    expect(originalCards[1].id).toBe(LANDING_PROOF_CARDS[0].id)
   })
 })

--- a/src/components/landing/data/fetchShowcaseSpots.ts
+++ b/src/components/landing/data/fetchShowcaseSpots.ts
@@ -1,3 +1,4 @@
+import { runtimeLogger } from '@/lib/runtime-logger'
 import { getCollection } from '@/lib/db'
 import { COLLECTIONS } from '@/lib/db'
 import type { DataReviewStatus } from '@/lib/real-image-data'
@@ -189,7 +190,7 @@ export async function fetchShowcaseSpots(): Promise<ShowcaseCard[]> {
 
     return [...cards, ...supplementalCards].slice(0, maxCards)
   } catch (error) {
-    console.error(
+    runtimeLogger.error(
       '[fetchShowcaseSpots] DB 조회 실패, 정적 스팟 사진 사용:',
       error
     )
@@ -219,7 +220,7 @@ export async function fetchCategoryImages(): Promise<
 
     return result
   } catch (error) {
-    console.error(
+    runtimeLogger.error(
       '[fetchCategoryImages] DB 조회 실패, 정적 스팟 사진 사용:',
       error
     )
@@ -289,7 +290,7 @@ export async function fetchProofImages(): Promise<
 
     return result
   } catch (error) {
-    console.warn(
+    runtimeLogger.warn(
       '[fetchProofImages] Showcase API 호출 실패, 정적 스팟 사진 사용:',
       error
     )
@@ -370,7 +371,10 @@ export async function fetchSocialProofCheckins(): Promise<
 
     return results
   } catch (error) {
-    console.error('[fetchSocialProofCheckins] 체크인 데이터 조회 실패:', error)
+    runtimeLogger.error(
+      '[fetchSocialProofCheckins] 체크인 데이터 조회 실패:',
+      error
+    )
     return []
   }
 }

--- a/src/components/landing/data/proofData.ts
+++ b/src/components/landing/data/proofData.ts
@@ -10,7 +10,7 @@ export interface ProofData {
   sceneImage?: string
 }
 
-export const PROOF_DUMMY_DATA: ProofData[] = [
+export const LANDING_PROOF_CARDS: ProofData[] = [
   {
     id: '1',
     categoryTag: 'animation',

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,3 +1,4 @@
+import { runtimeLogger } from '@/lib/runtime-logger'
 import { MongoClient, Db, Collection, Document } from 'mongodb'
 
 // MongoDB connection configuration
@@ -46,10 +47,10 @@ export async function connectToDatabase(): Promise<{
     cachedClient = client
     cachedDb = db
 
-    console.log('Connected to MongoDB successfully')
+    runtimeLogger.info('Connected to MongoDB successfully')
     return { client, db }
   } catch (error) {
-    console.error('Failed to connect to MongoDB:', error)
+    runtimeLogger.error('Failed to connect to MongoDB:', error)
     throw new Error('Database connection failed')
   }
 }
@@ -73,7 +74,7 @@ export async function closeDatabaseConnection(): Promise<void> {
     await cachedClient.close()
     cachedClient = null
     cachedDb = null
-    console.log('MongoDB connection closed')
+    runtimeLogger.info('MongoDB connection closed')
   }
 }
 

--- a/src/lib/ops/alerting.ts
+++ b/src/lib/ops/alerting.ts
@@ -1,3 +1,4 @@
+import { runtimeLogger } from '@/lib/runtime-logger'
 import { COLLECTIONS, getCollection } from '@/lib/db'
 
 const RETRY_LIMIT = 3
@@ -53,8 +54,7 @@ async function deliverWebhook(url: string, payload: unknown): Promise<void> {
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error))
       if (attempt === RETRY_LIMIT) {
-        // eslint-disable-next-line no-console
-        console.error('Alert webhook delivery failed:', {
+        runtimeLogger.error('Alert webhook delivery failed:', {
           url,
           attempt,
           error: lastError.message,

--- a/src/lib/runtime-logger.ts
+++ b/src/lib/runtime-logger.ts
@@ -1,0 +1,94 @@
+/* eslint-disable no-console */
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
+
+type LogMetadata = Record<string, unknown> | Error | unknown
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 50,
+}
+
+function resolveLogLevel(): LogLevel {
+  const configured = process.env.RUNTIME_LOG_LEVEL?.toLowerCase()
+
+  if (
+    configured === 'debug' ||
+    configured === 'info' ||
+    configured === 'warn' ||
+    configured === 'error' ||
+    configured === 'silent'
+  ) {
+    return configured
+  }
+
+  return process.env.NODE_ENV === 'production' ? 'warn' : 'info'
+}
+
+function shouldWrite(level: Exclude<LogLevel, 'silent'>): boolean {
+  return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[resolveLogLevel()]
+}
+
+function normalizeMetadata(metadata: LogMetadata | undefined) {
+  if (metadata instanceof Error) {
+    return {
+      name: metadata.name,
+      message: metadata.message,
+      stack: metadata.stack,
+    }
+  }
+
+  return metadata
+}
+
+function writeLog(
+  level: Exclude<LogLevel, 'silent'>,
+  message: string,
+  metadata?: LogMetadata
+): void {
+  if (!shouldWrite(level)) return
+
+  const normalizedMetadata = normalizeMetadata(metadata)
+  const payload = {
+    level,
+    message,
+    ...(normalizedMetadata === undefined
+      ? {}
+      : { metadata: normalizedMetadata }),
+  }
+
+  if (level === 'error') {
+    console.error(payload)
+    return
+  }
+
+  if (level === 'warn') {
+    console.warn(payload)
+    return
+  }
+
+  if (level === 'debug') {
+    console.debug(payload)
+    return
+  }
+
+  console.info(payload)
+}
+
+export const runtimeLogger = {
+  debug(message: string, metadata?: LogMetadata): void {
+    writeLog('debug', message, metadata)
+  },
+  info(message: string, metadata?: LogMetadata): void {
+    writeLog('info', message, metadata)
+  },
+  warn(message: string, metadata?: LogMetadata): void {
+    writeLog('warn', message, metadata)
+  },
+  error(message: string, metadata?: LogMetadata): void {
+    writeLog('error', message, metadata)
+  },
+}

--- a/src/lib/security/security-log.ts
+++ b/src/lib/security/security-log.ts
@@ -1,3 +1,4 @@
+import { runtimeLogger } from '@/lib/runtime-logger'
 import { COLLECTIONS, getCollection } from '@/lib/db'
 
 export interface SecurityLogDocument {
@@ -22,7 +23,6 @@ export async function writeSecurityLog(
       createdAt: new Date(),
     })
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('Failed to write security log:', error)
+    runtimeLogger.error('Failed to write security log:', error)
   }
 }

--- a/src/lib/spot-quality/lifecycle-manager.ts
+++ b/src/lib/spot-quality/lifecycle-manager.ts
@@ -1,3 +1,4 @@
+import { runtimeLogger } from '@/lib/runtime-logger'
 // ============================================
 // 스팟 라이프사이클 상태 전이 관리 모듈
 // Spec: 40-spot-quality-workflow
@@ -99,7 +100,7 @@ export async function transitionStatus(
     // 7. 성공 결과 반환
     return { success: true, newStatus: targetStatus }
   } catch (error) {
-    console.error('[lifecycle-manager] transitionStatus error:', error)
+    runtimeLogger.error('[lifecycle-manager] transitionStatus error:', error)
     return {
       success: false,
       error:


### PR DESCRIPTION
﻿## 관련 이슈

- Closes 없음

---

## PR 타입
- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] ui: UI/UX 개선, 스타일 수정
- [x] enhancement: 기존 기능 개선, 성능 최적화
- [x] chore: 빌드, 설정, 패키지 관리
- [ ] refactor: 코드 리팩토링 (기능 변경 없음)
- [x] docs: 문서 수정

---

## 작업 개요

Spec 54 launch content/runtime hygiene를 완료합니다. 출시 화면 proof data의 fixture-oriented 이름을 production-facing 이름으로 바꾸고, runtime logger wrapper를 추가해 high-signal server/runtime 경로부터 console logging migration을 시작했습니다.

---

## 변경 사항

- [x] `PROOF_DUMMY_DATA`를 `LANDING_PROOF_CARDS`로 rename
- [x] SocialProofSection 및 관련 테스트 참조 업데이트
- [x] `runtimeLogger` 추가: environment-aware level + structured metadata
- [x] DB 연결, alert delivery, security log fallback, lifecycle transition, landing showcase fetch logging migration
- [x] lint release warning baseline을 production console 51개로 강화
- [x] Spec 54 tasks/evidence 문서 추가

---

## 체크리스트
- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (`npm run release:check` 내 `build:route-budget`)
- [x] 주요 기능 동작 확인 (`SocialProofSection` targeted Jest 통과)

---

## 스크린샷 (선택)

N/A — naming/tooling/runtime hygiene 변경입니다.

---

## 추가 정보 (선택)

검증 완료:
- `npm run release:check`
- `npx jest --runInBand --runTestsByPath src/components/landing/__tests__/SocialProofSection.test.ts`
- `npm run type-check`
- `npm run lint:release`
- `git diff --check`

남은 logging hygiene는 의도적으로 `partially-fixed`입니다. API route-wide console migration은 별도 incremental pass로 진행해야 합니다.
