### PR TITLE
fix(auth): release credential hardening to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ AUTH_SECRET=your-secret-key-here
 # Required when running behind a reverse proxy that Auth.js cannot auto-detect.
 AUTH_TRUST_HOST=true
 
+# Password breach screening
+# Default is enabled and uses the Pwned Passwords k-anonymity range API.
+# Set PWNED_PASSWORD_CHECK=off only for isolated local/dev environments.
+PWNED_PASSWORD_CHECK=
+# If true, signup/password changes fail when the breach API is unavailable.
+PWNED_PASSWORD_CHECK_STRICT=false
+
 # Legacy NextAuth aliases are intentionally omitted. Runtime code reads AUTH_* first
 # and only keeps NEXTAUTH_* as a temporary deployment fallback.
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ postcss.config.mjs
 
 # 마크다운
 *.md
+.omx

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "landing:photos:apply": "node scripts/seed-landing-spot-photos.mjs --apply",
     "lint:release": "node scripts/check-lint-release-warnings.mjs",
     "build:route-budget": "node scripts/check-route-js-budget.mjs",
-    "release:check": "npm run lint && npm run lint:release && npm run type-check && npm run test:ci && npm run build:route-budget",
+    "release:check": "npm run lint && npm run lint:release && npm run format:check && npm run design-token:check && npm run routes:validate && npm run routes:validate:seeded && npm run type-check && npm run test:ci && npm run build:route-budget",
     "design-token:scan": "node scripts/check-design-token-raw-utilities.mjs",
     "design-token:check": "node scripts/check-design-token-raw-utilities.mjs --check",
     "design-token:update-baseline": "node scripts/check-design-token-raw-utilities.mjs --update-baseline"

--- a/src/app/api/account/__tests__/account-api.test.ts
+++ b/src/app/api/account/__tests__/account-api.test.ts
@@ -63,6 +63,10 @@ jest.mock('bcryptjs', () => ({
   ),
 }))
 
+jest.mock('@/lib/security', () => ({
+  validateNewPasswordSecurity: jest.fn(() => Promise.resolve({ ok: true })),
+}))
+
 // --- Imports (after mocks) ---
 import { GET, DELETE } from '../linked-accounts/route'
 import { POST } from '../set-password/route'

--- a/src/app/api/account/change-password/route.test.ts
+++ b/src/app/api/account/change-password/route.test.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from 'next/server'
+
+const mockUsersFindOne = jest.fn()
+const mockUsersUpdateOne = jest.fn()
+const mockValidateNewPasswordSecurity = jest.fn()
+let mockSession: { user: { id: string } } | null = null
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(() => Promise.resolve(mockSession)),
+}))
+
+jest.mock('@/lib/db', () => ({
+  getDb: jest.fn(() =>
+    Promise.resolve({
+      collection: () => ({
+        findOne: mockUsersFindOne,
+        updateOne: mockUsersUpdateOne,
+      }),
+    })
+  ),
+}))
+
+jest.mock('@/lib/security', () => ({
+  validateNewPasswordSecurity: (...args: unknown[]) =>
+    mockValidateNewPasswordSecurity(...args),
+}))
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn((plain: string) =>
+    Promise.resolve(plain === 'current-password')
+  ),
+  hash: jest.fn(() => Promise.resolve('$2a$12$newhash')),
+}))
+
+import { POST } from './route'
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/account/change-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/account/change-password', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSession = { user: { id: '507f1f77bcf86cd799439011' } }
+    mockUsersFindOne.mockResolvedValue({ password: '$2a$12$currenthash' })
+    mockUsersUpdateOne.mockResolvedValue({ modifiedCount: 1 })
+    mockValidateNewPasswordSecurity.mockResolvedValue({ ok: true })
+  })
+
+  test('requires authentication', async () => {
+    mockSession = null
+
+    const response = await POST(
+      createRequest({
+        currentPassword: 'current-password',
+        newPassword: 'new-safe-password',
+      })
+    )
+
+    expect(response.status).toBe(401)
+    expect(mockUsersUpdateOne).not.toHaveBeenCalled()
+  })
+
+  test('rejects the wrong current password before updating', async () => {
+    const response = await POST(
+      createRequest({
+        currentPassword: 'wrong-password',
+        newPassword: 'new-safe-password',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('현재 비밀번호가 일치하지 않습니다.')
+    expect(mockValidateNewPasswordSecurity).not.toHaveBeenCalled()
+    expect(mockUsersUpdateOne).not.toHaveBeenCalled()
+  })
+
+  test('rejects compromised replacement passwords before hashing', async () => {
+    mockValidateNewPasswordSecurity.mockResolvedValue({
+      ok: false,
+      error: 'compromised',
+      status: 400,
+    })
+
+    const response = await POST(
+      createRequest({
+        currentPassword: 'current-password',
+        newPassword: 'password123',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('compromised')
+    expect(mockUsersUpdateOne).not.toHaveBeenCalled()
+  })
+
+  test('updates the stored hash for a valid password change', async () => {
+    const response = await POST(
+      createRequest({
+        currentPassword: 'current-password',
+        newPassword: 'new-safe-password',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.message).toBe('비밀번호가 변경되었습니다.')
+    expect(mockValidateNewPasswordSecurity).toHaveBeenCalledWith(
+      'new-safe-password'
+    )
+    expect(mockUsersUpdateOne).toHaveBeenCalledWith(
+      { _id: expect.anything() },
+      {
+        $set: {
+          password: '$2a$12$newhash',
+          updatedAt: expect.any(Date),
+        },
+      }
+    )
+  })
+})

--- a/src/app/api/account/change-password/route.ts
+++ b/src/app/api/account/change-password/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ObjectId } from 'mongodb'
+import bcrypt from 'bcryptjs'
+import { auth } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+import { runtimeLogger } from '@/lib/runtime-logger'
+import { validateNewPasswordSecurity } from '@/lib/security'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const currentPassword =
+      typeof body.currentPassword === 'string' ? body.currentPassword : ''
+    const newPassword =
+      typeof body.newPassword === 'string' ? body.newPassword : ''
+
+    if (!currentPassword) {
+      return NextResponse.json(
+        { error: '현재 비밀번호를 입력해주세요.' },
+        { status: 400 }
+      )
+    }
+
+    if (newPassword.length < 6) {
+      return NextResponse.json(
+        { error: '새 비밀번호는 최소 6자 이상이어야 합니다.' },
+        { status: 400 }
+      )
+    }
+
+    if (currentPassword === newPassword) {
+      return NextResponse.json(
+        { error: '기존과 다른 새 비밀번호를 입력해주세요.' },
+        { status: 400 }
+      )
+    }
+
+    const db = await getDb()
+    const userId = new ObjectId(session.user.id)
+    const user = await db
+      .collection('users')
+      .findOne({ _id: userId }, { projection: { password: 1 } })
+
+    if (!user?.password) {
+      return NextResponse.json(
+        { error: '이 계정에는 비밀번호가 설정되어 있지 않습니다.' },
+        { status: 409 }
+      )
+    }
+
+    const currentPasswordMatches = await bcrypt.compare(
+      currentPassword,
+      user.password
+    )
+
+    if (!currentPasswordMatches) {
+      return NextResponse.json(
+        { error: '현재 비밀번호가 일치하지 않습니다.' },
+        { status: 400 }
+      )
+    }
+
+    const passwordSecurity = await validateNewPasswordSecurity(newPassword)
+    if (!passwordSecurity.ok) {
+      return NextResponse.json(
+        { error: passwordSecurity.error },
+        { status: passwordSecurity.status }
+      )
+    }
+
+    const hashedPassword = await bcrypt.hash(newPassword, 12)
+
+    await db.collection('users').updateOne(
+      { _id: userId },
+      {
+        $set: {
+          password: hashedPassword,
+          updatedAt: new Date(),
+        },
+      }
+    )
+
+    runtimeLogger.info(
+      `[Account] 비밀번호 변경 완료 — userId: ${session.user.id}`
+    )
+
+    return NextResponse.json({ message: '비밀번호가 변경되었습니다.' })
+  } catch (error) {
+    runtimeLogger.error('[Account] 비밀번호 변경 실패:', error)
+    return NextResponse.json(
+      { error: '처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/account/set-password/route.ts
+++ b/src/app/api/account/set-password/route.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcryptjs'
 import { auth } from '@/lib/auth'
 import { getDb } from '@/lib/db'
 import { runtimeLogger } from '@/lib/runtime-logger'
+import { validateNewPasswordSecurity } from '@/lib/security'
 
 /**
  * POST /api/account/set-password
@@ -32,6 +33,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json(
         { error: '비밀번호는 최소 6자 이상이어야 합니다.' },
         { status: 400 }
+      )
+    }
+
+    const passwordSecurity = await validateNewPasswordSecurity(password)
+    if (!passwordSecurity.ok) {
+      return NextResponse.json(
+        { error: passwordSecurity.error },
+        { status: passwordSecurity.status }
       )
     }
 

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -7,6 +7,7 @@ import {
   logIfSanitized,
   sanitizeOptionalPlainText,
   sanitizePlainText,
+  validateNewPasswordSecurity,
 } from '@/lib/security'
 
 export async function POST(request: NextRequest) {
@@ -16,7 +17,7 @@ export async function POST(request: NextRequest) {
     const email = String(body.email ?? '')
       .trim()
       .toLowerCase()
-    const password = body.password
+    const password = typeof body.password === 'string' ? body.password : ''
     const name = sanitizePlainText(body.name)
     const nickname = sanitizeOptionalPlainText(body.nickname) ?? name
 
@@ -57,6 +58,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: '비밀번호는 최소 6자 이상이어야 합니다.' },
         { status: 400 }
+      )
+    }
+
+    const passwordSecurity = await validateNewPasswordSecurity(password)
+    if (!passwordSecurity.ok) {
+      return NextResponse.json(
+        { error: passwordSecurity.error },
+        { status: passwordSecurity.status }
       )
     }
 

--- a/src/components/admin/AdminStatusReportReview.tsx
+++ b/src/components/admin/AdminStatusReportReview.tsx
@@ -134,10 +134,8 @@ export function AdminStatusReportReview({
         {/* 헤더 */}
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-xl font-bold text-neutral-800">
-              상태 신고 상세
-            </h2>
-            <p className="mt-1 text-sm text-neutral-500">
+            <h2 className="text-xl font-bold text-main-text">상태 신고 상세</h2>
+            <p className="mt-1 text-sm text-sub-text">
               스팟 ID: {report.spotId}
             </p>
           </div>
@@ -145,26 +143,26 @@ export function AdminStatusReportReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-          <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+        <section className="rounded-lg border border-border bg-surface p-4">
+          <h3 className="mb-3 text-sm font-semibold text-main-text">
             기본 정보
           </h3>
           <dl className="grid grid-cols-2 gap-3 text-sm">
             <div>
-              <dt className="text-neutral-400">신고 상태</dt>
-              <dd className="mt-0.5 font-medium text-neutral-700">
+              <dt className="text-sub-text">신고 상태</dt>
+              <dd className="mt-0.5 font-medium text-main-text">
                 {SPOT_STATUS_LABELS[report.status] || report.status}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-400">신고자</dt>
-              <dd className="mt-0.5 font-medium text-neutral-700">
+              <dt className="text-sub-text">신고자</dt>
+              <dd className="mt-0.5 font-medium text-main-text">
                 {report.reporterName}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-400">신고일</dt>
-              <dd className="mt-0.5 font-medium text-neutral-700">
+              <dt className="text-sub-text">신고일</dt>
+              <dd className="mt-0.5 font-medium text-main-text">
                 {new Date(report.createdAt).toLocaleDateString('ko-KR', {
                   year: 'numeric',
                   month: 'long',
@@ -176,19 +174,19 @@ export function AdminStatusReportReview({
         </section>
 
         {/* 설명 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-          <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+        <section className="rounded-lg border border-border bg-surface p-4">
+          <h3 className="mb-3 text-sm font-semibold text-main-text">
             신고 내용
           </h3>
-          <p className="whitespace-pre-wrap text-sm text-neutral-700">
+          <p className="whitespace-pre-wrap text-sm text-main-text">
             {report.description}
           </p>
         </section>
 
         {/* 증거 사진 */}
         {report.photoUrl && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-            <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+          <section className="rounded-lg border border-border bg-surface p-4">
+            <h3 className="mb-3 text-sm font-semibold text-main-text">
               증거 사진
             </h3>
             <div className="relative aspect-video w-full max-w-md overflow-hidden rounded-lg">
@@ -204,34 +202,34 @@ export function AdminStatusReportReview({
         )}
 
         {/* 인라인 메시지 */}
-        {error && <p className="text-sm text-red-500">{error}</p>}
+        {error && <p className="text-sm text-danger">{error}</p>}
         {successMessage && (
-          <p className="text-sm text-green-600">{successMessage}</p>
+          <p className="text-sm text-secondary-700">{successMessage}</p>
         )}
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
           <section className="space-y-4">
             {/* 확인 처리 */}
-            <div className="rounded-lg border border-neutral-200 bg-surface p-4">
-              <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+            <div className="rounded-lg border border-border bg-surface p-4">
+              <h3 className="mb-3 text-sm font-semibold text-main-text">
                 확인 처리
               </h3>
               <button
                 onClick={handleResolve}
                 disabled={loading}
-                className="w-full rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                className="w-full rounded-lg bg-secondary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-secondary-700 disabled:opacity-50"
               >
                 {loading ? '처리중...' : '✅ 확인 완료'}
               </button>
             </div>
 
             {/* 스팟 상태 수동 변경 */}
-            <div className="rounded-lg border border-neutral-200 bg-surface p-4">
-              <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+            <div className="rounded-lg border border-border bg-surface p-4">
+              <h3 className="mb-3 text-sm font-semibold text-main-text">
                 스팟 상태 수동 변경
               </h3>
-              <p className="mb-3 text-xs text-neutral-400">
+              <p className="mb-3 text-xs text-sub-text">
                 스팟 상태를 변경하면 해당 스팟의 대기 중인 모든 신고가 자동으로
                 확인 완료 처리됩니다
               </p>
@@ -241,7 +239,7 @@ export function AdminStatusReportReview({
                   onChange={(e) =>
                     setSelectedStatus(e.target.value as SpotStatus)
                   }
-                  className="flex-1 rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-neutral-400 focus:outline-none focus:ring-1 focus:ring-neutral-400"
+                  className="flex-1 rounded-lg border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   aria-label="스팟 상태 선택"
                 >
                   {SPOT_STATUS_OPTIONS.map((opt) => (
@@ -264,22 +262,22 @@ export function AdminStatusReportReview({
 
         {/* 이미 처리된 신고 안내 */}
         {!isPending && (
-          <div className="rounded-lg bg-neutral-50 p-4 text-center text-sm text-neutral-500">
+          <div className="rounded-lg bg-muted/10 p-4 text-center text-sm text-sub-text">
             이미 확인 완료된 상태 신고입니다
           </div>
         )}
 
-        <section className="rounded-lg border border-red-100 bg-red-50 p-4">
-          <h3 className="mb-2 text-sm font-semibold text-red-700">
+        <section className="rounded-lg border border-danger bg-danger-surface p-4">
+          <h3 className="mb-2 text-sm font-semibold text-danger">
             검토 항목 삭제
           </h3>
-          <p className="mb-3 text-xs text-red-600">
+          <p className="mb-3 text-xs text-danger">
             잘못 접수되었거나 중복된 상태 신고만 삭제하세요.
           </p>
           <button
             onClick={handleDelete}
             disabled={loading}
-            className="w-full rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+            className="w-full rounded-lg bg-danger px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-danger/90 disabled:opacity-50"
           >
             {loading ? '처리중...' : '삭제'}
           </button>
@@ -296,13 +294,13 @@ function ReviewStatusBadge({ reviewStatus }: { reviewStatus: string }) {
   > = {
     pending: {
       label: '대기 중',
-      bgColor: 'bg-amber-100',
-      textColor: 'text-amber-700',
+      bgColor: 'bg-sunset-100',
+      textColor: 'text-sunset-700',
     },
     resolved: {
       label: '확인 완료',
-      bgColor: 'bg-green-100',
-      textColor: 'text-green-700',
+      bgColor: 'bg-secondary-100',
+      textColor: 'text-secondary-700',
     },
   }
   const c = config[reviewStatus] || config.pending

--- a/src/components/admin/AdminSupplementReview.tsx
+++ b/src/components/admin/AdminSupplementReview.tsx
@@ -132,10 +132,8 @@ export function AdminSupplementReview({
         {/* 헤더 */}
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-xl font-bold text-neutral-800">
-              정보 보완 상세
-            </h2>
-            <p className="mt-1 text-sm text-neutral-500">
+            <h2 className="text-xl font-bold text-main-text">정보 보완 상세</h2>
+            <p className="mt-1 text-sm text-sub-text">
               스팟 ID: {supplement.spotId}
             </p>
           </div>
@@ -143,26 +141,26 @@ export function AdminSupplementReview({
         </div>
 
         {/* 기본 정보 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-          <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+        <section className="rounded-lg border border-border bg-surface p-4">
+          <h3 className="mb-3 text-sm font-semibold text-main-text">
             기본 정보
           </h3>
           <dl className="grid grid-cols-2 gap-3 text-sm">
             <div>
-              <dt className="text-neutral-400">보완 유형</dt>
-              <dd className="mt-0.5 font-medium text-neutral-700">
+              <dt className="text-sub-text">보완 유형</dt>
+              <dd className="mt-0.5 font-medium text-main-text">
                 {SUPPLEMENT_TYPE_LABELS[supplement.type] || supplement.type}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-400">기여자</dt>
-              <dd className="mt-0.5 font-medium text-neutral-700">
+              <dt className="text-sub-text">기여자</dt>
+              <dd className="mt-0.5 font-medium text-main-text">
                 {supplement.contributorName}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-400">제출일</dt>
-              <dd className="mt-0.5 font-medium text-neutral-700">
+              <dt className="text-sub-text">제출일</dt>
+              <dd className="mt-0.5 font-medium text-main-text">
                 {new Date(supplement.createdAt).toLocaleDateString('ko-KR', {
                   year: 'numeric',
                   month: 'long',
@@ -174,39 +172,39 @@ export function AdminSupplementReview({
         </section>
 
         {/* 보완 내용 */}
-        <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-          <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+        <section className="rounded-lg border border-border bg-surface p-4">
+          <h3 className="mb-3 text-sm font-semibold text-main-text">
             보완 내용
           </h3>
-          <p className="whitespace-pre-wrap text-sm text-neutral-700">
+          <p className="whitespace-pre-wrap text-sm text-main-text">
             {supplement.content}
           </p>
         </section>
 
         {/* 씬 정보 (scene_info 타입) */}
         {supplement.type === 'scene_info' && supplement.sceneInfo && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-            <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+          <section className="rounded-lg border border-border bg-surface p-4">
+            <h3 className="mb-3 text-sm font-semibold text-main-text">
               씬 정보
             </h3>
             <dl className="space-y-2 text-sm">
               <div>
-                <dt className="text-neutral-400">작품명</dt>
-                <dd className="mt-0.5 font-medium text-neutral-700">
+                <dt className="text-sub-text">작품명</dt>
+                <dd className="mt-0.5 font-medium text-main-text">
                   {supplement.sceneInfo.animeTitle}
                 </dd>
               </div>
               {supplement.sceneInfo.episodeInfo && (
                 <div>
-                  <dt className="text-neutral-400">에피소드</dt>
-                  <dd className="mt-0.5 font-medium text-neutral-700">
+                  <dt className="text-sub-text">에피소드</dt>
+                  <dd className="mt-0.5 font-medium text-main-text">
                     {supplement.sceneInfo.episodeInfo}
                   </dd>
                 </div>
               )}
               {supplement.sceneInfo.captureImageUrl && (
                 <div>
-                  <dt className="mb-1 text-neutral-400">캡처 이미지</dt>
+                  <dt className="mb-1 text-sub-text">캡처 이미지</dt>
                   <div className="relative aspect-video w-full max-w-md overflow-hidden rounded-lg">
                     <Image
                       src={supplement.sceneInfo.captureImageUrl}
@@ -224,8 +222,8 @@ export function AdminSupplementReview({
 
         {/* 사진 (photo 타입) */}
         {supplement.photos && supplement.photos.length > 0 && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-            <h3 className="mb-3 text-sm font-semibold text-neutral-700">
+          <section className="rounded-lg border border-border bg-surface p-4">
+            <h3 className="mb-3 text-sm font-semibold text-main-text">
               첨부 사진 ({supplement.photos.length}장)
             </h3>
             <div className="grid grid-cols-2 gap-3">
@@ -249,9 +247,9 @@ export function AdminSupplementReview({
 
         {/* 반려 사유 (이미 반려된 경우) */}
         {supplement.status === 'rejected' && supplement.rejectionReason && (
-          <div className="rounded-lg bg-red-50 p-4">
-            <p className="text-sm font-medium text-red-700">반려 사유</p>
-            <p className="mt-1 text-sm text-red-600">
+          <div className="rounded-lg bg-danger-surface p-4">
+            <p className="text-sm font-medium text-danger">반려 사유</p>
+            <p className="mt-1 text-sm text-danger">
               {supplement.rejectionReason}
             </p>
           </div>
@@ -259,12 +257,10 @@ export function AdminSupplementReview({
 
         {/* 검토 액션 (pending 상태일 때만) */}
         {isPending && (
-          <section className="rounded-lg border border-neutral-200 bg-surface p-4">
-            <h3 className="mb-3 text-sm font-semibold text-neutral-700">
-              검토
-            </h3>
+          <section className="rounded-lg border border-border bg-surface p-4">
+            <h3 className="mb-3 text-sm font-semibold text-main-text">검토</h3>
 
-            {error && <p className="mb-3 text-sm text-red-500">{error}</p>}
+            {error && <p className="mb-3 text-sm text-danger">{error}</p>}
 
             {showRejectForm ? (
               <div className="space-y-3">
@@ -276,13 +272,13 @@ export function AdminSupplementReview({
                   }}
                   placeholder="반려 사유를 입력하세요 (필수)"
                   rows={3}
-                  className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm focus:border-neutral-400 focus:outline-none focus:ring-1 focus:ring-neutral-400"
+                  className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 />
                 <div className="flex gap-2">
                   <button
                     onClick={handleReject}
                     disabled={loading}
-                    className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                    className="flex-1 rounded-lg bg-danger px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-danger/90 disabled:opacity-50"
                   >
                     {loading ? '처리중...' : '❌ 반려 확인'}
                   </button>
@@ -293,7 +289,7 @@ export function AdminSupplementReview({
                       setError(null)
                     }}
                     disabled={loading}
-                    className="rounded-lg bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-200 disabled:opacity-50"
+                    className="rounded-lg bg-muted/15 px-4 py-2 text-sm font-medium text-sub-text transition-colors hover:bg-muted/25 disabled:opacity-50"
                   >
                     취소
                   </button>
@@ -304,14 +300,14 @@ export function AdminSupplementReview({
                 <button
                   onClick={handleApprove}
                   disabled={loading}
-                  className="flex-1 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                  className="flex-1 rounded-lg bg-secondary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-secondary-700 disabled:opacity-50"
                 >
                   {loading ? '처리중...' : '✅ 승인'}
                 </button>
                 <button
                   onClick={() => setShowRejectForm(true)}
                   disabled={loading}
-                  className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                  className="flex-1 rounded-lg bg-danger px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-danger/90 disabled:opacity-50"
                 >
                   ❌ 반려
                 </button>
@@ -322,22 +318,22 @@ export function AdminSupplementReview({
 
         {/* 이미 처리된 보완 안내 */}
         {!isPending && supplement.status !== 'rejected' && (
-          <div className="rounded-lg bg-neutral-50 p-4 text-center text-sm text-neutral-500">
+          <div className="rounded-lg bg-muted/10 p-4 text-center text-sm text-sub-text">
             이미 처리된 정보 보완입니다
           </div>
         )}
 
-        <section className="rounded-lg border border-red-100 bg-red-50 p-4">
-          <h3 className="mb-2 text-sm font-semibold text-red-700">
+        <section className="rounded-lg border border-danger bg-danger-surface p-4">
+          <h3 className="mb-2 text-sm font-semibold text-danger">
             검토 항목 삭제
           </h3>
-          <p className="mb-3 text-xs text-red-600">
+          <p className="mb-3 text-xs text-danger">
             잘못 접수되었거나 중복된 정보 보완 요청만 삭제하세요.
           </p>
           <button
             onClick={handleDelete}
             disabled={loading}
-            className="w-full rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+            className="w-full rounded-lg bg-danger px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-danger/90 disabled:opacity-50"
           >
             {loading ? '처리중...' : '삭제'}
           </button>
@@ -354,18 +350,18 @@ function SupplementStatusBadge({ status }: { status: string }) {
   > = {
     pending: {
       label: '대기중',
-      bgColor: 'bg-amber-100',
-      textColor: 'text-amber-700',
+      bgColor: 'bg-sunset-100',
+      textColor: 'text-sunset-700',
     },
     approved: {
       label: '승인',
-      bgColor: 'bg-green-100',
-      textColor: 'text-green-700',
+      bgColor: 'bg-secondary-100',
+      textColor: 'text-secondary-700',
     },
     rejected: {
       label: '반려',
-      bgColor: 'bg-red-100',
-      textColor: 'text-red-700',
+      bgColor: 'bg-danger-surface',
+      textColor: 'text-danger',
     },
   }
   const c = config[status] || config.pending

--- a/src/components/profile/sections/ManagementSection.tsx
+++ b/src/components/profile/sections/ManagementSection.tsx
@@ -214,6 +214,137 @@ function SetPasswordForm({
 
 // ── 프로필 이미지 업로드 상수 ────────────────────────────────
 
+function ChangePasswordForm({
+  onSubmit,
+  isPending,
+  error,
+}: {
+  onSubmit: (currentPassword: string, newPassword: string) => Promise<void>
+  isPending: boolean
+  error: string | null
+}) {
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setValidationError(null)
+    setSuccess(false)
+
+    if (!currentPassword) {
+      setValidationError('현재 비밀번호를 입력해주세요.')
+      return
+    }
+    if (newPassword.length < 6) {
+      setValidationError('새 비밀번호는 최소 6자 이상이어야 합니다.')
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      setValidationError('새 비밀번호가 일치하지 않습니다.')
+      return
+    }
+    if (currentPassword === newPassword) {
+      setValidationError('기존과 다른 새 비밀번호를 입력해주세요.')
+      return
+    }
+
+    try {
+      await onSubmit(currentPassword, newPassword)
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+      setSuccess(true)
+    } catch {
+      // error is exposed by the mutation hook.
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="current-password"
+          className="mb-1 block text-sm font-medium text-text-secondary"
+        >
+          현재 비밀번호
+        </label>
+        <input
+          id="current-password"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          required
+          autoComplete="current-password"
+          className="w-full rounded-lg border border-border bg-surface px-4 py-3 text-text-primary placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary"
+          placeholder="현재 비밀번호"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="change-new-password"
+          className="mb-1 block text-sm font-medium text-text-secondary"
+        >
+          새 비밀번호
+        </label>
+        <input
+          id="change-new-password"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          required
+          minLength={6}
+          autoComplete="new-password"
+          className="w-full rounded-lg border border-border bg-surface px-4 py-3 text-text-primary placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary"
+          placeholder="최소 6자 이상"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="change-confirm-password"
+          className="mb-1 block text-sm font-medium text-text-secondary"
+        >
+          새 비밀번호 확인
+        </label>
+        <input
+          id="change-confirm-password"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          minLength={6}
+          autoComplete="new-password"
+          className="w-full rounded-lg border border-border bg-surface px-4 py-3 text-text-primary placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary"
+          placeholder="새 비밀번호 재입력"
+        />
+      </div>
+
+      {(validationError || error) && (
+        <p className="rounded-lg border border-danger bg-danger-surface p-3 text-sm text-danger">
+          {validationError || error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-lg border border-secondary-600 bg-secondary-100 p-3 text-sm text-secondary-700">
+          비밀번호가 변경되었습니다. 다음 로그인부터 새 비밀번호를 사용하세요.
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-full rounded-lg bg-primary py-3 text-surface transition hover:opacity-90 disabled:opacity-50"
+      >
+        {isPending ? '변경 중...' : '비밀번호 변경'}
+      </button>
+    </form>
+  )
+}
+
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
 const ALLOWED_TYPES_LABEL = 'JPG, PNG, GIF, WEBP'
@@ -442,6 +573,9 @@ function AccountsTab() {
     setPassword,
     isSettingPassword,
     setPasswordError,
+    changePassword,
+    isChangingPassword,
+    changePasswordError,
   } = useLinkedAccounts()
 
   const [actionError, setActionError] = useState<string | null>(null)
@@ -569,6 +703,23 @@ function AccountsTab() {
       </div>
 
       {/* 비밀번호 설정 폼 (소셜 전용 계정만) */}
+      {hasPassword && (
+        <div className="rounded-lg border border-border bg-surface p-4">
+          <h3 className="mb-2 text-base font-semibold text-text-primary">
+            비밀번호 변경
+          </h3>
+          <p className="mb-4 text-sm text-text-secondary">
+            브라우저가 유출된 비밀번호를 경고했다면 즉시 다른 비밀번호로
+            변경하세요.
+          </p>
+          <ChangePasswordForm
+            onSubmit={changePassword}
+            isPending={isChangingPassword}
+            error={changePasswordError}
+          />
+        </div>
+      )}
+
       {!hasPassword && (
         <div className="rounded-lg border border-border bg-surface p-4">
           <h3 className="mb-2 text-base font-semibold text-text-primary">

--- a/src/hooks/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts.ts
@@ -22,6 +22,11 @@ interface UnlinkError {
   error: string
 }
 
+interface ChangePasswordInput {
+  currentPassword: string
+  newPassword: string
+}
+
 // ── Query Keys ──────────────────────────────────────────────
 
 export const linkedAccountKeys = {
@@ -101,6 +106,24 @@ export function useLinkedAccounts() {
     },
   })
 
+  const changePasswordMutation = useMutation({
+    mutationFn: async ({
+      currentPassword,
+      newPassword,
+    }: ChangePasswordInput) => {
+      const res = await fetch(API_ROUTES.ACCOUNT.CHANGE_PASSWORD, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      })
+      if (!res.ok) {
+        const data: UnlinkError = await res.json()
+        throw new Error(data.error || '비밀번호 변경 실패')
+      }
+      return res.json()
+    },
+  })
+
   // 계정 연결 래퍼 (signIn 호출)
   const linkAccount = useCallback((provider: string) => {
     signIn(provider, { callbackUrl: '/settings/account' })
@@ -122,6 +145,16 @@ export function useLinkedAccounts() {
     [setPasswordMutation]
   )
 
+  const changePassword = useCallback(
+    async (currentPassword: string, newPassword: string) => {
+      await changePasswordMutation.mutateAsync({
+        currentPassword,
+        newPassword,
+      })
+    },
+    [changePasswordMutation]
+  )
+
   return {
     accounts: data?.accounts ?? [],
     hasPassword: data?.hasPassword ?? false,
@@ -135,5 +168,8 @@ export function useLinkedAccounts() {
     setPassword,
     isSettingPassword: setPasswordMutation.isPending,
     setPasswordError: setPasswordMutation.error?.message ?? null,
+    changePassword,
+    isChangingPassword: changePasswordMutation.isPending,
+    changePasswordError: changePasswordMutation.error?.message ?? null,
   }
 }

--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -108,6 +108,7 @@ export const API_ROUTES = {
   ACCOUNT: {
     LINKED_ACCOUNTS: '/api/account/linked-accounts',
     SET_PASSWORD: '/api/account/set-password',
+    CHANGE_PASSWORD: '/api/account/change-password',
   },
 
   // Admin

--- a/src/lib/release-check-contract.test.ts
+++ b/src/lib/release-check-contract.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs'
+import path from 'path'
+
+const repoRoot = process.cwd()
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+describe('release readiness command contract', () => {
+  it('runs the gates that protect formatting, tokens, route data, tests, and build budgets', () => {
+    const packageJson = JSON.parse(readText('package.json')) as {
+      scripts: Record<string, string>
+    }
+
+    const releaseCheck = packageJson.scripts['release:check']
+
+    expect(releaseCheck).toBeDefined()
+    expect(releaseCheck).toEqual(expect.stringContaining('npm run lint'))
+    expect(releaseCheck).toEqual(
+      expect.stringContaining('npm run lint:release')
+    )
+    expect(releaseCheck).toEqual(
+      expect.stringContaining('npm run format:check')
+    )
+    expect(releaseCheck).toEqual(
+      expect.stringContaining('npm run design-token:check')
+    )
+    expect(releaseCheck).toEqual(
+      expect.stringContaining('npm run routes:validate')
+    )
+    expect(releaseCheck).toEqual(
+      expect.stringContaining('npm run routes:validate:seeded')
+    )
+    expect(releaseCheck).toEqual(expect.stringContaining('npm run type-check'))
+    expect(releaseCheck).toEqual(expect.stringContaining('npm run test:ci'))
+    expect(releaseCheck).toEqual(
+      expect.stringContaining('npm run build:route-budget')
+    )
+  })
+
+  it('keeps local OMX runtime artifacts out of repository-wide Prettier checks', () => {
+    const prettierIgnore = readText('.prettierignore')
+
+    expect(prettierIgnore.split(/\r?\n/)).toContain('.omx')
+  })
+})

--- a/src/lib/security/index.ts
+++ b/src/lib/security/index.ts
@@ -1,6 +1,7 @@
 export * from './auth-security'
 export * from './input-sanitizer'
 export * from './nsfw-moderation'
+export * from './pwned-passwords'
 export * from './rate-limit'
 export * from './security-log'
 export * from './spam-guard'

--- a/src/lib/security/pwned-passwords-api-contract.test.ts
+++ b/src/lib/security/pwned-passwords-api-contract.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+const repoRoot = process.cwd()
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+describe('new password API security contract', () => {
+  test.each([
+    ['src/app/api/auth/register/route.ts', 'password'],
+    ['src/app/api/account/set-password/route.ts', 'password'],
+    ['src/app/api/account/change-password/route.ts', 'newPassword'],
+  ])(
+    '%s validates breach exposure before hashing a new password',
+    (file, passwordVariable) => {
+      const source = read(file)
+      const validateIndex = source.indexOf(
+        `validateNewPasswordSecurity(${passwordVariable})`
+      )
+      const hashIndex = source.indexOf(`bcrypt.hash(${passwordVariable}`)
+
+      expect(validateIndex).toBeGreaterThan(-1)
+      expect(hashIndex).toBeGreaterThan(-1)
+      expect(validateIndex).toBeLessThan(hashIndex)
+    }
+  )
+})

--- a/src/lib/security/pwned-passwords.test.ts
+++ b/src/lib/security/pwned-passwords.test.ts
@@ -1,0 +1,89 @@
+import {
+  COMPROMISED_PASSWORD_ERROR,
+  checkPwnedPassword,
+  getPwnedPasswordHashParts,
+  validateNewPasswordSecurity,
+} from './pwned-passwords'
+
+describe('pwned password checks', () => {
+  test('blocks obvious locally compromised passwords without a network request', async () => {
+    const fetcher = jest.fn()
+
+    const result = await checkPwnedPassword('password123', {
+      fetcher: fetcher as unknown as typeof fetch,
+    })
+
+    expect(result).toEqual({
+      compromised: true,
+      count: 1,
+      source: 'local',
+    })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  test('uses k-anonymity range lookup without sending the full hash suffix', async () => {
+    const password = 'correct horse battery staple 2026!'
+    const { prefix, suffix } = getPwnedPasswordHashParts(password)
+    const fetcher = jest.fn(async (url: string) => {
+      expect(url).toBe(`https://api.pwnedpasswords.com/range/${prefix}`)
+      expect(url).not.toContain(suffix)
+
+      return new Response(
+        `${suffix}:42\r\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:1`
+      )
+    })
+
+    const result = await checkPwnedPassword(password, {
+      fetcher: fetcher as unknown as typeof fetch,
+    })
+
+    expect(result).toEqual({
+      compromised: true,
+      count: 42,
+      source: 'pwned-passwords',
+    })
+  })
+
+  test('passes when the range response does not contain the hash suffix', async () => {
+    const fetcher = jest.fn(async () => new Response('ABCDEF:1\r\n123456:2'))
+
+    const result = await checkPwnedPassword('not in the sample response', {
+      fetcher: fetcher as unknown as typeof fetch,
+    })
+
+    expect(result).toEqual({
+      compromised: false,
+      count: 0,
+      source: 'pwned-passwords',
+    })
+  })
+
+  test('returns a user-safe validation error for compromised passwords', async () => {
+    const result = await validateNewPasswordSecurity('123456')
+
+    expect(result).toEqual({
+      ok: false,
+      error: COMPROMISED_PASSWORD_ERROR,
+      status: 400,
+    })
+  })
+
+  test('can run in strict mode when the breach service is unavailable', async () => {
+    const result = await validateNewPasswordSecurity('network outage sample', {
+      env: {
+        NODE_ENV: 'test',
+        PWNED_PASSWORD_CHECK_STRICT: 'true',
+      },
+      fetcher: jest.fn(async () => {
+        throw new Error('network unavailable')
+      }) as unknown as typeof fetch,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        '비밀번호 유출 여부를 확인하지 못했습니다. 잠시 후 다시 시도해주세요.',
+      status: 503,
+    })
+  })
+})

--- a/src/lib/security/pwned-passwords.ts
+++ b/src/lib/security/pwned-passwords.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'crypto'
+import { runtimeLogger } from '@/lib/runtime-logger'
+
+export const COMPROMISED_PASSWORD_ERROR =
+  '이 비밀번호는 알려진 정보 유출 데이터에 포함되어 있어 사용할 수 없습니다. 다른 비밀번호를 사용해주세요.'
+
+export const PASSWORD_BREACH_CHECK_UNAVAILABLE_ERROR =
+  '비밀번호 유출 여부를 확인하지 못했습니다. 잠시 후 다시 시도해주세요.'
+
+const PWNED_PASSWORDS_RANGE_ENDPOINT = 'https://api.pwnedpasswords.com/range'
+const DEFAULT_TIMEOUT_MS = 2500
+
+const COMMON_COMPROMISED_PASSWORDS = new Set(
+  [
+    '000000',
+    '111111',
+    '123123',
+    '123456',
+    '1234567',
+    '12345678',
+    '123456789',
+    '1234567890',
+    'admin',
+    'admin123',
+    'iloveyou',
+    'letmein',
+    'password',
+    'password1',
+    'password123',
+    'qwerty',
+    'qwerty123',
+    'test123',
+    'welcome',
+    'welcome1',
+  ].map((value) => value.toLowerCase())
+)
+
+export interface PwnedPasswordCheckResult {
+  compromised: boolean
+  count: number
+  source: 'local' | 'pwned-passwords' | 'disabled' | 'unavailable'
+}
+
+export interface PwnedPasswordCheckOptions {
+  fetcher?: typeof fetch
+  timeoutMs?: number
+  env?: NodeJS.ProcessEnv
+}
+
+function sha1Upper(value: string): string {
+  return createHash('sha1').update(value, 'utf8').digest('hex').toUpperCase()
+}
+
+export function getPwnedPasswordHashParts(password: string): {
+  prefix: string
+  suffix: string
+} {
+  const hash = sha1Upper(password)
+  return {
+    prefix: hash.slice(0, 5),
+    suffix: hash.slice(5),
+  }
+}
+
+function isLocalCommonCompromisedPassword(password: string): boolean {
+  return COMMON_COMPROMISED_PASSWORDS.has(password.trim().toLowerCase())
+}
+
+function isCheckDisabled(env: NodeJS.ProcessEnv): boolean {
+  return ['0', 'false', 'off', 'disabled'].includes(
+    String(env.PWNED_PASSWORD_CHECK ?? '')
+      .trim()
+      .toLowerCase()
+  )
+}
+
+function isStrictMode(env: NodeJS.ProcessEnv): boolean {
+  return ['1', 'true', 'strict'].includes(
+    String(env.PWNED_PASSWORD_CHECK_STRICT ?? '')
+      .trim()
+      .toLowerCase()
+  )
+}
+
+async function fetchRangeWithTimeout(
+  url: string,
+  fetcher: typeof fetch,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    return await fetcher(url, {
+      headers: {
+        'Add-Padding': 'true',
+        'User-Agent': 'not-a-trip-password-safety',
+      },
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function checkPwnedPassword(
+  password: string,
+  options: PwnedPasswordCheckOptions = {}
+): Promise<PwnedPasswordCheckResult> {
+  const env = options.env ?? process.env
+
+  if (isLocalCommonCompromisedPassword(password)) {
+    return {
+      compromised: true,
+      count: 1,
+      source: 'local',
+    }
+  }
+
+  if (isCheckDisabled(env)) {
+    return {
+      compromised: false,
+      count: 0,
+      source: 'disabled',
+    }
+  }
+
+  const { prefix, suffix } = getPwnedPasswordHashParts(password)
+  const fetcher = options.fetcher ?? fetch
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  try {
+    const response = await fetchRangeWithTimeout(
+      `${PWNED_PASSWORDS_RANGE_ENDPOINT}/${prefix}`,
+      fetcher,
+      timeoutMs
+    )
+
+    if (!response.ok) {
+      throw new Error(`Pwned Passwords responded with ${response.status}`)
+    }
+
+    const rows = (await response.text()).split(/\r?\n/)
+    const match = rows
+      .map((row) => row.trim())
+      .find((row) => row.toUpperCase().startsWith(`${suffix}:`))
+
+    if (!match) {
+      return {
+        compromised: false,
+        count: 0,
+        source: 'pwned-passwords',
+      }
+    }
+
+    const count = Number(match.split(':')[1] ?? 0)
+
+    return {
+      compromised: true,
+      count: Number.isFinite(count) ? count : 1,
+      source: 'pwned-passwords',
+    }
+  } catch (error) {
+    runtimeLogger.warn('[Security] Pwned password check unavailable', error)
+
+    return {
+      compromised: false,
+      count: 0,
+      source: 'unavailable',
+    }
+  }
+}
+
+export async function validateNewPasswordSecurity(
+  password: string,
+  options: PwnedPasswordCheckOptions = {}
+): Promise<{ ok: true } | { ok: false; error: string; status: number }> {
+  const result = await checkPwnedPassword(password, options)
+
+  if (result.compromised) {
+    return {
+      ok: false,
+      error: COMPROMISED_PASSWORD_ERROR,
+      status: 400,
+    }
+  }
+
+  if (
+    result.source === 'unavailable' &&
+    isStrictMode(options.env ?? process.env)
+  ) {
+    return {
+      ok: false,
+      error: PASSWORD_BREACH_CHECK_UNAVAILABLE_ERROR,
+      status: 503,
+    }
+  }
+
+  return { ok: true }
+}


### PR DESCRIPTION
## ?? ?? ??

- N/A (main release for PR #899 and PR #900)

---

## ?? PR ??

- [ ] **feat**: ??? ?? ??
- [x] **fix**: ?? ??
- [x] **ui**: UI/UX ??, ??? ??
- [x] **enhancement**: ?? ?? ??, ??/?? ???
- [x] **chore**: ??, ??, ??? ??
- [ ] **refactor**: ?? ???? (?? ?? ??)
- [ ] **docs**: ?? ??

---

## ?? ?? ??

> develop? PR #899, #900 ? ?? ??? ??? ??/?? ??? main ?? ???? cherry-pick????. ???? ?? ???? ??? ??? ??, ? ?? ???? ?? ??? ?? ???? ?? ??? ?????.

---

## ?? ?? ??

- [x] release:check? format/design-token/route-data/test/build-budget gate? ?? ????? main? ??
- [x] admin ?? UI raw color utility ?? ??
- [x] Pwned Passwords k-anonymity range API ?? ??? ?? ???? ?? ??
- [x] ????, ???/???? ??, ???? ?? ???? ?? ???? ??
- [x] ??? ?? ?? ??? ???? ?? ? ??
- [x] ?? API/??/?? ??? ??

---

## ? ?????

- [x] `npm run lint` ??
- [x] `npm run build:route-budget` ??
- [x] ?? ?? ?? ??: `npm run release:check` ?? ??

---

## ?? ???? (??)

- N/A (??/API ? ?? ?? ? ??)

---

## ?? ?? ?? (??)

- main branch ?? ??: `npm run release:check` ? 115 suites, 458 tests ??
- ?? develop? main? ???? ??, ?? ?? ?? ?? `cd93215`, `cfb0a22`? cherry-pick????.
- ???? password-manager ??? ??? ??? ? ?? ?? ?????.
