### PR TITLE
[Release] deploy spot detail main landmark fix

### DIFF
--- a/src/app/spots/[id]/page.tsx
+++ b/src/app/spots/[id]/page.tsx
@@ -84,11 +84,6 @@ export default async function SpotDetailPage({
           ])}
         />
       )}
-      <main>
-        <h1>{spot.name}</h1>
-        <p>{spot.description || spot.address}</p>
-        <p>{spot.address}</p>
-      </main>
       <SpotDetailClient />
     </>
   )


### PR DESCRIPTION
## 관련 이슈

- Closes #915
- Includes merged PR #916

---

## PR 유형
- [x] **fix**: 버그 수정

---

## 작업 개요

`develop`에서 검증·병합된 스팟 상세 페이지의 중첩 `<main>` 제거를 프로덕션 `main`에 배포합니다.

---

## 변경 사항

- 스팟 상세 페이지가 공통 레이아웃의 단일 `<main>` landmark를 사용하도록 정리
- SEO/접근성 문서 구조에서 중첩 `<main>` 제거

---

## 체크리스트
- [x] `develop` 대상 PR #916 병합 완료
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [x] `npm run lint:release` 통과
- [x] `npm run format:check` 통과
- [x] 전체 테스트 통과 (116 suites, 463 tests)
- [ ] `npm run build` 미실행
- [ ] 프로덕션 배포 후 주요 기능 수동 확인 대기

---

## 추가 정보

프로덕션 배포는 이 PR이 `main`에 병합된 뒤 GitHub/Vercel 자동 배포에 의해 수행됩니다.