### PR TITLE
[feat] 관리자 일간 페이지 조회수 추가

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -113,8 +113,9 @@ export default function AdminDashboardPage() {
               />
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-8">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5">
               {[
+                ['오늘 페이지 조회', summary?.pageViewsToday ?? 0],
                 ['오늘 DAU', summary?.dauToday ?? 0],
                 ['오늘 체크인', summary?.totalCheckInsToday ?? 0],
                 ['24시간 5xx 비율', `${summary?.errorRate24h ?? 0}%`],
@@ -139,7 +140,49 @@ export default function AdminDashboardPage() {
               ))}
             </div>
 
-            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+              <section className="rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold text-neutral-800">
+                    최근 7일 페이지 조회
+                  </h2>
+                  <span className="text-xs text-neutral-500">
+                    공개 화면 · KST
+                  </span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  {summary?.pageViewTrend.map((point) => (
+                    <div key={point.date}>
+                      <div className="mb-1 flex items-center justify-between text-sm">
+                        <span className="text-neutral-500">
+                          {formatTrendLabel(point.date)}
+                        </span>
+                        <span className="font-medium text-neutral-800">
+                          {point.count}
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-neutral-100">
+                        <div
+                          className="h-2 rounded-full bg-primary"
+                          style={{
+                            width: `${Math.max(
+                              8,
+                              ((point.count || 0) /
+                                Math.max(
+                                  ...((summary?.pageViewTrend ?? []).map(
+                                    (item) => item.count
+                                  ) || [1])
+                                )) *
+                                100
+                            )}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
               <section className="rounded-xl border border-neutral-200 bg-surface p-6 shadow-sm">
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-semibold text-neutral-800">

--- a/src/app/api/internal/ops/page-view/route.test.ts
+++ b/src/app/api/internal/ops/page-view/route.test.ts
@@ -1,0 +1,64 @@
+const mockRecordPageViewMetric = jest.fn()
+
+jest.mock('@/lib/ops/metrics', () => ({
+  recordPageViewMetric: (...args: unknown[]) =>
+    mockRecordPageViewMetric(...args),
+}))
+
+import { NextRequest } from 'next/server'
+import { POST } from './route'
+
+function createRequest(path: unknown, origin = 'https://not-a-trip.com') {
+  return new NextRequest('https://not-a-trip.com/api/internal/ops/page-view', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      origin,
+    },
+    body: JSON.stringify({ path }),
+  })
+}
+
+describe('POST /api/internal/ops/page-view', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRecordPageViewMetric.mockResolvedValue(undefined)
+  })
+
+  test('records a normalized same-origin public page view', async () => {
+    const response = await POST(createRequest('/map?category=anime'))
+
+    expect(response.status).toBe(202)
+    expect(mockRecordPageViewMetric).toHaveBeenCalledWith('/map')
+  })
+
+  test('rejects cross-origin ingestion', async () => {
+    const response = await POST(createRequest('/map', 'https://example.com'))
+
+    expect(response.status).toBe(403)
+    expect(mockRecordPageViewMetric).not.toHaveBeenCalled()
+  })
+
+  test('rejects ingestion without a browser origin', async () => {
+    const request = new NextRequest(
+      'https://not-a-trip.com/api/internal/ops/page-view',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: '/map' }),
+      }
+    )
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(403)
+    expect(mockRecordPageViewMetric).not.toHaveBeenCalled()
+  })
+
+  test('rejects excluded page paths', async () => {
+    const response = await POST(createRequest('/admin'))
+
+    expect(response.status).toBe(400)
+    expect(mockRecordPageViewMetric).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/internal/ops/page-view/route.ts
+++ b/src/app/api/internal/ops/page-view/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { normalizeTrackablePagePath } from '@/lib/analytics/page-views'
+import { recordPageViewMetric } from '@/lib/ops/metrics'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const origin = request.headers.get('origin')
+    if (origin !== request.nextUrl.origin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = (await request.json()) as { path?: unknown }
+    const path = normalizeTrackablePagePath(body.path)
+    if (!path) {
+      return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+    }
+
+    await recordPageViewMetric(path)
+    return NextResponse.json({ ok: true }, { status: 202 })
+  } catch {
+    return NextResponse.json(
+      { error: 'Page view ingestion failed' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import 'leaflet/dist/leaflet.css'
 import './globals.css'
 import JsonLd from '@/components/seo/JsonLd'
 import GoogleAnalytics from '@/components/seo/GoogleAnalytics'
+import PageViewTracker from '@/components/analytics/PageViewTracker'
 import {
   generateOrganizationJsonLd,
   generateWebSiteJsonLd,
@@ -76,6 +77,7 @@ export default function RootLayout({
       </head>
       <body className={`${pretendard.variable} antialiased`}>
         <GoogleAnalytics />
+        <PageViewTracker />
         <JsonLd data={generateWebSiteJsonLd()} />
         <JsonLd data={generateOrganizationJsonLd()} />
         {children}

--- a/src/components/analytics/PageViewTracker.test.tsx
+++ b/src/components/analytics/PageViewTracker.test.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+
+import { render, waitFor } from '@testing-library/react'
+import PageViewTracker from './PageViewTracker'
+
+let currentPathname = '/contents'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => currentPathname,
+}))
+
+describe('PageViewTracker', () => {
+  const mockFetch = jest.fn().mockResolvedValue({ ok: true })
+
+  beforeEach(() => {
+    currentPathname = '/contents'
+    mockFetch.mockClear()
+    global.fetch = mockFetch
+  })
+
+  test('tracks initial load and subsequent public route changes once', async () => {
+    const { rerender } = render(<PageViewTracker />)
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      '/api/internal/ops/page-view',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ path: '/contents' }),
+        keepalive: true,
+      })
+    )
+
+    rerender(<PageViewTracker />)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    currentPathname = '/map'
+    rerender(<PageViewTracker />)
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+  })
+
+  test('does not track excluded administration routes', async () => {
+    currentPathname = '/admin'
+    render(<PageViewTracker />)
+
+    await waitFor(() => expect(mockFetch).not.toHaveBeenCalled())
+  })
+})

--- a/src/components/analytics/PageViewTracker.tsx
+++ b/src/components/analytics/PageViewTracker.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+import { API_ROUTES } from '@/lib/api-routes'
+import { normalizeTrackablePagePath } from '@/lib/analytics/page-views'
+
+export default function PageViewTracker() {
+  const pathname = usePathname()
+  const lastTrackedPath = useRef<string | null>(null)
+
+  useEffect(() => {
+    const trackablePath = normalizeTrackablePagePath(pathname)
+    if (!trackablePath || lastTrackedPath.current === trackablePath) {
+      return
+    }
+
+    lastTrackedPath.current = trackablePath
+    void fetch(API_ROUTES.INTERNAL.PAGE_VIEW, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: trackablePath }),
+      keepalive: true,
+    }).catch(() => undefined)
+  }, [pathname])
+
+  return null
+}

--- a/src/lib/analytics/page-views.test.ts
+++ b/src/lib/analytics/page-views.test.ts
@@ -1,0 +1,33 @@
+import { normalizeTrackablePagePath } from './page-views'
+
+describe('page view path normalization', () => {
+  test.each(['/welcome', '/contents', '/contents/example', '/map', '/routes'])(
+    'accepts public path %s',
+    (path) => {
+      expect(normalizeTrackablePagePath(path)).toBe(path)
+    }
+  )
+
+  test.each([
+    '/admin',
+    '/admin/reports',
+    '/api/spots',
+    '/auth/signin',
+    '/offline',
+  ])('rejects non-public path %s', (path) => {
+    expect(normalizeTrackablePagePath(path)).toBeNull()
+  })
+
+  test('removes query strings and fragments before storage', () => {
+    expect(normalizeTrackablePagePath('/map?category=anime#results')).toBe(
+      '/map'
+    )
+  })
+
+  test('rejects malformed and oversized values', () => {
+    expect(normalizeTrackablePagePath('map')).toBeNull()
+    expect(normalizeTrackablePagePath(null)).toBeNull()
+    expect(normalizeTrackablePagePath('/map\nforged')).toBeNull()
+    expect(normalizeTrackablePagePath(`/${'a'.repeat(301)}`)).toBeNull()
+  })
+})

--- a/src/lib/analytics/page-views.ts
+++ b/src/lib/analytics/page-views.ts
@@ -1,0 +1,29 @@
+const EXCLUDED_PAGE_PREFIXES = [
+  '/admin',
+  '/api',
+  '/auth',
+  '/monitoring',
+  '/offline',
+  '/_next',
+]
+
+export function normalizeTrackablePagePath(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.startsWith('/')) {
+    return null
+  }
+
+  const pathname = value.split(/[?#]/, 1)[0]
+  if (
+    !pathname ||
+    pathname.length > 300 ||
+    /[\u0000-\u001f\u007f]/.test(pathname)
+  ) {
+    return null
+  }
+
+  const isExcluded = EXCLUDED_PAGE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  )
+
+  return isExcluded ? null : pathname
+}

--- a/src/lib/api-routes.ts
+++ b/src/lib/api-routes.ts
@@ -127,6 +127,11 @@ export const API_ROUTES = {
     DASHBOARD_SUMMARY: '/api/admin/dashboard/summary',
   },
 
+  // Internal first-party telemetry
+  INTERNAL: {
+    PAGE_VIEW: '/api/internal/ops/page-view',
+  },
+
   // Content Names (자동완성)
   CONTENT_NAMES: '/api/content-names',
 

--- a/src/lib/ops/dashboard.test.ts
+++ b/src/lib/ops/dashboard.test.ts
@@ -1,5 +1,6 @@
 const mockGetCollection = jest.fn()
 const mockGetTrackedApiErrorRate24h = jest.fn()
+const mockGetTrackedPageViewTrend = jest.fn()
 const mockGetSlaStatistics = jest.fn()
 
 jest.mock('@/lib/db', () => ({
@@ -20,6 +21,8 @@ jest.mock('@/lib/db', () => ({
 jest.mock('./metrics', () => ({
   getTrackedApiErrorRate24h: (...args: unknown[]) =>
     mockGetTrackedApiErrorRate24h(...args),
+  getTrackedPageViewTrend: (...args: unknown[]) =>
+    mockGetTrackedPageViewTrend(...args),
 }))
 
 jest.mock('@/lib/spot-quality/report-processor', () => ({
@@ -42,6 +45,12 @@ describe('ops dashboard summary', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetTrackedApiErrorRate24h.mockResolvedValue(12.5)
+    mockGetTrackedPageViewTrend.mockResolvedValue(
+      Array.from({ length: 7 }, (_, index) => ({
+        date: `2026-08-${String(20 + index).padStart(2, '0')}`,
+        count: index + 10,
+      }))
+    )
     mockGetSlaStatistics.mockResolvedValue({
       complianceRate: 95,
       averageProcessingTime: 18,
@@ -170,6 +179,7 @@ describe('ops dashboard summary', () => {
     expect(result.errorRate24h).toBe(12.5)
     expect(result.newUsersToday).toBe(8)
     expect(result.newSpotsToday).toBe(9)
+    expect(result.pageViewsToday).toBe(16)
     expect(result.qualitySla).toEqual({
       complianceRate: 95,
       averageProcessingTime: 18,
@@ -177,6 +187,7 @@ describe('ops dashboard summary', () => {
     })
     expect(result.dauTrend).toHaveLength(7)
     expect(result.checkInTrend).toHaveLength(7)
+    expect(result.pageViewTrend).toHaveLength(7)
     expect(result.generatedAt).toEqual(expect.any(String))
   })
 })

--- a/src/lib/ops/dashboard.ts
+++ b/src/lib/ops/dashboard.ts
@@ -1,6 +1,6 @@
 import { COLLECTIONS, getCollection } from '@/lib/db'
 import type { DashboardSummaryResponse } from '@/types/report'
-import { getTrackedApiErrorRate24h } from './metrics'
+import { getTrackedApiErrorRate24h, getTrackedPageViewTrend } from './metrics'
 import { getSlaStatistics } from '@/lib/spot-quality/report-processor'
 
 interface ActivityDocument {
@@ -176,6 +176,7 @@ export async function buildDashboardSummary(): Promise<DashboardSummaryResponse>
     qualitySla,
     dauTrend,
     checkInTrend,
+    pageViewTrend,
   ] = await Promise.all([
     getPendingReviewCounts(),
     getDauToday(),
@@ -186,6 +187,7 @@ export async function buildDashboardSummary(): Promise<DashboardSummaryResponse>
     getSlaStatistics(),
     getDauTrend(),
     getCheckInTrend(),
+    getTrackedPageViewTrend(),
   ])
 
   return {
@@ -198,6 +200,8 @@ export async function buildDashboardSummary(): Promise<DashboardSummaryResponse>
     qualitySla,
     dauTrend,
     checkInTrend,
+    pageViewsToday: pageViewTrend.at(-1)?.count ?? 0,
+    pageViewTrend,
     generatedAt: new Date().toISOString(),
   }
 }

--- a/src/lib/ops/metrics.test.ts
+++ b/src/lib/ops/metrics.test.ts
@@ -1,0 +1,71 @@
+const mockInsertOne = jest.fn()
+const mockAggregateToArray = jest.fn()
+const mockAggregate = jest.fn((_pipeline: unknown) => ({
+  toArray: mockAggregateToArray,
+}))
+
+jest.mock('@/lib/db', () => ({
+  COLLECTIONS: { OPS_METRICS: 'ops_metrics' },
+  getCollection: jest.fn().mockResolvedValue({
+    insertOne: (...args: unknown[]) => mockInsertOne(...args),
+    aggregate: (pipeline: unknown) => mockAggregate(pipeline),
+  }),
+}))
+
+import { getTrackedPageViewTrend, recordPageViewMetric } from './metrics'
+
+describe('page view metrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockInsertOne.mockResolvedValue({ acknowledged: true })
+  })
+
+  test('records only the page path and creation time', async () => {
+    await recordPageViewMetric('/contents/example')
+
+    expect(mockInsertOne).toHaveBeenCalledWith({
+      kind: 'page_view',
+      path: '/contents/example',
+      createdAt: expect.any(Date),
+    })
+  })
+
+  test('builds a zero-filled KST daily trend from page view events', async () => {
+    mockAggregateToArray.mockResolvedValue([
+      { _id: '2026-08-25', count: 4 },
+      { _id: '2026-08-26', count: 7 },
+    ])
+
+    const trend = await getTrackedPageViewTrend(
+      3,
+      new Date('2026-08-26T02:00:00.000Z')
+    )
+
+    expect(trend).toEqual([
+      { date: '2026-08-24', count: 0 },
+      { date: '2026-08-25', count: 4 },
+      { date: '2026-08-26', count: 7 },
+    ])
+    expect(mockAggregate).toHaveBeenCalledTimes(1)
+    expect(mockAggregate).toHaveBeenCalledWith([
+      {
+        $match: {
+          kind: 'page_view',
+          createdAt: { $gte: expect.any(Date), $lt: expect.any(Date) },
+        },
+      },
+      {
+        $group: {
+          _id: {
+            $dateToString: {
+              format: '%Y-%m-%d',
+              date: '$createdAt',
+              timezone: 'Asia/Seoul',
+            },
+          },
+          count: { $sum: 1 },
+        },
+      },
+    ])
+  })
+})

--- a/src/lib/ops/metrics.ts
+++ b/src/lib/ops/metrics.ts
@@ -1,10 +1,33 @@
 import { COLLECTIONS, getCollection } from '@/lib/db'
 
 export interface OpsMetricRecord {
-  kind: 'api_request' | 'api_error'
+  kind: 'api_request' | 'api_error' | 'page_view'
   path: string
   statusCode?: number
   createdAt: Date
+}
+
+const KOREA_TIME_OFFSET_MS = 9 * 60 * 60 * 1000
+
+function startOfKoreanDay(date: Date): Date {
+  const koreaDate = new Date(date.getTime() + KOREA_TIME_OFFSET_MS)
+  return new Date(
+    Date.UTC(
+      koreaDate.getUTCFullYear(),
+      koreaDate.getUTCMonth(),
+      koreaDate.getUTCDate()
+    ) - KOREA_TIME_OFFSET_MS
+  )
+}
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000)
+}
+
+function formatKoreanDayKey(date: Date): string {
+  return new Date(date.getTime() + KOREA_TIME_OFFSET_MS)
+    .toISOString()
+    .slice(0, 10)
 }
 
 export async function recordApiRequestMetric(path: string): Promise<void> {
@@ -30,6 +53,65 @@ export async function recordApiErrorMetric(params: {
     path: params.path,
     statusCode: params.statusCode ?? 500,
     createdAt: new Date(),
+  })
+}
+
+export async function recordPageViewMetric(path: string): Promise<void> {
+  const collection = await getCollection<OpsMetricRecord>(
+    COLLECTIONS.OPS_METRICS
+  )
+  await collection.insertOne({
+    kind: 'page_view',
+    path,
+    createdAt: new Date(),
+  })
+}
+
+export async function getTrackedPageViewTrend(
+  days = 7,
+  now = new Date()
+): Promise<Array<{ date: string; count: number }>> {
+  const collection = await getCollection<OpsMetricRecord>(
+    COLLECTIONS.OPS_METRICS
+  )
+  const dayStarts = Array.from({ length: days }, (_, index) =>
+    startOfKoreanDay(addDays(now, index - (days - 1)))
+  )
+
+  if (dayStarts.length === 0) {
+    return []
+  }
+
+  const counts = await collection
+    .aggregate<{ _id: string; count: number }>([
+      {
+        $match: {
+          kind: 'page_view',
+          createdAt: {
+            $gte: dayStarts[0],
+            $lt: addDays(dayStarts.at(-1)!, 1),
+          },
+        },
+      },
+      {
+        $group: {
+          _id: {
+            $dateToString: {
+              format: '%Y-%m-%d',
+              date: '$createdAt',
+              timezone: 'Asia/Seoul',
+            },
+          },
+          count: { $sum: 1 },
+        },
+      },
+    ])
+    .toArray()
+  const countByDate = new Map(counts.map((point) => [point._id, point.count]))
+
+  return dayStarts.map((dayStart) => {
+    const date = formatKoreanDayKey(dayStart)
+    return { date, count: countByDate.get(date) ?? 0 }
   })
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl
 
   if (pathname.startsWith('/api/')) {
-    if (pathname === '/api/internal/ops/request') {
+    if (pathname.startsWith('/api/internal/ops/')) {
       return NextResponse.next()
     }
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -219,6 +219,7 @@ export interface DashboardSummaryResponse {
   errorRate24h: number
   newUsersToday: number
   newSpotsToday: number
+  pageViewsToday: number
   qualitySla?: {
     complianceRate: number
     averageProcessingTime: number
@@ -226,6 +227,7 @@ export interface DashboardSummaryResponse {
   }
   dauTrend: Array<{ date: string; count: number }>
   checkInTrend: Array<{ date: string; count: number }>
+  pageViewTrend: Array<{ date: string; count: number }>
   generatedAt: string
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #922

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 개인정보를 저장하지 않는 공개 페이지 조회 집계를 추가하고 관리자 대시보드에서 일간 이용량을 확인합니다.

---

## 📋 변경 사항

- [x] 최초 로드와 클라이언트 라우트 이동을 중복 없이 기록하는 추적기 추가
- [x] 관리자/인증/API 화면과 쿼리 문자열을 제외하는 서버 검증 추가
- [x] KST 기준 오늘 페이지 조회수와 최근 7일 단일 MongoDB 집계 추가
- [x] 관리자 대시보드 지표 카드와 7일 추이 UI 추가
- [x] 경로 정규화, 수집 API, 클라이언트 추적, 운영 집계 회귀 테스트 추가

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

- 1440px 관리자 대시보드 전체 화면 확인
- 390px 관리자 대시보드 전체 화면 및 가로 오버플로 없음 확인

---

## 📝 추가 정보 (선택)

- 사용자 식별자, IP 주소, 쿼리 문자열은 저장하지 않습니다.
- 배포 전 날짜의 조회수는 소급 추정하지 않고 0으로 표시됩니다.
- 기존 GA4 수집은 유지하며 이번 지표는 독립적인 1차 운영 집계입니다.