### PR TITLE
fix(qa): promote predeploy hardening to main

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -118,7 +118,7 @@ export default withSentryConfig(withSerwist(nextConfig), {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
-  silent: !process.env.CI,
+  silent: !process.env.CI || !process.env.SENTRY_AUTH_TOKEN,
   widenClientFileUpload: true,
   tunnelRoute: '/monitoring',
   webpack: {

--- a/scripts/check-route-js-budget.mjs
+++ b/scripts/check-route-js-budget.mjs
@@ -97,6 +97,15 @@ function findBuildWarnings(output) {
   const cleanOutput = stripAnsi(output)
   return cleanOutput
     .split(/\r?\n/)
+    .filter(
+      (line) =>
+        ![
+          /No build cache found/,
+          /No auth token provided/,
+          /Will not create release/,
+          /Will not upload source maps/,
+        ].some((pattern) => pattern.test(line))
+    )
     .filter((line) =>
       [
         /^\s*⚠/,

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,7 +15,7 @@ export default function AdminDashboardPage() {
     data: summary,
     isLoading: dataLoading,
     error,
-  } = useAdminDashboardSummary()
+  } = useAdminDashboardSummary(isAuthorized)
 
   if (authLoading) {
     return (

--- a/src/components/common/AppIcon.tsx
+++ b/src/components/common/AppIcon.tsx
@@ -96,6 +96,7 @@ export function AppIcon({
       height={pixelSize}
       className={`object-contain ${className}`}
       style={{ width: 'auto', height: 'auto' }}
+      unoptimized
     />
   )
 }

--- a/src/components/common/MascotIllustration.tsx
+++ b/src/components/common/MascotIllustration.tsx
@@ -35,6 +35,7 @@ export function MascotIllustration({
         priority={priority}
         sizes="(max-width: 768px) 80px, 144px"
         className="object-contain drop-shadow-lg"
+        unoptimized
       />
     </div>
   )

--- a/src/components/common/OnboardingTour.tsx
+++ b/src/components/common/OnboardingTour.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { useEffect, useState, useCallback, useRef } from 'react'
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  type CSSProperties,
+} from 'react'
 import { TourStep } from '@/hooks/useOnboarding'
 
 interface OnboardingTourProps {
@@ -97,10 +103,18 @@ export default function OnboardingTour({
     left: 0,
   })
   const tooltipRef = useRef<HTMLDivElement>(null)
-  const nextButtonRef = useRef<HTMLButtonElement>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
 
   const step = steps[currentStep]
   const isLastStep = currentStep === steps.length - 1
+
+  const restoreFocus = useCallback(() => {
+    const target = step?.target
+      ? document.querySelector<HTMLElement>(step.target)
+      : null
+    const fallback = previouslyFocusedRef.current
+    ;(target || fallback)?.focus?.({ preventScroll: true })
+  }, [step])
 
   // 대상 요소 위치 계산
   const updateTargetRect = useCallback(() => {
@@ -156,33 +170,54 @@ export default function OnboardingTour({
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onSkip()
+        restoreFocus()
+        if (onDismiss) {
+          onDismiss()
+        } else {
+          onSkip()
+        }
       }
     }
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [isActive, onSkip])
+  }, [isActive, onDismiss, onSkip, restoreFocus])
 
-  // 투어 활성화 시 첫 번째 버튼에 포커스
   useEffect(() => {
-    if (isActive && nextButtonRef.current) {
-      nextButtonRef.current.focus()
-    }
+    if (!isActive) return
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
   }, [isActive, currentStep])
 
   if (!isActive || !step) return null
 
   const handleNext = () => {
     if (isLastStep) {
+      restoreFocus()
       onComplete()
     } else {
       onNext()
     }
   }
 
+  const handleSkip = () => {
+    restoreFocus()
+    if (onDismiss) {
+      onDismiss()
+    } else {
+      onSkip()
+    }
+  }
+
+  const handleDismiss = () => {
+    restoreFocus()
+    onDismiss?.()
+  }
+
   // box-shadow 기반 하이라이트: 대상 요소 크기의 투명 박스 + 거대한 box-shadow로 나머지 어둡게
-  const highlightStyle: React.CSSProperties = targetRect
+  const highlightStyle: CSSProperties = targetRect
     ? {
         position: 'fixed',
         top: targetRect.top - HIGHLIGHT_PADDING,
@@ -200,14 +235,10 @@ export default function OnboardingTour({
 
   return (
     <div
-      role="dialog"
-      aria-modal="true"
+      aria-live="polite"
       aria-describedby={tooltipId}
-      className="fixed inset-0 z-[9999]"
+      className="pointer-events-none fixed inset-0 z-[9999]"
     >
-      {/* 오버레이 클릭 방지 레이어 */}
-      <div className="fixed inset-0" aria-hidden="true" />
-
       {/* 하이라이트 영역 */}
       {targetRect && <div style={highlightStyle} aria-hidden="true" />}
 
@@ -216,7 +247,7 @@ export default function OnboardingTour({
         ref={tooltipRef}
         id={tooltipId}
         role="tooltip"
-        className="fixed z-[10000] w-80 max-w-[calc(100vw-32px)] rounded-xl bg-white p-5 shadow-2xl dark:bg-gray-800"
+        className="pointer-events-auto fixed z-[10000] w-80 max-w-[calc(100vw-32px)] rounded-xl bg-white p-5 shadow-2xl dark:bg-gray-800"
         style={{ top: tooltipPos.top, left: tooltipPos.left }}
       >
         <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-gray-100">
@@ -229,7 +260,7 @@ export default function OnboardingTour({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <button
-              onClick={onSkip}
+              onClick={handleSkip}
               className="text-xs font-medium text-gray-700 underline underline-offset-4 transition-colors hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
               type="button"
             >
@@ -238,7 +269,7 @@ export default function OnboardingTour({
 
             {onDismiss && (
               <button
-                onClick={onDismiss}
+                onClick={handleDismiss}
                 className="text-xs font-medium text-gray-700 underline underline-offset-4 transition-colors hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
                 type="button"
               >
@@ -254,7 +285,6 @@ export default function OnboardingTour({
             </span>
 
             <button
-              ref={nextButtonRef}
               onClick={handleNext}
               className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 active:bg-primary-800"
               type="button"

--- a/src/components/common/OptimizedImage.tsx
+++ b/src/components/common/OptimizedImage.tsx
@@ -33,6 +33,16 @@ function isGifUrl(src: ImageProps['src']): boolean {
   return src.split(/[?#]/, 1)[0].toLowerCase().endsWith('.gif')
 }
 
+function isLocalStaticAsset(src: ImageProps['src']): boolean {
+  if (typeof src !== 'string') {
+    return false
+  }
+
+  return ['/icons/', '/uploads/', '/images/'].some((prefix) =>
+    src.startsWith(prefix)
+  )
+}
+
 /**
  * OptimizedImage - next/image 래퍼 컴포넌트
  * - blur placeholder를 자동 적용하여 로딩 중 UX 개선
@@ -48,7 +58,8 @@ export function OptimizedImage({
   const blurProps = disableBlur ? {} : blurPlaceholderProps
   const safeSrc =
     typeof props.src === 'string' ? getSafeImageSrc(props.src) : props.src
-  const shouldSkipOptimization = isExternalUrl(safeSrc) || isGifUrl(safeSrc)
+  const shouldSkipOptimization =
+    isExternalUrl(safeSrc) || isGifUrl(safeSrc) || isLocalStaticAsset(safeSrc)
 
   return (
     <Image

--- a/src/components/content/ContentCard.tsx
+++ b/src/components/content/ContentCard.tsx
@@ -15,12 +15,21 @@ interface ContentCardProps {
   content: ContentListItem
 }
 
+function shouldBypassOptimizer(src: string): boolean {
+  return ['/uploads/', '/icons/', '/images/'].some((prefix) =>
+    src.startsWith(prefix)
+  )
+}
+
 export function ContentCard({ content }: ContentCardProps) {
   const [imageError, setImageError] = useState(false)
   const typeConfig = CONTENT_TYPE_CONFIG[content.contentType]
   const typeLabel = isDiscoverableContentType(content.contentType)
     ? DISCOVERABLE_CONTENT_TYPE_LABELS[content.contentType]
     : '콘텐츠'
+  const safeImageSrc = content.imageUrl
+    ? getSafeImageSrc(content.imageUrl)
+    : undefined
 
   return (
     <Link
@@ -28,14 +37,15 @@ export function ContentCard({ content }: ContentCardProps) {
       className="group block overflow-hidden rounded-lg border border-border bg-background transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
     >
       <div className="relative aspect-[4/3] w-full bg-border/30">
-        {content.imageUrl && !imageError ? (
+        {safeImageSrc && !imageError ? (
           <Image
-            src={getSafeImageSrc(content.imageUrl)}
+            src={safeImageSrc}
             alt={`${content.contentName} 대표 썸네일`}
             fill
             className="object-cover transition-transform group-hover:scale-105"
             sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
             onError={() => setImageError(true)}
+            unoptimized={shouldBypassOptimizer(safeImageSrc)}
           />
         ) : (
           <div className="flex h-full items-center justify-center">
@@ -45,6 +55,7 @@ export function ContentCard({ content }: ContentCardProps) {
               width={48}
               height={48}
               className="opacity-40"
+              unoptimized
             />
           </div>
         )}

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -7,27 +7,31 @@ import { HeroSection } from './HeroSection'
 import { useDeviceCapability } from '@/hooks/useDeviceCapability'
 import { useScrollPosition } from '@/hooks/useScrollPosition'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
-import { usePwaStore } from '@/stores/pwaStore'
 import type { ShowcaseCard } from './data/showcaseCards'
 import type { SpotCategory } from '@/types/spot'
 
 const EntryPointSection = dynamic(() =>
   import('./EntryPointSection').then((mod) => mod.EntryPointSection)
 )
-const HowItWorksSection = dynamic(() =>
-  import('./HowItWorksSection').then((mod) => mod.HowItWorksSection)
+const HowItWorksSection = dynamic(
+  () => import('./HowItWorksSection').then((mod) => mod.HowItWorksSection),
+  { ssr: false }
 )
-const StorytellingSection = dynamic(() =>
-  import('./StorytellingSection').then((mod) => mod.StorytellingSection)
+const StorytellingSection = dynamic(
+  () => import('./StorytellingSection').then((mod) => mod.StorytellingSection),
+  { ssr: false }
 )
-const SocialProofSection = dynamic(() =>
-  import('./SocialProofSection').then((mod) => mod.SocialProofSection)
+const SocialProofSection = dynamic(
+  () => import('./SocialProofSection').then((mod) => mod.SocialProofSection),
+  { ssr: false }
 )
-const ConversionSection = dynamic(() =>
-  import('./ConversionSection').then((mod) => mod.ConversionSection)
+const ConversionSection = dynamic(
+  () => import('./ConversionSection').then((mod) => mod.ConversionSection),
+  { ssr: false }
 )
-const FloatingCTA = dynamic(() =>
-  import('./FloatingCTA').then((mod) => mod.FloatingCTA)
+const FloatingCTA = dynamic(
+  () => import('./FloatingCTA').then((mod) => mod.FloatingCTA),
+  { ssr: false }
 )
 
 /**
@@ -63,8 +67,6 @@ export function WelcomePageClient({
 
   // PWA standalone 모드 감지
   const [isStandalone, setIsStandalone] = useState(false)
-  const triggerInstall = usePwaStore((s) => s.triggerInstall)
-  const isInstallable = usePwaStore((s) => s.isInstallable)
 
   useEffect(() => {
     setIsStandalone(window.matchMedia('(display-mode: standalone)').matches)
@@ -79,12 +81,9 @@ export function WelcomePageClient({
 
   // FloatingCTA 핸들러
   const handleInstallClick = async () => {
-    if (!isInstallable) {
-      // 설치 프롬프트 미지원 시 ConversionSection으로 스크롤
-      conversionRef.current?.scrollIntoView({ behavior: 'smooth' })
-      return
-    }
-    await triggerInstall()
+    // 설치 프롬프트 상태는 아래쪽 ConversionSection에서만 로드한다.
+    // Floating CTA는 초기 번들을 줄이기 위해 설치 영역으로 이동만 담당한다.
+    conversionRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   const handleExploreClick = () => {

--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -183,7 +183,7 @@ export default function SpotDetailMap({
         dragging={true}
         touchZoom={true}
         boxZoom={true}
-        keyboard={true}
+        keyboard={false}
         whenReady={() => {
           mapRef.current?.invalidateSize()
         }}

--- a/src/components/route/RouteDetailContent.tsx
+++ b/src/components/route/RouteDetailContent.tsx
@@ -297,6 +297,12 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
         <h2 className="mb-3 text-lg font-semibold text-text-primary">
           코스 지도
         </h2>
+        <a
+          href="#route-after-map"
+          className="sr-only focus:not-sr-only focus:mb-3 focus:inline-flex focus:rounded-md focus:bg-primary focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
+        >
+          코스 지도 건너뛰기
+        </a>
         <RouteMap
           spots={route.spots}
           startPoint={route.startPoint}
@@ -304,6 +310,7 @@ export function RouteDetailContent({ route }: RouteDetailContentProps) {
           currentSpotIndex={nav.isNavigating ? nav.currentSpotIndex : undefined}
           checkedSpotIds={nav.isNavigating ? nav.checkedSpotIds : undefined}
         />
+        <div id="route-after-map" tabIndex={-1} />
       </div>
 
       {/* 스팟 순서 목록 */}

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -218,6 +218,7 @@ export default function RouteMap({
         ref={mapRef}
         zoomControl={true}
         scrollWheelZoom={true}
+        keyboard={false}
       >
         <TileLayer
           attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'

--- a/src/components/spot/SpotDetailClient.tsx
+++ b/src/components/spot/SpotDetailClient.tsx
@@ -169,9 +169,9 @@ function SpotDetailPage({ spot, spotId, facilities }: SpotDetailPageProps) {
                 <ArrowLeftIcon size="md" />
                 <span>지도로 돌아가기</span>
               </Link>
-              <h1 className="mt-2 text-xl font-bold text-text-primary">
+              <p className="mt-2 text-xl font-bold text-text-primary">
                 특별한 여행지
-              </h1>
+              </p>
             </div>
 
             <div className="flex items-center gap-2">
@@ -448,9 +448,16 @@ function SpotDetailContent({
           <h2 className="mb-4 text-2xl font-bold text-text-primary">
             위치 및 근처 편의시설
           </h2>
+          <a
+            href="#spot-after-map"
+            className="sr-only focus:not-sr-only focus:mb-3 focus:inline-flex focus:rounded-md focus:bg-primary focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
+          >
+            스팟 지도 건너뛰기
+          </a>
           <div className="h-96 w-full overflow-hidden rounded-lg border border-border">
             <SpotDetailMap spot={spot} facilities={facilities} />
           </div>
+          <div id="spot-after-map" tabIndex={-1} />
           {facilities.length > 0 && (
             <div className="mt-4">
               <p className="text-sm text-text-secondary">

--- a/src/components/spot/scene/AddSceneModal.tsx
+++ b/src/components/spot/scene/AddSceneModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, FormEvent } from 'react'
 import { useCreateScene } from '@/hooks/useScenes'
+import { useAuth } from '@/hooks/useAuth'
 import { API_ROUTES } from '@/lib/api-routes'
 
 interface AddSceneModalProps {
@@ -9,8 +10,18 @@ interface AddSceneModalProps {
   onClose: () => void
 }
 
+const ALLOWED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]
+const ALLOWED_IMAGE_EXTENSION_PATTERN = /\.(jpe?g|png|gif|webp)$/i
+const AUTH_REQUIRED_MESSAGE = 'Log in to upload an image.'
+
 export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
   const createScene = useCreateScene()
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth()
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [episodeInfo, setEpisodeInfo] = useState('')
@@ -18,15 +29,30 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
   const [error, setError] = useState('')
   const [isUploading, setIsUploading] = useState(false)
 
+  const resetFile = () => {
+    setImageFile(null)
+    setImagePreview(null)
+  }
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
 
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
-    const allowedExtensions = /\.(jpe?g|png|gif|webp)$/i
+    if (isAuthLoading) {
+      setError('Checking login status. Try again shortly.')
+      e.target.value = ''
+      return
+    }
+
+    if (!isAuthenticated) {
+      setError(AUTH_REQUIRED_MESSAGE)
+      e.target.value = ''
+      return
+    }
+
     if (
-      !allowedTypes.includes(file.type) &&
-      !allowedExtensions.test(file.name)
+      !ALLOWED_IMAGE_TYPES.includes(file.type) &&
+      !ALLOWED_IMAGE_EXTENSION_PATTERN.test(file.name)
     ) {
       setError('지원하지 않는 파일 형식입니다. (JPG, PNG, GIF, WEBP만 가능)')
       return
@@ -50,6 +76,16 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError('')
+
+    if (isAuthLoading) {
+      setError('Checking login status. Try again shortly.')
+      return
+    }
+
+    if (!isAuthenticated) {
+      setError(AUTH_REQUIRED_MESSAGE)
+      return
+    }
 
     if (!imageFile) {
       setError('이미지를 선택해주세요')
@@ -91,6 +127,8 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
   }
 
   const isSubmitting = isUploading || createScene.isPending
+  const isFileSelectionDisabled =
+    isAuthLoading || !isAuthenticated || isSubmitting
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
@@ -100,7 +138,9 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
             작품 속 장면 추가
           </h3>
           <button
+            type="button"
             onClick={onClose}
+            aria-label="Close add scene dialog"
             className="text-neutral-400 hover:text-neutral-600"
           >
             <svg
@@ -108,6 +148,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -119,8 +160,29 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
           </button>
         </div>
 
+        {isAuthLoading && (
+          <div
+            className="mb-4 rounded-lg bg-blue-50 p-3 text-sm text-blue-700"
+            role="status"
+          >
+            Checking login status.
+          </div>
+        )}
+
+        {!isAuthLoading && !isAuthenticated && (
+          <div
+            className="mb-4 rounded-lg bg-amber-50 p-3 text-sm text-amber-700"
+            role="status"
+          >
+            {AUTH_REQUIRED_MESSAGE}
+          </div>
+        )}
+
         {error && (
-          <div className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-600">
+          <div
+            className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-600"
+            role="alert"
+          >
             {error}
           </div>
         )}
@@ -143,10 +205,8 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
                   </div>
                   <button
                     type="button"
-                    onClick={() => {
-                      setImageFile(null)
-                      setImagePreview(null)
-                    }}
+                    onClick={resetFile}
+                    aria-label="Remove selected image"
                     className="absolute -right-2 -top-2 rounded-full bg-red-500 p-1 text-white shadow-md hover:bg-red-600"
                   >
                     <svg
@@ -154,6 +214,7 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
+                      aria-hidden="true"
                     >
                       <path
                         strokeLinecap="round"
@@ -165,7 +226,13 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
                   </button>
                 </div>
               ) : (
-                <label className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-neutral-300 bg-neutral-50 p-6 transition-colors hover:border-primary-400 hover:bg-neutral-100">
+                <label
+                  className={
+                    isFileSelectionDisabled
+                      ? 'flex cursor-not-allowed flex-col items-center justify-center rounded-lg border-2 border-dashed border-neutral-200 bg-neutral-50 p-6 opacity-60'
+                      : 'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-neutral-300 bg-neutral-50 p-6 transition-colors hover:border-primary-400 hover:bg-neutral-100'
+                  }
+                >
                   <svg
                     className="mb-2 h-10 w-10 text-neutral-400"
                     fill="none"
@@ -187,8 +254,9 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
                   </span>
                   <input
                     type="file"
-                    accept="image/jpeg,image/png,image/gif,image/webp"
+                    accept="image/jpeg,image/png,image/gif,image/webp,.jpg,.jpeg,.png,.gif,.webp"
                     onChange={handleFileChange}
+                    disabled={isFileSelectionDisabled}
                     className="hidden"
                   />
                 </label>
@@ -232,8 +300,8 @@ export function AddSceneModal({ spotId, onClose }: AddSceneModalProps) {
             </button>
             <button
               type="submit"
-              disabled={isSubmitting}
-              className="flex-1 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
+              disabled={isSubmitting || isAuthLoading || !isAuthenticated}
+              className="flex-1 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isSubmitting ? '업로드 중...' : '추가하기'}
             </button>

--- a/src/hooks/useAdminQueries.ts
+++ b/src/hooks/useAdminQueries.ts
@@ -160,9 +160,10 @@ export const adminKeys = {
  * 관리자 대시보드 요약 데이터 조회 훅
  * Requirements: 5.1, 5.2
  */
-export function useAdminDashboardSummary() {
+export function useAdminDashboardSummary(enabled = true) {
   return useQuery({
     queryKey: adminKeys.dashboardSummary(),
+    enabled,
     queryFn: async (): Promise<DashboardSummaryResponse> => {
       const res = await fetch(API_ROUTES.ADMIN.DASHBOARD_SUMMARY)
       if (!res.ok) {

--- a/src/lib/qa-hardening-static.test.ts
+++ b/src/lib/qa-hardening-static.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs'
+
+function read(path: string): string {
+  return fs.readFileSync(path, 'utf8')
+}
+
+describe('QA hardening static contracts', () => {
+  it('keeps onboarding as a non-modal coach mark that cannot block route clicks', () => {
+    const tour = read('src/components/common/OnboardingTour.tsx')
+    const hook = read('src/hooks/useOnboarding.ts')
+
+    expect(tour).not.toContain('role="dialog"')
+    expect(tour).not.toContain('aria-modal="true"')
+    expect(tour).toContain('pointer-events-none fixed inset-0')
+    expect(tour).toContain('pointer-events-auto fixed z-[10000]')
+    expect(tour).not.toContain('nextButtonRef.current.focus')
+    expect(hook).toContain('const dismiss = useCallback')
+    expect(hook).toContain('setStoredDismissed(storageKey, true)')
+    expect(tour).toContain('if (onDismiss)')
+  })
+
+  it('gates scene upload file selection behind settled authentication state', () => {
+    const modal = read('src/components/spot/scene/AddSceneModal.tsx')
+
+    expect(modal).toContain('AUTH_REQUIRED_MESSAGE')
+    expect(modal).toContain('isFileSelectionDisabled')
+    expect(modal).toContain('disabled={isFileSelectionDisabled}')
+    expect(modal).toContain('.jpg,.jpeg,.png,.gif,.webp')
+    expect(modal).toContain('useAuth()')
+  })
+
+  it('bypasses next/image optimizer for fragile local static and upload assets', () => {
+    const optimizedImage = read('src/components/common/OptimizedImage.tsx')
+    const appIcon = read('src/components/common/AppIcon.tsx')
+    const mascot = read('src/components/common/MascotIllustration.tsx')
+    const contentCard = read('src/components/content/ContentCard.tsx')
+
+    for (const prefix of ['/icons/', '/uploads/', '/images/']) {
+      expect(optimizedImage).toContain(prefix)
+      expect(contentCard).toContain(prefix)
+    }
+    expect(appIcon).toContain('unoptimized')
+    expect(mascot).toContain('unoptimized')
+  })
+
+  it('keeps representative spot and route map areas keyboard-escapable', () => {
+    const spotDetail = read('src/components/spot/SpotDetailClient.tsx')
+    const spotMap = read('src/components/map/SpotDetailMap.tsx')
+    const routeDetail = read('src/components/route/RouteDetailContent.tsx')
+    const routeMap = read('src/components/route/RouteMap.tsx')
+
+    expect((spotDetail.match(/<h1\b/g) ?? []).length).toBe(1)
+    expect(spotDetail).toContain('href="#spot-after-map"')
+    expect(routeDetail).toContain('href="#route-after-map"')
+    expect(spotMap).toContain('keyboard={false}')
+    expect(routeMap).toContain('keyboard={false}')
+  })
+})

--- a/src/lib/route-spot-availability.test.ts
+++ b/src/lib/route-spot-availability.test.ts
@@ -10,22 +10,39 @@ describe('isRouteSpotAvailable', () => {
     ).toBe(true)
   })
 
+  it('keeps spots available when optional status aliases are missing', () => {
+    expect(isRouteSpotAvailable({ id: 'REAL-ANI-002' })).toBe(true)
+  })
+
+  it('keeps null and unknown statuses available by default', () => {
+    expect(
+      isRouteSpotAvailable({
+        id: 'REAL-ANI-003',
+        status: null,
+        spotStatus: 'normal',
+        lifecycleStatus: 'mystery-but-not-explicitly-closed',
+      })
+    ).toBe(true)
+  })
+
   it('marks deleted route references unavailable when the backing spot is missing', () => {
     expect(isRouteSpotAvailable(undefined)).toBe(false)
   })
 
   const unavailableStatusCases = [
-    {
-      label: 'legacy lost status',
-      spot: { id: 'SPOT-001', status: 'lost' },
-    },
+    { label: 'legacy lost status', spot: { id: 'SPOT-001', status: 'lost' } },
+    { label: 'removed status', spot: { id: 'SPOT-002', status: 'removed' } },
     {
       label: 'demolished status report',
-      spot: { id: 'SPOT-002', spotStatus: 'demolished' },
+      spot: { id: 'SPOT-003', spotStatus: 'demolished' },
     },
     {
       label: 'closed lifecycle',
-      spot: { id: 'SPOT-003', lifecycleStatus: 'closed' },
+      spot: { id: 'SPOT-004', lifecycleStatus: 'closed' },
+    },
+    {
+      label: 'unavailable alias',
+      spot: { id: 'SPOT-005', spotStatus: 'unavailable' },
     },
   ]
 

--- a/src/lib/route-spot-availability.ts
+++ b/src/lib/route-spot-availability.ts
@@ -3,45 +3,42 @@
  *
  * A route spot is unavailable only when its backing spot document is gone or
  * the backing spot is explicitly marked as unavailable by one of the supported
- * status fields.
+ * status fields. Missing or unknown status aliases stay available so legacy
+ * route data cannot collapse into an all-lost course page.
  */
 
 export interface RouteSpotAvailabilitySource {
   id?: string
-  status?: string
-  spotStatus?: string
-  lifecycleStatus?: string
+  status?: string | null
+  spotStatus?: string | null
+  lifecycleStatus?: string | null
 }
 
-const LEGACY_UNAVAILABLE_STATUSES = new Set(['lost'])
-const SPOT_STATUS_UNAVAILABLE_STATUSES = new Set(['demolished'])
-const LIFECYCLE_UNAVAILABLE_STATUSES = new Set(['closed'])
+const EXPLICIT_UNAVAILABLE_STATUSES = new Set([
+  'lost',
+  'removed',
+  'deleted',
+  'closed',
+  'closure',
+  'demolished',
+  'unavailable',
+  'inactive',
+  'archived',
+])
+
+function hasExplicitUnavailableStatus(
+  value: string | null | undefined
+): boolean {
+  if (!value) return false
+  return EXPLICIT_UNAVAILABLE_STATUSES.has(value.trim().toLowerCase())
+}
 
 export function isRouteSpotAvailable(
   spot: RouteSpotAvailabilitySource | undefined
 ): boolean {
   if (!spot) return false
 
-  if (
-    spot.status &&
-    LEGACY_UNAVAILABLE_STATUSES.has(spot.status.toLowerCase())
-  ) {
-    return false
-  }
-
-  if (
-    spot.spotStatus &&
-    SPOT_STATUS_UNAVAILABLE_STATUSES.has(spot.spotStatus.toLowerCase())
-  ) {
-    return false
-  }
-
-  if (
-    spot.lifecycleStatus &&
-    LIFECYCLE_UNAVAILABLE_STATUSES.has(spot.lifecycleStatus.toLowerCase())
-  ) {
-    return false
-  }
-
-  return true
+  return ![spot.status, spot.spotStatus, spot.lifecycleStatus].some(
+    hasExplicitUnavailableStatus
+  )
 }

--- a/src/lib/upload/validation.test.ts
+++ b/src/lib/upload/validation.test.ts
@@ -16,15 +16,20 @@ function createFile(
   } as File
 }
 
+const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xee])
+const pngBuffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const gifBuffer = Buffer.from('GIF89a')
+const webpBuffer = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+])
+
 describe('upload validation', () => {
   test('detects jpeg by magic bytes', () => {
-    const buffer = Buffer.from([0xff, 0xd8, 0xff, 0xee])
-    expect(detectImageFormat(buffer)).toBe('jpeg')
+    expect(detectImageFormat(jpegBuffer)).toBe('jpeg')
   })
 
   test('detects png by magic bytes', () => {
-    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
-    expect(detectImageFormat(buffer)).toBe('png')
+    expect(detectImageFormat(pngBuffer)).toBe('png')
   })
 
   test('rejects unsupported mime types', () => {
@@ -38,28 +43,40 @@ describe('upload validation', () => {
 
   test('rejects mismatched mime type and magic bytes', () => {
     expect(() =>
-      validateUploadFile(
-        createFile('image/png', 1024, 'test.png'),
-        Buffer.from([0xff, 0xd8, 0xff])
-      )
-    ).toThrow('MIME 타입과 실제 파일 형식')
+      validateUploadFile(createFile('image/png', 1024, 'test.png'), jpegBuffer)
+    ).toThrow('MIME')
   })
 
   test('accepts png uploads when browser MIME is wrong but extension and magic bytes are png', () => {
-    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
-
     expect(
-      validateUploadFile(createFile('image/jpeg', 1024, 'scene.png'), buffer)
+      validateUploadFile(createFile('image/jpeg', 1024, 'scene.png'), pngBuffer)
     ).toBe('png')
   })
 
-  test('accepts valid webp uploads', () => {
-    const buffer = Buffer.from([
-      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
-    ])
-
+  test('accepts png uploads when browser reports a generic binary MIME', () => {
     expect(
-      validateUploadFile(createFile('image/webp', 1024, 'test.webp'), buffer)
-    ).toBe('webp')
+      validateUploadFile(
+        createFile('application/octet-stream', 1024, 'scene.png'),
+        pngBuffer
+      )
+    ).toBe('png')
+  })
+
+  test('reports file size errors before type mismatch errors', () => {
+    expect(() =>
+      validateUploadFile(
+        createFile('application/pdf', 11 * 1024 * 1024, 'scene.pdf'),
+        jpegBuffer
+      )
+    ).toThrow('10MB')
+  })
+
+  test.each([
+    ['jpeg', createFile('image/jpeg', 1024, 'scene.jpeg'), jpegBuffer],
+    ['png', createFile('image/png', 1024, 'scene.png'), pngBuffer],
+    ['gif', createFile('image/gif', 1024, 'scene.gif'), gifBuffer],
+    ['webp', createFile('image/webp', 1024, 'scene.webp'), webpBuffer],
+  ])('accepts %s extension/MIME/binary agreement', (format, file, buffer) => {
+    expect(validateUploadFile(file, buffer)).toBe(format)
   })
 })

--- a/src/lib/upload/validation.ts
+++ b/src/lib/upload/validation.ts
@@ -7,6 +7,12 @@ export const ALLOWED_IMAGE_MIME_TYPES = [
   'image/webp',
 ] as const
 
+const UNRELIABLE_BROWSER_MIME_TYPES = new Set([
+  '',
+  'application/octet-stream',
+  'binary/octet-stream',
+])
+
 export type AllowedImageMimeType = (typeof ALLOWED_IMAGE_MIME_TYPES)[number]
 export type DetectedImageFormat = 'jpeg' | 'png' | 'gif' | 'webp'
 
@@ -106,26 +112,39 @@ export function validateUploadFile(
   file: File,
   buffer: Buffer
 ): DetectedImageFormat {
-  if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type as AllowedImageMimeType)) {
+  if (file.size > TEN_MB) {
     throw new UploadValidationError(
-      '지원되지 않는 파일 형식입니다. JPEG, PNG, GIF, WebP만 업로드할 수 있습니다.'
+      '\ud30c\uc77c \ud06c\uae30\ub294 10MB \uc774\ud558\uc5ec\uc57c \ud569\ub2c8\ub2e4.'
     )
   }
 
-  if (file.size > TEN_MB) {
-    throw new UploadValidationError('파일 크기는 10MB 이하여야 합니다.')
+  const mimeType = file.type || ''
+  const normalizedMimeType = mimeType.toLowerCase()
+  const isAllowedMime = ALLOWED_IMAGE_MIME_TYPES.includes(
+    normalizedMimeType as AllowedImageMimeType
+  )
+  const isUnreliableMime = UNRELIABLE_BROWSER_MIME_TYPES.has(normalizedMimeType)
+
+  if (!isAllowedMime && !isUnreliableMime) {
+    throw new UploadValidationError(
+      '\uc9c0\uc6d0\ub418\uc9c0 \uc54a\ub294 \ud30c\uc77c \ud615\uc2dd\uc785\ub2c8\ub2e4. JPEG, PNG, GIF, WebP\ub9cc \uc5c5\ub85c\ub4dc\ud560 \uc218 \uc788\uc2b5\ub2c8\ub2e4.'
+    )
   }
 
   const detectedFormat = detectImageFormat(buffer)
 
   if (!detectedFormat) {
-    throw new UploadValidationError('파일의 실제 형식을 확인할 수 없습니다.')
+    throw new UploadValidationError(
+      '\ud30c\uc77c\uc758 \uc2e4\uc81c \ud615\uc2dd\uc744 \ud655\uc778\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.'
+    )
   }
 
-  const mimeMatches = formatMatchesMimeType(
-    file.type as AllowedImageMimeType,
-    detectedFormat
-  )
+  const mimeMatches =
+    isAllowedMime &&
+    formatMatchesMimeType(
+      normalizedMimeType as AllowedImageMimeType,
+      detectedFormat
+    )
   const extensionMatches = formatMatchesExtension(
     getFileExtension(file.name),
     detectedFormat
@@ -133,7 +152,7 @@ export function validateUploadFile(
 
   if (!mimeMatches && !extensionMatches) {
     throw new UploadValidationError(
-      '파일 확장자 또는 MIME 타입과 실제 파일 형식이 일치하지 않습니다.'
+      '\ud30c\uc77c \ud655\uc7a5\uc790 \ub610\ub294 MIME \ud0c0\uc785\uacfc \uc2e4\uc81c \ud30c\uc77c \ud615\uc2dd\uc774 \uc77c\uce58\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4.'
     )
   }
 


### PR DESCRIPTION
## 관련 이슈

- Closes #889

---

## PR 타입
- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [x] 🚀 **enhancement**: 기존 기능 개선, 성능 최적화
- [x] 🔧 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📝 **docs**: 문서 수정

---

## 작업 개요

PR #889에서 검증된 QA 하드닝 중 배포에 필요한 런타임/검증 코드만 `main`으로 승격합니다. `.kiro/specs/**/tasks.md` 작업 추적 문서는 main 승격 대상에서 제외했습니다.

---

## 변경 사항

- [x] PR #889의 배포 코드 커밋만 cherry-pick (`7b04d3b`, 원본 `8052cbc`)
- [x] 비로그인 admin 접근의 사전 401 API 호출 방지
- [x] 온보딩/장면 업로드/이미지 렌더링/지도 접근성/route spot availability QA 하드닝 포함
- [x] `/welcome` main route budget 초과를 막기 위해 초기 PWA store import 제거
- [x] CI의 선택적 Sentry auth-token/build-cache 경고가 route size gate를 오염시키지 않도록 release gate 안정화
- [x] `.kiro/specs/**/tasks.md` 문서 커밋 제외 확인

---

## 체크리스트
- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (`npm run build:route-budget`가 내부 build 실행)
- [x] 주요 기능 동작 확인

---

## 스크린샷 (선택)

- 해당 없음

---

## 추가 정보 (선택)

검증:
- `npm run type-check`
- `npm run lint`
- `npm run test:ci` (104 suites / 433 tests)
- `CI=true npm run build:route-budget` without `SENTRY_AUTH_TOKEN`
  - `/welcome` 245 <= 245
  - `/spots/[id]` 309 <= 310
  - `/routes/[id]` 284 <= 285
  - `/gallery` 278 <= 280
  - `/map` 274 <= 275
  - shared 229 <= 230
- `npm run routes:validate:seeded`
- `git diff --check origin/main..HEAD`
- main release diff에 `.kiro/*` 없음 확인

수동 QA:
- PR #889 단계에서 Chrome 실제 브라우저 13 personas 최종 13/13 pass