### PR TITLE
[fix] MongoDB 백업 및 복구 대상 환경 로드

### DIFF
--- a/scripts/backup-mongodb.mjs
+++ b/scripts/backup-mongodb.mjs
@@ -1,6 +1,12 @@
 import { spawnSync } from 'child_process'
 import { mkdirSync, readdirSync, rmSync, statSync } from 'fs'
 import { join } from 'path'
+import {
+  describeMongoTarget,
+  loadRepositoryEnv,
+} from './lib/load-repository-env.mjs'
+
+loadRepositoryEnv()
 
 const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/not-a-trip'
 const backupRoot = process.env.BACKUP_DIR || 'backups'
@@ -9,6 +15,7 @@ const timestamp = now.toISOString().replace(/[:.]/g, '-')
 const archivePath = join(backupRoot, `mongodb-backup-${timestamp}.archive.gz`)
 
 mkdirSync(backupRoot, { recursive: true })
+console.log(`Backup target: ${describeMongoTarget(uri)}`)
 
 const result = spawnSync(
   'mongodump',

--- a/scripts/lib/load-repository-env.mjs
+++ b/scripts/lib/load-repository-env.mjs
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * @param {{ cwd?: string, env?: Record<string, string | undefined> }} options
+ */
+export function loadRepositoryEnv({
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  for (const file of ['.env.local', '.env']) {
+    const filePath = path.join(cwd, file)
+    if (!fs.existsSync(filePath)) continue
+
+    for (const line of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+      const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
+      if (!match || env[match[1]]) continue
+
+      let value = match[2].trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      env[match[1]] = value
+    }
+  }
+
+  return env
+}
+
+export function describeMongoTarget(uri) {
+  try {
+    const parsed = new URL(uri)
+    const database = parsed.pathname.replace(/^\//, '') || 'default'
+    return `${parsed.hostname}/${database}`
+  } catch {
+    return 'unparseable-target'
+  }
+}

--- a/scripts/lib/load-repository-env.test.ts
+++ b/scripts/lib/load-repository-env.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  describeMongoTarget,
+  loadRepositoryEnv,
+} from './load-repository-env.mjs'
+
+describe('repository environment loader', () => {
+  it('loads .env.local before .env without replacing explicit variables', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-env-'))
+    try {
+      fs.writeFileSync(
+        path.join(directory, '.env.local'),
+        'MONGODB_URI="mongodb+srv://user:pass@example.test/not-a-trip"\nKEEP=local\n'
+      )
+      fs.writeFileSync(
+        path.join(directory, '.env'),
+        'MONGODB_URI=mongodb://localhost/fallback\nKEEP=file\n'
+      )
+      const env: Record<string, string | undefined> = { KEEP: 'explicit' }
+
+      loadRepositoryEnv({ cwd: directory, env })
+
+      expect(env).toEqual({
+        KEEP: 'explicit',
+        MONGODB_URI: 'mongodb+srv://user:pass@example.test/not-a-trip',
+      })
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('describes a MongoDB target without exposing credentials', () => {
+    expect(
+      describeMongoTarget(
+        'mongodb+srv://private-user:private-pass@example.test/not-a-trip'
+      )
+    ).toBe('example.test/not-a-trip')
+  })
+})

--- a/scripts/restore-mongodb.mjs
+++ b/scripts/restore-mongodb.mjs
@@ -1,4 +1,10 @@
 import { spawnSync } from 'child_process'
+import {
+  describeMongoTarget,
+  loadRepositoryEnv,
+} from './lib/load-repository-env.mjs'
+
+loadRepositoryEnv()
 
 const archivePath = process.argv[2]
 const targetDb = process.argv[3]
@@ -10,6 +16,9 @@ if (!archivePath || !targetDb) {
   )
   process.exit(1)
 }
+
+console.log(`Restore source target: ${describeMongoTarget(uri)}`)
+console.log(`Restore destination database: ${targetDb}`)
 
 const result = spawnSync(
   'mongorestore',


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #928

---

## 📋 PR 타입

- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> MongoDB 백업·복구 스크립트가 저장소 환경을 읽지 않고 로컬 DB를 대상으로 삼는 문제를 차단합니다.

---

## 📋 변경 사항

- [x] `.env.local`, `.env` 순서로 환경을 로드하는 공용 유틸리티 추가
- [x] 백업·복구 대상 호스트와 DB를 자격 증명 없이 출력
- [x] 환경 우선순위와 자격 증명 비노출 회귀 테스트 추가
- [x] Atlas 실제 백업 생성 및 핵심 컬렉션 문서 수 확인

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- 운영 스크립트 변경으로 UI 스크린샷 없음 -->

---

## 📝 추가 정보 (선택)

- 실제 백업 대상: `notatrip.7c4nizs.mongodb.net/not-a-trip`
- 실제 백업: `backups/mongodb-backup-2026-08-30T16-51-35-713Z.archive.gz` (로컬 보관, Git 제외)
- 백업 확인: 스팟 115개, 코스 16개, 콘텐츠 마스터 123개, 관계 141개
- 검증: 127 test suites / 512 tests 및 Next.js production build
- 실제 복구는 파괴적 작업이므로 실행하지 않음