### PR TITLE
[ui] 정보 탐색 중심 랜딩으로 전환

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,118 +1,100 @@
 # Design
 
 ## Source of truth
+
 - Status: Active
-- Last refreshed: 2026-05-29
-- Primary product surfaces: landing `/welcome`, map `/map`, content discovery, gallery/check-in, route planning, spot detail/reporting.
-- Evidence reviewed:
-  - `src/app/globals.css` — CSS variable color tokens and semantic roles.
-  - `tailwind.config.ts` — Tailwind token exposure.
-  - `src/components/layout/Header.tsx` and `HeaderAuthControls.tsx` — global navigation color usage.
-  - `src/components/landing/*` — landing hero, cards, CTA, and theme behavior.
-  - `.kiro/specs/22-landing-page/design.md`, `.kiro/specs/23-landing-page-polish/design.md`, `.kiro/specs/27-theme-selector-menu/design.md` — prior landing/theme intent.
-  - External travel references reviewed on 2026-05-29: Airbnb-style warm coral accents, Expedia-style blue/gold trust/excitement, and general travel palettes using neutral backgrounds with teal/coral/amber accents.
+- Last refreshed: 2026-08-26
+- Primary product surfaces: `/welcome`, `/contents`, `/map`, `/routes`, `/spots/[id]`
+- Evidence reviewed: live production pages, public API inventory, `src/components/landing`, `src/components/layout/Header.tsx`, `src/app/globals.css`, design tokens in `tailwind.config.ts`, repository QA reports, prior landing/theme specs under `.kiro/specs`
 
 ## Brand
-- Personality: fan-travel companion, warm, exploratory, trustworthy, slightly playful.
-- Trust signals: readable map/data UI, stable CTA hierarchy, clear categories, restrained motion, consistent semantic tokens.
-- Avoid: one-note purple surfaces, every button having a different color, low-contrast pastel text, hard-edged heavy typography, neon overload.
+
+- Personality: knowledgeable, calm, fan-aware, practical
+- Trust signals: real-place photography, clear work-to-place relationships, map context, route duration and difficulty, visible information provenance when available
+- Avoid: fabricated community momentum, decorative sections without a user job, repeated install prompts, game-like terminology before the information value is clear
 
 ## Product goals
-- Goals:
-  - Help fans discover real-world places connected to works, artists, teams, and scenes.
-  - Make map exploration, route following, and check-in proof feel connected.
-  - Keep the interface approachable in both light and dark modes.
-- Non-goals:
-  - Do not turn the app into a generic travel agency booking interface.
-  - Do not replace category colors with arbitrary decorative colors per component.
-- Success signals:
-  - Primary actions remain obvious.
-  - Cards feel varied but not chaotic.
-  - Light/dark modes share the same brand logic.
+
+- Goals: help fans find real places connected to works and prepare a visit with useful context
+- Non-goals: presenting Not a Trip as a social network before sustained community activity exists; making PWA installation a primary conversion goal
+- Success signals: search or curated discovery leads to a content, spot, map, or route detail; users can understand what information is available before signing in
 
 ## Personas and jobs
-- Primary personas:
-  - Fan traveler planning a location visit.
-  - Casual browser looking for places from a favorite work.
-  - Community contributor uploading proof/check-ins.
-- User jobs:
-  - Search by work/place.
-  - Browse by category.
-  - Follow a route.
-  - Save/report/verify a spot.
-- Key contexts of use: mobile-first travel planning, outdoor navigation, quick browsing before/while traveling.
+
+- Primary personas: first-time fan traveler, location researcher, itinerary planner
+- User jobs: find a place by work or name; understand where it is; compare relevant places; follow a practical route
+- Key contexts of use: trip research on desktop, in-transit lookup on mobile, on-site map use
 
 ## Information architecture
-- Primary navigation: home, map, contents, gallery, routes, spot registration, profile/auth.
-- Core routes/screens: `/welcome`, `/map`, `/contents`, `/gallery`, `/routes`, `/spots/[id]`, `/reports`.
-- Content hierarchy: value proposition → search/discovery → category/story cards → social proof → conversion CTA.
+
+- Primary navigation: home, works, places/map, curated routes
+- Secondary navigation: check-ins, place contribution, account and settings
+- Core routes/screens: `/welcome`, `/contents`, `/contents/[name]`, `/map`, `/spots/[id]`, `/routes`, `/routes/[id]`
+- Content hierarchy: search intent -> work/place context -> visit information -> map/route action -> optional contribution
 
 ## Design principles
-- Principle 1: One dominant action color, multiple supporting travel hues.
-- Principle 2: Semantic tokens first; component-specific colors only for category/status meaning.
-- Principle 3: Surfaces should feel continuous across scroll sections, not like isolated panels.
-- Tradeoffs: keep purple/indigo brand recognition, but balance it with teal for discovery and sunset for warm travel moments.
+
+- Information before participation: show useful public data before asking users to sign in, install, upload, or post.
+- Evidence before social proof: community activity is displayed only when it comes from real production records.
+- One section, one job: avoid repeating the same discovery choices through chips, cards, process diagrams, and floating prompts.
+- Map as a view, not the whole identity: map exploration supports the information architecture rather than replacing it.
+- Tradeoffs: retain the mascot as a restrained brand accent, but do not use it as filler in every section.
 
 ## Visual language
-- Color:
-  - Primary: Harbor Indigo for core actions, focus, route/navigation confidence.
-  - Secondary: Sea Teal for discovery, map, category exploration, hover states.
-  - Sunset: warm accent for admin/special states, passport/check-in warmth, subtle highlights.
-  - Background: restrained stone/off-white in light mode, deep slate/navy in dark mode; borders must stay visibly darker than warm surfaces.
-  - Category/content colors: related but varied; use category tokens rather than ad hoc Tailwind colors.
-- Typography: Pretendard/system; prefer `font-semibold`, relaxed line height, and slight negative tracking on large display text.
-- Spacing/layout rhythm: mobile-first, generous card padding, section rhythm of 16–24 spacing units.
-- Shape/radius/elevation: rounded cards (`1rem–1.5rem`), soft shadows, avoid sharp rectangular panels on marketing surfaces.
-- Motion: subtle hover lift and fade/slide; respect reduced motion.
-- Imagery/iconography: real spot images first, mascot/icons as supportive cues.
+
+- Color: existing Harbor Indigo primary, Sea Teal secondary, Sunset accent, and neutral semantic tokens; neutral surfaces carry most informational content
+- Typography: Pretendard with strong Korean readability, concise headings, and comfortable body line height
+- Spacing/layout rhythm: compact editorial sections with a maximum content width; avoid full-screen height unless the user job benefits
+- Shape/radius/elevation: existing rounded cards with lower shadow emphasis for information surfaces
+- Motion: optional and short; content must remain visible when motion libraries fail or reduced motion is requested
+- Imagery/iconography: real location images first, work covers second, mascot only as a small brand accent
 
 ## Components
-- Existing components to reuse:
-  - `ThemeSelector`, `Header`, `CTAButton`, landing cards, `ProofCard`, category/content token configs.
-- New/changed components:
-  - `LandingThemeProvider` for landing theme parity without full session/query providers.
-- Variants and states:
-  - Primary button: indigo.
-  - Secondary/support action: teal or neutral surface.
-  - Warm/special accent: sunset.
-  - Category chips/cards: category tokens.
-- Token/component ownership:
-  - Global palette lives in `src/app/globals.css`.
-  - Tailwind token exposure lives in `tailwind.config.ts`.
-  - Do not hardcode new brand hex colors in components unless SVG/gradient limitations require it.
+
+- Existing components to reuse: `LandingHeader`, `HeroSection`, `EntryPointSection`, `StorytellingSection`, `CategoryCard`, semantic design tokens
+- New/changed components: `InformationStandardsSection`; information-first variants of hero and entry-point copy
+- Variants and states: real empty states must not be replaced with fictional testimonials
+- Token/component ownership: palette variables remain in `src/app/globals.css`; Tailwind exposure remains in `tailwind.config.ts`; components use semantic and category tokens instead of new raw colors
 
 ## Accessibility
-- Target standard: practical WCAG AA contrast for text and controls.
-- Keyboard/focus behavior: use visible focus rings based on primary token.
-- Contrast/readability: pastel fills must pair with dark enough foreground tokens.
-- Screen-reader semantics: preserve route/section labels and button labels.
-- Reduced motion and sensory considerations: avoid essential information in animation only.
+
+- Target standard: WCAG 2.1 AA for core public discovery flows
+- Keyboard/focus behavior: all search, chips, cards, and links remain keyboard reachable with visible focus states
+- Contrast/readability: semantic text and surface tokens; no text rendered only through imagery
+- Screen-reader semantics: one `h1`, ordered section headings, descriptive labels, decorative mascots hidden
+- Reduced motion and sensory considerations: content is immediately visible without animation and respects reduced-motion preference
 
 ## Responsive behavior
-- Supported breakpoints/devices: mobile-first through desktop.
-- Layout adaptations: stack cards on mobile; preserve CTA reachability.
-- Touch/hover differences: hover color/lift should be enhancement only.
+
+- Supported breakpoints/devices: 280px minimum defensive width, 390px primary mobile, tablet, 1440px desktop
+- Layout adaptations: single-column mobile cards, bounded horizontal content, desktop grids without off-canvas document overflow
+- Touch/hover differences: touch does not depend on hover; targets remain at least 44px where practical
 
 ## Interaction states
-- Loading: skeleton/shimmer on neutral/accent surfaces.
-- Empty: mascot/icon plus clear recovery action.
-- Error: danger token, concise recovery path.
-- Success: secondary/sunset can support positive/check-in moments without replacing primary action hierarchy.
-- Disabled: reduce opacity and preserve text contrast where possible.
-- Offline/slow network: keep fallback content visible and avoid blank marketing sections.
+
+- Loading: preserve layout and show useful text before deferred visual content
+- Empty: state the absence honestly and point to available information paths
+- Error: keep navigation and retry context available
+- Success: route users to a concrete content, place, map, or route result
+- Disabled: explain why an action is unavailable
+- Offline/slow network: retain PWA support as infrastructure, not primary landing-page promotion
 
 ## Content voice
-- Tone: warm, direct, fan-aware, not corporate.
-- Terminology: use “장소”, “스팟”, “코스”, “인증”, “여권” consistently.
-- Microcopy rules: prefer conversational guidance over command-heavy phrasing.
+
+- Tone: direct, factual, concise, fan-aware without exaggerated enthusiasm
+- Terminology: use `작품`, `장소`, `스팟`, `코스`, `방문 정보`; reserve `인증` for real user check-ins
+- Microcopy rules: describe what the user will see after an action; do not imply user counts or testimonials without production data
 
 ## Implementation constraints
-- Framework/styling system: Next.js App Router, Tailwind, CSS variables, `next-themes`.
-- Design-token constraints: use semantic tokens (`background`, `surface`, `main-text`, `sub-text`) and role tokens (`primary`, `secondary`, `sunset`).
-- Performance constraints: avoid adding runtime color libraries or heavy visual dependencies.
-- Compatibility constraints: dark mode is class-based; landing must not force `.dark`.
-- Test/screenshot expectations: token changes require static token tests plus type/lint/build verification; visual screenshots are recommended for future pixel-level work.
+
+- Framework/styling system: Next.js App Router, React, Tailwind CSS, existing semantic tokens
+- Design-token constraints: no raw color utility expansion without updating the repository token baseline
+- Performance constraints: server-render useful public text; dynamically load only non-critical interaction and animation
+- Compatibility constraints: preserve `/` first-visit routing, returning-user `/map` routing, authentication behavior, and public SEO metadata
+- Test/screenshot expectations: targeted Jest contracts, lint, type-check, build, 390px and 1440px screenshots, horizontal overflow check
 
 ## Open questions
-- [ ] Should the mascot/logo asset itself be recolored to match Harbor Indigo/Sea Teal/Sunset? Owner: design/product. Impact: stronger brand consistency.
-- [ ] Should admin-only surfaces keep sunset accents or move to a stricter utility/status palette? Owner: product. Impact: admin IA clarity.
+
+- [ ] Define which spot fields qualify as verified and how the last-reviewed date is exposed / product owner / trust labeling
+- [ ] Decide when real check-in volume is sufficient to restore community proof on the landing page / product owner / social proof
+- [ ] Validate the primary navigation reduction in the next independent work unit / frontend / global IA

--- a/src/app/(landing)/welcome/page.tsx
+++ b/src/app/(landing)/welcome/page.tsx
@@ -4,7 +4,6 @@ import { WelcomePageClient } from '@/components/landing/WelcomePageClient'
 import {
   fetchShowcaseSpots,
   fetchCategoryImages,
-  fetchProofImages,
 } from '@/components/landing/data/fetchShowcaseSpots'
 import { auth } from '@/lib/auth'
 import {
@@ -14,16 +13,16 @@ import {
 } from '@/lib/seo/metadata'
 
 export const metadata: Metadata = {
-  title: '환영합니다',
+  title: '작품 속 실제 장소 정보',
   description:
-    '관광지가 아닌 성지를 탐험하세요. 애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+    '애니메이션, 영화, 스포츠, 음악과 게임 속 실제 장소를 작품별로 찾고 지도 위치와 추천 방문 코스를 확인하세요.',
   alternates: {
     canonical: getCanonicalUrl('/welcome'),
   },
   openGraph: {
-    title: 'Not a Trip - 관광지가 아닌 성지를 탐험하세요',
+    title: 'Not a Trip - 작품 속 실제 장소 정보 가이드',
     description:
-      '애니메이션 성지순례, 영화 촬영지, 콘서트 장소 등 팬들만 아는 특별한 여행지를 발견하세요.',
+      '작품별 실제 장소, 지도 위치, 추천 방문 코스를 한곳에서 확인하세요.',
     url: getCanonicalUrl('/welcome'),
     type: 'website',
     siteName: SITE_NAME,
@@ -37,16 +36,14 @@ export default async function WelcomePage() {
     redirect('/map')
   }
 
-  const [showcaseSpots, categoryImages, proofImages] = await Promise.all([
+  const [showcaseSpots, categoryImages] = await Promise.all([
     fetchShowcaseSpots(),
     fetchCategoryImages(),
-    fetchProofImages(),
   ])
   return (
     <WelcomePageClient
       showcaseSpots={showcaseSpots}
       categoryImages={categoryImages}
-      proofImages={proofImages}
     />
   )
 }

--- a/src/components/landing/EntryPointSection.tsx
+++ b/src/components/landing/EntryPointSection.tsx
@@ -1,10 +1,7 @@
 import Link from 'next/link'
-import Image from 'next/image'
-import { MASCOT_ASSETS } from '@/components/common/mascotAssets'
 
 /**
- * 랜딩 페이지 목적별 진입점 섹션
- * "작품으로 찾기", "코스로 따라가기", "인증 둘러보기" 3개 카드 진입점
+ * 랜딩 페이지 정보 탐색 진입점 섹션
  * 서버 컴포넌트 (인터랙션 없음, Link만 사용)
  * Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7
  */
@@ -19,21 +16,21 @@ interface EntryPoint {
 const ENTRY_POINTS: EntryPoint[] = [
   {
     icon: '🎬',
-    title: '작품으로 찾기',
-    description: '이름만 떠올라도 관련 스팟을 바로 모아볼 수 있어요',
+    title: '작품별 장소 찾기',
+    description: '작품과 아티스트별로 연결된 실제 장소를 모아봅니다',
     href: '/contents',
   },
   {
     icon: '🗺️',
-    title: '코스로 따라가기',
-    description: '처음 가는 도시에서도 순서대로 따라가면 됩니다',
-    href: '/routes',
+    title: '지도에서 위치 확인',
+    description: '지역과 카테고리별 장소를 지도 위에서 비교합니다',
+    href: '/map',
   },
   {
-    icon: '📸',
-    title: '인증 둘러보기',
-    description: '다른 팬들의 사진과 후기로 분위기를 먼저 확인해요',
-    href: '/gallery',
+    icon: '🧭',
+    title: '추천 코스 살펴보기',
+    description: '예상 시간과 난이도가 정리된 방문 동선을 확인합니다',
+    href: '/routes',
   },
 ]
 
@@ -47,26 +44,15 @@ export function EntryPointSection() {
         {/* 헤더 */}
         <header className="mb-12 text-center">
           <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl">
-            오늘은 어떻게{' '}
+            어떤 정보부터{' '}
             <span className="text-primary-600 dark:text-primary-300">
-              떠나볼까요?
+              찾아볼까요?
             </span>
           </h2>
           <p className="text-base leading-7 text-sub-text md:text-lg">
-            원하는 시작점만 고르면 나머지는 자연스럽게 이어집니다
+            작품, 위치, 동선 중 지금 필요한 기준으로 바로 시작하세요
           </p>
         </header>
-
-        {/* 진입점 카드 그리드 — 모바일 세로 스택, 태블릿 이상 가로 병렬 */}
-        <div className="mb-10 flex justify-center" aria-hidden="true">
-          <Image
-            src={MASCOT_ASSETS.boat}
-            alt=""
-            width={88}
-            height={88}
-            className="h-20 w-20 object-contain md:h-24 md:w-24"
-          />
-        </div>
 
         <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
           {ENTRY_POINTS.map((entry) => (

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,15 +1,13 @@
 'use client'
 
 import { forwardRef, useState } from 'react'
-import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { FloatingCardsCollage } from './FloatingCardsCollage'
 import { LandingHeader } from './LandingHeader'
-import { MASCOT_ASSETS } from '@/components/common/mascotAssets'
 import type { ShowcaseCard } from './data/showcaseCards'
 
 /**
- * 히어로 섹션 컴포넌트 — 발견형 검색 히어로
+ * 히어로 섹션 컴포넌트 — 정보 탐색형 검색 히어로
  * - 랜딩 전용 미니 헤더
  * - 강한 카피 + 검색창 + 카테고리 칩 6개
  * - 우측 플로팅 카드 콜라주 (실제 스팟 썸네일)
@@ -51,7 +49,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
     return (
       <section
         ref={ref}
-        className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-b from-primary-50 via-background to-background dark:from-slate-950 dark:via-background dark:to-background"
+        className="relative flex min-h-[700px] flex-col overflow-hidden bg-gradient-to-b from-primary-50 via-background to-background dark:from-slate-950 dark:via-background dark:to-background md:min-h-[760px] lg:min-h-[680px]"
         aria-label="히어로 섹션"
       >
         {/* 랜딩 전용 미니 헤더 */}
@@ -93,29 +91,29 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
         </div>
 
         {/* 메인 콘텐츠 */}
-        <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-1 flex-col items-center gap-8 px-4 pb-16 pt-24 lg:flex-row lg:items-center lg:gap-12 lg:pt-0">
+        <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-1 flex-col items-center gap-8 px-4 pb-14 pt-16 lg:flex-row lg:items-center lg:gap-12 lg:py-12">
           {/* 좌측: 텍스트 + 검색 + 칩 */}
           <div className="flex flex-1 flex-col items-center text-center lg:items-start lg:text-left">
             {/* 상단 뱃지 */}
             <div className="mb-5 inline-flex items-center gap-1.5 rounded-full border border-primary-500/20 bg-surface/80 px-3 py-1 text-xs font-medium text-primary-700 shadow-sm backdrop-blur-sm dark:border-primary-400/25 dark:bg-white/10 dark:text-primary-300">
-              <span>🗺️</span>
-              <span>팬들이 남긴 실제 장소를 모아봤어요</span>
+              <span>🧭</span>
+              <span>팬 여행을 위한 실제 장소 정보 가이드</span>
             </div>
 
             {/* 헤드라인 */}
-            <h1 className="mb-5 text-4xl font-semibold leading-[1.08] tracking-[-0.045em] text-main-text md:text-5xl lg:text-6xl">
-              좋아하는 장면을
+            <h1 className="mb-5 text-4xl font-semibold leading-[1.08] tracking-[-0.045em] text-main-text md:text-5xl">
+              좋아하는 작품의
               <br />
               <span className="text-primary-600 dark:text-primary-300">
-                여행지
+                실제 장소
               </span>
-              로 만나보세요
+              를 찾아보세요
             </h1>
 
             <p className="mb-8 max-w-md text-base leading-7 text-sub-text md:text-lg md:leading-8">
-              애니메이션 성지, 촬영지, 콘서트 장소까지.
+              애니메이션, 영화, 스포츠, 음악과 게임까지.
               <br className="hidden sm:block" />
-              지도에서 찾고 코스로 따라가며 방문 기록까지 남겨보세요.
+              작품별 스팟과 지도 위치, 추천 코스를 한곳에서 확인하세요.
             </p>
 
             {/* 검색창 */}
@@ -125,7 +123,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
                   type="text"
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
-                  placeholder="작품명, 장소명으로 검색..."
+                  placeholder="작품명 또는 장소명으로 검색..."
                   className="flex-1 bg-transparent px-4 py-3 text-sm text-main-text placeholder-muted outline-none"
                   aria-label="성지 검색"
                 />
@@ -135,7 +133,7 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
                   aria-label="검색"
                 >
                   <SearchIcon />
-                  <span className="hidden sm:inline">찾기</span>
+                  <span className="hidden sm:inline">정보 찾기</span>
                 </button>
               </div>
             </form>
@@ -170,23 +168,6 @@ export const HeroSection = forwardRef<HTMLElement, HeroSectionProps>(
               reducedMotion={reducedMotion}
               showcaseSpots={showcaseSpots}
               className="h-[calc(100vw-2rem)] max-h-80 w-[calc(100vw-2rem)] max-w-80 md:h-[480px] md:w-[480px] md:max-w-none lg:h-[min(640px,55vh)] lg:w-[min(640px,55vh)]"
-            />
-          </div>
-        </div>
-
-        {/* 하단 스크롤 힌트 */}
-        <div
-          className="relative z-10 flex justify-center pb-8"
-          aria-hidden="true"
-        >
-          <div className="flex flex-col items-center gap-1 text-muted dark:text-white/35">
-            <span className="text-xs">아래에서 탐색 방법 보기</span>
-            <Image
-              src={MASCOT_ASSETS.cheer}
-              alt=""
-              width={48}
-              height={48}
-              className="h-12 w-12 object-contain"
             />
           </div>
         </div>

--- a/src/components/landing/InformationStandardsSection.tsx
+++ b/src/components/landing/InformationStandardsSection.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link'
+
+const INFORMATION_STANDARDS = [
+  {
+    number: '01',
+    title: '작품과 장소를 연결합니다',
+    description:
+      '작품별로 관련 스팟을 모아 보고, 어떤 장면과 장소가 연결되는지 빠르게 파악할 수 있습니다.',
+  },
+  {
+    number: '02',
+    title: '현장 위치를 확인합니다',
+    description:
+      '지도에서 실제 위치와 주변 스팟을 함께 확인해 이동 거리와 방문 범위를 계획할 수 있습니다.',
+  },
+  {
+    number: '03',
+    title: '방문 순서를 제안합니다',
+    description:
+      '편집 코스의 예상 시간과 난이도, 스팟 순서를 참고해 현실적인 동선을 만들 수 있습니다.',
+  },
+]
+
+export function InformationStandardsSection() {
+  return (
+    <section
+      className="border-t border-border bg-gradient-to-b from-background to-primary-50/55 py-16 dark:to-primary-900/10 md:py-20"
+      aria-labelledby="information-standards-title"
+    >
+      <div className="mx-auto max-w-6xl px-4">
+        <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:items-start">
+          <header>
+            <p className="mb-3 text-sm font-semibold text-primary-600 dark:text-primary-300">
+              NOT A TRIP INFORMATION GUIDE
+            </p>
+            <h2
+              id="information-standards-title"
+              className="text-3xl font-semibold tracking-[-0.035em] text-main-text md:text-4xl"
+            >
+              방문을 결정하기 전에
+              <br />
+              필요한 정보를 모았습니다
+            </h2>
+            <p className="mt-5 max-w-md text-base leading-7 text-sub-text">
+              로그인이나 앱 설치보다 먼저, 작품과 실제 장소를 이해하는 데 필요한
+              공개 정보를 제공합니다.
+            </p>
+            <Link
+              href="/routes"
+              className="mt-7 inline-flex min-h-11 items-center rounded-full bg-primary-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+            >
+              편집 코스 살펴보기
+              <span className="ml-2" aria-hidden="true">
+                →
+              </span>
+            </Link>
+          </header>
+
+          <ol className="grid gap-4">
+            {INFORMATION_STANDARDS.map((item) => (
+              <li
+                key={item.number}
+                className="grid gap-3 rounded-[1.5rem] border border-border bg-surface/90 p-6 shadow-sm sm:grid-cols-[3rem_1fr] sm:items-start"
+              >
+                <span className="text-sm font-bold text-primary-600 dark:text-primary-300">
+                  {item.number}
+                </span>
+                <div>
+                  <h3 className="text-lg font-semibold text-main-text">
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-sub-text md:text-base md:leading-7">
+                    {item.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/StorytellingSection.tsx
+++ b/src/components/landing/StorytellingSection.tsx
@@ -1,10 +1,8 @@
 'use client'
 
 import { useRef, useEffect } from 'react'
-import Image from 'next/image'
 import { CATEGORY_STORIES } from './data/categoryStories'
 import { CategoryCard } from './CategoryCard'
-import { MASCOT_ASSETS } from '@/components/common/mascotAssets'
 import type { SpotCategory } from '@/types/spot'
 
 /**
@@ -17,20 +15,6 @@ interface StorytellingSectionProps {
   isHighEnd: boolean
   reducedMotion: boolean
   categoryImages: Record<SpotCategory, string>
-}
-
-function SectionMascot() {
-  return (
-    <div className="mb-10 flex justify-center" aria-hidden="true">
-      <Image
-        src={MASCOT_ASSETS.peace}
-        alt=""
-        width={88}
-        height={88}
-        className="h-20 w-20 object-contain md:h-24 md:w-24"
-      />
-    </div>
-  )
 }
 
 export function StorytellingSection({
@@ -90,14 +74,12 @@ function StorytellingSectionWithGSAP({
       <div className="mx-auto max-w-6xl px-4">
         <header className="mb-12 text-center md:mb-16">
           <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl lg:text-4xl">
-            취향별로 <span className="text-secondary-600">골라볼까요?</span>
+            관심 분야별 <span className="text-secondary-600">장소 정보</span>
           </h2>
           <p className="text-base leading-7 text-sub-text md:text-lg">
-            장르마다 다른 분위기의 스팟을 카드로 먼저 살펴보세요
+            분야별 대표 장소를 확인하고 지도에서 더 자세히 살펴보세요
           </p>
         </header>
-
-        <SectionMascot />
 
         <div
           ref={containerRef}
@@ -151,14 +133,12 @@ function StorytellingSectionFallback({
       <div className="mx-auto max-w-6xl px-4">
         <header className="mb-12 text-center md:mb-16">
           <h2 className="mb-3 text-2xl font-semibold tracking-[-0.025em] text-main-text md:text-3xl lg:text-4xl">
-            취향별로 <span className="text-secondary-600">골라볼까요?</span>
+            관심 분야별 <span className="text-secondary-600">장소 정보</span>
           </h2>
           <p className="text-base leading-7 text-sub-text md:text-lg">
-            장르마다 다른 분위기의 스팟을 카드로 먼저 살펴보세요
+            분야별 대표 장소를 확인하고 지도에서 더 자세히 살펴보세요
           </p>
         </header>
-
-        <SectionMascot />
 
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {stories.map((story, index) => (

--- a/src/components/landing/WelcomePageClient.tsx
+++ b/src/components/landing/WelcomePageClient.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect } from 'react'
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/navigation'
 import { HeroSection } from './HeroSection'
 import { useDeviceCapability } from '@/hooks/useDeviceCapability'
-import { useScrollPosition } from '@/hooks/useScrollPosition'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import type { ShowcaseCard } from './data/showcaseCards'
 import type { SpotCategory } from '@/types/spot'
@@ -13,64 +11,32 @@ import type { SpotCategory } from '@/types/spot'
 const EntryPointSection = dynamic(() =>
   import('./EntryPointSection').then((mod) => mod.EntryPointSection)
 )
-const HowItWorksSection = dynamic(
-  () => import('./HowItWorksSection').then((mod) => mod.HowItWorksSection),
-  { ssr: false }
+const InformationStandardsSection = dynamic(() =>
+  import('./InformationStandardsSection').then(
+    (mod) => mod.InformationStandardsSection
+  )
 )
 const StorytellingSection = dynamic(
   () => import('./StorytellingSection').then((mod) => mod.StorytellingSection),
   { ssr: false }
 )
-const SocialProofSection = dynamic(
-  () => import('./SocialProofSection').then((mod) => mod.SocialProofSection),
-  { ssr: false }
-)
-const ConversionSection = dynamic(
-  () => import('./ConversionSection').then((mod) => mod.ConversionSection),
-  { ssr: false }
-)
-const FloatingCTA = dynamic(
-  () => import('./FloatingCTA').then((mod) => mod.FloatingCTA),
-  { ssr: false }
-)
-
 /**
  * 랜딩 페이지 클라이언트 컴포넌트
- * 모든 섹션을 통합하고 디바이스 능력/스크롤/모션 훅을 연결
- * Requirements: 5.2, 5.3, 5.4, 6.1, 6.2, 6.3
+ * 정보 탐색 중심 섹션을 통합하고 디바이스 능력/모션 훅을 연결한다.
  */
 interface WelcomePageClientProps {
   /** 서버에서 fetch한 쇼케이스 스팟 데이터 */
   showcaseSpots: ShowcaseCard[]
-  /** 소셜 프루프용 카테고리별 스팟 이미지 목록 */
+  /** 카테고리별 실제 스팟 이미지 */
   categoryImages: Record<SpotCategory, string>
-  proofImages: Record<string, string[]>
 }
 
 export function WelcomePageClient({
   showcaseSpots,
   categoryImages,
-  proofImages,
 }: WelcomePageClientProps) {
-  const router = useRouter()
   const { isHighEnd, isReady } = useDeviceCapability()
   const reducedMotion = usePrefersReducedMotion()
-
-  // 섹션 ref — useScrollPosition에 전달
-  const heroRef = useRef<HTMLElement>(null)
-  const conversionRef = useRef<HTMLElement>(null)
-
-  const { heroExited, conversionVisible } = useScrollPosition({
-    heroRef,
-    conversionRef,
-  })
-
-  // PWA standalone 모드 감지
-  const [isStandalone, setIsStandalone] = useState(false)
-
-  useEffect(() => {
-    setIsStandalone(window.matchMedia('(display-mode: standalone)').matches)
-  }, [])
 
   /** 페이지 이탈 시에도 has_visited 쿠키 설정 */
   useEffect(() => {
@@ -79,34 +45,14 @@ export function WelcomePageClient({
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
   }, [])
 
-  // FloatingCTA 핸들러
-  const handleInstallClick = async () => {
-    // 설치 프롬프트 상태는 아래쪽 ConversionSection에서만 로드한다.
-    // Floating CTA는 초기 번들을 줄이기 위해 설치 영역으로 이동만 담당한다.
-    conversionRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }
-
-  const handleExploreClick = () => {
-    setHasVisitedCookie()
-    router.push('/map')
-  }
-
   return (
     <div className="min-h-screen overflow-x-hidden bg-background">
-      {/* 히어로 — SSR 시점부터 바로 렌더 (스켈레톤 없음) */}
       <HeroSection
-        ref={heroRef}
         reducedMotion={reducedMotion}
         showcaseSpots={showcaseSpots}
       />
 
-      {/* EntryPointSection — 목적별 3개 카드 진입점 (Requirements 4.1) */}
       <EntryPointSection />
-
-      {/* HowItWorks — 4단계 플로우 */}
-      <HowItWorksSection />
-
-      {/* StorytellingSection — 카테고리 스토리텔링 */}
       <div
         className="h-px bg-gradient-to-r from-transparent via-primary-500/30 to-transparent"
         aria-hidden="true"
@@ -116,24 +62,7 @@ export function WelcomePageClient({
         reducedMotion={reducedMotion}
         categoryImages={categoryImages}
       />
-
-      {/* SocialProofSection — 자동 스크롤 슬라이더 */}
-      <div
-        className="h-px bg-gradient-to-r from-transparent via-border to-transparent dark:via-white/10"
-        aria-hidden="true"
-      />
-      <SocialProofSection proofImages={proofImages} />
-
-      {/* ConversionSection — PWA 설치 유도 전환 영역 */}
-      <ConversionSection ref={conversionRef} isStandalone={isStandalone} />
-
-      {/* FloatingCTA — Hero 이탈 후 ~ Conversion 진입 전 표시 */}
-      <FloatingCTA
-        visible={heroExited && !conversionVisible}
-        isStandalone={isStandalone}
-        onInstallClick={handleInstallClick}
-        onExploreClick={handleExploreClick}
-      />
+      <InformationStandardsSection />
     </div>
   )
 }

--- a/src/components/landing/__tests__/information-first-landing.test.ts
+++ b/src/components/landing/__tests__/information-first-landing.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs'
+import path from 'path'
+
+const projectRoot = path.resolve(__dirname, '../../../../')
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+}
+
+describe('information-first landing contract', () => {
+  it('keeps the landing sequence focused on public discovery information', () => {
+    const page = read('src/app/(landing)/welcome/page.tsx')
+    const client = read('src/components/landing/WelcomePageClient.tsx')
+
+    expect(page).toContain('fetchShowcaseSpots')
+    expect(page).toContain('fetchCategoryImages')
+    expect(page).not.toContain('fetchProofImages')
+
+    expect(client).toContain('<HeroSection')
+    expect(client).toContain('<EntryPointSection />')
+    expect(client).toContain('<StorytellingSection')
+    expect(client).toContain('<InformationStandardsSection />')
+    expect(client).not.toContain('<SocialProofSection')
+    expect(client).not.toContain('<ConversionSection')
+    expect(client).not.toContain('<FloatingCTA')
+    expect(client).not.toContain('proofImages')
+  })
+
+  it('routes the three primary entry points to information surfaces', () => {
+    const entryPoints = read('src/components/landing/EntryPointSection.tsx')
+
+    expect(entryPoints).toContain("href: '/contents'")
+    expect(entryPoints).toContain("href: '/map'")
+    expect(entryPoints).toContain("href: '/routes'")
+    expect(entryPoints).not.toContain("href: '/gallery'")
+    expect(entryPoints).toContain('작품별 장소 찾기')
+    expect(entryPoints).toContain('지도에서 위치 확인')
+    expect(entryPoints).toContain('추천 코스 살펴보기')
+  })
+
+  it('does not present static testimonials as current community activity', () => {
+    const hero = read('src/components/landing/HeroSection.tsx')
+    const entryPoints = read('src/components/landing/EntryPointSection.tsx')
+
+    expect(hero).not.toContain('팬들이 남긴 실제 장소')
+    expect(entryPoints).not.toContain('다른 팬들의 사진과 후기')
+    expect(hero).toContain('실제 장소 정보 가이드')
+  })
+})

--- a/src/components/landing/__tests__/landing-theme-softening.test.ts
+++ b/src/components/landing/__tests__/landing-theme-softening.test.ts
@@ -37,15 +37,17 @@ describe('landing theme and softer visual tone', () => {
   it('핵심 카드/히어로 섹션은 시맨틱 텍스트 토큰과 부드러운 라운딩을 사용한다', () => {
     const hero = read('src/components/landing/HeroSection.tsx')
     const entry = read('src/components/landing/EntryPointSection.tsx')
-    const howItWorks = read('src/components/landing/HowItWorksSection.tsx')
+    const informationStandards = read(
+      'src/components/landing/InformationStandardsSection.tsx'
+    )
     const proofCard = read('src/components/landing/ProofCard.tsx')
 
     expect(hero).toContain('text-main-text')
     expect(hero).toContain('text-sub-text')
     expect(entry).toContain('text-main-text')
     expect(entry).toContain('rounded-[1.5rem]')
-    expect(howItWorks).toContain('text-main-text')
-    expect(howItWorks).toContain('rounded-[1.5rem]')
+    expect(informationStandards).toContain('text-main-text')
+    expect(informationStandards).toContain('rounded-[1.5rem]')
     expect(proofCard).toContain('rounded-[1.35rem]')
   })
 
@@ -69,9 +71,11 @@ describe('landing theme and softer visual tone', () => {
   it('강조 문구는 무지개형 그라데이션 텍스트 대신 단색 브랜드 텍스트를 사용한다', () => {
     const hero = read('src/components/landing/HeroSection.tsx')
     const entry = read('src/components/landing/EntryPointSection.tsx')
-    const howItWorks = read('src/components/landing/HowItWorksSection.tsx')
+    const informationStandards = read(
+      'src/components/landing/InformationStandardsSection.tsx'
+    )
 
-    for (const source of [hero, entry, howItWorks]) {
+    for (const source of [hero, entry, informationStandards]) {
       expect(source).not.toContain('bg-clip-text text-transparent')
       expect(source).not.toContain(
         'from-primary-600 via-secondary-600 to-sunset-500'
@@ -80,7 +84,9 @@ describe('landing theme and softer visual tone', () => {
 
     expect(hero).toContain('text-primary-600 dark:text-primary-300')
     expect(entry).toContain('text-primary-600 dark:text-primary-300')
-    expect(howItWorks).toContain('text-primary-600 dark:text-primary-300')
+    expect(informationStandards).toContain(
+      'text-primary-600 dark:text-primary-300'
+    )
   })
   it('uses actual spot photos instead of category icons for landing card visuals', () => {
     const categoryCard = read('src/components/landing/CategoryCard.tsx')


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #918

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [x] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 첫 방문자가 Not a Trip을 작품 속 실제 장소 정보 가이드로 이해하도록 랜딩의 정보 구조와 메시지를 재구성합니다.

---

## 📋 변경 사항

- [x] 검색, 작품, 지도, 편집 코스를 1차 정보 탐색 흐름으로 재구성
- [x] 실제 인증이 없는 상태의 정적 소셜 프루프와 반복 PWA 설치 전환 제거
- [x] DESIGN.md에 정보 우선 IA, 신뢰 원칙, 콘텐츠 위계 기록
- [x] 정보 우선 랜딩 회귀 테스트 및 기존 테마 테스트 갱신

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

- Before: 프로덕션 `/welcome`의 검색, 사용법, 카테고리, 정적 후기, 설치 전환이 이어지는 약 5,258px 데스크톱 랜딩
- After: 검색 → 정보 진입점 → 분야별 장소 → 정보 구성 원칙으로 축소
- 1440×1100 데스크톱과 390×844 모바일 Playwright 캡처로 줄바꿈과 가로 오버플로우 확인

---

## 📝 추가 정보 (선택)

- 검증: `npm run release:check`, `npm run build`
- 결과: 117 test suites / 466 tests, lint, format, design-token, route validation, type-check, route JS budget 통과
- `/welcome` First Load JS: 244 kB (budget 245 kB)
- 인증된 복귀 사용자의 프로덕션 리다이렉트는 develop 머지 이후 배포 환경에서 별도 확인이 필요합니다.
