### PR TITLE
[Fix] SEO main 중첩 제거

### DIFF
--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -84,11 +84,6 @@ export default async function SpotDetailPage({
           ])}
         />
       )}
-      <main>
-        <h1>{spot.name}</h1>
-        <p>{spot.description || spot.address}</p>
-        <p>{spot.address}</p>
-      </main>
       <SpotDetailClient />
     </>
   )


### PR DESCRIPTION
## 관련 이슈

- Closes #915

---

## PR 유형
- [x] **fix**: 버그 수정

---

## 작업 개요

스팟 상세 페이지가 공통 레이아웃의 `<main>` 내부에서 추가 `<main>`을 렌더링해 HTML 문서 구조가 중첩되던 문제를 제거했습니다. 기존 상세 콘텐츠는 `SpotDetailClient`가 담당하므로 중복 서버 마크업만 삭제했습니다.

---

## 변경 사항

- `src/app/spots/[id]/page.tsx`의 중복 `<main>`/기본 상세 텍스트 블록 제거
- 공통 레이아웃과 상세 클라이언트 콘텐츠의 단일 `<main>` 구조 유지

---

## 체크리스트
- [x] `npm run lint` 통과
- [x] `npm run type-check` 통과
- [x] `npm run lint:release` 통과
- [x] `npm run format:check` 통과
- [x] `npm test -- --runInBand` 통과 (116 suites, 463 tests)
- [ ] `npm run build` 미실행
- [ ] 주요 기능 수동 확인 미실행

---

## 추가 정보

로컬 검증은 현재 커밋 `92b6c90`에서 수행했습니다.