### PR TITLE
[ui] 정보 우선 전역 내비게이션 재구성

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,7 +27,7 @@
 
 ## Information architecture
 
-- Primary navigation: home, works, places/map, curated routes
+- Primary navigation: works, places/map, curated routes; the brand logo owns the home action
 - Secondary navigation: check-ins, place contribution, account and settings
 - Core routes/screens: `/welcome`, `/contents`, `/contents/[name]`, `/map`, `/spots/[id]`, `/routes`, `/routes/[id]`
 - Content hierarchy: search intent -> work/place context -> visit information -> map/route action -> optional contribution
@@ -52,7 +52,7 @@
 ## Components
 
 - Existing components to reuse: `LandingHeader`, `HeroSection`, `EntryPointSection`, `StorytellingSection`, `CategoryCard`, semantic design tokens
-- New/changed components: `InformationStandardsSection`; information-first variants of hero and entry-point copy
+- New/changed components: `InformationStandardsSection`; information-first variants of hero, entry-point copy, and global header navigation
 - Variants and states: real empty states must not be replaced with fictional testimonials
 - Token/component ownership: palette variables remain in `src/app/globals.css`; Tailwind exposure remains in `tailwind.config.ts`; components use semantic and category tokens instead of new raw colors
 
@@ -97,4 +97,4 @@
 
 - [ ] Define which spot fields qualify as verified and how the last-reviewed date is exposed / product owner / trust labeling
 - [ ] Decide when real check-in volume is sufficient to restore community proof on the landing page / product owner / social proof
-- [ ] Validate the primary navigation reduction in the next independent work unit / frontend / global IA
+- [x] Validate the primary navigation reduction in an independent work unit / frontend / global IA / 2026-08-26

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -32,39 +32,45 @@ const HeaderThemeSelectorHost = dynamic(
 
 const HIDDEN_HEADER_PATHS = ['/welcome']
 
-const NAV_ITEMS: NavItem[] = [
-  { href: '/', label: '홈', match: (pathname) => pathname === '/' },
-  {
-    href: '/map',
-    label: '지도 탐색',
-    icon: 'map',
-    match: (pathname) => pathname === '/map',
-  },
+const PRIMARY_NAV_ITEMS: NavItem[] = [
   {
     href: '/contents',
-    label: '작품 탐색',
+    label: '작품',
     icon: 'content-wise',
     match: (pathname) => pathname.startsWith('/contents'),
   },
   {
+    href: '/map',
+    label: '장소',
+    icon: 'map',
+    match: (pathname) => pathname === '/map',
+  },
+  {
+    href: '/routes',
+    label: '코스',
+    icon: 'map',
+    match: (pathname) => pathname.startsWith('/routes'),
+  },
+]
+
+const PARTICIPATION_NAV_ITEMS: NavItem[] = [
+  {
     href: '/gallery',
-    label: '성지 인증',
+    label: '방문 기록',
     icon: 'gallery',
     match: (pathname) => pathname.startsWith('/gallery'),
   },
   {
-    href: '/routes',
-    label: '성지 코스',
-    icon: 'map',
-    match: (pathname) => pathname.startsWith('/routes'),
-  },
-  {
     href: '/spots/register',
-    label: '스팟 등록',
+    label: '장소 제보',
     icon: 'spot',
     match: (pathname) => pathname.startsWith('/spots/register'),
   },
 ]
+
+function isNavItemActive(item: NavItem, pathname: string) {
+  return item.match?.(pathname) ?? pathname === item.href
+}
 
 function getNavLinkClass(isActive: boolean, mobile = false) {
   const base = mobile
@@ -91,6 +97,9 @@ export function Header() {
   }
 
   const closeMobileMenu = () => setIsMobileMenuOpen(false)
+  const isParticipationActive = PARTICIPATION_NAV_ITEMS.some((item) =>
+    isNavItemActive(item, pathname)
+  )
 
   return (
     <>
@@ -118,8 +127,8 @@ export function Header() {
             className="hidden items-center gap-1 lg:flex"
             aria-label="주요 메뉴"
           >
-            {NAV_ITEMS.map((item) => {
-              const isActive = item.match?.(pathname) ?? pathname === item.href
+            {PRIMARY_NAV_ITEMS.map((item) => {
+              const isActive = isNavItemActive(item, pathname)
               return (
                 <Link
                   key={item.href}
@@ -131,6 +140,50 @@ export function Header() {
                 </Link>
               )
             })}
+            <span className="mx-2 h-5 w-px bg-border" aria-hidden="true" />
+            <details className="group relative">
+              <summary
+                className={`${getNavLinkClass(isParticipationActive)} flex cursor-pointer list-none items-center gap-1.5 [&::-webkit-details-marker]:hidden`}
+                aria-label="참여 메뉴 열기"
+              >
+                참여
+                <svg
+                  className="h-4 w-4 transition group-open:rotate-180"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="m6 9 6 6 6-6"
+                  />
+                </svg>
+              </summary>
+              <div className="absolute right-0 top-[calc(100%+0.5rem)] w-48 rounded-2xl border border-border bg-surface p-2 shadow-lg">
+                <p className="text-text-tertiary px-3 pb-1 pt-2 text-xs font-semibold">
+                  정보에 참여하기
+                </p>
+                {PARTICIPATION_NAV_ITEMS.map((item) => {
+                  const isActive = isNavItemActive(item, pathname)
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={getNavLinkClass(isActive, true)}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      {item.icon && (
+                        <AppIcon name={item.icon} size="sm" alt="" />
+                      )}
+                      {item.label}
+                    </Link>
+                  )
+                })}
+              </div>
+            </details>
           </nav>
 
           <div className="flex items-center gap-2 sm:gap-3">
@@ -185,24 +238,56 @@ export function Header() {
             className="border-t border-border bg-surface/95 backdrop-blur-sm lg:hidden"
             aria-label="모바일 메뉴"
           >
-            <div className="space-y-1 px-4 py-3">
-              {NAV_ITEMS.map((item) => {
-                const isActive =
-                  item.match?.(pathname) ?? pathname === item.href
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={closeMobileMenu}
-                    className={getNavLinkClass(isActive, true)}
-                    aria-current={isActive ? 'page' : undefined}
-                  >
-                    {item.icon && <AppIcon name={item.icon} size="sm" alt="" />}
-                    {item.label}
-                  </Link>
-                )
-              })}
-              <div className="border-t border-border pt-2">
+            <div className="px-4 py-3">
+              <p className="text-text-tertiary px-3.5 pb-1 pt-1 text-xs font-semibold">
+                정보 탐색
+              </p>
+              <div className="space-y-1">
+                {PRIMARY_NAV_ITEMS.map((item) => {
+                  const isActive = isNavItemActive(item, pathname)
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={closeMobileMenu}
+                      className={getNavLinkClass(isActive, true)}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      {item.icon && (
+                        <AppIcon name={item.icon} size="sm" alt="" />
+                      )}
+                      {item.label}
+                    </Link>
+                  )
+                })}
+              </div>
+
+              <div className="mt-3 border-t border-border pt-3">
+                <p className="text-text-tertiary px-3.5 pb-1 text-xs font-semibold">
+                  참여
+                </p>
+                <div className="space-y-1">
+                  {PARTICIPATION_NAV_ITEMS.map((item) => {
+                    const isActive = isNavItemActive(item, pathname)
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={closeMobileMenu}
+                        className={getNavLinkClass(isActive, true)}
+                        aria-current={isActive ? 'page' : undefined}
+                      >
+                        {item.icon && (
+                          <AppIcon name={item.icon} size="sm" alt="" />
+                        )}
+                        {item.label}
+                      </Link>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div className="mt-3 border-t border-border pt-2">
                 <HeaderAuthControls
                   mobileMenuOpen
                   onMobileNavigate={closeMobileMenu}

--- a/src/lib/user-journey-ux.test.ts
+++ b/src/lib/user-journey-ux.test.ts
@@ -15,15 +15,19 @@ describe('spec 46 user journey UX hardening', () => {
     expect(workflow).toContain('테스트 파일을 main에서 제거하지 않는다')
     expect(workflow).toContain('develop을 main에 무차별 merge하지 않는다')
   })
-  test('global header exposes map navigation without removing existing IA', () => {
+  test('global header prioritizes public information without hiding participation', () => {
     const header = read('src/components/layout/Header.tsx')
 
+    expect(header).toContain('const PRIMARY_NAV_ITEMS')
+    expect(header).toContain('const PARTICIPATION_NAV_ITEMS')
     expect(header).toContain("href: '/map'")
-    expect(header).toContain("label: '지도 탐색'")
+    expect(header).toContain("label: '장소'")
     expect(header).toContain("href: '/contents'")
     expect(header).toContain("href: '/gallery'")
     expect(header).toContain("href: '/routes'")
     expect(header).toContain("href: '/spots/register'")
+    expect(header).toContain('정보 탐색')
+    expect(header).toContain('정보에 참여하기')
   })
 
   test('spot detail returns directly to map instead of root redirect branch', () => {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #920

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [x] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 전역 내비게이션을 정보 탐색 중심으로 재구성하고 참여 기능을 명확한 보조 영역으로 분리합니다.

---

## 📋 변경 사항

- [x] 데스크톱 주요 메뉴를 작품, 장소, 코스로 축소하고 중복 홈 링크 제거
- [x] 방문 기록과 장소 제보를 별도 참여 메뉴로 분리
- [x] 모바일 메뉴에 정보 탐색/참여 섹션과 현재 페이지 상태 적용
- [x] 정보 구조 계약 문서와 회귀 테스트 갱신

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

- 1440px 데스크톱 기본/참여 메뉴 열림 상태 확인
- 390px 모바일 메뉴 열림 상태 및 가로 오버플로 없음 확인

---

## 📝 추가 정보 (선택)

- 기존 `/contents`, `/map`, `/routes`, `/gallery`, `/spots/register` 경로는 모두 유지됩니다.
- 인증 사용자 및 관리자 메뉴 변형은 자동 검사 범위에 포함되지만 별도 시각 검증은 수행하지 않았습니다.