### PR TITLE
fix(map): CARTO API KEY REQUIRED 워터마크 제거

### DIFF
--- a/src/components/map/SpotDetailMap.tsx
+++ b/src/components/map/SpotDetailMap.tsx
@@ -189,8 +189,8 @@ export default function SpotDetailMap({
         }}
       >
         <TileLayer
-          attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
-          url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           className="map-tiles"
           maxZoom={19}
           tileSize={256}

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -221,8 +221,8 @@ export default function RouteMap({
         keyboard={false}
       >
         <TileLayer
-          attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
-          url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           className="map-tiles"
           maxZoom={19}
         />

--- a/src/components/spot/LocationPicker.tsx
+++ b/src/components/spot/LocationPicker.tsx
@@ -194,8 +194,8 @@ export function LocationPicker({
           touchZoom={true}
         >
           <TileLayer
-            attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
-            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
             maxZoom={19}
           />
 

--- a/src/lib/map-tile-provider.test.ts
+++ b/src/lib/map-tile-provider.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const repoRoot = process.cwd()
+
+const mapSources = [
+  'src/components/map/PilgrimageMap.tsx',
+  'src/components/map/SpotDetailMap.tsx',
+  'src/components/route/RouteMap.tsx',
+  'src/components/spot/LocationPicker.tsx',
+]
+
+describe('map tile provider contract', () => {
+  test.each(mapSources)(
+    '%s uses the keyless OpenStreetMap tile endpoint',
+    (file) => {
+      const source = readFileSync(path.join(repoRoot, file), 'utf8')
+
+      expect(source).toContain(
+        'url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"'
+      )
+      expect(source).toContain('https://www.openstreetmap.org/copyright')
+      expect(source).not.toContain('basemaps.cartocdn.com')
+    }
+  )
+
+  test('service worker does not retain the obsolete CARTO tile cache route', () => {
+    const source = readFileSync(path.join(repoRoot, 'src/sw.ts'), 'utf8')
+
+    expect(source).toContain('tile\\.openstreetmap\\.org')
+    expect(source).not.toContain('basemaps\\.cartocdn\\.com')
+    expect(source).not.toContain("cacheName: 'external-tiles'")
+  })
+})

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -49,19 +49,6 @@ const serwist = new Serwist({
         ],
       }),
     },
-    // 외부 타일 서버 (Carto): CacheFirst (요구사항 3.7)
-    {
-      matcher: /^https:\/\/.*basemaps\.cartocdn\.com/,
-      handler: new CacheFirst({
-        cacheName: 'external-tiles',
-        plugins: [
-          new ExpirationPlugin({
-            maxEntries: 500,
-            maxAgeSeconds: 30 * 24 * 60 * 60,
-          }),
-        ],
-      }),
-    },
     // 스팟 데이터 API: StaleWhileRevalidate
     {
       matcher: /\/api\/spots/,


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #932

---

## 🏷 PR 유형
- [ ] ✨ **feat**: 새로운 기능 추가
- [x] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🔧 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📝 **docs**: 문서 수정

---

## 📝 작업 개요

CARTO가 무키 Voyager raster tile 요청에 `API KEY REQUIRED` 워터마크를 표시하기 시작해 스팟 상세, 코스 상세, 위치 선택 지도가 깨져 보이는 문제를 제거합니다. 등록된 Google Maps 키는 CARTO 인증과 무관하므로, 이미 메인 지도에서 사용하는 키 없는 OpenStreetMap 표준 타일로 공급자를 통일했습니다.

---

## 🔨 변경 사항

- [x] 스팟 상세, 코스 상세, 위치 선택 지도의 CARTO 타일을 OpenStreetMap으로 교체
- [x] 서비스 워커의 obsolete CARTO runtime cache matcher 제거
- [x] 모든 지도 컴포넌트가 키 없는 OSM endpoint를 유지하는 회귀 테스트 추가

---

## ✅ 체크리스트
- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

배포 후 프로덕션 스팟 상세와 코스 상세 지도를 Playwright로 재검증합니다.

---

## 📌 추가 정보 (선택)

- 전체 테스트: 128 suites, 517 tests 통과
- `npm run type-check`, `npm run format:check` 통과
- Google Places용 `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`는 변경하지 않습니다.