### PR TITLE
fix: correct production SEO canonical domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ MONGODB_URI=mongodb://localhost:27017/not-a-trip
 MONGODB_DB=not-a-trip
 
 # Auth.js / NextAuth v5
-# Production must use the canonical https:// site URL.
+# Production must use https://www.not-a-trip.xyz.
 AUTH_URL=http://localhost:3000
 # Required. Replace with a strong random value in every non-local environment.
 AUTH_SECRET=your-secret-key-here
@@ -16,6 +16,8 @@ AUTH_TRUST_HOST=true
 # Default is enabled and uses the Pwned Passwords k-anonymity range API.
 # Set PWNED_PASSWORD_CHECK=off only for isolated local/dev environments.
 PWNED_PASSWORD_CHECK=
+# Production decision: keep false unless the product explicitly accepts
+# signup/password-change outages during Pwned Passwords API incidents.
 # If true, signup/password changes fail when the breach API is unavailable.
 PWNED_PASSWORD_CHECK_STRICT=false
 
@@ -43,7 +45,7 @@ TWITTER_CLIENT_SECRET=your-twitter-client-secret
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key
 
 # Site URL (SEO)
-# Production must use the canonical https:// site URL.
+# Production must use https://www.not-a-trip.xyz.
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # Google Analytics 4

--- a/src/app/(landing)/welcome/page.tsx
+++ b/src/app/(landing)/welcome/page.tsx
@@ -7,15 +7,27 @@ import {
   fetchProofImages,
 } from '@/components/landing/data/fetchShowcaseSpots'
 import { auth } from '@/lib/auth'
+import {
+  SITE_NAME,
+  getCanonicalUrl,
+  getDefaultOgImage,
+} from '@/lib/seo/metadata'
 
 export const metadata: Metadata = {
   title: '환영합니다',
   description:
     '관광지가 아닌 성지를 탐험하세요. 애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+  alternates: {
+    canonical: getCanonicalUrl('/welcome'),
+  },
   openGraph: {
     title: 'Not a Trip - 관광지가 아닌 성지를 탐험하세요',
     description:
       '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    url: getCanonicalUrl('/welcome'),
+    type: 'website',
+    siteName: SITE_NAME,
+    images: [getDefaultOgImage()],
   },
 }
 

--- a/src/app/(main)/contents/[name]/page.tsx
+++ b/src/app/(main)/contents/[name]/page.tsx
@@ -1,5 +1,11 @@
 import { Metadata } from 'next'
 import { ContentHubClient } from '@/components/content/ContentHubClient'
+import {
+  DEFAULT_SEO_KEYWORDS,
+  SITE_NAME,
+  getCanonicalUrl,
+  getDefaultOgImage,
+} from '@/lib/seo/metadata'
 
 interface ContentHubPageProps {
   params: Promise<{ name: string }>
@@ -14,13 +20,31 @@ export async function generateMetadata({
 }: ContentHubPageProps): Promise<Metadata> {
   const { name } = await params
   const contentName = decodeURIComponent(name)
+  const canonicalUrl = getCanonicalUrl(
+    `/contents/${encodeURIComponent(contentName)}`
+  )
+  const title = `${contentName} 작품 허브`
+  const description = `${contentName} 관련 성지순례 스팟, 코스, 인증 정보를 한눈에 확인하세요.`
 
   return {
-    title: `${contentName} - 작품 허브 | Not a Trip`,
-    description: `${contentName} 관련 성지순례 스팟, 코스, 인증 정보를 한눈에 확인하세요.`,
+    title,
+    description,
+    keywords: [
+      contentName,
+      '작품 허브',
+      '작품별 성지순례',
+      ...DEFAULT_SEO_KEYWORDS,
+    ],
+    alternates: {
+      canonical: canonicalUrl,
+    },
     openGraph: {
-      title: `${contentName} - 작품 허브`,
-      description: `${contentName} 관련 성지순례 스팟, 코스, 인증 정보를 한눈에 확인하세요.`,
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url: canonicalUrl,
+      type: 'website',
+      siteName: SITE_NAME,
+      images: [getDefaultOgImage()],
     },
   }
 }

--- a/src/app/(main)/contents/page.tsx
+++ b/src/app/(main)/contents/page.tsx
@@ -1,13 +1,32 @@
 import { Metadata } from 'next'
 import { ContentListClient } from '@/components/content/ContentListClient'
 import { fetchDiscoverableContents } from '@/lib/content-list'
+import {
+  DEFAULT_SEO_KEYWORDS,
+  SITE_NAME,
+  getCanonicalUrl,
+  getDefaultOgImage,
+} from '@/lib/seo/metadata'
 
 export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
-  title: '콘텐츠 탐색 | Not a Trip',
+  title: '콘텐츠 탐색',
   description:
     '애니메이션, 게임, 아티스트 콘텐츠를 탐색하고 관련 성지순례 스팟을 찾아보세요.',
+  keywords: ['콘텐츠 탐색', '작품별 성지순례', ...DEFAULT_SEO_KEYWORDS],
+  alternates: {
+    canonical: getCanonicalUrl('/contents'),
+  },
+  openGraph: {
+    title: `콘텐츠 탐색 | ${SITE_NAME}`,
+    description:
+      '애니메이션, 게임, 아티스트 콘텐츠를 탐색하고 관련 성지순례 스팟을 찾아보세요.',
+    url: getCanonicalUrl('/contents'),
+    type: 'website',
+    siteName: SITE_NAME,
+    images: [getDefaultOgImage()],
+  },
 }
 
 export default async function ContentsPage() {

--- a/src/app/community/layout.tsx
+++ b/src/app/community/layout.tsx
@@ -8,6 +8,9 @@ export const metadata: Metadata = {
   title: '커뮤니티',
   description:
     '팬들과 함께 성지 방문 경험을 나누고 정보를 공유하세요. 스팟 후기, 여행 팁, 작품 이야기를 자유롭게 올릴 수 있습니다.',
+  alternates: {
+    canonical: `${baseUrl}/community`,
+  },
   openGraph: {
     title: '커뮤니티 | Not a Trip',
     description:

--- a/src/app/gallery/layout.tsx
+++ b/src/app/gallery/layout.tsx
@@ -8,6 +8,9 @@ export const metadata: Metadata = {
   title: '갤러리',
   description:
     '팬들의 성지 인증과 명예의 전당을 확인하세요. 애니메이션, 영화, 스포츠 직관 등 다양한 현장 순간을 공유합니다.',
+  alternates: {
+    canonical: `${baseUrl}/gallery`,
+  },
   openGraph: {
     title: '갤러리 | Not a Trip',
     description:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,16 @@ import 'leaflet/dist/leaflet.css'
 import './globals.css'
 import JsonLd from '@/components/seo/JsonLd'
 import GoogleAnalytics from '@/components/seo/GoogleAnalytics'
-import { generateWebSiteJsonLd } from '@/lib/seo/json-ld'
-import { getBaseUrl } from '@/lib/seo/metadata'
+import {
+  generateOrganizationJsonLd,
+  generateWebSiteJsonLd,
+} from '@/lib/seo/json-ld'
+import {
+  DEFAULT_SEO_KEYWORDS,
+  DEFAULT_SITE_DESCRIPTION,
+  DEFAULT_SITE_TITLE,
+  getBaseUrl,
+} from '@/lib/seo/metadata'
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -27,10 +35,10 @@ export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   title: {
     template: '%s | Not a Trip',
-    default: 'Not a Trip - 애니메이션·영화 성지순례 여행 기록',
+    default: DEFAULT_SITE_TITLE,
   },
-  description:
-    '애니메이션과 영화의 배경지를 찾아, 덕질 경험을 기록하고 공유하는 성지순례 여행 플랫폼입니다.',
+  description: DEFAULT_SITE_DESCRIPTION,
+  keywords: DEFAULT_SEO_KEYWORDS,
   alternates: {
     canonical: baseUrl,
   },
@@ -44,16 +52,14 @@ export const metadata: Metadata = {
     siteName: 'Not a Trip',
     type: 'website',
     url: baseUrl,
-    title: 'Not a Trip - 애니메이션·영화 성지순례 여행 기록',
-    description:
-      '애니메이션과 영화의 배경지를 찾아, 덕질 경험을 기록하고 공유하는 성지순례 여행 플랫폼입니다.',
+    title: DEFAULT_SITE_TITLE,
+    description: DEFAULT_SITE_DESCRIPTION,
     images: [`${baseUrl}/api/og?type=default`],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Not a Trip - 애니메이션·영화 성지순례 여행 기록',
-    description:
-      '애니메이션과 영화의 배경지를 찾아, 덕질 경험을 기록하고 공유하는 성지순례 여행 플랫폼입니다.',
+    title: DEFAULT_SITE_TITLE,
+    description: DEFAULT_SITE_DESCRIPTION,
     images: [`${baseUrl}/api/og?type=default`],
   },
 }
@@ -71,6 +77,7 @@ export default function RootLayout({
       <body className={`${pretendard.variable} antialiased`}>
         <GoogleAnalytics />
         <JsonLd data={generateWebSiteJsonLd()} />
+        <JsonLd data={generateOrganizationJsonLd()} />
         {children}
       </body>
     </html>

--- a/src/app/routes/[id]/page.tsx
+++ b/src/app/routes/[id]/page.tsx
@@ -2,10 +2,14 @@ import type { Metadata } from 'next'
 import { getCollection, COLLECTIONS } from '@/lib/db'
 import {
   generateRouteMetadata,
+  getCanonicalUrl,
   getDefaultMetadata,
   type RouteSeoData,
 } from '@/lib/seo/metadata'
-import { generateRouteJsonLd } from '@/lib/seo/json-ld'
+import {
+  generateBreadcrumbJsonLd,
+  generateRouteJsonLd,
+} from '@/lib/seo/json-ld'
 import JsonLd from '@/components/seo/JsonLd'
 import RouteDetailClient from '@/components/route/RouteDetailClient'
 
@@ -66,6 +70,15 @@ export default async function RouteDetailPage({
   return (
     <>
       {route && <JsonLd data={generateRouteJsonLd(route)} />}
+      {route && (
+        <JsonLd
+          data={generateBreadcrumbJsonLd([
+            { name: '홈', url: getCanonicalUrl('/') },
+            { name: '코스', url: getCanonicalUrl('/routes') },
+            { name: route.name, url: getCanonicalUrl(`/routes/${route.id}`) },
+          ])}
+        />
+      )}
       <RouteDetailClient />
     </>
   )

--- a/src/app/routes/layout.tsx
+++ b/src/app/routes/layout.tsx
@@ -8,6 +8,9 @@ export const metadata: Metadata = {
   title: '코스',
   description:
     '다른 팬들이 만든 코스를 탐색하고 따라가보세요. 애니메이션, 영화 촬영지, 콘서트 명소 등 테마별 코스를 제공합니다.',
+  alternates: {
+    canonical: `${baseUrl}/routes`,
+  },
   openGraph: {
     title: '코스 | Not a Trip',
     description:

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,7 +13,25 @@ function getStaticPages(baseUrl: string): MetadataRoute.Sitemap {
       priority: 1.0,
     },
     {
+      url: `${baseUrl}/welcome`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/map`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/gallery`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/contents`,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 0.8,

--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -2,10 +2,11 @@ import type { Metadata } from 'next'
 import { getCollection, COLLECTIONS } from '@/lib/db'
 import {
   generateSpotMetadata,
+  getCanonicalUrl,
   getDefaultMetadata,
   type SpotSeoData,
 } from '@/lib/seo/metadata'
-import { generateSpotJsonLd } from '@/lib/seo/json-ld'
+import { generateBreadcrumbJsonLd, generateSpotJsonLd } from '@/lib/seo/json-ld'
 import JsonLd from '@/components/seo/JsonLd'
 import SpotDetailClient from '@/components/spot/SpotDetailClient'
 
@@ -70,6 +71,15 @@ export default async function SpotDetailPage({
   return (
     <>
       {spot && <JsonLd data={generateSpotJsonLd(spot)} />}
+      {spot && (
+        <JsonLd
+          data={generateBreadcrumbJsonLd([
+            { name: '홈', url: getCanonicalUrl('/') },
+            { name: '스팟', url: getCanonicalUrl('/map') },
+            { name: spot.name, url: getCanonicalUrl(`/spots/${spot.id}`) },
+          ])}
+        />
+      )}
       <SpotDetailClient />
     </>
   )

--- a/src/lib/deployment/seo-validator.ts
+++ b/src/lib/deployment/seo-validator.ts
@@ -62,10 +62,13 @@ export function validateSeoMetadata(options?: {
       layoutSource.includes('alternates:') ||
       metadataUtilSource.includes('alternates:'),
     hasAbsoluteOgImages:
-      layoutSource.includes('`${baseUrl}/api/og?type=default`') &&
+      (layoutSource.includes('getDefaultOgImage') ||
+        layoutSource.includes('`${baseUrl}/api/og?type=default`')) &&
       metadataUtilSource.includes(
         '`${baseUrl}/api/og?type=spot&id=${spot.id}`'
-      ),
+      ) &&
+      metadataUtilSource.includes('PRODUCTION_BASE_URL') &&
+      metadataUtilSource.includes('isLocalUrl'),
   }
 
   const issues: ValidationIssue[] = []

--- a/src/lib/seo/json-ld.ts
+++ b/src/lib/seo/json-ld.ts
@@ -1,5 +1,10 @@
 import type { SpotSeoData, RouteSeoData } from './metadata'
-import { getBaseUrl } from './metadata'
+import {
+  DEFAULT_SITE_DESCRIPTION,
+  SITE_NAME,
+  getBaseUrl,
+  getCanonicalUrl,
+} from './metadata'
 import { CATEGORY_CONFIG } from '@/types/spot'
 
 // ============================================
@@ -11,6 +16,8 @@ export function generateSpotJsonLd(spot: SpotSeoData): Record<string, unknown> {
   const jsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'TouristAttraction',
+    '@id': getCanonicalUrl(`/spots/${spot.id}`),
+    url: getCanonicalUrl(`/spots/${spot.id}`),
     name: spot.name,
     address: spot.address,
     geo: {
@@ -48,6 +55,8 @@ export function generateRouteJsonLd(
   return {
     '@context': 'https://schema.org',
     '@type': 'TouristTrip',
+    '@id': getCanonicalUrl(`/routes/${route.id}`),
+    url: getCanonicalUrl(`/routes/${route.id}`),
     name: route.name,
     description,
     itinerary: route.spots.map((spot) => ({
@@ -64,12 +73,45 @@ export function generateWebSiteJsonLd(): Record<string, unknown> {
   return {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
-    name: 'Not a Trip',
+    '@id': `${baseUrl}/#website`,
+    name: SITE_NAME,
+    description: DEFAULT_SITE_DESCRIPTION,
     url: baseUrl,
     potentialAction: {
       '@type': 'SearchAction',
-      target: `${baseUrl}/spots?q={search_term_string}`,
+      target: `${baseUrl}/map?q={search_term_string}`,
       'query-input': 'required name=search_term_string',
     },
+  }
+}
+
+/** Organization JSON-LD 생성 (루트 레이아웃용) */
+export function generateOrganizationJsonLd(): Record<string, unknown> {
+  const baseUrl = getBaseUrl()
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `${baseUrl}/#organization`,
+    name: SITE_NAME,
+    url: baseUrl,
+    logo: `${baseUrl}/icons/icon-512x512.png`,
+    description: DEFAULT_SITE_DESCRIPTION,
+  }
+}
+
+/** BreadcrumbList JSON-LD 생성 */
+export function generateBreadcrumbJsonLd(
+  items: Array<{ name: string; url: string }>
+): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
   }
 }

--- a/src/lib/seo/metadata.test.ts
+++ b/src/lib/seo/metadata.test.ts
@@ -1,0 +1,76 @@
+import {
+  PRODUCTION_BASE_URL,
+  generateRouteMetadata,
+  generateSpotMetadata,
+  getBaseUrl,
+  getCanonicalUrl,
+} from './metadata'
+
+describe('SEO metadata helpers', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  afterEach(() => {
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: originalNodeEnv,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  it('keeps localhost only outside production', () => {
+    expect(
+      getBaseUrl({
+        NODE_ENV: 'development',
+        NEXT_PUBLIC_BASE_URL: 'http://localhost:3000/',
+      } as NodeJS.ProcessEnv)
+    ).toBe('http://localhost:3000')
+  })
+
+  it('blocks localhost canonical origins in production', () => {
+    expect(
+      getBaseUrl({
+        NODE_ENV: 'production',
+        NEXT_PUBLIC_BASE_URL: 'http://localhost:3000',
+      } as NodeJS.ProcessEnv)
+    ).toBe(PRODUCTION_BASE_URL)
+  })
+
+  it('keeps the custom domain even when Vercel exposes a default production hostname', () => {
+    expect(
+      getBaseUrl({
+        NODE_ENV: 'production',
+        NEXT_PUBLIC_BASE_URL: 'http://localhost:3000',
+        VERCEL_PROJECT_PRODUCTION_URL: 'not-a-trip.vercel.app',
+      } as NodeJS.ProcessEnv)
+    ).toBe(PRODUCTION_BASE_URL)
+  })
+
+  it('builds stable canonical URLs from paths', () => {
+    expect(
+      getCanonicalUrl('/routes/ROUTE-109', {
+        NODE_ENV: 'production',
+        NEXT_PUBLIC_BASE_URL: PRODUCTION_BASE_URL,
+      } as NodeJS.ProcessEnv)
+    ).toBe(`${PRODUCTION_BASE_URL}/routes/ROUTE-109`)
+  })
+
+  it('lets Next title templates add the site name once for dynamic pages', () => {
+    const spotMetadata = generateSpotMetadata({
+      id: 'REAL-ANI-017',
+      name: '가부키초',
+      description: '은혼 배경지',
+      address: '도쿄 신주쿠',
+      photos: [],
+      coordinates: { lat: 35.695, lng: 139.703 },
+    })
+    const routeMetadata = generateRouteMetadata({
+      id: 'ROUTE-109',
+      name: '우지 유포니엄 코스',
+      description: '우지 핵심 순례 코스입니다.',
+      spots: [{ spotName: '우지교' }],
+    })
+
+    expect(spotMetadata.title).toBe('가부키초')
+    expect(routeMetadata.title).toBe('우지 유포니엄 코스')
+  })
+})

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -1,6 +1,21 @@
 import type { Metadata } from 'next'
 import { CATEGORY_CONFIG, type SpotCategory } from '@/types/spot'
 
+export const SITE_NAME = 'Not a Trip'
+export const PRODUCTION_BASE_URL = 'https://www.not-a-trip.xyz'
+export const DEFAULT_SITE_TITLE =
+  'Not a Trip - 애니메이션·영화 성지순례 여행 기록'
+export const DEFAULT_SITE_DESCRIPTION =
+  '애니메이션과 영화의 배경지를 찾아, 덕질 경험을 기록하고 공유하는 성지순례 여행 플랫폼입니다.'
+export const DEFAULT_SEO_KEYWORDS = [
+  '성지순례',
+  '애니메이션 성지',
+  '영화 촬영지',
+  '덕질 여행',
+  '팬 여행',
+  'Not a Trip',
+]
+
 // ============================================
 // SEO 데이터 인터페이스 (DB 조회 최소화용 경량 타입)
 // ============================================
@@ -32,36 +47,104 @@ export interface PostSeoData {
 // 유틸리티 함수
 // ============================================
 
-/** Base URL 반환 (환경 변수 기반, 미설정 시 localhost 폴백) */
-export function getBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
+function removeTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+function normalizeUrl(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const withProtocol = /^https?:\/\//i.test(trimmed)
+      ? trimmed
+      : `https://${trimmed}`
+    const url = new URL(withProtocol)
+    return removeTrailingSlash(url.toString())
+  } catch {
+    return null
+  }
+}
+
+function isLocalUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return ['localhost', '127.0.0.1', '0.0.0.0'].includes(url.hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Canonical base URL.
+ *
+ * Production must never emit localhost into canonical, robots, sitemap, OG, or
+ * JSON-LD URLs. If deployment env is missing or accidentally points at
+ * localhost, fall back to the canonical custom domain instead of poisoning
+ * crawler signals or leaking the Vercel default hostname.
+ */
+export function getBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const configuredUrl = normalizeUrl(env.NEXT_PUBLIC_BASE_URL)
+  const isProduction = env.NODE_ENV === 'production'
+
+  if (configuredUrl && (!isProduction || !isLocalUrl(configuredUrl))) {
+    return configuredUrl
+  }
+
+  if (isProduction) {
+    return PRODUCTION_BASE_URL
+  }
+
+  return configuredUrl ?? 'http://localhost:3000'
+}
+
+export function getCanonicalUrl(
+  path = '',
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const baseUrl = getBaseUrl(env)
+  const normalizedPath = path.trim()
+
+  if (!normalizedPath || normalizedPath === '/') {
+    return baseUrl
+  }
+
+  return `${baseUrl}${normalizedPath.startsWith('/') ? '' : '/'}${normalizedPath}`
+}
+
+export function getDefaultOgImage(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  return `${getBaseUrl(env)}/api/og?type=default`
 }
 
 /** 기본 메타데이터 생성 (조회 실패 시 폴백용) */
 export function getDefaultMetadata(): Metadata {
   const baseUrl = getBaseUrl()
-  const ogImage = `${baseUrl}/api/og?type=default`
+  const ogImage = getDefaultOgImage()
+
   return {
-    title: 'Not a Trip - 팬들만 아는 특별한 여행지',
-    description:
-      '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    title: DEFAULT_SITE_TITLE,
+    description: DEFAULT_SITE_DESCRIPTION,
+    keywords: DEFAULT_SEO_KEYWORDS,
     alternates: {
       canonical: baseUrl,
     },
     openGraph: {
-      title: 'Not a Trip - 팬들만 아는 특별한 여행지',
-      description:
-        '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+      title: DEFAULT_SITE_TITLE,
+      description: DEFAULT_SITE_DESCRIPTION,
       images: [ogImage],
       url: baseUrl,
       type: 'website',
-      siteName: 'Not a Trip',
+      siteName: SITE_NAME,
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Not a Trip - 팬들만 아는 특별한 여행지',
-      description:
-        '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+      title: DEFAULT_SITE_TITLE,
+      description: DEFAULT_SITE_DESCRIPTION,
       images: [ogImage],
     },
   }
@@ -74,7 +157,8 @@ export function getDefaultMetadata(): Metadata {
 /** 스팟 페이지 메타데이터 생성 */
 export function generateSpotMetadata(spot: SpotSeoData): Metadata {
   const baseUrl = getBaseUrl()
-  const title = `${spot.name} | Not a Trip`
+  const title = spot.name
+  const socialTitle = `${spot.name} | ${SITE_NAME}`
 
   // description 폴백: 비어 있으면 카테고리+주소 조합
   const description = spot.description
@@ -90,20 +174,26 @@ export function generateSpotMetadata(spot: SpotSeoData): Metadata {
   return {
     title,
     description,
+    keywords: [
+      spot.name,
+      spot.address,
+      spot.category ? CATEGORY_CONFIG[spot.category].label : '',
+      ...DEFAULT_SEO_KEYWORDS,
+    ].filter(Boolean),
     alternates: {
       canonical: url,
     },
     openGraph: {
-      title,
+      title: socialTitle,
       description,
       images: [ogImage],
       url,
       type: 'website',
-      siteName: 'Not a Trip',
+      siteName: SITE_NAME,
     },
     twitter: {
       card: 'summary_large_image',
-      title,
+      title: socialTitle,
       description,
       images: twitterImages,
     },
@@ -113,7 +203,8 @@ export function generateSpotMetadata(spot: SpotSeoData): Metadata {
 /** 코스 페이지 메타데이터 생성 */
 export function generateRouteMetadata(route: RouteSeoData): Metadata {
   const baseUrl = getBaseUrl()
-  const title = `${route.name} | Not a Trip`
+  const title = route.name
+  const socialTitle = `${route.name} | ${SITE_NAME}`
 
   // description 폴백: 비어 있으면 스팟 이름 조합
   const description = route.description
@@ -126,20 +217,25 @@ export function generateRouteMetadata(route: RouteSeoData): Metadata {
   return {
     title,
     description,
+    keywords: [
+      route.name,
+      ...route.spots.map((spot) => spot.spotName),
+      ...DEFAULT_SEO_KEYWORDS,
+    ].filter(Boolean),
     alternates: {
       canonical: url,
     },
     openGraph: {
-      title,
+      title: socialTitle,
       description,
       images: [ogImage],
       url,
       type: 'website',
-      siteName: 'Not a Trip',
+      siteName: SITE_NAME,
     },
     twitter: {
       card: 'summary_large_image',
-      title,
+      title: socialTitle,
       description,
       images: [ogImage],
     },
@@ -149,7 +245,8 @@ export function generateRouteMetadata(route: RouteSeoData): Metadata {
 /** 게시글 페이지 메타데이터 생성 */
 export function generatePostMetadata(post: PostSeoData): Metadata {
   const baseUrl = getBaseUrl()
-  const title = `${post.title} | Not a Trip 커뮤니티`
+  const title = `${post.title} | 커뮤니티`
+  const socialTitle = `${post.title} | ${SITE_NAME} 커뮤니티`
 
   // content 150자 truncation
   const description =
@@ -162,19 +259,20 @@ export function generatePostMetadata(post: PostSeoData): Metadata {
   return {
     title,
     description,
+    keywords: [post.title, '커뮤니티', '팬 후기', ...DEFAULT_SEO_KEYWORDS],
     alternates: {
       canonical: url,
     },
     openGraph: {
-      title,
+      title: socialTitle,
       description,
       url,
       type: 'article',
-      siteName: 'Not a Trip',
+      siteName: SITE_NAME,
     },
     twitter: {
       card: 'summary_large_image',
-      title,
+      title: socialTitle,
       description,
     },
   }


### PR DESCRIPTION
## ?? ??

- Closes #904

---

## PR ??
- [ ] feat: ??? ?? ??
- [x] fix: ?? ??
- [ ] ui: UI/UX ??, ??? ??
- [x] enhancement: ?? ?? ??, ?? ???
- [ ] chore: ??, ??, ??? ??
- [ ] refactor: ?? ???? (?? ?? ??)
- [ ] docs: ?? ??

---

## ?? ??

Production SEO metadata now uses https://www.not-a-trip.xyz as the single canonical origin. The change blocks localhost and Vercel default-host leakage in robots, sitemap, canonical, Open Graph, and JSON-LD output.

---

## ?? ??

- [x] Guard production base URL resolution against localhost and Vercel default-host leakage.
- [x] Add canonical metadata to public section pages.
- [x] Add sitemap entries for welcome, map, and contents.
- [x] Add Organization and Breadcrumb JSON-LD for safer structured data coverage.
- [x] Add SEO helper regression tests for production origin behavior.

---

## ?????
- [x] `npm run lint` ??
- [x] `npm run type-check` ??
- [x] `npm test -- --runInBand src/lib/seo/metadata.test.ts src/lib/deployment/seo-validator.test.ts` ??
- [x] `npm run build:route-budget` ??
- [x] ?? SEO smoke ??

---

## ???? (??)

N/A - SEO metadata and crawler output change only.

---

## ?? ?? (??)

Authenticated production password-change smoke remains blocked without a production test account. Non-mutating production checks and compromised password registration rejection were verified earlier.