### PR TITLE
feat(data): 신규 스팟 근처 편의시설 보강

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "routes:validate:seeded": "node scripts/validate-routes.mjs --seeded-only",
     "pilgrimage:sync": "node scripts/sync-japan-anime-pilgrimage-catalog.mjs --write",
     "pilgrimage:check": "node scripts/sync-japan-anime-pilgrimage-catalog.mjs",
+    "facilities:missing:dry": "node scripts/seed-missing-spot-facilities.mjs",
+    "facilities:missing:apply": "node scripts/seed-missing-spot-facilities.mjs --apply",
     "qa:landing-mobile-overflow": "node scripts/verify-landing-mobile-overflow.mjs",
     "prepare": "husky install",
     "commit": "git-cz",

--- a/scripts/lib/nearby-facility-import.mjs
+++ b/scripts/lib/nearby-facility-import.mjs
@@ -1,0 +1,234 @@
+const EARTH_RADIUS_METERS = 6_371_000
+
+const DEFAULT_NAME_BY_TYPE = {
+  cafe: 'カフェ',
+  convenience_store: 'コンビニエンスストア',
+  other: '観光案内所',
+  public_restroom: '公衆トイレ',
+  restaurant: '飲食店',
+  station: '駅',
+}
+
+export function calculateDistanceMeters(origin, destination) {
+  const toRadians = Math.PI / 180
+  const deltaLat = (destination.lat - origin.lat) * toRadians
+  const deltaLng = (destination.lng - origin.lng) * toRadians
+  const originLat = origin.lat * toRadians
+  const destinationLat = destination.lat * toRadians
+  const haversine =
+    Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(originLat) * Math.cos(destinationLat) * Math.sin(deltaLng / 2) ** 2
+
+  return (
+    2 *
+    EARTH_RADIUS_METERS *
+    Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine))
+  )
+}
+
+export function normalizeCoordinates(coordinates) {
+  if (
+    Array.isArray(coordinates) &&
+    coordinates.length === 2 &&
+    coordinates.every(Number.isFinite)
+  ) {
+    return { lat: coordinates[0], lng: coordinates[1] }
+  }
+
+  if (
+    coordinates &&
+    Number.isFinite(coordinates.lat) &&
+    Number.isFinite(coordinates.lng)
+  ) {
+    return coordinates
+  }
+
+  return null
+}
+
+export function mapOsmFacilityType(tags = {}) {
+  if (tags.amenity === 'cafe') return 'cafe'
+  if (['restaurant', 'fast_food', 'food_court'].includes(tags.amenity)) {
+    return 'restaurant'
+  }
+  if (['convenience', 'supermarket'].includes(tags.shop)) {
+    return 'convenience_store'
+  }
+  if (
+    ['station', 'halt'].includes(tags.railway) ||
+    tags.public_transport === 'station' ||
+    tags.amenity === 'bus_station'
+  ) {
+    return 'station'
+  }
+  if (tags.amenity === 'toilets') return 'public_restroom'
+  if (tags.tourism === 'information' || tags.amenity === 'pharmacy') {
+    return 'other'
+  }
+
+  return null
+}
+
+function extractCoordinates(element) {
+  const lat = element.lat ?? element.center?.lat
+  const lng = element.lon ?? element.center?.lon
+  return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null
+}
+
+function extractName(tags, facilityType) {
+  return (
+    tags['name:ko'] ||
+    tags.name ||
+    tags['name:ja'] ||
+    tags['name:en'] ||
+    DEFAULT_NAME_BY_TYPE[facilityType]
+  )
+}
+
+function extractAddress(tags) {
+  if (tags['addr:full']) return tags['addr:full']
+
+  const locality = [
+    tags['addr:province'],
+    tags['addr:city'],
+    tags['addr:suburb'],
+    tags['addr:quarter'],
+    tags['addr:street'],
+    tags['addr:housenumber'],
+  ].filter(Boolean)
+
+  return locality.join(' ') || 'OpenStreetMap address unavailable'
+}
+
+export function normalizeOsmElement(element, spot) {
+  const facilityType = mapOsmFacilityType(element.tags)
+  const coordinates = extractCoordinates(element)
+  if (!facilityType || !coordinates) return null
+
+  const distance = Math.round(
+    calculateDistanceMeters(spot.coordinates, coordinates)
+  )
+
+  return {
+    name: extractName(element.tags ?? {}, facilityType),
+    type: facilityType,
+    address: extractAddress(element.tags ?? {}),
+    coordinates,
+    spotId: spot.id,
+    status: 'needs_verification',
+    verificationScore: 0,
+    upvotes: 0,
+    downvotes: 0,
+    source: {
+      provider: 'openstreetmap',
+      elementId: `${element.type}/${element.id}`,
+      url: `https://www.openstreetmap.org/${element.type}/${element.id}`,
+    },
+    distance,
+  }
+}
+
+export function selectFacilityCandidates(elements, spot, options = {}) {
+  const radiusMeters = options.radiusMeters ?? 2_000
+  const maxResults = options.maxResults ?? 5
+  const candidates = elements
+    .map((element) => normalizeOsmElement(element, spot))
+    .filter((facility) => facility && facility.distance <= radiusMeters)
+    .sort((left, right) => left.distance - right.distance)
+
+  const selected = []
+  const usedSources = new Set()
+  const usedTypes = new Set()
+  const usedNames = new Set()
+
+  for (const facility of candidates) {
+    if (usedSources.has(facility.source.elementId)) continue
+    if (usedTypes.has(facility.type)) continue
+    selected.push(facility)
+    usedSources.add(facility.source.elementId)
+    usedTypes.add(facility.type)
+    usedNames.add(`${facility.type}:${facility.name}`)
+    if (selected.length === maxResults) return selected
+  }
+
+  for (const facility of candidates) {
+    if (usedSources.has(facility.source.elementId)) continue
+    if (usedNames.has(`${facility.type}:${facility.name}`)) continue
+    selected.push(facility)
+    usedSources.add(facility.source.elementId)
+    usedNames.add(`${facility.type}:${facility.name}`)
+    if (selected.length === maxResults) break
+  }
+
+  return selected
+}
+
+export function hasNearbyFacility(spot, facilities, radiusMeters = 2_000) {
+  return facilities.some((facility) => {
+    const coordinates = normalizeCoordinates(facility.coordinates)
+    return (
+      coordinates &&
+      calculateDistanceMeters(spot.coordinates, coordinates) <= radiusMeters
+    )
+  })
+}
+
+function decodeXml(value) {
+  return value
+    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([\da-f]+);/gi, (_match, code) =>
+      String.fromCodePoint(Number.parseInt(code, 16))
+    )
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+export function parseOsmMapNodes(xml) {
+  const elements = []
+  const nodePattern = /<node\b([^>]*)>([\s\S]*?)<\/node>/g
+  const attributePattern = /\b(id|lat|lon)="([^"]+)"/g
+  const tagPattern = /<tag\s+k="([^"]+)"\s+v="([^"]*)"\s*\/>/g
+
+  for (const nodeMatch of xml.matchAll(nodePattern)) {
+    const attributes = Object.fromEntries(
+      [...nodeMatch[1].matchAll(attributePattern)].map((match) => [
+        match[1],
+        match[2],
+      ])
+    )
+    const tags = Object.fromEntries(
+      [...nodeMatch[2].matchAll(tagPattern)].map((match) => [
+        decodeXml(match[1]),
+        decodeXml(match[2]),
+      ])
+    )
+    if (!attributes.id || !attributes.lat || !attributes.lon) continue
+
+    elements.push({
+      type: 'node',
+      id: Number(attributes.id),
+      lat: Number(attributes.lat),
+      lon: Number(attributes.lon),
+      tags,
+    })
+  }
+
+  return elements
+}
+
+export function buildOsmMapUrl({ lat, lng }, radiusMeters) {
+  const latitudeDelta = radiusMeters / 111_320
+  const longitudeDelta =
+    radiusMeters / (111_320 * Math.cos((lat * Math.PI) / 180))
+  const bbox = [
+    lng - longitudeDelta,
+    lat - latitudeDelta,
+    lng + longitudeDelta,
+    lat + latitudeDelta,
+  ].join(',')
+
+  return `https://api.openstreetmap.org/api/0.6/map?bbox=${bbox}`
+}

--- a/scripts/lib/nearby-facility-import.test.ts
+++ b/scripts/lib/nearby-facility-import.test.ts
@@ -1,0 +1,109 @@
+import {
+  buildOsmMapUrl,
+  calculateDistanceMeters,
+  hasNearbyFacility,
+  mapOsmFacilityType,
+  normalizeOsmElement,
+  parseOsmMapNodes,
+  selectFacilityCandidates,
+} from './nearby-facility-import.mjs'
+
+const spot = {
+  id: 'REAL-ANI-054',
+  coordinates: { lat: 36.25, lng: 139.5 },
+}
+
+function element(id: number, tags: Record<string, string>, offset = 0.001) {
+  return {
+    type: 'node',
+    id,
+    lat: spot.coordinates.lat + offset,
+    lon: spot.coordinates.lng,
+    tags,
+  }
+}
+
+describe('nearby facility import', () => {
+  it('uses the same two-kilometer distance boundary as the spot API', () => {
+    expect(
+      calculateDistanceMeters({ lat: 35, lng: 139 }, { lat: 35.01, lng: 139 })
+    ).toBeCloseTo(1111.95, 0)
+    expect(
+      hasNearbyFacility(spot, [
+        { coordinates: [spot.coordinates.lat + 0.001, spot.coordinates.lng] },
+      ])
+    ).toBe(true)
+    expect(
+      hasNearbyFacility(spot, [
+        { coordinates: { lat: spot.coordinates.lat + 0.03, lng: 139.5 } },
+      ])
+    ).toBe(false)
+  })
+
+  it.each([
+    [{ amenity: 'cafe' }, 'cafe'],
+    [{ amenity: 'restaurant' }, 'restaurant'],
+    [{ amenity: 'toilets' }, 'public_restroom'],
+    [{ shop: 'convenience' }, 'convenience_store'],
+    [{ railway: 'halt' }, 'station'],
+    [{ tourism: 'information' }, 'other'],
+    [{ amenity: 'parking' }, null],
+  ])('maps supported OSM tags only', (tags, expected) => {
+    expect(mapOsmFacilityType(tags)).toBe(expected)
+  })
+
+  it('normalizes source identity, address fallback, and verification state', () => {
+    expect(
+      normalizeOsmElement(element(123, { amenity: 'toilets' }), spot)
+    ).toMatchObject({
+      name: '公衆トイレ',
+      type: 'public_restroom',
+      address: 'OpenStreetMap address unavailable',
+      spotId: spot.id,
+      status: 'needs_verification',
+      source: {
+        provider: 'openstreetmap',
+        elementId: 'node/123',
+        url: 'https://www.openstreetmap.org/node/123',
+      },
+    })
+  })
+
+  it('selects nearby category diversity first and de-duplicates OSM IDs', () => {
+    const candidates = selectFacilityCandidates(
+      [
+        element(1, { amenity: 'cafe', name: 'A' }, 0.001),
+        element(1, { amenity: 'cafe', name: 'A' }, 0.001),
+        element(2, { amenity: 'cafe', name: 'B' }, 0.002),
+        element(3, { shop: 'convenience', name: 'C' }, 0.003),
+      ],
+      spot,
+      { maxResults: 3 }
+    )
+
+    expect(candidates.map(({ name }) => name)).toEqual(['A', 'C', 'B'])
+  })
+
+  it('parses tagged nodes from the OSM map API fallback', () => {
+    const xml = `<osm><node id="123" lat="36.251" lon="139.5"><tag k="amenity" v="cafe"/><tag k="name" v="Tom &amp; Jerry"/></node><node id="456" lat="36.252" lon="139.5"/></osm>`
+    expect(parseOsmMapNodes(xml)).toEqual([
+      {
+        type: 'node',
+        id: 123,
+        lat: 36.251,
+        lon: 139.5,
+        tags: { amenity: 'cafe', name: 'Tom & Jerry' },
+      },
+    ])
+  })
+
+  it('builds an OSM map bounding box around the target', () => {
+    const url = new URL(buildOsmMapUrl(spot.coordinates, 500))
+    const bbox = url.searchParams.get('bbox')?.split(',').map(Number) ?? []
+    expect(bbox).toHaveLength(4)
+    expect(bbox[0]).toBeLessThan(spot.coordinates.lng)
+    expect(bbox[1]).toBeLessThan(spot.coordinates.lat)
+    expect(bbox[2]).toBeGreaterThan(spot.coordinates.lng)
+    expect(bbox[3]).toBeGreaterThan(spot.coordinates.lat)
+  })
+})

--- a/scripts/seed-missing-spot-facilities.mjs
+++ b/scripts/seed-missing-spot-facilities.mjs
@@ -1,0 +1,140 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { MongoClient } from 'mongodb'
+import {
+  buildOsmMapUrl,
+  hasNearbyFacility,
+  parseOsmMapNodes,
+  selectFacilityCandidates,
+} from './lib/nearby-facility-import.mjs'
+import {
+  describeMongoTarget,
+  loadRepositoryEnv,
+} from './lib/load-repository-env.mjs'
+
+const TARGET_ID_PATTERN = '^REAL-ANI-(05[0-9]|06[0-9]|07[0-9]|08[0-9]|09[0-3])$'
+const RADIUS_METERS = 2_000
+const APPLY = process.argv.includes('--apply')
+const execFileAsync = promisify(execFile)
+
+async function fetchOsmElements(spot, radiusMeters) {
+  const { stdout } = await execFileAsync(
+    'curl',
+    [
+      '--silent',
+      '--show-error',
+      '--fail-with-body',
+      '--max-time',
+      '60',
+      '--header',
+      'User-Agent: not-a-trip-facility-maintenance/1.0',
+      buildOsmMapUrl(spot.coordinates, radiusMeters),
+    ],
+    { maxBuffer: 50 * 1024 * 1024 }
+  )
+  return parseOsmMapNodes(stdout)
+}
+
+function facilityDocument(candidate, now) {
+  const document = { ...candidate }
+  delete document.distance
+  return { ...document, createdAt: now, updatedAt: now }
+}
+
+async function main() {
+  loadRepositoryEnv()
+  if (!process.env.MONGODB_URI) {
+    throw new Error('MONGODB_URI is required')
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI)
+  await client.connect()
+
+  try {
+    const db = client.db(process.env.MONGODB_DB || undefined)
+    const spotsCollection = db.collection('spots')
+    const facilitiesCollection = db.collection('facilities')
+    const spots = await spotsCollection
+      .find(
+        { id: { $regex: TARGET_ID_PATTERN } },
+        { projection: { _id: 0, id: 1, name: 1, coordinates: 1 } }
+      )
+      .sort({ id: 1 })
+      .toArray()
+    const facilities = await facilitiesCollection
+      .find({ status: { $ne: 'hidden' } }, { projection: { coordinates: 1 } })
+      .toArray()
+    const missingSpots = spots.filter(
+      (spot) => !hasNearbyFacility(spot, facilities, RADIUS_METERS)
+    )
+
+    console.log(
+      JSON.stringify(
+        {
+          mode: APPLY ? 'apply' : 'dry-run',
+          target: describeMongoTarget(process.env.MONGODB_URI),
+          targetSpotCount: spots.length,
+          missingSpotCount: missingSpots.length,
+        },
+        null,
+        2
+      )
+    )
+
+    const plans = []
+    for (const spot of missingSpots) {
+      let elements = await fetchOsmElements(spot, 500)
+      let candidates = selectFacilityCandidates(elements, spot, {
+        radiusMeters: RADIUS_METERS,
+        maxResults: 5,
+      })
+      if (candidates.length === 0) {
+        elements = await fetchOsmElements(spot, RADIUS_METERS)
+        candidates = selectFacilityCandidates(elements, spot, {
+          radiusMeters: RADIUS_METERS,
+          maxResults: 5,
+        })
+      }
+      if (candidates.length === 0) {
+        throw new Error(`${spot.id} has no usable OpenStreetMap facilities`)
+      }
+      plans.push({ spot, candidates })
+      console.log(
+        `${spot.id}: ${candidates.map(({ name, type, distance }) => `${name} [${type}, ${distance}m]`).join(', ')}`
+      )
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+
+    if (!APPLY) {
+      console.log(
+        `Dry run complete: ${plans.reduce((sum, plan) => sum + plan.candidates.length, 0)} facilities planned. Re-run with --apply to persist.`
+      )
+      return
+    }
+
+    let upsertedCount = 0
+    const now = new Date()
+    for (const { candidates } of plans) {
+      for (const candidate of candidates) {
+        const result = await facilitiesCollection.updateOne(
+          {
+            'source.provider': candidate.source.provider,
+            'source.elementId': candidate.source.elementId,
+          },
+          { $setOnInsert: facilityDocument(candidate, now) },
+          { upsert: true }
+        )
+        upsertedCount += result.upsertedCount
+      }
+    }
+
+    console.log(`Apply complete: ${upsertedCount} facilities inserted.`)
+  } finally {
+    await client.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
﻿## 🔗 관련 이슈

- Closes #935

---

## 📋 PR 타입

- [x] ✨ **feat**: 새로운 기능 추가
- [ ] 🐛 **fix**: 버그 수정
- [ ] 🎨 **ui**: UI/UX 개선, 스타일 수정
- [ ] ⚡ **enhancement**: 기존 기능 개선, 성능 최적화
- [ ] 🧹 **chore**: 빌드, 설정, 패키지 관리
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변경 없음)
- [ ] 📚 **docs**: 문서 수정

---

## ✨ 작업 개요

> 신규 일본 애니메이션 스팟 중 반경 2km 내 편의시설이 없는 곳만 OSM 데이터로 안전하게 보강합니다.

---

## 📋 변경 사항

- [x] REAL-ANI-050~093의 기존 편의시설 존재 여부를 판별하는 드라이런/적용 스크립트 추가
- [x] OSM 원본 ID 기반 멱등 upsert와 기존 facilities 데이터 보존
- [x] 거리 계산, 타입 매핑, XML 파싱, 후보 중복 제거 회귀 테스트 추가
- [x] 프로덕션 누락 37개 스팟에 153개 시설 반영 후 누락 0건 확인

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [ ] `npm run build` 통과
- [x] 주요 기능 동작 확인

---

## 📸 스크린샷 (선택)

<!-- UI 변경 없음 -->

---

## 📝 추가 정보 (선택)

- `npm run facilities:missing:dry`는 기본 읽기 전용입니다.
- 실제 반영은 `npm run facilities:missing:apply`에서만 수행합니다.
- 검증: Jest 12개, type-check, ESLint, Prettier, 프로덕션 재점검 `missingSpotCount: 0`.
